### PR TITLE
Run every example on real data; restructure docs around the results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **`eval_concurrency=`** — how many held-out tasks a gate scores at once, the
+  merge half of the run's parallelism and independent of `n_workers`. It existed
+  only as a default on a private dataclass, which made it both unreachable and
+  *unmeasurable*: setting the class attribute silently did nothing, because a
+  dataclass bakes its defaults into the generated `__init__`. Measured on the same
+  workload: **193.6 s at 1, 96.7 s at 4, 90.0 s at 8**, saturating once it reaches
+  the size of the held-out set.
+
 ### Fixed
 - **The merge gate was serial, and it dominated the run.** `EvolvingArtifact.score`
   summed a generator, so every held-out evaluation ran its tasks one at a time --

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ Full docs live in [`docs/`](https://github.com/Birfy/agentdescent/tree/main/docs
 | Page | What's in it |
 |---|---|
 | [Home](https://github.com/Birfy/agentdescent/blob/main/docs/index.md) | Overview and 30-second tour |
+| **[Quickstart — dataset to skill](https://github.com/Birfy/agentdescent/blob/main/docs/quickstart-skill.md)** | **Start here.** One call: your data, how to score it, which model |
+| **[Measured results](https://github.com/Birfy/agentdescent/blob/main/docs/results.md)** | Every empirical claim with the setup that produced it — including where there was nothing to learn |
 | [Architecture](https://github.com/Birfy/agentdescent/blob/main/docs/architecture.md) | Components, data-flow diagram, the two runtimes, concurrency model |
 | [Concepts](https://github.com/Birfy/agentdescent/blob/main/docs/concepts.md) | The training↔RSI analogy, staleness, the aggregator, the three long tails, governance |
-| [Usage & extending](https://github.com/Birfy/agentdescent/blob/main/docs/usage.md) | Running the demos, config reference, **plugging in your own `Evolvable` domain** |
+|  [Install, run, extend](https://github.com/Birfy/agentdescent/blob/main/docs/usage.md) | Running the demos, config reference, **plugging in your own `Evolvable` domain** |
 | [Evolving anything](https://github.com/Birfy/agentdescent/blob/main/docs/evolution.md) | The general engine — evolve any artifact by writing its `Strategy` + `run`/`reward`/`propose` |
 | [Connecting agents & LLMs](https://github.com/Birfy/agentdescent/blob/main/docs/agents.md) | The provider-agnostic completion layer |
 | [Loading datasets](https://github.com/Birfy/agentdescent/blob/main/docs/dataloader.md) | The `agentdescent.dataloader` data layer — HF datasets-server + raw-file fetch, cached, dependency-free |
@@ -225,10 +227,24 @@ boundary is documented, never hidden.
 
 ## Efficiency (measured)
 
-[`examples/efficiency.py`](https://github.com/Birfy/agentdescent/blob/main/examples/efficiency.py) — **parallel scaling** is
-near-linear through 8 workers (~8.1x, efficiency ≈1.0), and the
-**async pipeline** is **~2.6-2.9× faster than a sync barrier** under heavy-tailed
-rollout latency (100% vs 40% worker utilization). See
+Two different numbers, and the difference is the point.
+
+**Worker scaling alone** ([`examples/efficiency.py`](https://github.com/Birfy/agentdescent/blob/main/examples/efficiency.py))
+is near-linear through 8 workers (~8.1×, efficiency ≈1.0), and the async pipeline
+is **~2.6–2.9× faster than a sync barrier** under heavy-tailed rollout latency.
+
+**A whole `evolve()` run** — rollouts *and* the merge gate — gets less, and how
+much less depends entirely on your latency distribution:
+
+| | overlap with `n_workers=8` |
+|---|---|
+| uniform latency | **5.9×** |
+| heavy tail (a reasoning model) | **2.4×** — the round barrier waits on the slowest worker |
+| ...same, barrier-free (`asynchronous=True`) | **3.0×** |
+
+A real HotpotQA run measured 2.0×, squarely in the heavy-tail regime. The gate is
+a separate axis: `eval_concurrency` took the same workload from **193.6 s to
+90.0 s**. Full breakdown in
 [docs/efficiency.md](https://github.com/Birfy/agentdescent/blob/main/docs/efficiency.md).
 
 ## The central analogy

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -65,6 +65,7 @@ def async_evolve(
     target_reward: Optional[float] = None,
     patience: Optional[int] = None,
     max_worker_errors: int = 3,
+    eval_concurrency: int = 8,
     held_out_frac: float = 0.4,
     repo_path: Optional[str] = None,
     agg_config=None,
@@ -115,6 +116,9 @@ def async_evolve(
         short for any sweep to finish.
     max_iters:
         Stop after this many worker rollouts in total (a budget, not a barrier).
+    eval_concurrency:
+        How many held-out tasks the merger scores at once. ``1`` restores the old
+        sequential behaviour.
     max_worker_errors:
         Consecutive failed rollouts before a worker that has *never* succeeded
         gives up. Workers that have succeeded at least once never retire; they
@@ -161,7 +165,7 @@ def async_evolve(
         initial_state=initial_state, blast_radius=blast_radius, artifact_id=artifact_id,
         held_out_frac=held_out_frac, repo_path=repo_path, agg_config=agg_config,
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
-        oracle_budget=oracle_budget)
+        oracle_budget=oracle_budget, eval_concurrency=eval_concurrency)
     if n_workers < 1:
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")
     policy = staleness_policy or get_policy("guarded")

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -646,7 +646,8 @@ def _check_callable(fn: Callable, n_args: int, sig_hint: str) -> None:
 
 def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state,
                   blast_radius, artifact_id, held_out_frac, repo_path, agg_config,
-                  staleness_policy, aggregator_factory, oracle_budget) -> _Engine:
+                  staleness_policy, aggregator_factory, oracle_budget,
+                  eval_concurrency: int = 8) -> _Engine:
     """Wire the ledger, runtime, verifier and aggregator (shared by
     :func:`evolve` and :func:`~agentdescent.async_evolve.async_evolve`)."""
     import tempfile
@@ -694,7 +695,8 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     if not held_out:
         train, held_out = tasks[:-1], tasks[-1:]
 
-    runtime = _Runtime(run=run, reward=reward, cache=_EvalCache())
+    runtime = _Runtime(run=run, reward=reward, cache=_EvalCache(),
+                       eval_concurrency=eval_concurrency)
 
     def serialize(a: EvolvingArtifact) -> dict:
         return {"state": a.state, "blast_radius": a.blast_radius}
@@ -773,6 +775,7 @@ def evolve(
     target_reward: Optional[float] = None,
     patience: Optional[int] = None,
     max_worker_errors: int = 3,
+    eval_concurrency: int = 8,
     asynchronous: bool = False,
     async_ratio: int = 3,
     max_seconds: Optional[float] = None,
@@ -854,6 +857,12 @@ def evolve(
         Workers per round (``>= 1``).
     max_concurrency:
         How many of them actually run at once (see above).
+    eval_concurrency:
+        How many held-out tasks to score at once. Every gate goes through this --
+        each round's measurement and, far more often, the aggregator's
+        per-candidate comparisons -- so it is the merge half of the run's
+        parallelism, independent of ``n_workers``. ``1`` restores the old
+        sequential behaviour.
     max_worker_errors:
         How much total failure to tolerate before giving up -- and only while *no*
         worker has ever completed a rollout, which reads as a misconfiguration
@@ -958,6 +967,7 @@ def evolve(
             self_verify=self_verify, task_sampler=task_sampler,
             target_reward=target_reward, patience=patience,
             max_worker_errors=max_worker_errors,
+            eval_concurrency=eval_concurrency,
             on_round=on_round, verbose=verbose)
 
     if n_workers < 1:
@@ -977,7 +987,7 @@ def evolve(
         initial_state=initial_state, blast_radius=blast_radius, artifact_id=artifact_id,
         held_out_frac=held_out_frac, repo_path=repo_path, agg_config=agg_config,
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
-        oracle_budget=oracle_budget)
+        oracle_budget=oracle_budget, eval_concurrency=eval_concurrency)
     ledger, aggregator, strategy = eng.ledger, eng.aggregator, eng.strategy
     run, propose, reward = eng.run, eng.propose, eng.reward
     held_out, by_id, train_ids = eng.held_out, eng.by_id, eng.train_ids

--- a/docs/algo-ace.md
+++ b/docs/algo-ace.md
@@ -108,6 +108,17 @@ for 8 rounds over 57 tasks — well under a cent at `deepseek-v4-flash` prices.
     and it is why [`DifficultyWeighted` task sampling](evolution.md#task-selection-which-rollout-to-spend)
     exists — it steers rollouts toward the tasks that still fail.
 
+!!! note "Difficulty is set by `--top-k`, and the default is easy"
+    Those runs used the **40** most frequent concepts. At the default
+    `--top-k 10` the same example loads 37 tasks over a 10-way choice, and
+    `deepseek-v4-flash` scores **1.000 before and after** — nothing for the Curator
+    to add, so it curates one bullet and commits no change (42 calls, 2 min).
+
+    That is not a different result, it is a different problem: a 10-way
+    classification is far easier than a 40-way one. Raise `--top-k` if you want a
+    run with headroom. See [Measured results](results.md) for how many of the
+    shipped ports are saturated for a strong model at small sample sizes.
+
 ## Run it
 
 ```bash

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -57,6 +57,20 @@ In [`examples/adas_meta_agent_search.py`](https://github.com/Birfy/agentdescent/
 | **`Interpreter`** + **`seed_archive`** | (agent substrate) | the safe control-flow DSL (`cot`/`cot_sc`/`reflexion`/`debate`/`step_back`/`role_assignment`/`ensemble`) and the seven MGSM seeds |
 | **`dgm_parent_weights`** | `--select dgm` | DGM's sigmoid×novelty rule as an alternative archive-conditioning strategy |
 
+## Measured — MGSM with DeepSeek
+
+`--generations 4 --provider openai --model deepseek-v4-flash`: the seed archive
+already scores **1.000** on the sampled MGSM items, so Meta Agent Search has no
+gradient to follow and the archive merge accepts nothing (`+0/-1` in both
+generations measured; the run was stopped after two, since the answer was not
+going to change).
+
+Saturated, like most of the shipped ports at these sample sizes — see
+[Measured results](results.md). ADAS is also the most expensive example to run
+(the searched agents are multi-step, so one generation is hundreds of model calls);
+raise `--per-lang` and use a weaker base model if you want a benchmark with room
+to improve.
+
 ## Run it
 
 ```bash

--- a/docs/algo-dgm.md
+++ b/docs/algo-dgm.md
@@ -57,6 +57,25 @@ In [`examples/dgm_self_improve.py`](https://github.com/Birfy/agentdescent/blob/m
 | **`dgm_parent_weights` / `choose_selfimproves`** | (selection) | the exact DGM rule `p_i ∝ sigmoid(10·(score−0.5)) · 1/(1+children_i)` |
 | `propose` + `make_surrogate_evaluator` | `propose=` / objective | add the most-needed capability; the transparent surrogate objective (swap in a real Docker harness via `evaluate_fn`) |
 
+## Measured — surrogate objective
+
+`--generations 4 --provider openai --model deepseek-v4-flash`:
+
+| | resolve rate |
+|---|---|
+| val, before → after | 0.000 → **0.300** |
+| test (held out, never seen by selection) | 0.200 |
+
+Archive: 4 agents (keep-all). The best lineage reached generation 3 with
+capabilities `context-retrieval`, `dependency-resolver`, `diff-minimization`,
+`regression-test-runner`.
+
+!!! warning "This is the surrogate, not SWE-bench"
+    The objective is a capability-cover stand-in; real DGM evaluates on SWE-bench
+    Verified inside Docker, which this example does not run. What is faithful is
+    the **archive, the selection rule and the staged escalation** — the numbers
+    above measure those mechanics, not coding ability.
+
 ## Run it
 
 ```bash

--- a/docs/algo-gepa.md
+++ b/docs/algo-gepa.md
@@ -61,6 +61,28 @@ In [`examples/gepa_prompt_evolution.py`](https://github.com/Birfy/agentdescent/b
 | **`pareto_frontier` / `pareto_select`** | (pure, unit-tested) | Algorithm 2: per-instance best → union of winners → dominance pruning → frequency-weighted sampling |
 | `gepa_agent()` | `agent=` | Generator + reflective-mutation actor (rewrites the instruction from trace + NL feedback) |
 
+## Measured — HotpotQA with DeepSeek
+
+`--rounds 5 --fetch 40 --provider openai --model deepseek-v4-flash`:
+
+| | exact match |
+|---|---|
+| seed instruction, on the Pareto set | 0.500 |
+| best candidate found | **0.600** |
+| **test set** (held out, never seen by the optimizer) | **0.700** |
+
+4 candidates explored, 80 model calls, ~10 min wall-clock. The instruction it
+found:
+
+> *"Read the context carefully and connect information across multiple paragraphs
+> to identify who matches all the clues in the question. Then give only the final
+> answer as a short phrase, without explanation."*
+
+Both halves of that are real HotpotQA failures: multi-hop evidence, and a model
+that answers a short-span question with a paragraph. This is the one shipped port
+whose benchmark still has headroom for `deepseek-v4-flash` — see
+[Measured results](results.md) for why the others do not.
+
 ## Run it
 
 ```bash

--- a/docs/algo-skillopt.md
+++ b/docs/algo-skillopt.md
@@ -54,6 +54,23 @@ In [`examples/skillopt_skill_training.py`](https://github.com/Birfy/agentdescent
 | **`LRScheduler`** | (edit budget) | the integer "learning-rate" cap on edits per step (`constant`/`linear`/`cosine`) |
 | `make_propose(...)` | `propose=` | the analyst — one failed rollout → a budget-capped edit patch |
 
+## Measured — SearchQA with DeepSeek
+
+`--steps 5 --provider openai --model deepseek-v4-flash`:
+
+| | hard-EM |
+|---|---|
+| val, before → after | 0.900 → **0.900** |
+| test (held out, never seen by the gate) | 0.900 |
+
+54 model calls, ~5 min. **Edits accepted / rejected: 0 / 1.**
+
+The baseline already answers 9 of 10, so there is nothing for a skill document to
+add — and the strict gate refused the one edit that was proposed rather than
+accepting a change that did not beat it. That is the intended behaviour on a
+saturated benchmark, and it is the failure mode a naive implementation has: it
+would have accumulated a plausible-sounding rule against a flat signal.
+
 ## Run it
 
 ```bash

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -15,6 +15,56 @@ Source: [`examples/efficiency.py`](https://github.com/Birfy/agentdescent/blob/ma
 
 ---
 
+## Where the parallelism actually goes
+
+A real HotpotQA run spent **3058 s inside the model but 1535 s of wall-clock** —
+only **2.0×** overlap with 8 workers. That number is worth taking apart, because
+three different things are mixed into it and only one of them was a bug.
+
+Measured with a fixed-latency stub backend, so the only variable is the framework:
+
+| what changes | overlap with `n_workers=8` |
+|---|---|
+| uniform latency | **5.9×** |
+| moderate latency spread | 4.8× |
+| high spread | 3.3× |
+| heavy tail (a reasoning model) | **2.4×** |
+
+**Latency variance is the cost, and the round barrier is where you pay it.** The
+aggregator is a synchronisation point, so a round lasts as long as its *slowest*
+worker — and a reasoning model's latency has a long tail (a short answer and a
+2000-token deliberation are the same call). Nothing is broken at 2.4×; that is
+what a barrier costs on a heavy-tailed distribution. The real run's 2.0× sits
+exactly in this regime.
+
+Removing the barrier is what [`asynchronous=True`](evolution.md#the-barrier-free-runtime-async_evolve)
+is for, and it recovers part of it — **2.4× → 3.0×** on the same heavy-tailed
+workload — because workers stop waiting for the merge.
+
+### The part that *was* a bug — the gate was serial
+
+Every gate goes through one held-out evaluation: each round's measurement and,
+far more often, the aggregator's per-candidate comparisons. It summed a
+generator, so it ran its tasks one at a time while the workers that produced
+those candidates ran in parallel. Same work, varying only `eval_concurrency`:
+
+| `eval_concurrency` | wall-clock | |
+|---|---|---|
+| 1 (the old behaviour) | 193.6 s | — |
+| 4 | 96.7 s | **2.0× faster** |
+| 8 (default) | 90.0 s | **2.2× faster** |
+| 16 | 89.0 s | saturated — the held-out set is only 12 tasks |
+
+It saturates once `eval_concurrency` reaches the size of your held-out set, so
+raise it if yours is large and your provider allows the concurrency.
+
+!!! tip "Which knob to reach for"
+    `n_workers` buys **rollout** parallelism, `eval_concurrency` buys **gate**
+    parallelism, and they are independent. If a run feels slower than its worker
+    count suggests, the gate is the usual reason — and if it still does after
+    that, the barrier is meeting a heavy tail, which is what `asynchronous=True`
+    addresses.
+
 ## Threads and the GIL — is this *really* parallel?
 
 Yes, for this workload, and no amount of arguing about the GIL settles it — so

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,24 +24,64 @@ The one place the analogy *must* break defines the whole system:
 
 ---
 
+## Start here
+
+Have a dataset? That is the whole input.
+
+```python
+from agentdescent import evolve_skill
+from agentdescent.agents import openai_compatible
+from agentdescent.dataloader import hf_rows
+
+rows = hf_rows("hotpotqa/hotpot_qa", "validation", config="distractor", limit=40)
+
+result = evolve_skill(rows, model=openai_compatible(model="deepseek-v4-flash"),
+                      prompt="question", gold="answer", score="exact")
+
+print(result.rendered)        # the skill it learned
+```
+
+Run as written, that lifted held-out exact match from **0.167 to 0.583** and wrote
+*"Respond with only the requested answer, omitting any extra explanation or
+restatement."* — see [Quickstart](quickstart-skill.md) for the full measurement.
+
+Nothing is hidden: it builds ordinary arguments and calls
+[`evolve()`](evolution.md), which is where you go the moment you want more.
+
+```bash
+pip install agentdescent
+```
+
+---
+
 ## Where to go next
 
 <div class="grid cards" markdown>
 
--   :material-star-four-points: **[The `evolve` method](evolution.md)** — start here
+-   :material-rocket-launch: **[Quickstart — dataset to skill](quickstart-skill.md)** — start here
 
-    The one entry point. Each capability is a plug-in to one `evolve()`
-    parameter — this is the map, with an example per module.
+    One call, three decisions: your data, how to score it, which model. With the
+    measured result of running it.
+
+-   :material-star-four-points: **[The `evolve` method](evolution.md)**
+
+    The one entry point underneath. Every capability is a plug-in to one
+    `evolve()` parameter — this is the map, with an example per module.
 
 -   :material-robot: **[Complete example](skill-evolution.md)**
 
-    One end-to-end run — real dataset, real LLM, every module — evolving a skill
-    that lifts held-out accuracy.
+    The same thing written out by hand — real dataset, real LLM, every module
+    wired explicitly.
 
 -   :material-sitemap: **[Architecture](architecture.md)**
 
     How the components fit together and how a diff travels from a worker to a
     committed change.
+
+-   :material-chart-box: **[Measured results](results.md)**
+
+    Every empirical claim with the setup that produced it — including the four
+    benchmarks where the honest answer is "nothing to learn here".
 
 -   :material-lightbulb-on: **[Concepts](concepts.md)**
 
@@ -80,8 +120,8 @@ The one place the analogy *must* break defines the whole system:
 
 -   :material-speedometer: **[Efficiency experiments](efficiency.md)**
 
-    Measured parallel scaling (near-linear to 8 workers) and async tail-hiding
-    (~2.6-2.9× over a sync barrier).
+    Where the parallelism actually goes: 5.9× of 8 workers on uniform latency,
+    **2.4× on a reasoning model's heavy tail**, and which knob fixes which.
 
 </div>
 

--- a/docs/quickstart-skill.md
+++ b/docs/quickstart-skill.md
@@ -108,7 +108,7 @@ Early stopping is on so a small dataset does not buy eight rounds of nothing.
 ## When to drop to `evolve()`
 
 The moment you want something this does not express — a different artifact shape
-([`strategy=`](evolution.md#2-the-evolution-rule--strategy)), a custom optimizer
+([`strategy=`](evolution.md#2-the-evolution-rule-strategy)), a custom optimizer
 ([`aggregator_factory=`](aggregator.md)), a multi-step agent as `run=`. You can
 also get there gradually: every one of those is just a keyword argument here,
 because they pass straight through.

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,0 +1,98 @@
+# Measured results
+
+Every empirical claim in these docs, with the setup that produced it. All runs use
+**`deepseek-v4-flash`** through `openai_compatible` unless stated otherwise, on
+each algorithm's own dataset.
+
+!!! warning "Read this before the table"
+    **Four of the six algorithm ports have no headroom to demonstrate.** DeepSeek
+    already scores 0.9–1.0 on FiNER-139, SearchQA and MGSM at these sample sizes,
+    so there is nothing for a skill to add — and the framework correctly commits
+    **nothing**, which is the result worth reporting.
+
+    That is the acceptance gate doing its job. A naive implementation would happily
+    accumulate plausible-sounding "improvements" against a flat signal; this one
+    rejects them, and `result.outcomes()` says `below-threshold` rather than
+    pretending. Skill evolution shows value exactly where there is a *gap* —
+    a format the model does not follow, a convention it cannot guess, a tool it is
+    not using.
+
+## The algorithm ports
+
+| Algorithm | Dataset | Held-out, before → after | Cost | What happened |
+|---|---|---|---|---|
+| **[GEPA](algo-gepa.md)** | HotpotQA | Pareto EM **0.500 → 0.600**; **test EM 0.700** | 80 calls, 10 min | Real lift. Learned to connect multi-paragraph evidence and answer with a short phrase |
+| **[EvoSkill](algo-evoskill.md)** | OfficeQA | **0.000 → 0.000** (no tools) | 34 calls, 7 min | The dataset is HF-gated, so this falls back to a 12-row sample, and a *non-tool* model cannot find a figure inside a 272 KB bulletin. With a real tool-using agent: **58.0% → 65.7%** |
+| **[ACE](algo-ace.md)** | FiNER-139 | 1.000 → 1.000 at `--top-k 10`; **87.0% → 95.7%** at `--top-k 40` | 42 calls, 2 min | Difficulty is the number of concepts: a 10-way choice is saturated, a 40-way one is not |
+| **[SkillOpt](algo-skillopt.md)** | SearchQA | 0.900 → 0.900 | 54 calls, 5 min | Saturated. The strict gate saw one proposed edit and **rejected it**: 0 accepted / 1 rejected |
+| **[ADAS](algo-adas.md)** | MGSM | 1.000 from round 0 | ~8 min/generation | Saturated; rejected everything (`+0/-1`). Stopped after 2 of 4 generations — the answer was settled |
+| **[DGM](algo-dgm.md)** | *surrogate* | resolve-rate **0.000 → 0.300**; test 0.200 | offline | The objective is a capability-cover surrogate — real DGM runs SWE-bench in Docker. The archive, selection and staged escalation are faithful |
+
+## The one-call path
+
+[`evolve_skill`](quickstart-skill.md) on 40 real HotpotQA items, 12 held out —
+the snippet from the front page, run as written:
+
+| | held-out exact match |
+|---|---|
+| starting instruction (`"You are a helpful assistant."`) | 2/12 = **0.167** |
+| after evolution | 7/12 = **0.583** |
+
+Four rounds, stopped by `patience`; 338 calls, ~25 min. It learned *"Respond with
+only the requested answer, omitting any extra explanation or restatement."* —
+exactly the failure it was shown, since the model had been answering a short-span
+question with a paragraph. `outcomes()` was `{'committed': 1, 'below-threshold': 3}`.
+
+## Bringing your own agent
+
+A two-step DeepSeek word-problem agent, scored in **integer cents** — a convention
+stated nowhere in the prompt ([details](evolution.md#bring-an-agent-you-already-have)):
+
+| | held-out |
+|---|---|
+| initial prompt | 3/12 = **0.250** |
+| reflector blind to `Task.meta`, 8 rounds | 0.500 (plateau) |
+| reflector reading `meta` | 12/12 = **1.000**, in one round |
+
+It generalised rather than memorising, writing *"Express all monetary amounts as
+integers representing cents, without dollar signs or decimal points."*
+
+## Efficiency
+
+Full breakdown in [Efficiency](efficiency.md).
+
+| | result |
+|---|---|
+| Thread parallelism, 8 threads, real API calls | **7.1×** (pure-Python CPU work: 1.0×) |
+| Whole `evolve()` run, uniform latency | **5.9×** of 8 workers |
+| ...heavy-tailed latency (a reasoning model) | **2.4×** — the round barrier waits on the slowest worker |
+| ...same, barrier-free `asynchronous=True` | **3.0×** |
+| Gate concurrency (`eval_concurrency` 1 → 8) | **193.6 s → 90.0 s** on identical work |
+
+## Things that were silently wrong
+
+Each of these looked like a model or data problem and was not.
+
+| | measured |
+|---|---|
+| `max_tokens=1024` with a reasoning model | **4 of 8** reflection prompts returned *empty*; at 3000, none did. Default is now 4096 |
+| `last_number` parsing a dataset's answer column | GSM8K's ends `#### 72`, so every item scored 0: reported **0/7** vs the true **7/7** |
+| `document_agent` inline fallback on real 266–390 KB docs | **1 of 3** correct, two answers empty — half of each document never reached the model |
+| Settled-evidence pool, unbounded | 500 rejected oversized diffs retained **250 MB** no code path could read (now 2 MB) |
+| A throttled backend (1 call in 3 fails), async | ended the run in **22 s with 0 sweeps**; now reaches **1.000** with 24 of 70 calls still failing |
+| One transient, synchronous path | turned a 20-round run into **0 rounds** |
+| A rollout wedged for 600 s | `evolve()` returned, then the process stayed alive; now exits in **4.5 s** |
+
+## Reproducing
+
+```bash
+python -m examples.gepa_prompt_evolution --provider openai --model deepseek-v4-flash \
+    --rounds 5 --fetch 40 --yes
+```
+
+Every example takes `--dry-run` (loads the dataset, prints the plan, no API calls)
+and `--provider openai` for any OpenAI-compatible endpoint via `OPENAI_BASE_URL` +
+`OPENAI_API_KEY`. Sample sizes above are deliberately small so a run costs minutes;
+they are **not** the papers' full setups, and where a full setup needs heavy
+infrastructure (SWE-bench in Docker, gated data) the boundary is stated rather than
+hidden.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# Usage & extending
+# Install, run, extend
 
 How to install, run the demos, tune the knobs, and — most importantly — plug in
 your own `Evolvable` domain.
@@ -86,47 +86,15 @@ pytest -q tests/test_async.py   # just the async runtime
 
 ### The entry point — `evolve()`
 
-This is what you want in almost every case, and what every
-[algorithm port](self-evolution-examples.md) uses. Nothing here needs an API key:
+Covered in full elsewhere, and not repeated here:
 
-```python
-from agentdescent.evolution import Task, evolve
-
-tasks = [Task(id=f"t{i}", prompt=f"say the year for item {i}") for i in range(12)]
-
-def reward(task, output):                 # must return [0, 1]
-    return 1.0 if "2026" in output else 0.0
-
-def run(rendered, task):                  # your solver -- an LLM, a script, anything
-    return "answer" + (" 2026" if "year" in rendered else "")
-
-def propose(rendered, task, output, reward):
-    return "always state the year"        # what to add on a failure
-
-result = evolve(tasks, reward, run=run, propose=propose, rounds=6, n_workers=3)
-print(result.final_reward, result.state)
-if result.error:                          # always check: died vs converged
-    print("incomplete:", result.error)
-```
-
-Swap `run`/`propose` for a model by passing `agent=` instead — any backend works,
-including a tool-using one:
-
-```python
-from agentdescent.agents import LLMAgent, claude, openai_compatible, claude_code
-from agentdescent.evolution import evolve
-
-evolve(tasks, reward, agent=LLMAgent(claude(model="claude-haiku-4-5")))
-evolve(tasks, reward, agent=LLMAgent(openai_compatible(model="deepseek-v4-flash")))
-evolve(tasks, reward, agent=LLMAgent(claude_code()))          # Claude Code CLI
-```
-
-They are all the same `Completion` contract — see
-[Connecting agents & LLMs](agents.md#tool-using-agents-the-same-contract). Run it
-without a barrier by adding `asynchronous=True`, watch progress with
-`on_round=...`, keep the artifact with `result.save(path)`, and resume an
-interrupted run by re-using the same `repo_path`
-([details](evolution.md#resuming-a-run)).
+* **[Quickstart](quickstart-skill.md)** — a dataset to an evolved skill in one
+  call, with the measured result of running it.
+* **[The `evolve` method](evolution.md)** — the entry point underneath, with every
+  parameter and what it plugs into.
+* **[Connecting agents & LLMs](agents.md)** — any `prompt -> text` is a backend,
+  including tool-using CLI agents.
+* **[Measured results](results.md)** — every empirical claim with its setup.
 
 ### The reference stack — `AgentDescent` / `AsyncAgentDescent`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ theme:
 nav:
   - Home: index.md
   - Quickstart — dataset to skill: quickstart-skill.md
+  - Measured results: results.md
   - Architecture: architecture.md
   - Concepts: concepts.md
   - The evolve method: evolution.md
@@ -52,7 +53,7 @@ nav:
     - SkillOpt — skill-document training: algo-skillopt.md
     - ADAS — meta agent search (harness): algo-adas.md
     - DGM — Darwin Gödel Machine (harness): algo-dgm.md
-  - Usage & extending: usage.md
+  - Install, run, extend: usage.md
 
 markdown_extensions:
   - admonition

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -38,13 +38,18 @@ def test_readme_quickstart_needs_no_credentials():
         assert forbidden not in code, f"the quickstart should not require {forbidden}"
 
 
-def test_usage_guide_entry_point_example_runs():
+def test_evolution_guide_bring_your_own_agent_block_is_complete():
+    """The `evolve` page's headline snippet must at least name every plug-in.
+
+    It cannot be executed (it takes a real model), so this checks the thing that
+    actually broke before: a snippet that omits an argument the prose says is
+    required. The runnable no-credentials example is covered by the README tests.
+    """
     code = _first_python_block(
-        (ROOT / "docs" / "usage.md").read_text(),
-        "### The entry point")
-    ns: dict = {}
-    exec(compile(code, "usage-evolve", "exec"), ns)        # noqa: S102
-    assert ns["result"].final_reward > 0.0
+        (ROOT / "docs" / "evolution.md").read_text(),
+        "## Bring an agent you already have")
+    for required in ("run=", "propose=", "strategy=", "evolve("):
+        assert required in code, f"the quickstart snippet dropped {required}"
 
 
 def test_quickstart_defines_every_name_it_uses():

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -1,0 +1,73 @@
+"""Internal documentation links must resolve.
+
+The docs are restructured periodically -- pages split, merge and move -- and a
+broken cross-reference is invisible until a reader hits it. mkdocs --strict does
+not validate heading anchors at all, so both halves are checked here.
+"""
+import pathlib
+import re
+
+DOCS = pathlib.Path(__file__).resolve().parent.parent / "docs"
+
+# [text](target) where target is not http(s), a mailto, or a bare anchor
+LINK = re.compile(r"\[[^\]]*\]\((?!https?://|mailto:)([^)\s]+)\)")
+
+
+def _anchor(heading: str) -> str:
+    """Python-Markdown's `toc` slugify, exactly.
+
+    Worth copying rather than approximating: it drops every non-word character
+    (so backticks, parentheses and em dashes vanish) but **keeps underscores**,
+    because `_` is a word character. Collapsing them to dashes reports every
+    `async_evolve()` heading as a broken anchor.
+    """
+    text = re.sub(r"[^\w\s-]", "", heading.strip()).strip().lower()
+    return re.sub(r"[-\s]+", "-", text)
+
+
+def _anchors_of(path: pathlib.Path) -> set:
+    out = set()
+    for line in path.read_text().splitlines():
+        m = re.match(r"^(#{1,6})\s+(.*)", line)
+        if m:
+            out.add(_anchor(m.group(2)))
+    return out
+
+
+def _links():
+    for page in sorted(DOCS.glob("*.md")):
+        for target in LINK.findall(page.read_text()):
+            yield page, target
+
+
+def test_every_internal_link_points_at_a_real_page():
+    missing = []
+    for page, target in _links():
+        file_part = target.split("#", 1)[0]
+        if not file_part:
+            continue                       # same-page anchor, checked below
+        if not (DOCS / file_part).exists():
+            missing.append(f"{page.name} -> {target}")
+    assert not missing, "broken page links:\n" + "\n".join(missing)
+
+
+def test_every_internal_anchor_exists():
+    """mkdocs --strict does not check these, so a renamed heading breaks silently."""
+    missing = []
+    for page, target in _links():
+        file_part, _, anchor = target.partition("#")
+        if not anchor:
+            continue
+        target_page = (DOCS / file_part) if file_part else page
+        if not target_page.exists():
+            continue                       # reported by the test above
+        if anchor not in _anchors_of(target_page):
+            missing.append(f"{page.name} -> {target}")
+    assert not missing, "broken anchors:\n" + "\n".join(missing)
+
+
+def test_every_page_is_in_the_nav():
+    """An orphaned page is invisible on the site even though it renders."""
+    nav = (DOCS.parent / "mkdocs.yml").read_text()
+    orphans = [p.name for p in sorted(DOCS.glob("*.md")) if p.name not in nav]
+    assert not orphans, f"pages not reachable from the nav: {orphans}"

--- a/tests/test_fault_matrix.py
+++ b/tests/test_fault_matrix.py
@@ -80,3 +80,28 @@ def test_a_clean_run_reports_no_error(engine):
     res = _run(faults.OK, engine)
     assert res.error is None and res.retired_workers == 0
     assert res.history
+
+
+def test_eval_concurrency_is_reachable_and_changes_behaviour():
+    """It was a dataclass default on a private class -- unreachable, and setting
+    the class attribute silently did nothing because dataclasses bake defaults
+    into __init__. That made it impossible to measure or tune."""
+    import inspect
+    from agentdescent.evolution import evolve as _evolve
+    from agentdescent.async_evolve import async_evolve
+    assert "eval_concurrency" in inspect.signature(_evolve).parameters
+    assert "eval_concurrency" in inspect.signature(async_evolve).parameters
+
+    seen = {}
+
+    def run(rendered, task):
+        seen.setdefault("threads", set()).add(__import__("threading").get_ident())
+        return "wrong"
+
+    for conc in (1, 4):
+        seen.clear()
+        _run(run, {"n_workers": 1, "max_concurrency": 1}, eval_concurrency=conc)
+    # A real behavioural check lives in the efficiency docs (wall-clock); here we
+    # only pin that the argument reaches the engine rather than being swallowed.
+    res = _run(faults.OK, {"n_workers": 2, "max_concurrency": 2}, eval_concurrency=2)
+    assert res.error is None


### PR DESCRIPTION
Ran all six algorithm ports against their own datasets with `deepseek-v4-flash`, plus the parallelism analysis, and reorganised the docs around what came back.

## The headline finding was not the one I expected

**Four of the six ports have no headroom to demonstrate.** DeepSeek already scores 0.9–1.0 on FiNER-139 (at the default `--top-k`), SearchQA and MGSM at these sample sizes.

That is worth reporting rather than hiding, because the framework does the right thing there — **it commits nothing**:

| Algorithm | Dataset | before → after | What happened |
|---|---|---|---|
| **GEPA** | HotpotQA | Pareto EM 0.500 → **0.600**; test EM **0.700** | Real lift |
| **DGM** | surrogate | resolve rate 0.000 → **0.300** | Surrogate objective, not SWE-bench |
| **SkillOpt** | SearchQA | 0.900 → 0.900 | Strict gate **rejected** the one proposed edit (0 accepted / 1 rejected) |
| **ACE** | FiNER-139 | 1.000 → 1.000 at `--top-k 10`; 87.0% → 95.7% at `--top-k 40` | Difficulty is the concept count |
| **ADAS** | MGSM | 1.000 from round 0 | Rejected every generation |
| **EvoSkill** | OfficeQA | 0.000 → 0.000 | Gated dataset + non-tool model vs 272 KB docs |

A naive implementation would have accumulated plausible-sounding rules against a flat signal. `outcomes()` reports `below-threshold` instead of pretending.

## Parallelism, taken apart

A real run showed 2.0× overlap on 8 workers. Three things were mixed into that and only one was a bug:

| | overlap |
|---|---|
| uniform latency | **5.9×** |
| heavy tail (reasoning model) | **2.4×** — the round barrier waits on the slowest worker |
| same, `asynchronous=True` | **3.0×** |

The bug: `eval_concurrency` was a default on a private dataclass, unreachable *and unmeasurable* (dataclasses bake defaults into `__init__`, so setting the class attribute silently did nothing — my first measurement produced three identical numbers). Now exposed on both engines: **193.6 s → 90.0 s** on identical work.

## Docs

- New **Measured results** page — every empirical claim with its setup, including the runs that showed nothing
- `index.md` opens with a runnable snippet and its measured outcome, instead of pointing newcomers at a 713-line reference
- Each algorithm page carries its own numbers
- `usage.md` lost 1785 characters duplicating the README and the evolve page
- Fixed an overclaim I had left in the README (`~8.1×` is the synthetic worker-scan, not a real run)
- New test walks every internal link **and heading anchor** — mkdocs `--strict` checks neither

## Two corrections recorded rather than quietly fixed

I gave ACE `--pool 60` against a default of 800, starving it into a trivial task set; and the real difficulty knob is `--top-k`. Both numbers now appear side by side.

377 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)