### PR TITLE
fix: promote dev→stable after regression-free rounds, not after K commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **The stable branch was never promoted, because `promote_after_k` counted
+  commits instead of regression-free rounds.** The counter was bumped on the
+  commit path, so it measured how many times an artifact had *changed* -- the
+  opposite of what every description of it said ("survival rounds",
+  "regression-free rounds", "EMA confirmation rounds"). The incentive was
+  inverted: an artifact that converged stopped committing and could therefore
+  never be promoted, while one that thrashed promoted every K commits. In
+  `examples/run_demo` the artifact reached 1.000 held-out accuracy after two
+  commits and `stable` then sat at **0.000 for all 40 rounds**, while
+  `docs/usage.md` published a table showing it catching up at round 8 -- output
+  this code could not produce. One round is now one `step()`; a commit restarts
+  the clock (the new version has survived nothing yet) and so does an oracle
+  rejection, while a `below-threshold` rejection counts as a round *survived*,
+  because the gate turning a challenger away is the artifact winning. Promotion is
+  idempotent per version (an unchanged head was being re-copied every K sweeps --
+  52 times in one 6-second async run, each a handful of git operations under the
+  lock every worker queues behind), and a clean run calls `finalize()` to publish
+  its head, since `target_reward` fires on the very commit that reaches it and
+  confirmation takes K rounds it will never get.
+
+### Changed
+- **The documented aggregator pipeline now matches the code.** All four copies --
+  both `docs/architecture.md` diagrams, the `concepts.md` §4 list and
+  `aggregator.py`'s module docstring -- listed the audit as stage 7, after the
+  commit, drawn with a dotted "spot-check" arrow. It actually runs at stage **4**,
+  before the Beta-posterior acceptance test, and returns `oracle-rejected`
+  outright: a blocking gate on the accept path, not an advisory review. Three
+  consequences the old ordering hid: the budgeted oracle sits on the critical path
+  of every merge that trips `force_oracle`; `oracle-rejected` masks candidates that
+  would also have failed the acceptance test, so `outcomes()` under-counts
+  `below-threshold`; and `prob_improvement` runs 4000 Monte-Carlo draws before a
+  gate that may discard the result unused.
+- `docs/usage.md`'s `run_demo` output was refreshed against a real run (the fork
+  baseline had drifted from 0.353 to 0.379).
+
 ### Added
 - **`eval_concurrency=`** — how many held-out tasks a gate scores at once, the
   merge half of the run's parallelism and independent of `n_workers`. It existed

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -11,10 +11,17 @@ The per-bucket pipeline (design doc, section 4):
        + rebase & cheap re-verify
     3. conflict resolution     (section 4.3)  semantic contradiction / PCGrad-drop
        + candidate fusion tournament          (model-soup style)
-    4. Beta-posterior accept   (section 4.4)  P(delta > 0) > 1 - delta
-    5. CAS / 2PC commit        (section 4.1)
-    6. dual-branch promotion   (section 4.5)  EMA-style dev -> stable
-    7. audit submission        (section 5.3)  the optimizer audits itself
+    4. audit gate              (section 5.3)  high blast radius / low trust -> the
+       oracle decides, and can veto here      optimizer audits itself
+    5. Beta-posterior accept   (section 4.4)  P(delta > 0) > 1 - delta
+    6. CAS / 2PC commit        (section 4.1)
+    7. dual-branch promotion   (section 4.5)  EMA-style dev -> stable, after K
+                                              regression-free rounds
+
+The audit is stage **4**, not a post-commit spot-check. It runs before the
+acceptance test and returns ``oracle-rejected`` outright, so it is a blocking gate
+on the accept path -- the diagrams used to draw it after the commit with a dotted
+"spot-check" arrow, which reads as advisory when it holds a veto.
 """
 
 from __future__ import annotations
@@ -72,7 +79,7 @@ class AggregatorConfig:
     #: say) could commit a 500 KB value that then renders into every later prompt.
     #: Real ops in the shipped ports are ~2.5k chars, so this is ~12x headroom.
     trust_region_chars: int = 32_000
-    promote_after_k: int = 3        # dev->stable survival rounds (EMA)
+    promote_after_k: int = 3        # dev->stable: regression-free ROUNDS (EMA)
 
 
 class AggregatorContractError(ContractError, TypeError):
@@ -269,6 +276,8 @@ class Aggregator:
         self._posteriors: Dict[str, BetaPosterior] = defaultdict(BetaPosterior)
         # dev-branch survival counter for EMA-style promotion.
         self._survival: Dict[str, int] = defaultdict(int)
+        # dev version last copied onto stable, so an unchanged head is not re-promoted.
+        self._promoted_at: Dict[str, int] = {}
 
     # -- staleness (section 4.2) ---------------------------------------------
 
@@ -366,7 +375,64 @@ class Aggregator:
         reports: List[MergeReport] = []
         for aid in self.buffer.ready(self.config):
             reports.append(self._process(aid))
+        self._age_and_promote(reports)
         return reports
+
+    # -- dual-branch EMA promotion (section 4.5) -----------------------------
+
+    def _age_and_promote(self, reports: List[MergeReport]) -> None:
+        """Promote dev -> stable after K **regression-free rounds** on dev.
+
+        The counter used to be bumped on the *commit* path, so it measured how many
+        times an artifact had **changed**, not how long it had held up -- the exact
+        opposite of what every description of it says ("survival rounds",
+        "regression-free rounds", "EMA confirmation rounds"). The incentive was
+        inverted: an artifact that converged, which is the success state, stopped
+        committing and could therefore never be promoted, while one that thrashed
+        promoted every K commits. In the shipped demo the artifact reached 1.000
+        held-out accuracy after two commits and then sat there for 36 rounds with
+        `stable` stuck at 0.000 for the entire run.
+
+        So: one round is one ``step()``. A commit restarts the clock (the new
+        version has survived nothing yet) and so does an oracle rejection (a
+        measured regression). Everything else is a round survived.
+        """
+        by_id = {r.artifact_id: r for r in reports}
+        for aid in set(self._survival) | set(by_id):
+            rep = by_id.get(aid)
+            if rep is not None and (rep.committed_version is not None
+                                    or rep.category == "oracle-rejected"):
+                self._survival[aid] = 0        # changed, or measurably worse
+                continue
+            self._survival[aid] += 1
+            if self._survival[aid] >= self.config.promote_after_k:
+                self._promote(aid)
+                self._survival[aid] = 0
+
+    def _promote(self, artifact_id: str) -> None:
+        """Copy dev onto stable, skipping the git work when they already agree.
+
+        The synchronous driver calls ``step()`` once per round, but the async
+        merger polls it every couple of milliseconds -- so without this a converged
+        async run re-promoted an unchanged artifact every K sweeps (52 times in one
+        6-second run), each a handful of git operations under the ledger lock that
+        every worker is queued behind."""
+        dev_v = self.ledger.head_version(Ledger.DEV).get(artifact_id, 0)
+        if self._promoted_at.get(artifact_id) == dev_v:
+            return
+        if self.ledger.promote_to_stable(artifact_id) is not None:
+            self._promoted_at[artifact_id] = dev_v
+
+    def finalize(self) -> None:
+        """Publish the current dev head to stable at the end of a clean run.
+
+        Confirmation takes ``promote_after_k`` rounds, and a run can legitimately
+        stop before that many have elapsed -- ``target_reward`` fires on the very
+        commit that reaches it, so the artifact the run was *for* would otherwise
+        never reach the branch production reads. Only ever called when a run
+        finishes without an error, and never in place of the round-based rule."""
+        for aid in list(self._survival):
+            self._promote(aid)
 
     def _process(self, artifact_id: str) -> MergeReport:
         cards = self.buffer.drain(artifact_id)
@@ -476,11 +542,9 @@ class Aggregator:
 
         prior.update(True, weight=2.0)  # a committed improvement is strong evidence.
 
-        # -- dual-branch EMA promotion (section 4.5) -------------------------
-        self._survival[artifact_id] += 1
-        if self._survival[artifact_id] >= self.config.promote_after_k:
-            self.ledger.promote_to_stable(artifact_id)
-            self._survival[artifact_id] = 0
+        # Promotion is decided in `_age_and_promote`, per round, not per commit:
+        # a commit restarts the survival clock rather than advancing it.
+        self._survival[artifact_id] = 0
 
         return MergeReport(artifact_id, best_diff, fused, n_considered, len(survivors),
                            len(discarded), conflicts, p_improve, new_version,

--- a/agentdescent/async_runtime.py
+++ b/agentdescent/async_runtime.py
@@ -333,6 +333,10 @@ class AsyncAgentDescent:
             t.join(timeout=2.0)
         agg_thread.join(timeout=2.0)
 
+        if self.stats.error is None:
+            # Confirmation takes promote_after_k rounds and this loop can stop the
+            # instant target_accuracy is hit, so publish the head the run produced.
+            self.aggregator.finalize()
         self.stats.wallclock = time.time() - start
         self.stats.final_dev_accuracy = self._dev_accuracy()
         self.stats.final_stable_accuracy = self._stable_accuracy()

--- a/agentdescent/ledger.py
+++ b/agentdescent/ledger.py
@@ -360,8 +360,10 @@ class Ledger:
         """EMA-style confirmation: copy dev's current artifact onto stable.
 
         Called by the aggregator's dual-branch logic after an artifact has
-        survived K rounds on dev without a regression report (design doc,
-        section 4.5)."""
+        survived ``promote_after_k`` rounds on dev without a commit or a measured
+        regression (design doc, section 4.5). A commit restarts that clock -- the
+        new version has survived nothing yet -- so a *converged* artifact is the
+        one most likely to be promoted, which is the point."""
         with self._lock:
             self._ensure_open()
             self._checkout(self.DEV)

--- a/agentdescent/orchestrator.py
+++ b/agentdescent/orchestrator.py
@@ -128,6 +128,7 @@ class AgentDescent:
                     )
             reports = self.aggregator.step()
             history.append(self._collect(r, reports))
+        self.aggregator.finalize()      # publish the head this run produced
         return history
 
     def _collect(self, r: int, reports: Sequence[MergeReport]) -> RoundStat:

--- a/docs/aggregator.md
+++ b/docs/aggregator.md
@@ -21,8 +21,10 @@ Evidence cards are bucketed by artifact; a bucket fires on batch size `B` or a
 3. **Fusion tournament** — complementary diffs are fused (model-soup style) and run against the singles on held-out; the best wins.
 4. **Statistical acceptance** — commit only if `P(Δ > 0) > 1 − δ` under a Beta posterior (not a point threshold); `δ` anneals with version.
 5. **Commit** — compare-and-swap on `dev`, one artifact per merge. The `Ledger` *also* offers `commit_atomic` (2PC across several artifacts, for a contract-breaking diff that must land with its adapters), but the reference aggregator buckets by artifact and never needs it — no engine path calls it today.
-6. **Dual-branch promotion** — `dev → stable` every *K* **accepted commits** (EMA-style confirmation). Note it counts commits, not rounds: a round that merges nothing does not advance the counter, and there is no separate regression check — the guard is the acceptance test each commit already passed.
-7. **Audit** — the merge is submitted to the `AuditScheduler`; high-blast-radius / L1 merges are forced through the oracle. *The optimizer audits itself.*
+4. **Audit gate** — the candidate is submitted to the `AuditScheduler`; a high-blast-radius / low-trust merge is forced through the oracle, which can **veto it outright** (`oracle-rejected`) before the acceptance test runs. *The optimizer audits itself.* This is a blocking gate on the accept path, not a post-commit spot-check.
+5. **Statistical acceptance** — `P(Δ > 0) > 1 − δ` under a Beta posterior comparison, not a point threshold.
+6. **Commit** — compare-and-swap on `dev`, one artifact per merge.
+7. **Dual-branch promotion** — `dev → stable` after *K* **regression-free rounds** on dev. One round is one `step()`. A commit restarts the clock (the new version has survived nothing yet) and so does an oracle rejection. So a *converged* artifact — one that stopped committing because nothing beats it — is the one most likely to be promoted, which is the point.
 
 Deep dive on the *why*: [concepts §4](concepts.md#4-the-aggregator-a-discrete-space-optimizer).
 
@@ -52,7 +54,7 @@ evolve(tasks, reward, agent=agent, agg_config=AggregatorConfig(
 | `base_delta` | acceptance strictness (`1 − δ` threshold), annealed by version |
 | `alpha_head` / `alpha_tail` | staleness tolerance `α` (hot vs cold artifacts) |
 | `trust_region_ops` | diff-size cap (the trust region) |
-| `promote_after_k` | dev→stable EMA confirmation rounds |
+| `promote_after_k` | dev→stable after this many regression-free rounds (EMA) |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,17 +36,17 @@ flowchart TD
         direction TB
         S1[1. staleness filter η vs α] --> S2[2. conflict resolution]
         S2 --> S3[3. fusion tournament]
-        S3 --> S4["4. Beta acceptance P(Δ>0) &gt; 1−δ"]
-        S4 --> S5[5. commit CAS]
-        S5 --> S6[6. dual-branch dev→stable]
-        S6 --> S7[7. audit]
+        S3 --> S7["4. audit gate (force_oracle)"]
+        S7 --> S4["5. Beta acceptance P(Δ>0) &gt; 1−δ"]
+        S4 --> S5[6. commit CAS]
+        S5 --> S6[7. dual-branch dev→stable]
     end
     AG -->|commit| LG["Ledger (git-backed)<br/>dev + stable branches"]
     LG -->|broadcast changed artifact| W1
     LG -->|broadcast| W2
     LG -->|broadcast| WN
-    S7 -.->|Ĝ priority| AUD["AuditScheduler → Oracle"]
-    AUD -.->|spot-check| LG
+    S7 -->|Ĝ priority| AUD["AuditScheduler → Oracle"]
+    AUD -->|veto: oracle-rejected| OUT[dropped]
 ```
 
 The same flow, with the design-doc section numbers annotated:
@@ -74,10 +74,10 @@ The same flow, with the design-doc section numbers annotated:
         │  1. staleness filter   η vs α  → ACCEPT/REBASE/DISCARD│  §4.2
         │  2. conflict resolve   contradictions dropped         │  §4.3
         │  3. fusion tournament  complementary diffs merged     │  §4.3
-        │  4. Beta acceptance    P(Δ>0) > 1−δ                    │  §4.4
-        │  5. commit             CAS (one artifact per merge)     │  §4.1
-        │  6. dual-branch        dev → stable (EMA)              │  §4.5
-        │  7. audit              submit merge to AuditScheduler  │  §5.3
+        │  4. audit gate         oracle may VETO here            │  §5.3
+        │  5. Beta acceptance    P(Δ>0) > 1−δ                    │  §4.4
+        │  6. commit             CAS (one artifact per merge)     │  §4.1
+        │  7. dual-branch        dev → stable, K clean rounds     │  §4.5
         └───────────────────────────┬─────────────────────────┘
                                      ▼
                     Ledger  (git-backed, version-vectored)         §3.1
@@ -89,7 +89,13 @@ The same flow, with the design-doc section numbers annotated:
 ```
 
 The three-layer **verifier** (rule / learned / oracle) is the evaluation backend
-the Aggregator calls at steps 1–4 (cheap) and step 7 (oracle, budgeted).
+the Aggregator calls at steps 1–3 and 5 (cheap) and at step 4 (oracle, budgeted).
+
+!!! note "The audit is a gate, not a spot-check"
+    It runs *before* the acceptance test and can return `oracle-rejected` outright,
+    so it sits on the critical path of every merge that trips `force_oracle` — the
+    diagrams used to place it after the commit with a dotted "spot-check" arrow,
+    which reads as advisory when it holds a veto.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -169,19 +169,23 @@ artifacts don't starve). Then, in order:
    contradicts.
 3. **Fusion tournament** — complementary diffs are fused (model-soup analogy)
    and run against the individual candidates on held-out data; the best wins.
-4. **Statistical acceptance** — commit only if `P(Δ > 0) > 1 − δ` under a Beta
+4. **Audit gate** — the candidate is submitted to the AuditScheduler, and a
+   high-blast-radius or low-trust one is forced through the oracle, which can
+   **veto it here** (`oracle-rejected`) before the acceptance test runs. **The
+   optimizer audits itself** — as a blocking gate on the accept path, not a
+   post-commit spot-check.
+5. **Statistical acceptance** — commit only if `P(Δ > 0) > 1 − δ` under a Beta
    posterior comparison of candidate vs base, **not** a point threshold. `δ`
    anneals with version (LR decay); a trust-region caps diff size.
-5. **Commit** — compare-and-swap on `dev`, one artifact per merge. (`Ledger`
+6. **Commit** — compare-and-swap on `dev`, one artifact per merge. (`Ledger`
    also implements `commit_atomic`, a 2PC across artifacts for a
    contract-breaking diff that must land with its adapters, but the reference
    aggregator buckets per artifact and no engine path uses it.)
-6. **Dual-branch promotion** — `dev → stable` every *K* accepted commits
-   (EMA-style confirmation). Production workers ride `stable`; explorers ride
+7. **Dual-branch promotion** — `dev → stable` after *K* **regression-free
+   rounds** on dev (EMA-style confirmation). A commit restarts the clock, so the
+   artifact most likely to be promoted is the one that has *stopped* changing
+   because nothing beats it. Production workers ride `stable`; explorers ride
    `dev`.
-7. **Audit** — the merge decision is itself submitted to the AuditScheduler;
-   high-blast-radius or low-trust merges are forced through the oracle. **The
-   optimizer audits itself.**
 
 !!! info "Why a statistical test, not a threshold"
     A Beta posterior gives evidence-starved *tail* artifacts an automatically

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -233,7 +233,7 @@ the merge is a conflict-free union. It needs a strategy with a fixed key space
 (`KeyedRules`; `AppendRules` content-addresses its keys and is refused), and
 `route=` maps a task to the artifact key its failure will edit so each worker only
 sees tasks it may act on. Out-of-section proposals are rejected and counted as
-`section-violation` in [`result.outcomes()`](#7-reading-the-result). See
+`section-violation` in [`result.outcomes()`](#what-evolve-returns). See
 [Parallelism](parallelism.md).
 
 `PipelineParallel` is **not** an `evolve()` mode — it needs one artifact per stage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,13 +36,13 @@ budget, then prints the learning curve and the comparison:
 
 ```
 round  dev_acc   stable  commit  fused  stale  confl  oracle
-    0    0.853    0.000       1      1      0      0       0
-    2    0.983    0.000       1      1      0      1       0     ← a contradiction dropped
-    8    1.000    1.000       1      0      0      0       0     ← stable branch catches up
+    0    0.828    0.000       1      1      0      0       0
+    3    1.000    0.000       1      0      0      1       0     ← a contradiction dropped
+    8    1.000    1.000       0      0      0      0       0     ← stable branch catches up
 
 AgentDescent (merge) held-out accuracy : 1.000
-Fork/archive best-fork accuracy     : 0.353
-merge advantage                     : +0.647
+Fork/archive best-fork accuracy     : 0.379
+merge advantage                     : +0.621
 ```
 
 ### Async stage orchestration (FlashEvolve-style)

--- a/tests/test_dual_branch_promotion.py
+++ b/tests/test_dual_branch_promotion.py
@@ -1,0 +1,171 @@
+"""`dev -> stable` promotion must reward an artifact for *holding up*.
+
+The counter was bumped on the commit path, so it measured how many times an
+artifact had **changed** -- the opposite of what every description of it says
+("survival rounds", "regression-free rounds", "EMA confirmation rounds"). The
+incentive was inverted: an artifact that converged stopped committing and could
+therefore never be promoted, while one that thrashed promoted every K commits.
+
+`python -m examples.run_demo` showed it plainly -- `stable` sat at 0.000 for all
+40 rounds while `dev` reached 1.000 by round 3 -- and nothing caught it, because
+`run_demo` is one of the examples with no test at all.
+"""
+
+import tempfile
+
+import pytest
+
+from agentdescent.aggregator import Aggregator, AggregatorConfig, MergeReport
+from agentdescent.domains.router import (
+    RouterSkill, deserialize_router, make_task_universe, router_eval,
+    serialize_router,
+)
+from agentdescent.evolvable import Diff
+from agentdescent.ledger import Ledger
+from agentdescent.orchestrator import AgentDescent
+from agentdescent.scheduler import AuditScheduler
+from agentdescent.verifier import ThreeLayerVerifier, VerifierBudget
+
+
+def _aggregator(tmp_path, promote_after_k=3):
+    universe = make_task_universe(seed=7)
+    _, held_out = universe.split()
+    ledger = Ledger(str(tmp_path), serialize_router, deserialize_router)
+    ledger.register(RouterSkill("art", table={}))
+    verifier = ThreeLayerVerifier(eval_fn=router_eval, held_out=held_out,
+                                 budget=VerifierBudget(oracle_calls_remaining=50))
+    return Aggregator(ledger, verifier, AuditScheduler(),
+                      AggregatorConfig(promote_after_k=promote_after_k))
+
+
+def _stable_version(agg):
+    return agg.ledger.head_version(Ledger.STABLE).get("art", 0)
+
+
+def test_a_converged_artifact_is_promoted(tmp_path):
+    """The success state -- nothing left to commit -- must not block promotion.
+
+    This is the whole bug: under the old rule, "no more commits" meant "no more
+    promotions", so the better the artifact the less likely it was to reach
+    `stable`.
+    """
+    agg = _aggregator(tmp_path, promote_after_k=3)
+    agg._survival["art"] = 0
+    before = _stable_version(agg)
+    for _ in range(3):
+        agg.step()                       # quiet rounds: nothing to merge
+    assert _stable_version(agg) > before, \
+        "an artifact that stopped changing was never promoted to stable"
+
+
+def test_a_commit_restarts_the_clock(tmp_path):
+    """A freshly committed version has survived nothing yet."""
+    agg = _aggregator(tmp_path, promote_after_k=3)
+    agg._age_and_promote([_report("below-threshold")])    # the artifact is now tracked
+    agg.step()
+    assert agg._survival["art"] == 2
+    agg._age_and_promote([_report("committed", committed=7)])
+    assert agg._survival["art"] == 0, "a commit must restart the survival clock"
+
+
+def test_a_measured_regression_restarts_the_clock(tmp_path):
+    """An oracle rejection is the one signal that the artifact got worse."""
+    agg = _aggregator(tmp_path, promote_after_k=3)
+    agg._age_and_promote([_report("below-threshold")])
+    agg.step()
+    assert agg._survival["art"] == 2
+    agg._age_and_promote([_report("oracle-rejected")])
+    assert agg._survival["art"] == 0, "a regression must restart the survival clock"
+
+
+def _report(category, committed=None):
+    """A MergeReport carrying just the fields promotion looks at."""
+    return MergeReport("art", None, False, 1, 1, 0, 0, 0.5, committed,
+                       category, category)
+
+
+def test_a_rejected_candidate_is_not_a_regression(tmp_path):
+    """`below-threshold` means the artifact held its ground, which is survival.
+
+    The gate rejecting a challenger is the artifact *winning*; treating that as a
+    regression would make a healthy converged run un-promotable again.
+    """
+    agg = _aggregator(tmp_path, promote_after_k=5)
+    agg._age_and_promote([_report("below-threshold")])
+    assert agg._survival["art"] == 1, "surviving a challenge is a round survived"
+
+
+def test_an_unchanged_head_is_promoted_once_not_every_k_rounds(tmp_path):
+    """Confirmation is per *version*, not a heartbeat.
+
+    The synchronous driver steps once per round, but the async merger polls every
+    couple of milliseconds -- so re-copying an unchanged artifact every K sweeps
+    ran 52 promotions in one 6-second run, each a handful of git operations under
+    the lock every worker queues behind.
+    """
+    agg = _aggregator(tmp_path, promote_after_k=3)
+    agg._age_and_promote([_report("below-threshold")])     # start tracking
+    versions = []
+    for _ in range(12):
+        agg.step()
+        versions.append(_stable_version(agg))
+    promotions = sum(1 for a, b in zip(versions, versions[1:]) if b > a)
+    assert promotions == 1, (
+        f"an unchanged dev head was copied to stable {promotions} times; "
+        "promotion should be idempotent per version")
+
+
+def test_a_new_dev_version_becomes_promotable_again(tmp_path):
+    """Idempotence must not mean "promote once and never again"."""
+    agg = _aggregator(tmp_path, promote_after_k=2)
+    agg._age_and_promote([_report("below-threshold")])
+    for _ in range(3):
+        agg.step()
+    first = _stable_version(agg)
+    assert first > 0, "premise: the initial head should have been promoted"
+
+    # dev moves on -- commit a real new version through the ledger
+    snap = agg.ledger.snapshot(Ledger.DEV)
+    art = snap.get("art")
+    agg.ledger.commit(art.apply(Diff("d", "art", {"kw00": "acidbase"})),
+                      {"art": snap.version["art"]}, branch=Ledger.DEV)
+    agg._age_and_promote([_report("committed", committed=2)])
+    for _ in range(3):
+        agg.step()
+    assert _stable_version(agg) > first, \
+        "a newly committed version was never confirmed onto stable"
+
+
+def test_finalize_publishes_a_head_that_stopped_before_confirming(tmp_path):
+    """`target_reward` fires on the very commit that reaches it.
+
+    Confirmation takes K rounds, so without this the artifact the run was *for*
+    would never reach the branch production reads.
+    """
+    agg = _aggregator(tmp_path, promote_after_k=99)        # unreachable in this test
+    agg._age_and_promote([_report("committed", committed=1)])
+    assert _stable_version(agg) == 1, "premise: nothing confirmed yet"
+    agg.finalize()
+    assert _stable_version(agg) > 1, "a clean run must publish its head"
+
+
+# -- end to end: the demo that made this visible -------------------------------
+
+
+def test_the_reference_run_actually_reaches_the_stable_branch():
+    """`run_demo`'s headline table showed `stable` at 0.000 for all 40 rounds.
+
+    The docs published a table where it caught up at round 8 -- output this code
+    could not produce. This is the assertion that was missing.
+    """
+    universe = make_task_universe(seed=7)
+    with tempfile.TemporaryDirectory() as repo:
+        system = AgentDescent(repo, universe, n_workers=6, noise=0.15,
+                              refresh_interval=2, seed=0)
+        history = system.run(rounds=20)
+        # inside the context: `final_accuracy` reads the ledger, which lives here
+        assert history[-1].dev_accuracy > 0.9, "premise: dev should converge"
+        assert history[-1].stable_accuracy > 0.9, (
+            "the stable branch never caught up with dev; dual-branch promotion "
+            f"(design §4.5) is not firing. stable={history[-1].stable_accuracy}")
+        assert system.final_accuracy(branch=Ledger.STABLE) > 0.9


### PR DESCRIPTION
Closes #16, closes #27.

## The stable branch was never promoted

```bash
python -m examples.run_demo
```

```
round  dev_acc   stable  commit  fused  stale  confl  oracle
    0    0.828    0.000       1      1      0      0       0
    3    1.000    0.000       1      0      0      1       0
    ...
   39    1.000    0.000       0      0      0      0       0
```

`stable` at **0.000 for all 40 rounds**, while `dev` converged by round 3. Meanwhile `docs/usage.md:41` published a table showing it catching up at round 8 — output this code could not produce.

The counter was bumped on the commit path:

```python
self._survival[artifact_id] += 1          # only ever on a successful CAS
if self._survival[artifact_id] >= self.config.promote_after_k:
    self.ledger.promote_to_stable(artifact_id)
```

So it measured how many times an artifact had **changed**, not how long it had held up — the opposite of what every description says: `# dev->stable survival rounds`, *"survived K rounds on dev without a regression report"*, *"K regression-free rounds"*. The incentive was inverted: **an artifact that converged stopped committing and could therefore never be promoted**, while one that thrashed promoted every K commits.

### After

```
    0    0.828    0.000       1      1      0      0       0
    3    1.000    0.000       1      0      0      1       0
    8    1.000    1.000       0      0      0      0       0     ← stable catches up
```

- One round is one `step()`.
- A **commit** restarts the clock — the new version has survived nothing yet.
- An **oracle rejection** restarts it — that is the one signal the artifact got measurably worse.
- A **`below-threshold`** rejection counts as a round *survived*: the gate turning a challenger away is the artifact winning, and treating it as a regression would make a healthy converged run un-promotable all over again.

### Two things that fell out of doing it properly

**Promotion is idempotent per version.** The sync driver steps once per round, but the async merger polls `step()` every ~2ms — so an unchanged head was re-copied every K sweeps: **52 promotions in one 6-second run**, each a handful of git operations under the lock every worker queues behind. `_promote` now skips when dev and stable already agree.

**A clean run publishes its head (`finalize()`).** Confirmation takes K rounds and a run can legitimately stop before that many elapse — `target_reward`/`target_accuracy` fires on the very commit that reaches it, so the artifact the run was *for* would never reach the branch production reads. Called only on a clean finish, never in place of the round rule.

## The documented pipeline order was wrong in all four places

`docs/architecture.md` (mermaid **and** ASCII), `docs/concepts.md` §4, and `aggregator.py`'s module docstring all listed `… → 4 Beta acceptance → 5 commit → 6 dev→stable → 7 audit`, with the audit drawn as a dotted `spot-check` arrow *after* the commit.

The code runs **1 → 2 → 3 → 7 → 4 → 5 → 6**:

```
405  best_diff, best_state = self._tournament(...)              # 3
439  self.audit.submit(...)                                     # "7"
441  if self.audit.force_oracle(...):
450      return MergeReport(..., "oracle-rejected")             # <-- vetoes here
457  if p_improve <= 1.0 - delta or cand_score < base_score:    # 4
467  _, new_version = self.ledger.commit(...)                   # 5
```

Not a numbering nit — it misrepresents what the audit *is*. Three consequences the old ordering hid:

1. the **budgeted** oracle sits on the critical path of every merge that trips `force_oracle`, not off it;
2. `oracle-rejected` returns first, so it masks candidates that would also have failed the acceptance test — `result.outcomes()` under-counts `below-threshold`, and the two need opposite fixes;
3. `prob_improvement` runs 4000 Monte-Carlo draws at `:433`, before a gate at `:441` that may discard the result unused.

Renumbered to match, and redrawn as a solid gate with a `veto: oracle-rejected` edge.

## Tests

`tests/test_dual_branch_promotion.py`, 8 cases — the converged artifact is promoted, a commit and an oracle rejection each restart the clock, a `below-threshold` rejection does not, an unchanged head promotes once, a new version becomes promotable again, `finalize()` publishes a head that stopped short, and an end-to-end assertion that `run_demo`'s reference run actually reaches `stable`. That last one is the assertion the repo most needed: `run_demo` produces the headline RQ1 number quoted in three docs pages and had **no test at all**.

**390 passed, 1 skipped.**

<details>
<summary>One pre-existing flake seen once under full-suite load</summary>

`test_async.py::test_guarded_discards_more_than_reflective` asserts `r.final_dev_accuracy >= g.final_dev_accuracy` across two independently-timed 12s async runs. It failed once at 0.9655 vs 1.0 during a full-suite run, and passes 5/5 in isolation **on this branch and on `main` alike**. This change does not touch dev accuracy — only the `stable` branch — so it is not from here. Worth tightening separately.
</details>

## Docs

- `docs/aggregator.md` — stages 4–7 rewritten; `promote_after_k` row
- `docs/architecture.md` — both diagrams renumbered; new note that the audit is a gate, not a spot-check
- `docs/concepts.md` §4 — items 4–7
- `docs/usage.md` — `run_demo` output refreshed against a real run (the fork baseline had drifted from 0.353 to 0.379, and `stable` now genuinely catches up)
- `aggregator.py` module docstring, `AggregatorConfig.promote_after_k`, `Ledger.promote_to_stable`, CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
