### PR TITLE
fix: the ledger can no longer refuse to start, or take a run down with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **A personal `~/.gitconfig` could stop `evolve()` before it ran a single task.**
+  The ledger shelled out to plain `git`, so `commit.gpgsign = true` -- a common
+  setting, and the default in several corporate onboarding scripts -- failed the
+  genesis commit and raised `GitError` out of `Ledger.__init__`, from a call whose
+  signature mentions git nowhere. A global `core.hooksPath` ran the user's
+  `pre-commit` hook against a temp directory it knew nothing about. These are the
+  ledger's own bookkeeping commits in a scratch repo the caller never sees, so git
+  now runs with an isolated config (`GIT_CONFIG_NOSYSTEM`, signing and hooks off)
+  plus `GIT_TERMINAL_PROMPT=0` and a timeout, so a credential prompt or a stalled
+  filesystem surfaces as an error instead of wedging every worker behind the
+  ledger lock. A missing `git` binary now says so by name instead of raising a
+  bare `OSError`.
+- **A ledger failure mid-run escaped as an exception, discarding the artifact.**
+  `EvolutionResult` documents that "a run that died still returns a (partial)
+  result rather than raising", and every rollout, reward and merge call site was
+  wrapped -- but the ledger's five call sites were not. The worst case: `ledger.log()`
+  was fetched *inside the `return` expression*, purely to fill the cosmetic
+  `ledger_log`, so a git failure there threw away a run that had already completed
+  every round and computed its final reward. A ledger failure is now its own
+  category alongside a caller-contract violation (raises) and a backend blip
+  (absorbed): it ends the run, names itself in `error`, and still hands back what
+  was learned. `ledger_log` degrades to `[]`.
+- **Scratch ledgers were reclaimed only at interpreter exit.** `atexit` does not
+  run on SIGKILL or an OOM kill, so each such death leaked a git repo into
+  `$TMPDIR` -- 115 directories totalling 19 MB accumulated on one machine in a
+  single day. Worse, inside a notebook or a parameter sweep `atexit` fires only
+  when the *process* ends, so every run in the process held a live repo. `evolve()`
+  and `async_evolve()` now remove their own scratch ledger on the way out (a
+  caller-supplied `repo_path` is never touched -- it is how a run is resumed), and
+  each run first collects orphans older than a day.
+
+### Fixed
 - **The merge gate was serial, and it dominated the run.** `EvolvingArtifact.score`
   summed a generator, so every held-out evaluation ran its tasks one at a time --
   and the aggregator calls it once per candidate, so a round paid N x held-out

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -37,12 +37,13 @@ import warnings
 from typing import Callable, Dict, List, Optional
 
 from .evolution import (
+    _safe_log,
     Agent, EvolutionResult, Propose, Reward, RoundInfo, Run, Strategy, Task, _tally,
     _build_engine, _checked_proposal, _checked_reward,
 )
 from .aggregator import AggregatorConfig, check_reports
 from .evolvable import ContractError, EvidenceCard, vv_staleness
-from .ledger import Ledger
+from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
 from .staleness import StaleAction, StalenessPolicy, get_policy
 
@@ -187,6 +188,9 @@ def async_evolve(
     # the merger closure can mutate it without a `nonlocal` per field.
     best: List[float] = [float('-inf'), 0]
     errors: List[Optional[str]] = [None]      # first backend failure seen (diagnostic)
+    # Most recent artifact read from the ledger, so a failing final read still
+    # yields a result instead of an exception (same reasoning as the sync path).
+    last_good: List[object] = [None]
     died = [False]                            # True only if the run ENDED on failure
     contract_error: List[Optional[BaseException]] = [None]   # caller bug -> re-raise
     n_live = sum(1 for s in shards if s)      # workers that will actually start
@@ -338,6 +342,7 @@ def async_evolve(
         reports = check_reports(eng.aggregator.step(), eng.aggregator)
         committed = sum(1 for x in reports if x.committed_version is not None)
         dev = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
+        last_good[0] = dev
         # Must be the real held-out reward: MergeReport.prob_improve is P(Δ>0)
         # from the Beta posterior, a *probability*, and reporting it here would
         # both corrupt `history` and make `target_reward` fire spuriously. This
@@ -440,7 +445,22 @@ def async_evolve(
 
     if contract_error[0] is not None:
         raise contract_error[0]
-    final = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
+    try:
+        final = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
+    except LedgerFailure as e:
+        # The ledger is infrastructure: neither a caller bug nor a backend blip.
+        # Its failure must still leave a result behind (see the sync path), so fall
+        # back to whatever the merger last read.
+        final = last_good[0]
+        errors[0] = (f"the final ledger read failed, so the returned artifact is "
+                     f"the last one successfully read: {type(e).__name__}: "
+                     f"{str(e)[:160]}")
+        died[0] = True
+    if final is None:                  # nothing was ever read: hand back the seed
+        from .evolution import EvolvingArtifact
+        final = EvolvingArtifact(eng.artifact_id, dict(eng.strategy.initial()),
+                                 blast_radius=eng.blast_radius,
+                                 runtime=eng.runtime, strategy=eng.strategy)
     # Scoring the final artifact runs the agent too, so a dead backend must not
     # raise out of the driver -- that would discard the work already committed.
     # Retry it: scoring is memoised per (artifact, task), so a retry re-runs only
@@ -473,7 +493,9 @@ def async_evolve(
             print(f"async run ended with a backend failure: {run_error[:140]}")
         warnings.warn(f"async_evolve() ended with a backend failure: {run_error}",
                       RuntimeWarning, stacklevel=2)
-    return EvolutionResult(state=dict(final.state), rendered=final.render(),
-                           final_reward=final_reward, history=history,
-                           ledger_log=eng.ledger.log(Ledger.DEV, limit=40),
-                           error=run_error, retired_workers=retired[0])
+    result = EvolutionResult(state=dict(final.state), rendered=final.render(),
+                             final_reward=final_reward, history=history,
+                             ledger_log=_safe_log(eng.ledger),
+                             error=run_error, retired_workers=retired[0])
+    eng.cleanup()          # do not hold a scratch git repo for the whole process
+    return result

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import atexit
 import hashlib
+import os
 import re
 import shutil
 import threading
@@ -43,7 +44,7 @@ from .aggregator import (
 )
 from .evolvable import Contract, ContractError, Diff, EvidenceCard
 from .governance import assert_mutable
-from .ledger import Ledger
+from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import AuditScheduler
 from .staleness import StalenessPolicy
@@ -504,6 +505,51 @@ class _Runtime:
 # ---------------------------------------------------------------------------
 
 
+#: Scratch ledgers are named so they can be recognised and reclaimed later.
+_SCRATCH_PREFIX = "agentdescent-evolve-"
+#: How long an orphaned scratch ledger may sit in $TMPDIR before the next run
+#: collects it. Generous, because a *live* run's directory must never be touched.
+_SCRATCH_MAX_AGE = 24 * 3600.0
+
+
+def _reap_stale_scratch_repos(max_age: float = _SCRATCH_MAX_AGE) -> int:
+    """Delete scratch ledgers left behind by processes that never exited cleanly.
+
+    ``atexit`` does not run on SIGKILL, an OOM kill or a hard container stop, so
+    every such death leaks a git repo into ``$TMPDIR``. Best-effort and silent:
+    reclaiming disk must never be able to fail a run."""
+    import tempfile
+    removed = 0
+    try:
+        root = tempfile.gettempdir()
+        cutoff = time.time() - max_age
+        for name in os.listdir(root):
+            if not name.startswith(_SCRATCH_PREFIX):
+                continue
+            path = os.path.join(root, name)
+            try:
+                if os.path.isdir(path) and os.path.getmtime(path) < cutoff:
+                    shutil.rmtree(path, ignore_errors=True)
+                    removed += 1
+            except OSError:
+                continue
+    except OSError:
+        return removed
+    return removed
+
+
+def _safe_log(ledger: Ledger, limit: int = 40) -> List[str]:
+    """``ledger.log()``, but never at the cost of the result.
+
+    ``ledger_log`` is a diagnostic -- the last few commit subjects. It used to be
+    fetched inside the ``return`` expression, so a git failure there discarded a
+    run that had already completed every round and computed its final reward."""
+    try:
+        return ledger.log(Ledger.DEV, limit=limit)
+    except LedgerFailure:
+        return []
+
+
 def _tally(reports) -> Dict[str, int]:
     """Count merge outcomes by stable category (see ``MergeReport.category``)."""
     out: Dict[str, int] = {}
@@ -534,11 +580,15 @@ class EvolutionResult:
     final_reward: float
     history: List[RoundInfo]
     ledger_log: List[str]
-    #: ``None`` on a clean run; otherwise a description of the backend failure that
-    #: either ended the run early **or** made its final measurement unusable (in
-    #: which case ``final_reward`` falls back to the last measured round, and the
-    #: message says so). The artifact evolved so far is still returned -- check this
-    #: to tell "converged" from "died".
+    #: ``None`` on a clean run; otherwise a description of the failure that either
+    #: ended the run early **or** made its final measurement unusable (in which case
+    #: ``final_reward`` falls back to the last measured round, and the message says
+    #: so). Covers both a *backend* failure (a rate limit, a dead endpoint) and a
+    #: *ledger* failure (a held ``index.lock``, a full ``$TMPDIR``) -- neither is
+    #: allowed to escape as an exception. A caller-contract violation is the one
+    #: thing that still raises, because the run is meaningless either way. The
+    #: artifact evolved so far is still returned -- check this to tell "converged"
+    #: from "died".
     error: Optional[str] = None
     #: Workers that gave up after repeated backend failures (async path only). A
     #: run can finish *cleanly* at a fraction of its requested concurrency, so
@@ -623,6 +673,16 @@ class _Engine:
     train_ids: List[str]
     artifact_id: str
     blast_radius: float
+    #: Set only when the ledger lives in a throwaway directory this call created;
+    #: ``None`` when the caller passed ``repo_path`` (theirs to keep, and how a run
+    #: is resumed).
+    scratch_repo: Optional[str] = None
+
+    def cleanup(self) -> None:
+        """Remove the scratch ledger, if this call created one. Idempotent."""
+        if self.scratch_repo:
+            shutil.rmtree(self.scratch_repo, ignore_errors=True)
+            self.scratch_repo = None
 
 
 def _check_callable(fn: Callable, n_args: int, sig_hint: str) -> None:
@@ -703,12 +763,20 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
         return EvolvingArtifact(aid, state.get("state", {}), version,
                                 state.get("blast_radius", blast_radius), runtime, strategy)
 
+    scratch: Optional[str] = None
     if repo_path:
         repo = repo_path              # caller-owned (and how a run is resumed): keep it
     else:
         # A scratch ledger per run would otherwise pile up in $TMPDIR forever --
-        # one git repo per evolve() call, never reclaimed.
-        repo = tempfile.mkdtemp(prefix="agentdescent-evolve-")
+        # one git repo per evolve() call, never reclaimed. atexit alone was not
+        # enough: it does not run on SIGKILL/OOM, and inside a notebook or a
+        # parameter sweep it fires only when the *interpreter* exits, so every run
+        # in the process held a live git repo. The driver now removes its own
+        # scratch repo on the way out; atexit stays as the belt-and-braces path for
+        # an exception escaping the driver, and the reaper collects what earlier
+        # killed processes left behind.
+        _reap_stale_scratch_repos()
+        repo = scratch = tempfile.mkdtemp(prefix=_SCRATCH_PREFIX)
         atexit.register(shutil.rmtree, repo, True)
     ledger = Ledger(repo, serialize, deserialize)
     # `register` is a no-op when the artifact already exists, which is what makes
@@ -750,7 +818,7 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
 
     return _Engine(ledger, runtime, verifier, aggregator, strategy, run, reward,
                    propose, train, held_out, {t.id: t for t in train},
-                   [t.id for t in train], artifact_id, blast_radius)
+                   [t.id for t in train], artifact_id, blast_radius, scratch)
 
 
 def evolve(
@@ -891,8 +959,13 @@ def evolve(
     held_out_frac:
         Fraction of ``tasks`` reserved for held-out scoring, in ``(0, 1)``.
     repo_path:
-        Where the git-backed ledger lives. Omit for a scratch repo that is
-        cleaned up at exit; **passing the same path again resumes** that ledger.
+        Where the git-backed ledger lives. Omit for a throwaway repo that is
+        removed when this call returns (not held until interpreter exit, so a
+        sweep does not accumulate one git repo per run); **passing the same path
+        again resumes** that ledger, and a caller-supplied path is never deleted.
+        Git runs with an isolated config, so a personal ``~/.gitconfig``
+        (``commit.gpgsign``, ``core.hooksPath``) cannot fail the ledger's own
+        bookkeeping commits.
     agg_config:
         Tuning for the reference aggregator (batching, acceptance risk, trust
         region, staleness tolerance).
@@ -984,6 +1057,9 @@ def evolve(
 
     history: List[RoundInfo] = []
     run_error: Optional[str] = None
+    #: The most recent artifact successfully read from the ledger. If the final
+    #: read fails there is still a real result to hand back instead of an exception.
+    last_good: Optional[EvolvingArtifact] = None
     straggler_rounds = 0
     best_reward = float('-inf')
     stalled = 0
@@ -998,7 +1074,25 @@ def evolve(
             if verbose:
                 print(f"round {r:>3}  stopping: max_seconds={max_seconds} reached")
             break
-        snap = ledger.snapshot(Ledger.DEV)
+        try:
+            snap = ledger.snapshot(Ledger.DEV)
+        except LedgerFailure as e:
+            # The ledger is infrastructure, not a backend and not a caller bug, so
+            # it fits neither existing category -- and letting it propagate broke
+            # the one guarantee the result contract makes ("a run that died still
+            # returns a partial result"). Treat it like an unmeasurable round: the
+            # same tally decides whether to keep going or give up.
+            if first_error[0] is None:
+                first_error[0] = f"ledger read failed: {type(e).__name__}: {str(e)[:200]}"
+            dead_rounds += 1
+            if dead_rounds >= max_worker_errors:
+                run_error = first_error[0]
+                if verbose:
+                    print(f"round {r:>3}  giving up: {run_error}")
+                break
+            if verbose:
+                print(f"round {r:>3}  ledger unreadable, skipping: {str(e)[:100]}")
+            continue
         artifact = snap.get(artifact_id)
         base_v = snap.version.get(artifact_id, 0)
         assert_mutable(artifact)
@@ -1149,7 +1243,17 @@ def evolve(
             break
         committed = sum(1 for x in reports if x.committed_version is not None)
         rejected = sum(1 for x in reports if x.committed_version is None)
-        dev = ledger.snapshot(Ledger.DEV).get(artifact_id)
+        try:
+            dev = ledger.snapshot(Ledger.DEV).get(artifact_id)
+        except LedgerFailure as e:      # as at the round head: skip, do not raise
+            if first_error[0] is None:
+                first_error[0] = f"ledger read failed: {type(e).__name__}: {str(e)[:200]}"
+            dead_rounds += 1
+            if dead_rounds >= max_worker_errors:
+                run_error = first_error[0]
+                break
+            continue
+        last_good = dev
         # Scoring held-out runs the agent, so it is a backend call like any other and
         # must not raise out of the driver -- that would discard everything already
         # committed. Treat an unmeasurable round like a failed one: keep the last
@@ -1218,7 +1322,20 @@ def evolve(
                 warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
                               RuntimeWarning, stacklevel=2)
 
-    final = ledger.snapshot(Ledger.DEV).get(artifact_id)
+    try:
+        final = ledger.snapshot(Ledger.DEV).get(artifact_id)
+    except LedgerFailure as e:
+        # Fall back to the last artifact we did read. Raising here would throw away
+        # a run that has already finished all its rounds, which is exactly what the
+        # result contract promises not to do.
+        final = last_good
+        run_error = run_error or (
+            f"the final ledger read failed, so the returned artifact is the last "
+            f"one successfully read: {type(e).__name__}: {str(e)[:160]}")
+    if final is None:                 # nothing was ever read: hand back the seed
+        final = EvolvingArtifact(artifact_id, dict(initial_state or strategy.initial()),
+                                 blast_radius=blast_radius, runtime=eng.runtime,
+                                 strategy=strategy)
     # Scoring runs the agent, so a dead backend must not raise out of the driver
     # and discard everything already committed.
     try:
@@ -1233,6 +1350,10 @@ def evolve(
         # result is otherwise indistinguishable from a converged one.
         warnings.warn(f"evolve() stopped early after {len(history)} round(s): "
                       f"{run_error}", RuntimeWarning, stacklevel=2)
-    return EvolutionResult(state=dict(final.state), rendered=final.render(),
-                           final_reward=final_reward, history=history,
-                           ledger_log=ledger.log(Ledger.DEV, limit=40), error=run_error)
+    # Read the log before reclaiming the repo, then hand the scratch directory
+    # back rather than holding it for the lifetime of the interpreter.
+    result = EvolutionResult(state=dict(final.state), rendered=final.render(),
+                             final_reward=final_reward, history=history,
+                             ledger_log=_safe_log(ledger), error=run_error)
+    eng.cleanup()
+    return result

--- a/agentdescent/ledger.py
+++ b/agentdescent/ledger.py
@@ -66,18 +66,66 @@ class GitError(RuntimeError):
     """A git command failed; the message carries git's own stderr."""
 
 
+#: What a ledger read or write can fail with -- a third category alongside
+#: ``ContractError`` (a caller bug: propagate) and a backend failure (absorb and
+#: report). The ledger is *infrastructure*: a held ``index.lock``, a full
+#: ``$TMPDIR``, a killed ``git``. Its failure ends the run but must still leave a
+#: partial result behind, so the drivers catch this tuple rather than letting it
+#: escape (which used to discard a completed run -- even when the failing call was
+#: only fetching the cosmetic ``ledger_log``).
+LedgerFailure = (GitError, OSError, json.JSONDecodeError)
+
+
+# Config the ledger imposes on every invocation, overriding whatever the user has
+# in ~/.gitconfig. These commits are the ledger's bookkeeping, not the user's, and
+# a scratch repo in $TMPDIR has no business honouring personal git preferences:
+# `commit.gpgsign = true` -- a common setting -- failed the genesis commit, so
+# `evolve()` raised before running a single task, from a call that mentions git
+# nowhere. `core.hooksPath` would likewise run the user's pre-commit hook against
+# a temp directory it knows nothing about.
+_GIT_OVERRIDES = (
+    "-c", "commit.gpgsign=false",
+    "-c", "tag.gpgsign=false",
+    "-c", "core.hooksPath=",
+    "-c", "gc.auto=0",
+)
+# 120s is enormous for the operations here (all local, all tiny) and exists only
+# so a wedged git -- an NFS stall, a held index.lock -- surfaces as a GitError
+# instead of hanging the process. Every call holds the ledger lock, so one
+# blocked git would otherwise stall every worker.
+_GIT_TIMEOUT = 120.0
+
+
 def _git(repo: str, *args: str) -> str:
     """Run a git command, surfacing *why* it failed.
 
     ``capture_output=True`` swallows stderr, so a failure used to read only
     "returned non-zero exit status 128" -- the actual cause (a missing repo, an
     index lock held by another process) was discarded.
+
+    The environment is isolated (see ``_GIT_OVERRIDES``): system and user config
+    must not decide whether the ledger can write, and ``GIT_TERMINAL_PROMPT=0``
+    keeps a credential prompt from wedging a run that has no terminal.
     """
-    out = subprocess.run(
-        ["git", "-C", repo, *args],
-        capture_output=True,
-        text=True,
-    )
+    env = {**os.environ, "GIT_CONFIG_NOSYSTEM": "1", "GIT_TERMINAL_PROMPT": "0"}
+    try:
+        out = subprocess.run(
+            ["git", "-C", repo, *_GIT_OVERRIDES, *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+            env=env,
+        )
+    except FileNotFoundError as e:
+        # Otherwise a machine without git fails with a bare OSError traceback,
+        # while every other missing-executable path in the package names it.
+        raise GitError(
+            "'git' is not installed or not on PATH; the Ledger stores artifacts "
+            "in a git repository, so it is required") from e
+    except subprocess.TimeoutExpired as e:
+        raise GitError(
+            f"git {' '.join(args)} in {repo} exceeded {_GIT_TIMEOUT}s and was "
+            "abandoned (a held index.lock or a stalled filesystem)") from e
     if out.returncode != 0:
         detail = (out.stderr or out.stdout or "").strip() or "no output"
         raise GitError(f"git {' '.join(args)} failed in {repo}: {detail}")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ the Aggregator calls at steps 1–4 (cheap) and step 7 (oracle, budgeted).
 | Component | Module | Responsibility |
 |---|---|---|
 | **Evolvable** | [`evolvable.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolvable.py) | The interface every unit of evolution implements (`diff`/`apply`/`cheap_eval`/`full_eval`). Also `Diff`, `EvidenceCard`, version-vector math. |
-| **Ledger** | [`ledger.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/ledger.py) | Git-backed store. Per-artifact integer versions form the version vector. CAS commits and `dev`/`stable` branches; `commit_atomic` (2PC across artifacts) is provided and tested but not used by any engine path today. |
+| **Ledger** | [`ledger.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/ledger.py) | Git-backed store. Per-artifact integer versions form the version vector. CAS commits and `dev`/`stable` branches; `commit_atomic` (2PC across artifacts) is provided and tested but not used by any engine path today. Runs git with an isolated config (no system/user `gitconfig`, no hooks, no signing) so a personal git preference cannot decide whether the ledger can write. |
 | **Aggregator** | [`aggregator.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/aggregator.py) | The optimizer. Buckets evidence by artifact and runs the 7-step merge pipeline. Owns the per-artifact Beta posteriors. |
 | **StalenessPolicy** | [`staleness.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/staleness.py) | Full / Guarded / Reflective. Decides `ACCEPT/REBASE/DISCARD` for a stale diff. Swappable without touching the pipeline. |
 | **Verifier** | [`verifier.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/verifier.py) | rule (cheap subset), learned (noisy + uncertainty), oracle (ground truth, budgeted). |
@@ -188,6 +188,11 @@ explicitly:
   calls don't race.
 - **Verifier / posteriors** — touched only by the single aggregator thread, so
   they need no locking.
+
+A ledger failure is its own category, distinct from a caller bug (`ContractError`,
+propagated) and a backend blip (absorbed and retried): it is infrastructure, it
+ends the run, and the drivers still return the artifact evolved so far rather than
+raising. See the failure-category table in [evolution.md](evolution.md).
 
 The GIL means threads don't give true CPU parallelism, but the **pipeline
 overlap** and every concurrency-control mechanism (CAS, version vectors,

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -456,7 +456,17 @@ The second call starts from the artifact the first one committed, not from
 * `initial_state=` is ignored when the artifact already exists (a `RuntimeWarning`
   says so). Use a fresh `repo_path` to start over.
 
-Omit `repo_path` and the ledger is a scratch directory, cleaned up at exit.
+Omit `repo_path` and the ledger is a throwaway directory, removed when `evolve()`
+returns — not held until the interpreter exits, so a notebook or a parameter sweep
+does not accumulate one git repo per run. A process killed outright (SIGKILL, OOM)
+skips that cleanup; the next run in a fresh process collects anything older than a
+day.
+
+The ledger also runs git with **its own configuration**, ignoring your
+`~/.gitconfig` and `/etc/gitconfig`. These are the ledger's internal bookkeeping
+commits in a directory you never see — `commit.gpgsign = true` or a global
+`core.hooksPath` used to fail them, and with it the whole run, before a single
+task had executed.
 
 The engine returns **partial results** if the model backend fails mid-run (rate
 limit, credit exhaustion) — progress isn't lost.
@@ -475,6 +485,18 @@ limit, credit exhaustion) — progress isn't lost.
     `error` means *the run ended because of this failure* — a transient error the
     workers retried past leaves it `None`. A `RuntimeWarning` is also emitted, so
     a failed run is never completely silent even at the default `verbose=False`.
+
+!!! note "Three failure categories, not two"
+    | category | example | what happens |
+    |---|---|---|
+    | **caller contract** | `reward` returns `47`, `propose` returns an `int` | raises (`ContractError`) — the run is meaningless, so failing fast is the only useful answer |
+    | **backend** | 429, dead endpoint, credit exhausted | absorbed, retried, tolerated; ends the run only when nothing can make progress, and then `error` names it |
+    | **ledger** | a held `index.lock`, a full `$TMPDIR`, a killed `git` | ends the run, but still returns the artifact evolved so far with `error` naming git |
+
+    The third used to escape as a bare `GitError`, discarding a completed run —
+    including when the failing call was only fetching the cosmetic
+    `result.ledger_log`, which now degrades to `[]` rather than taking the result
+    with it.
 
 **Actor signatures are checked before the first rollout.** `run` and `propose` are
 bound-tested up front, so a plain typo (a `propose` missing its `reward`

--- a/tests/test_ledger_resilience.py
+++ b/tests/test_ledger_resilience.py
@@ -1,0 +1,229 @@
+"""The ledger must not be able to take a run down with it.
+
+The ledger is the third failure category, alongside a caller bug (`ContractError`,
+propagate) and a backend blip (absorb and report): it is *infrastructure*. Three
+things used to go wrong and each is pinned here.
+
+1. It refused to start at all under an ordinary `~/.gitconfig` -- `commit.gpgsign
+   = true` failed the genesis commit, so `evolve()` raised before running a single
+   task, from a call that mentions git nowhere.
+2. A failure mid-run escaped as an exception, discarding the artifact evolved so
+   far -- directly against the documented contract that a run that died still
+   returns a partial result. Worst case, the failing call was `ledger.log()`,
+   fetched inside the `return` expression purely for the cosmetic `ledger_log`.
+3. Scratch repos were reclaimed only at interpreter exit, so a killed process
+   leaked one and a long-lived process (a notebook, a sweep) held every repo it
+   had ever created.
+"""
+
+import glob
+import os
+import tempfile
+import time
+import warnings
+
+import pytest
+
+import agentdescent.ledger as ledger_mod
+from agentdescent.evolution import (
+    AppendRules, SingleSlot, Task, _reap_stale_scratch_repos, evolve,
+)
+from agentdescent.ledger import GitError, Ledger
+
+TASKS = [Task(id=str(i), prompt=str(i), meta={"gold": str(i)}) for i in range(8)]
+
+
+def _reward(task, output):
+    return 1.0 if "rule" in (output or "") else 0.0
+
+
+def _run(rendered, task):
+    return "rule ok" if "rule" in rendered else "no"
+
+
+def _propose(rendered, task, output, score):
+    return "rule-A"
+
+
+def _evolve(**kw):
+    kw.setdefault("rounds", 8)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return evolve(TASKS, _reward, run=_run, propose=_propose,
+                      strategy=SingleSlot(initial_value="v"),
+                      n_workers=2, max_concurrency=1, held_out_frac=0.5, **kw)
+
+
+# -- 1. the user's git config must not decide whether the ledger can write ------
+
+
+def test_a_global_gitconfig_with_commit_signing_does_not_break_a_run(tmp_path,
+                                                                    monkeypatch):
+    """`commit.gpgsign = true` is a common setting and used to be fatal.
+
+    These are the ledger's own bookkeeping commits in a throwaway directory --
+    they have no business honouring personal git preferences.
+    """
+    cfg = tmp_path / "gitconfig"
+    cfg.write_text("[commit]\n\tgpgsign = true\n[user]\n\tsigningkey = DEADBEEF\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(cfg))
+    res = _evolve()
+    assert res.error is None, f"a user gitconfig broke the run: {res.error}"
+    assert res.rendered == "rule-A", "the run did not actually evolve anything"
+
+
+def test_a_global_hooks_path_does_not_run_against_the_scratch_repo(tmp_path,
+                                                                  monkeypatch):
+    """A user pre-commit hook must not fire on the ledger's internal commits."""
+    hooks = tmp_path / "hooks"
+    hooks.mkdir()
+    hook = hooks / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n")      # a hook that rejects every commit
+    hook.chmod(0o755)
+    cfg = tmp_path / "gitconfig"
+    cfg.write_text(f"[core]\n\thooksPath = {hooks}\n")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(cfg))
+    res = _evolve()
+    assert res.error is None, f"a user pre-commit hook broke the run: {res.error}"
+
+
+def test_a_missing_git_binary_names_git(tmp_path, monkeypatch):
+    """Otherwise it is a bare OSError traceback, unlike every other exec path."""
+    monkeypatch.setenv("PATH", str(tmp_path))     # no git on it
+    with pytest.raises(GitError) as excinfo:
+        Ledger(str(tmp_path / "repo"), lambda a: {}, lambda i, v, s: None)
+    assert "git" in str(excinfo.value).lower()
+    assert "path" in str(excinfo.value).lower()
+
+
+# -- 2. a ledger failure ends the run but still hands back what it learned ------
+
+
+def _git_dies_after(n):
+    """Patch `_git` to fail after `n` calls -- a held index.lock, a full disk."""
+    original = ledger_mod._git
+    calls = {"n": 0}
+
+    def failing(repo, *args):
+        calls["n"] += 1
+        if calls["n"] > n:
+            raise GitError(f"git {args[0]} failed in {repo}: index.lock exists")
+        return original(repo, *args)
+    return failing, original, calls
+
+
+def _count_git_calls(fn):
+    original = ledger_mod._git
+    calls = {"n": 0}
+
+    def counting(repo, *args):
+        calls["n"] += 1
+        return original(repo, *args)
+    ledger_mod._git = counting
+    try:
+        fn()
+    finally:
+        ledger_mod._git = original
+    return calls["n"]
+
+
+def test_a_ledger_failure_mid_run_returns_a_partial_result_rather_than_raising():
+    """The contract: "a run that died still returns a (partial) result"."""
+    n = [0]
+
+    def many_proposals(rendered, task, output, score):
+        n[0] += 1
+        return f"rule number {n[0]}"
+
+    def kw():
+        return dict(strategy=AppendRules(), rounds=10, n_workers=3,
+                    max_concurrency=1, held_out_frac=0.5)
+
+    def clean():
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            evolve(TASKS, lambda t, o: 0.5, run=lambda r, t: r,
+                   propose=many_proposals, **kw())
+
+    n[0] = 0
+    total = _count_git_calls(clean)
+    # Fail somewhere inside the loop, past construction (which legitimately raises:
+    # nothing has been produced yet, so there is no partial result to preserve).
+    failing, original, _ = _git_dies_after(total - 4)
+    ledger_mod._git = failing
+    n[0] = 0
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = evolve(TASKS, lambda t, o: 0.5, run=lambda r, t: r,
+                         propose=many_proposals, **kw())
+    finally:
+        ledger_mod._git = original
+    assert res.error is not None, "a dead ledger ended the run silently"
+    assert "git" in res.error.lower()
+    assert res.rendered, "the artifact evolved before the failure was discarded"
+
+
+def test_a_failing_ledger_log_does_not_discard_a_completed_run():
+    """`ledger_log` is a diagnostic. Losing it must not lose the run.
+
+    It used to be fetched inside the `return` expression, so a git failure there
+    threw away a run that had already finished every round and scored itself.
+    """
+    original = ledger_mod._git
+
+    def no_log(repo, *args):
+        if args and args[0] == "log":
+            raise GitError("git log failed: index.lock exists")
+        return original(repo, *args)
+
+    ledger_mod._git = no_log
+    try:
+        res = _evolve()
+    finally:
+        ledger_mod._git = original
+    assert res.rendered == "rule-A", "a completed run was discarded"
+    assert res.final_reward == 1.0
+    assert res.ledger_log == [], "the log should degrade to empty, not explode"
+    assert res.error is None, "losing a diagnostic is not a failed run"
+
+
+# -- 3. scratch ledgers are reclaimed, not held for the process lifetime --------
+
+
+def _live_scratch_repos():
+    return set(glob.glob(os.path.join(tempfile.gettempdir(),
+                                      "agentdescent-evolve-*")))
+
+
+def test_a_scratch_ledger_is_reclaimed_when_evolve_returns():
+    """atexit alone meant a sweep held one git repo per run until the process died."""
+    before = _live_scratch_repos()
+    for _ in range(3):
+        _evolve(rounds=2)
+    assert _live_scratch_repos() - before == set(), \
+        "evolve() left its scratch ledger behind"
+
+
+def test_a_caller_supplied_repo_path_is_never_reclaimed(tmp_path):
+    """`repo_path` is caller-owned -- and how a run is resumed."""
+    repo = tmp_path / "mine"
+    _evolve(repo_path=str(repo), rounds=2)
+    assert repo.is_dir() and (repo / ".git").is_dir(), \
+        "a caller-owned repo was deleted; resuming would be impossible"
+
+
+def test_the_reaper_collects_orphans_but_spares_live_repos():
+    """A killed process (SIGKILL, OOM) skips atexit and leaks its repo."""
+    orphan = tempfile.mkdtemp(prefix="agentdescent-evolve-")
+    fresh = tempfile.mkdtemp(prefix="agentdescent-evolve-")
+    old = time.time() - 48 * 3600
+    os.utime(orphan, (old, old))
+    try:
+        _reap_stale_scratch_repos()
+        assert not os.path.exists(orphan), "an orphaned scratch ledger was not reaped"
+        assert os.path.exists(fresh), "a live scratch ledger was reaped -- data loss"
+    finally:
+        for d in (orphan, fresh):
+            if os.path.exists(d):
+                os.rmdir(d)


### PR DESCRIPTION
Three independent ways the ledger could lose work that was never its to lose. Each has a reproduction and a regression test.

Closes #5, closes #29, closes #14.

---

### 1. A personal `~/.gitconfig` could stop `evolve()` before it ran a single task (#5)

```
GitError: git commit -q -m genesis failed in /var/folders/.../tmpxlckfyno:
error: gpg failed to sign the data
fatal: failed to write commit object
```

That is `Ledger._init_repo`, fired at construction, from a call that passed no git-related arguments and whose signature mentions git nowhere. The trigger is `commit.gpgsign = true` in the user's global config — a common setting. A global `core.hooksPath` is the same class of problem: the user's `pre-commit` hook runs against a temp directory it knows nothing about.

These are the ledger's **own bookkeeping commits in a scratch repo the caller never sees**. `_git` now runs with `GIT_CONFIG_NOSYSTEM=1` and `-c commit.gpgsign=false -c tag.gpgsign=false -c core.hooksPath= -c gc.auto=0`, which beat the user's config without modifying it. Also added, since they were missing from the one subprocess in the package that lacked them:

- `GIT_TERMINAL_PROMPT=0` — a credential prompt would otherwise hang the process, since there was no timeout
- a 120s timeout — every call holds the ledger lock, so one wedged git stalled *every* worker
- `FileNotFoundError` → `GitError` naming git, matching what `agents._CliAgent` already did

### 2. A ledger failure mid-run escaped as an exception (#29)

`EvolutionResult` documents:

> **Check `error`**: it is `None` only on a clean run, and **a run that died still returns a (partial) result rather than raising.**

Every rollout, reward and merge call site honoured that. The ledger's five did not — `evolve()`'s try block spans 1077–1149 and four ledger calls sit outside it. Injecting a `GitError` partway:

```
git dies halfway through:   PROPAGATED GitError: git commit failed in ...
git dies late in the run:   PROPAGATED GitError: git log failed in ...
```

The second is the sharp one: `ledger.log()` was called **inside the `return` expression**, purely to fill the cosmetic `ledger_log` (the last 40 commit subjects). A failure fetching it discarded a run that had already completed every round and computed `final_reward`.

A ledger failure is now its own category — `ledger.LedgerFailure` — alongside a caller-contract violation (raises; the run is meaningless either way) and a backend blip (absorbed and retried). It ends the run, names itself in `error`, and hands back what was learned. `ledger_log` degrades to `[]` rather than taking the result with it. After:

```
git dies at call 18 (in-loop) -> RESULT: items=3 rounds=0 error='GitError: git rev-parse failed...'
git dies at call 20 (in-loop) -> RESULT: items=6 rounds=1 error='GitError: git commit failed...'
```

A failure during *construction* still raises, deliberately: nothing has been produced yet, so there is no partial result to preserve and an immediate error is the legible answer.

### 3. Scratch ledgers were reclaimed only at interpreter exit (#14)

`atexit` does not run on SIGKILL, an OOM kill or a hard container stop, so each such death leaked a git repo. On one development machine `$TMPDIR` held **115 `agentdescent-evolve-*` directories totalling 19 MB, all created within a single day**.

Worse for the ordinary case: `atexit` fires at *interpreter* exit, so in a notebook or a parameter sweep every run in the process held a live repo — `5 × evolve()` meant +5 repos and +6 never-fired callbacks, freed only when the process ended.

Both drivers now reclaim their own scratch repo on the way out, and each run first collects orphans older than a day. A caller-supplied `repo_path` is **never** touched — it is how a run is resumed, and there is a test pinning that.

---

### Tests

`tests/test_ledger_resilience.py`, 8 cases: a signing gitconfig, a rejecting global pre-commit hook, a missing git binary, a mid-run failure yielding a partial result, a failing `ledger.log` not discarding a completed run, scratch reclamation, a caller-owned repo surviving, and the reaper collecting orphans while sparing live directories.

Full suite: **368 passed, 1 skipped** (was 360/1). `mkdocs build --strict` clean.

### Docs

- `docs/evolution.md` — `repo_path` now describes eager cleanup and config isolation; new "Three failure categories, not two" table (caller contract / backend / ledger)
- `docs/architecture.md` — Ledger row in the component table; ledger failures added to the concurrency & correctness section
- docstrings for `evolve(repo_path=)` and `EvolutionResult.error`
- CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)