### PR TITLE
fix: three footguns a caller hits directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **`openai_compatible` returned `None` on reasoning models.** `Completion` is
+  `prompt -> str`, but a model that spends its whole budget on `reasoning_content`
+  answers with JSON `null` for `content` -- DeepSeek's reasoner and GLM's thinking
+  modes both do. The `None` surfaced as
+  `'NoneType' object has no attribute 'strip'` from inside `LLMAgent`, which the
+  engine caught and **retried as a backend transient**, diagnosing a systematic
+  model/parameter mismatch as a flaky endpoint. Doubly unfortunate: `LLMAgent`
+  already carries the right diagnosis for a starved reasoning model, and never got
+  to run it. Normalised to `""` so that warning fires instead.
+- **HTTP errors discarded the provider's message.** The useful part -- "rate
+  limit: retry in 12s", "context length exceeded", "insufficient quota" -- lives on
+  `e.read()`, so re-raising bare collapsed every 4xx to `HTTP Error 429: Too Many
+  Requests`, for the error class most likely to occur in a loop making thousands
+  of calls. `_git` and `_CliAgent` both surface the underlying detail; this was the
+  one provider path that did not. An HTTP 200 carrying `{"error": ...}` (some
+  proxies) now names the endpoint and model instead of raising a bare `KeyError`.
+
+### Added
+- **`EvolutionResult.stop_reason`** -- `"target_reward"` / `"patience"` /
+  `"rounds"` / `"max_seconds"` / `"max_iters"` / `"error"`. A run that converged
+  and a run that ran out of budget both returned `error=None` with a populated
+  `history`, and the only way to tell them apart was re-deriving `len(history)`
+  against arguments whose meaning changes between the two paths. The `verbose`
+  print lines always knew; now a non-interactive caller does too.
+- **`evolve(shuffle=, seed=)`** (and on `async_evolve`). The train/held-out split
+  is positional -- the last `held_out_frac` of `tasks`, in the order given -- which
+  is right for a pre-split `Dataset` and wrong for grouped data. On a 20-task set
+  whose first 12 are one class, the default holds out **0/8 of that class**;
+  `shuffle=True` gives 5/3. Every gate in the run is measured on that set. Off by
+  default so `Dataset.val_frac` keeps its meaning and seeded runs stay
+  reproducible.
+- **`openai_compatible(**create_kwargs)`** -- `temperature=0` and provider-specific
+  fields now reach the request body, matching `claude()`.
+
+### Changed
+- `evolve(asynchronous=True)` warns about the two parameters it silently
+  *redefined* rather than ignored: `max_seconds=None` becomes 20 seconds (it means
+  "unbounded" on the synchronous path, so flipping one boolean could truncate a
+  run into something that looked converged), and `rounds` becomes a
+  `rounds x n_workers` rollout budget with `RoundInfo.round` as a sweep index. The
+  three it *ignores* already warned.
+- A held-out set smaller than 4 tasks warns: at 1 item `final_reward` is 0.0 or
+  1.0 and nothing in between, yet it still gates every acceptance decision.
+
+### Fixed
 - **The oracle audit could never fire below `blast_radius=0.5`.** `force_oracle`
   gates on `blast_radius >= 0.5 or trust < 0.75`, and `update_trust` -- the only
   writer of trust -- sat *inside* that branch. The condition gated the one thing

--- a/agentdescent/agents.py
+++ b/agentdescent/agents.py
@@ -23,6 +23,7 @@ import os
 import threading
 import time
 import subprocess
+import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, Protocol, Sequence, runtime_checkable
@@ -287,7 +288,8 @@ def openai_compatible(model: str, *, base_url_env: str = "OPENAI_BASE_URL",
                       api_key_env: str = "OPENAI_API_KEY",
                       default_base_url: str = "https://api.openai.com/v1",
                       max_tokens: int = 4096, timeout: float = 120.0,
-                      usage: Optional[Usage] = None, retries: int = 3) -> Completion:
+                      usage: Optional[Usage] = None, retries: int = 3,
+                      **create_kwargs) -> Completion:
     """A completion for any OpenAI-compatible chat endpoint (GLM/Zhipu, proxies,
     local servers, OpenAI itself).
 
@@ -298,7 +300,10 @@ def openai_compatible(model: str, *, base_url_env: str = "OPENAI_BASE_URL",
 
     ``max_tokens`` defaults high on purpose -- see :func:`claude`: a reasoning
     model starved of budget returns empty content, and at 1024 that happened for
-    half of one measured batch of reflection prompts."""
+    half of one measured batch of reflection prompts.
+
+    Extra keyword arguments go into the request body, so ``temperature=0`` and any
+    provider-specific field work the same way they do on :func:`claude`."""
     def complete(prompt: str) -> str:
         base = os.environ.get(base_url_env, default_base_url).rstrip("/")
         key = os.environ.get(api_key_env)
@@ -308,6 +313,7 @@ def openai_compatible(model: str, *, base_url_env: str = "OPENAI_BASE_URL",
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": max_tokens,
+            **create_kwargs,
         }).encode()
         req = urllib.request.Request(
             f"{base}/chat/completions", data=body,
@@ -316,6 +322,21 @@ def openai_compatible(model: str, *, base_url_env: str = "OPENAI_BASE_URL",
         try:
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 data = json.load(resp)
+        except urllib.error.HTTPError as e:
+            # The body carries the only useful part -- "rate limit: retry in 12s",
+            # "context length exceeded", "insufficient quota" -- and it lives on
+            # e.read(), so re-raising bare collapses every 4xx to "HTTP Error 429:
+            # Too Many Requests". `_git` and `_CliAgent` both surface the
+            # underlying detail; this was the one provider path that did not.
+            if usage is not None:
+                usage.record(seconds=time.time() - t0, failed=True)
+            try:
+                detail = e.read().decode("utf-8", "replace").strip()[:400]
+            except Exception:  # noqa: BLE001 - the body is best-effort
+                detail = ""
+            raise RuntimeError(
+                f"{base} returned HTTP {e.code} for model {model!r}"
+                + (f": {detail}" if detail else "")) from e
         except Exception:
             if usage is not None:
                 usage.record(seconds=time.time() - t0, failed=True)
@@ -325,6 +346,21 @@ def openai_compatible(model: str, *, base_url_env: str = "OPENAI_BASE_URL",
             usage.record(prompt_tokens=u.get("prompt_tokens", 0) or 0,
                          completion_tokens=u.get("completion_tokens", 0) or 0,
                          seconds=time.time() - t0)
-        return data["choices"][0]["message"]["content"]
+        try:
+            message = data["choices"][0]["message"]
+        except (KeyError, IndexError, TypeError):
+            # Some proxies answer HTTP 200 with {"error": ...}; without this the
+            # caller gets a bare KeyError naming nothing.
+            raise RuntimeError(
+                f"{base} returned a response with no choices for model {model!r}: "
+                f"{json.dumps(data)[:300]}") from None
+        # `content` is JSON null, not "", when a reasoning model spends its whole
+        # budget on `reasoning_content` -- DeepSeek's reasoner and GLM's thinking
+        # modes both do it. Returning None breaks the one contract in the package
+        # (`Completion` is prompt -> str) and surfaces as
+        # "'NoneType' object has no attribute 'strip'" from inside LLMAgent, which
+        # the engine then retries as a *backend transient*. Normalising to "" lets
+        # the empty-completion warning fire and say the true cause.
+        return message.get("content") or ""
 
     return with_retries(complete, attempts=retries) if retries > 1 else complete

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -74,6 +74,8 @@ def async_evolve(
     aggregator_factory=None,
     oracle_budget: int = 200,
     cheap_eval_tasks: Optional[int] = None,
+    shuffle: bool = False,
+    seed: int = 0,
     self_verify: bool = True,
     shutdown_grace: float = 2.0,
     task_sampler: Optional["TaskSampler"] = None,
@@ -136,6 +138,9 @@ def async_evolve(
     cheap_eval_tasks:
         As in :func:`evolve`: how many held-out tasks the cheap layer scores when
         ranking candidates. ``None`` scores them all.
+    shuffle, seed:
+        As in :func:`evolve`: shuffle before the positional train/held-out split.
+        Off by default.
     self_verify:
         As in :func:`evolve`. ``False`` skips the extra per-trajectory rollout,
         which is what ports that judge candidates only on held-out want.
@@ -157,7 +162,9 @@ def async_evolve(
     -------
     EvolutionResult
         ``error`` is set only when the run **ended** because of a failure -- a
-        transient error the workers retried past leaves it ``None``.
+        transient error the workers retried past leaves it ``None``, so read
+        ``stop_reason`` to tell ``"target_reward"`` from ``"max_seconds"`` /
+        ``"max_iters"`` / ``"patience"``.
 
         ``history`` holds one entry per **merger sweep** that had cards to merge,
         not per round: its length tracks how fast the workers produced and is not
@@ -171,7 +178,7 @@ def async_evolve(
         held_out_frac=held_out_frac, repo_path=repo_path, agg_config=agg_config,
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
         oracle_budget=oracle_budget, eval_concurrency=eval_concurrency,
-        cheap_eval_tasks=cheap_eval_tasks)
+        cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed)
     if n_workers < 1:
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")
     policy = staleness_policy or get_policy("guarded")
@@ -202,6 +209,7 @@ def async_evolve(
     last_good: List[object] = [None]
     died = [False]                            # True only if the run ENDED on failure
     contract_error: List[Optional[BaseException]] = [None]   # caller bug -> re-raise
+    stop_reason = ["max_seconds"]             # overwritten by whichever bound fires
     n_live = sum(1 for s in shards if s)      # workers that will actually start
     live = [n_live]                           # workers still running
     retired = [0]                             # workers that gave up (diagnostic)
@@ -327,6 +335,7 @@ def async_evolve(
             with counter_lock:
                 counter[0] += 1
                 if max_iters is not None and counter[0] >= max_iters:
+                    stop_reason[0] = "max_iters"
                     stop.set()
 
     def _drain_and_merge() -> None:
@@ -374,8 +383,10 @@ def async_evolve(
                 warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
                               RuntimeWarning, stacklevel=2)
         if target_reward is not None and r >= target_reward:
+            stop_reason[0] = "target_reward"
             stop.set()
         elif patience is not None and best[1] >= patience:
+            stop_reason[0] = "patience"
             stop.set()
 
     def _merger() -> None:
@@ -505,6 +516,7 @@ def async_evolve(
     result = EvolutionResult(state=dict(final.state), rendered=final.render(),
                              final_reward=final_reward, history=history,
                              ledger_log=_safe_log(eng.ledger),
-                             error=run_error, retired_workers=retired[0])
+                             error=run_error, retired_workers=retired[0],
+                             stop_reason="error" if run_error else stop_reason[0])
     eng.cleanup()          # do not hold a scratch git repo for the whole process
     return result

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -671,6 +671,14 @@ class EvolutionResult:
     #: artifact evolved so far is still returned -- check this to tell "converged"
     #: from "died".
     error: Optional[str] = None
+    #: Why the run ended -- ``"target_reward"`` / ``"patience"`` / ``"rounds"`` /
+    #: ``"max_seconds"`` / ``"max_iters"`` / ``"error"``. Without it a budget
+    #: expiry is indistinguishable from convergence: ``error`` is ``None`` for
+    #: both, ``history`` has entries for both, and the only other clue is
+    #: re-deriving ``len(history)`` against arguments whose meaning changes between
+    #: the sync and async paths. The ``verbose`` print lines always knew the
+    #: reason; this makes it available to a non-interactive caller.
+    stop_reason: str = "rounds"
     #: Workers that gave up after repeated backend failures (async path only). A
     #: run can finish *cleanly* at a fraction of its requested concurrency, so
     #: `error` stays `None` while throughput quietly drops -- check this to tell a
@@ -714,6 +722,7 @@ class EvolutionResult:
                 for h in self.history
             ],
             "retired_workers": self.retired_workers,
+            "stop_reason": self.stop_reason,
             "ledger_log": list(self.ledger_log),
         }
         with open(path, "w", encoding="utf-8") as fh:
@@ -732,6 +741,7 @@ class EvolutionResult:
             history=[RoundInfo(**h) for h in d.get("history", [])],
             ledger_log=d.get("ledger_log", []), error=d.get("error"),
             retired_workers=d.get("retired_workers", 0),
+            stop_reason=d.get("stop_reason", "rounds"),
         )
 
 
@@ -794,7 +804,8 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
                   blast_radius, artifact_id, held_out_frac, repo_path, agg_config,
                   staleness_policy, aggregator_factory, oracle_budget,
                   eval_concurrency: int = 8,
-                  cheap_eval_tasks: Optional[int] = None) -> _Engine:
+                  cheap_eval_tasks: Optional[int] = None,
+                  shuffle: bool = False, seed: int = 0) -> _Engine:
     """Wire the ledger, runtime, verifier and aggregator (shared by
     :func:`evolve` and :func:`~agentdescent.async_evolve.async_evolve`)."""
     import tempfile
@@ -834,6 +845,14 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     # target: nothing was mutated, but the async path burned its whole budget
     # first and then reported the violation as a *backend failure*.
     assert_mutable(EvolvingArtifact(artifact_id, {}, blast_radius=blast_radius))
+    if shuffle:
+        # Off by default so `Dataset.val_frac` keeps its promise ("the engine's
+        # held-out split is exactly this Dataset's val", which only holds because
+        # `trainval` is train + val in that order and the split below is
+        # positional) and so a seeded run stays reproducible.
+        import random as _random
+        tasks = list(tasks)
+        _random.Random(seed).shuffle(tasks)
     # round, not truncate: Dataset.val_frac promises "the engine's held-out split
     # is exactly this Dataset's val", and float truncation (13.9999 -> 13) quietly
     # pushed one train item into held-out for many dataset sizes.
@@ -841,6 +860,18 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     train, held_out = tasks[:cut], tasks[cut:]
     if not held_out:
         train, held_out = tasks[:-1], tasks[-1:]
+    # Every gate in the run -- the Beta acceptance test, target_reward, patience,
+    # final_reward -- is measured on this set. At 3 items a single binary rollout
+    # moves the reported reward by 0.33, and at 1 it is 0.0 or 1.0 and nothing
+    # else. The engine already refuses fewer than 4 tasks; this is the same
+    # argument one level down, where it decides whether the numbers mean anything.
+    if len(held_out) < 4:
+        warnings.warn(
+            f"the held-out set has only {len(held_out)} task(s) "
+            f"({len(tasks)} tasks x held_out_frac={held_out_frac}), so every "
+            "acceptance decision and the reported final_reward rest on that many "
+            "rollouts. Pass more tasks or raise held_out_frac.",
+            RuntimeWarning, stacklevel=3)
 
     runtime = _Runtime(run=run, reward=reward, cache=_EvalCache(),
                        eval_concurrency=eval_concurrency)
@@ -956,6 +987,8 @@ def evolve(
     aggregator_factory: Optional[AggregatorFactory] = None,
     oracle_budget: int = 200,
     cheap_eval_tasks: Optional[int] = None,
+    shuffle: bool = False,
+    seed: int = 0,
     on_round: Optional[Callable[["RoundInfo"], None]] = None,
     verbose: bool = False,
 ) -> EvolutionResult:
@@ -993,8 +1026,18 @@ def evolve(
     Parameters
     ----------
     tasks:
-        The work the artifact is evaluated on. Split into train / held-out by
-        ``held_out_frac``; at least 4 are required and ids must be unique.
+        The work the artifact is evaluated on. Split into train / held-out **by
+        position** -- the last ``held_out_frac`` of the sequence is held out, in
+        the order given. At least 4 are required and ids must be unique.
+    shuffle, seed:
+        Shuffle ``tasks`` before that positional split. Off by default, which
+        keeps a run reproducible and keeps
+        :attr:`~agentdescent.dataloader.Dataset.val_frac`'s promise that the
+        engine's held-out split is exactly that ``Dataset``'s ``val``. Turn it on
+        for **grouped** data -- anything ordered by category, source, difficulty
+        or date -- where the tail of the file is a different distribution from
+        the head, and every gate in the run (the acceptance test,
+        ``target_reward``, ``final_reward``) would then be measured against it.
     reward:
         ``(task, output) -> [0, 1]``. Scores in ``[0, 1]``; the engine treats
         ``>= 0.999`` as a pass (no proposal is requested).
@@ -1120,9 +1163,12 @@ def evolve(
     Returns
     -------
     EvolutionResult
-        The evolved artifact plus ``history`` and ``error``. **Check ``error``**:
-        it is ``None`` only on a clean run, and a run that died still returns a
-        (partial) result rather than raising.
+        The evolved artifact plus ``history``, ``error`` and ``stop_reason``.
+        **Check ``error``**: it is ``None`` only on a clean run, and a run that
+        died still returns a (partial) result rather than raising. **Check
+        ``stop_reason``** to tell convergence (``"target_reward"``) from a budget
+        expiry (``"max_seconds"`` / ``"rounds"`` / ``"max_iters"``) -- ``error``
+        is ``None`` for both.
     """
     from concurrent.futures import ThreadPoolExecutor, wait as futures_wait
     from .parallel import DataParallel
@@ -1150,6 +1196,26 @@ def evolve(
                     f"evolve(asynchronous=True) ignores {name}=: {why}. Use the "
                     f"synchronous path if you need it.", RuntimeWarning,
                     stacklevel=2)
+        # The two above that are *not* ignored but silently REDEFINED were the
+        # sharper edge, because nothing said so. Flipping one boolean turned an
+        # unbounded run into a 20-second one, and a partial artifact with
+        # `error=None` and a populated `history` is indistinguishable from a
+        # converged one.
+        if max_seconds is None:
+            warnings.warn(
+                "evolve(asynchronous=True) has no unbounded mode: max_seconds=None "
+                "becomes 20.0 seconds here, where it means 'no limit' on the "
+                "synchronous path. Pass max_seconds= explicitly, and check "
+                "result.stop_reason -- a budget expiry otherwise looks exactly "
+                "like convergence.", RuntimeWarning, stacklevel=2)
+        if rounds != 15:                     # i.e. the caller chose a value
+            warnings.warn(
+                f"evolve(asynchronous=True) has no round barrier, so rounds={rounds} "
+                f"is reinterpreted as a budget of {rounds * max(1, n_workers)} worker "
+                "rollouts, and RoundInfo.round becomes a merger-sweep index -- "
+                "len(result.history) is not comparable with the synchronous path. "
+                "Call async_evolve(max_iters=) directly for an exact count.",
+                RuntimeWarning, stacklevel=2)
         from .async_evolve import async_evolve
         return async_evolve(
             tasks, reward, agent=agent, run=run, propose=propose, strategy=strategy,
@@ -1159,7 +1225,7 @@ def evolve(
             max_iters=rounds * max(1, n_workers), held_out_frac=held_out_frac,
             repo_path=repo_path, agg_config=agg_config, staleness_policy=staleness_policy,
             aggregator_factory=aggregator_factory, oracle_budget=oracle_budget,
-            cheap_eval_tasks=cheap_eval_tasks,
+            cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed,
             self_verify=self_verify, task_sampler=task_sampler,
             target_reward=target_reward, patience=patience,
             max_worker_errors=max_worker_errors,
@@ -1189,7 +1255,7 @@ def evolve(
         held_out_frac=held_out_frac, repo_path=repo_path, agg_config=agg_config,
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
         oracle_budget=oracle_budget, eval_concurrency=eval_concurrency,
-        cheap_eval_tasks=cheap_eval_tasks)
+        cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed)
     ledger, aggregator, strategy = eng.ledger, eng.aggregator, eng.strategy
     run, propose, reward = eng.run, eng.propose, eng.reward
     held_out, by_id, train_ids = eng.held_out, eng.by_id, eng.train_ids
@@ -1208,8 +1274,10 @@ def evolve(
     any_success = [False]      # has ANY worker ever completed a rollout?
     dead_rounds = 0            # consecutive rounds where every worker failed
     deadline = time.time() + max_seconds if max_seconds else None
+    stop_reason = "rounds"
     for r in range(rounds):
         if deadline is not None and time.time() >= deadline:
+            stop_reason = "max_seconds"
             if verbose:
                 print(f"round {r:>3}  stopping: max_seconds={max_seconds} reached")
             break
@@ -1452,6 +1520,7 @@ def evolve(
             print(f"round {r:>3}  reward={info.held_out_reward:.3f}  "
                   f"items={info.n_items}  +{committed}/-{rejected}")
         if target_reward is not None and info.held_out_reward >= target_reward:
+            stop_reason = "target_reward"
             if verbose:
                 print(f"round {r:>3}  target_reward={target_reward} reached, stopping")
             if on_round is not None:
@@ -1461,6 +1530,7 @@ def evolve(
                     pass
             break
         if patience is not None and stalled >= patience:
+            stop_reason = "patience"
             if verbose:
                 print(f"round {r:>3}  no improvement for {stalled} rounds, stopping")
             break
@@ -1504,6 +1574,7 @@ def evolve(
     # back rather than holding it for the lifetime of the interpreter.
     result = EvolutionResult(state=dict(final.state), rendered=final.render(),
                              final_reward=final_reward, history=history,
-                             ledger_log=_safe_log(ledger), error=run_error)
+                             ledger_log=_safe_log(ledger), error=run_error,
+                             stop_reason="error" if run_error else stop_reason)
     eng.cleanup()
     return result

--- a/agentdescent/skill.py
+++ b/agentdescent/skill.py
@@ -90,7 +90,9 @@ def evolve_skill(
     **evolve_kwargs:
         Passed to :func:`~agentdescent.evolution.evolve` and override the defaults
         chosen here (``asynchronous=True``, a different ``strategy=``, an
-        ``aggregator_factory=``, ...).
+        ``aggregator_factory=``, ...). ``shuffle=True`` is worth knowing about:
+        rows arrive in dataset order and the train/held-out split is positional,
+        so grouped data otherwise holds out one end of the file.
 
     The defaults it picks -- and why they are defaults, not decisions
     ----------------------------------------------------------------

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -40,6 +40,21 @@ robust = with_retries(claude(model="claude-haiku-4-5"), attempts=3)
 `claude()` accepts a `client=` to reuse an existing `anthropic.Anthropic`
 instance, and forwards extra kwargs to `messages.create`.
 
+!!! warning "`content: null` is not the same as `""`"
+    On OpenAI-compatible endpoints a reasoning model that spends its whole budget
+    on `reasoning_content` answers with JSON `null`, not an empty string.
+    `openai_compatible` normalises that to `""`, because returning `None` breaks
+    the one contract in the package (`Completion` is `prompt -> str`) and used to
+    surface as `'NoneType' object has no attribute 'strip'` from inside
+    `LLMAgent` — which the engine then **retried as a backend transient**,
+    diagnosing a systematic model/parameter mismatch as a flaky endpoint. With the
+    empty string the warning above fires instead and names the real cause.
+
+    HTTP errors carry the provider's own message too (`rate limit: retry in 12s`,
+    `context length exceeded`), rather than collapsing to `HTTP Error 429`. Extra
+    keyword arguments — `temperature=0` and any provider-specific field — go
+    straight into the request body, matching `claude()`.
+
 !!! tip "Give a reasoning model room"
     A reasoning model spends its budget on internal reasoning *before* emitting
     visible text, so too small a `max_tokens` yields an **empty completion**, not a

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -469,6 +469,27 @@ The second call starts from the artifact the first one committed, not from
 * `initial_state=` is ignored when the artifact already exists (a `RuntimeWarning`
   says so). Use a fresh `repo_path` to start over.
 
+!!! note "The train/held-out split is positional"
+    The last `held_out_frac` of `tasks` is held out, **in the order given** — no
+    shuffle. That keeps `Dataset.val_frac`'s promise (the engine's held-out split
+    is exactly that `Dataset`'s `val`, which only holds because `trainval` is
+    train + val in that order) and keeps a seeded run reproducible.
+
+    It is the wrong default for **grouped** data — anything ordered by category,
+    source, difficulty or date, which is most benchmarks loaded raw through
+    `hf_rows`. On a 20-task set whose first 12 are class `a`:
+
+    ```
+    shuffle=False   held-out classes: ['b']        a/b: 0/8
+    shuffle=True    held-out classes: ['a', 'b']   a/b: 5/3
+    ```
+
+    Every gate in the run — the acceptance test, `target_reward`, `patience`,
+    `final_reward` — is measured on that set, so pass `shuffle=True, seed=...`
+    (or pre-split with `dataloader.split_dataset`, which shuffles and can
+    stratify). A held-out set of fewer than 4 tasks now warns: at 1 item
+    `final_reward` is 0.0 or 1.0 and nothing in between.
+
 Omit `repo_path` and the ledger is a throwaway directory, removed when `evolve()`
 returns — not held until the interpreter exits, so a notebook or a parameter sweep
 does not accumulate one git repo per run. A process killed outright (SIGKILL, OOM)
@@ -498,6 +519,22 @@ limit, credit exhaustion) — progress isn't lost.
     `error` means *the run ended because of this failure* — a transient error the
     workers retried past leaves it `None`. A `RuntimeWarning` is also emitted, so
     a failed run is never completely silent even at the default `verbose=False`.
+
+!!! warning "`error` cannot tell convergence from a spent budget — `stop_reason` can"
+    A run that reached `target_reward` and a run that ran out of budget both come
+    back with `error=None` and a populated `history`:
+
+    ```python
+    result.stop_reason   # "target_reward" | "patience" | "rounds"
+                         # | "max_seconds" | "max_iters" | "error"
+    ```
+
+    This matters most under `asynchronous=True`, where **`max_seconds=None` means
+    20 seconds**, not "unbounded" as it does on the synchronous path — flipping one
+    boolean could truncate a run and the result looked converged. Both that and
+    `rounds` changing meaning (it becomes a `rounds × n_workers` rollout budget,
+    and `RoundInfo.round` becomes a merger-sweep index) now emit a
+    `RuntimeWarning`.
 
 !!! note "Three failure categories, not two"
     | category | example | what happens |

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -366,9 +366,27 @@ def score_mgsm(target: str, prediction: Optional[str]) -> bool:
     return target.replace(",", "") == prediction.replace(",", "")
 
 
-def evaluate_agent(interp: Interpreter, program: dict,
-                   examples: List[Tuple[str, str]]) -> List[float]:
-    return [1.0 if score_mgsm(a, interp.run(program, q)) else 0.0 for q, a in examples]
+def evaluate_agent(interp: Interpreter, program: dict, examples: List[Tuple[str, str]],
+                   concurrency: int = 8) -> List[float]:
+    """Score a program on each example, concurrently.
+
+    This was a sequential list comprehension, and it is the whole run: every
+    candidate is scored on every example, and each score is a *multi-step* program
+    (debate and self-consistency make several model calls per question). Serially
+    that made ADAS's effective concurrency ~1 no matter how many workers the
+    engine was given -- measured, a 6-example generation had not finished after 25
+    minutes. `Interpreter` holds only a completion, so the runs are independent.
+    """
+    if not examples:
+        return []
+    from concurrent.futures import ThreadPoolExecutor
+
+    def one(ex):
+        q, a = ex
+        return 1.0 if score_mgsm(a, interp.run(program, q)) else 0.0
+
+    with ThreadPoolExecutor(max(1, min(concurrency, len(examples)))) as pool:
+        return list(pool.map(one, examples))
 
 
 def load_dataset(langs: List[str], per_lang: int, seed: int = 0,
@@ -477,7 +495,17 @@ class MetaSearchAggregator(AggregatorProtocol):
     def _fitness(self, head, design: str) -> float:
         art = head.apply(Diff(diff_id="eval", target=self.aid,
                               ops={"design": design}, author="adas"))
-        correct = [art.score([t]) for t in self.verifier.held_out]   # 0/1 per instance
+        # Per-instance 0/1, because the bootstrap CI needs the individual outcomes --
+        # but scored concurrently. One task per `score()` call sidesteps the
+        # engine's own fan-out (it short-circuits at a single task), so this loop
+        # was serial even though everything under it is not.
+        from concurrent.futures import ThreadPoolExecutor
+        held = list(self.verifier.held_out)
+        if held:
+            with ThreadPoolExecutor(max(1, min(8, len(held)))) as pool:
+                correct = list(pool.map(lambda t: art.score([t]), held))
+        else:
+            correct = []
         return bootstrap_ci(correct, seed=self.boot_seed)[0]
 
     def ingest(self, card: EvidenceCard) -> None:

--- a/tests/test_provider_and_split_contracts.py
+++ b/tests/test_provider_and_split_contracts.py
@@ -1,0 +1,213 @@
+"""Three things a caller hits directly, each of which failed quietly.
+
+* a provider that answered `content: null` broke the one contract in the package
+  (`Completion` is prompt -> str) and the failure was then *retried as a backend
+  transient*;
+* flipping `asynchronous=True` turned an unbounded run into a 20-second one, and
+  the truncated result was indistinguishable from a converged one;
+* the train/held-out split is positional, so grouped data holds out one end of
+  the file and every gate in the run is then measured against a different
+  distribution.
+"""
+
+import io
+import json
+import os
+import urllib.error
+import urllib.request
+import warnings
+
+import pytest
+
+import agentdescent.evolution as ev
+from agentdescent.agents import openai_compatible
+from agentdescent.evolution import LLMAgent, SingleSlot, Task, evolve
+
+
+# -- the provider contract ------------------------------------------------------
+
+
+def _stub_response(payload, monkeypatch):
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda *a, **kw: _Resp(json.dumps(payload).encode()))
+
+
+def test_a_reasoning_model_that_returns_null_content_still_returns_a_string(monkeypatch):
+    """`Completion` is `prompt -> str`. DeepSeek's reasoner and GLM's thinking
+    modes answer with `content: null` and the visible text in `reasoning_content`
+    when the budget goes to reasoning."""
+    _stub_response({"choices": [{"message": {"role": "assistant", "content": None,
+                                             "reasoning_content": "..."}}]}, monkeypatch)
+    out = openai_compatible(model="deepseek-reasoner", retries=1)("hi")
+    assert out == "", f"expected a string, got {out!r}"
+
+
+def test_null_content_surfaces_as_the_empty_completion_warning(monkeypatch):
+    """It used to raise `'NoneType' object has no attribute 'strip'` from inside
+    `LLMAgent`, which the engine caught and retried as a *backend transient* --
+    diagnosing a systematic model/parameter mismatch as a flaky endpoint.
+
+    `LLMAgent.propose` already has the right diagnosis for this; it just never
+    got the chance to run.
+    """
+    _stub_response({"choices": [{"message": {"content": None}}]}, monkeypatch)
+    agent = LLMAgent(openai_compatible(model="deepseek-reasoner", retries=1))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert agent.propose("skill", Task(id="1", prompt="q"), "out", 0.0) is None
+    assert any("empty completion" in str(w.message) for w in caught), \
+        "the reflector's own empty-completion diagnosis never fired"
+
+
+def test_an_http_error_carries_the_provider_s_message(monkeypatch):
+    """The body is the only useful part, and it lives on `e.read()`."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def boom(*a, **kw):
+        raise urllib.error.HTTPError(
+            "u", 429, "Too Many Requests", {},
+            io.BytesIO(b'{"error":{"message":"rate limit: retry in 12s"}}'))
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    with pytest.raises(RuntimeError) as excinfo:
+        openai_compatible(model="m", retries=1)("hi")
+    assert "429" in str(excinfo.value)
+    assert "retry in 12s" in str(excinfo.value), "the provider's message was discarded"
+
+
+def test_a_200_with_no_choices_names_the_endpoint(monkeypatch):
+    """Some proxies answer HTTP 200 with `{"error": ...}`."""
+    _stub_response({"error": {"message": "model not found"}}, monkeypatch)
+    with pytest.raises(RuntimeError) as excinfo:
+        openai_compatible(model="nope", retries=1)("hi")
+    assert "no choices" in str(excinfo.value) and "nope" in str(excinfo.value)
+
+
+def test_extra_kwargs_reach_the_request_body(monkeypatch):
+    """`claude()` takes **create_kwargs; this had no way to set temperature."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    sent = {}
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def capture(req, **kw):
+        sent.update(json.loads(req.data))
+        return _Resp(json.dumps({"choices": [{"message": {"content": "ok"}}]}).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", capture)
+    openai_compatible(model="m", retries=1, temperature=0)("hi")
+    assert sent.get("temperature") == 0
+
+
+# -- the silent async redefinitions ---------------------------------------------
+
+
+def _tasks(n=8):
+    return [Task(id=str(i), prompt=str(i), meta={"gold": "y"}) for i in range(n)]
+
+
+def _quick(**kw):
+    return evolve(_tasks(), lambda t, o: 1.0, run=lambda r, t: "y",
+                  propose=lambda *a: None, strategy=SingleSlot(initial_value="v"),
+                  n_workers=2, held_out_frac=0.5, **kw)
+
+
+def test_async_says_that_an_unset_max_seconds_becomes_twenty():
+    """`None` means "no limit" on one path and "20 seconds" on the other."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _quick(rounds=1, asynchronous=True)
+    assert any("20.0 seconds" in str(w.message) for w in caught), \
+        "flipping one boolean silently bounded the run"
+
+
+def test_async_says_that_rounds_changes_meaning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _quick(rounds=3, asynchronous=True, max_seconds=1.0)
+    assert any("rollouts" in str(w.message) and "rounds=3" in str(w.message)
+               for w in caught)
+
+
+def test_stop_reason_tells_convergence_from_a_spent_budget():
+    """`error` is None for both, and `history` has entries for both."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        converged = _quick(rounds=20, target_reward=0.5)
+        exhausted = _quick(rounds=2)
+    assert converged.stop_reason == "target_reward"
+    assert exhausted.stop_reason == "rounds"
+    assert converged.error is exhausted.error is None, \
+        "premise: `error` cannot distinguish these two"
+
+
+def test_stop_reason_survives_save_and_load(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = _quick(rounds=20, target_reward=0.5)
+    path = tmp_path / "r.json"
+    res.save(str(path))
+    from agentdescent.evolution import EvolutionResult
+    assert EvolutionResult.load(str(path)).stop_reason == "target_reward"
+
+
+# -- the positional split -------------------------------------------------------
+
+
+def _split(tasks, **kw):
+    eng = ev._build_engine(
+        tasks, lambda t, o: 1.0, agent=None, run=lambda r, t: "y",
+        propose=lambda *a: None, strategy=SingleSlot(initial_value="v"),
+        initial_state=None, blast_radius=0.2, artifact_id="a", held_out_frac=0.4,
+        repo_path=None, agg_config=None, staleness_policy=None,
+        aggregator_factory=None, oracle_budget=10, **kw)
+    return eng.train, eng.held_out
+
+
+def _grouped(n=20):
+    """A dataset ordered by class -- FiNER, SWE-bench and friends all are."""
+    return [Task(id=str(i), prompt="a" if i < 12 else "b", meta={"gold": "y"})
+            for i in range(n)]
+
+
+def test_an_ordered_dataset_holds_out_one_end_of_the_file_by_default():
+    """Documented, not fixed by default: the split is positional on purpose, so
+    `Dataset.val_frac` keeps meaning "exactly this Dataset's val"."""
+    _, held_out = _split(_grouped())
+    assert {t.prompt for t in held_out} == {"b"}, \
+        "premise: the tail of a grouped file is one class"
+
+
+def test_shuffle_makes_the_held_out_set_representative():
+    _, held_out = _split(_grouped(), shuffle=True, seed=7)
+    assert {t.prompt for t in held_out} == {"a", "b"}, \
+        "every gate in the run is measured on this set"
+
+
+def test_shuffling_is_deterministic_given_a_seed():
+    a, _ = _split(_grouped(), shuffle=True, seed=3)
+    b, _ = _split(_grouped(), shuffle=True, seed=3)
+    c, _ = _split(_grouped(), shuffle=True, seed=4)
+    assert [t.id for t in a] == [t.id for t in b]
+    assert [t.id for t in a] != [t.id for t in c]
+
+
+def test_a_tiny_held_out_set_is_called_out():
+    """At 1 item `final_reward` is 0.0 or 1.0 and nothing else."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _split([Task(id=str(i), prompt="q", meta={"gold": "y"}) for i in range(4)])
+    assert any("held-out set has only" in str(w.message) for w in caught)


### PR DESCRIPTION
Closes #11, closes #7, closes #9. Independent fixes, grouped because all three are things a first-time caller trips over and none of them fails loudly.

---

## 1. `openai_compatible` returned `None` on reasoning models (#11)

`Completion` is documented as the one contract in the package — `Callable[[str], str]`. A model that spends its whole budget on `reasoning_content` answers with JSON `null` for `content`, not `""`:

```python
>>> c = openai_compatible(model="deepseek-reasoner")
>>> c("hi")
None
>>> LLMAgent(c).solve("skill", task)
AttributeError: 'NoneType' object has no attribute 'strip'
```

That `AttributeError` came out of `LLMAgent`/`_Runtime.eval_one`, where the generic backend handler caught it, **retried it three times, and reported it as a transient** — diagnosing a systematic model/parameter mismatch as a flaky endpoint.

Doubly unfortunate, because the codebase already has the right diagnosis and never got to use it:

> An empty completion is almost never "no rule would help" … it is nearly always a starved reasoning model: the token budget went to internal reasoning and no visible content came back.

That warning handles the empty-**string** case. The `None` case failed one frame earlier. Normalised to `""`, so it fires and says the true cause. Also here:

- **HTTP errors carry the provider's message.** It lives on `e.read()`, so re-raising bare collapsed every 4xx to `HTTP Error 429: Too Many Requests` — for the error class most likely to occur in a loop making thousands of calls. `_git` and `_CliAgent` both surface the underlying detail; this was the one provider path that didn't.
- **HTTP 200 with `{"error": ...}`** (some proxies) names the endpoint and model instead of raising a bare `KeyError`.
- **`**create_kwargs`** reach the request body, so `temperature=0` works as it does on `claude()`.

## 2. A spent budget was indistinguishable from convergence (#7)

`evolve(asynchronous=True)` doesn't just ignore some parameters — it **redefines** two, and those were the ones that said nothing:

| parameter | `asynchronous=False` | `asynchronous=True` | warned before? |
|---|---|---|---|
| `max_seconds` | `None` = unbounded | `None` becomes **20.0 seconds** | ❌ |
| `rounds` | round barriers | a `rounds × n_workers` rollout budget | ❌ |
| `parallel` / `max_concurrency` / `round_timeout` | honoured | ignored | ✅ |

So a working synchronous run, one boolean flipped to go faster, stops after 20 seconds with a partial artifact — `error=None`, `history` populated, indistinguishable from converged. Both now warn.

The deeper fix is **`EvolutionResult.stop_reason`**: `"target_reward"` / `"patience"` / `"rounds"` / `"max_seconds"` / `"max_iters"` / `"error"`. It was the missing field on *both* paths — the `verbose` print lines always knew why a run ended, and a non-interactive caller had to re-derive it from `len(history)` against arguments whose meaning changes between the two paths. Survives `save()`/`load()`.

## 3. The train/held-out split is positional, with no way to shuffle (#9)

```python
cut = max(1, round(len(tasks) * (1 - held_out_frac)))
train, held_out = tasks[:cut], tasks[cut:]
```

No shuffle, no `seed`. Correct for a pre-split `Dataset` — and it's load-bearing there, since `Dataset.val_frac`'s promise that "the engine's held-out split is exactly this `Dataset`'s `val`" only holds because `trainval` is train + val *in that order*. Wrong for **grouped** data, which is most benchmarks loaded raw through `hf_rows` (the quickstart's own program does exactly this). On a 20-task set whose first 12 are one class:

```
shuffle=False   held-out classes: ['b']        a/b: 0/8
shuffle=True    held-out classes: ['a', 'b']   a/b: 5/3
```

Every gate in the run — the Beta acceptance test, `target_reward`, `patience`, `final_reward` — is measured on that set, so the run optimises against one distribution and reports against another. `shuffle=True, seed=...` is now available on `evolve` / `async_evolve` / `evolve_skill`, **off by default** so `Dataset.val_frac` keeps its meaning and seeded runs stay reproducible.

A held-out set of fewer than 4 tasks also warns now: the engine validates `len(tasks) >= 4` but not that the *resulting* held-out set can support the test that gates every merge. At 1 item `final_reward` is 0.0 or 1.0 and nothing in between.

## Tests

`tests/test_provider_and_split_contracts.py`, 13 cases: null content returns a string and routes to the empty-completion warning; HTTP errors keep the provider's message; a 200-with-no-choices names the endpoint; kwargs reach the body; both async redefinitions warn; `stop_reason` separates convergence from exhaustion and survives a round-trip; an ordered dataset holds out one class by default; `shuffle` fixes it deterministically; a tiny held-out set warns.

**410 passed, 1 skipped.** `mkdocs build --strict` clean.

The provider tests stub `urllib.request.urlopen`, so no network and no credentials.

## Docs

- `docs/agents.md` — new note on `content: null` vs `""`, HTTP error detail, passthrough kwargs
- `docs/evolution.md` — `stop_reason` callout next to the existing "always check `result.error`" warning; a note that the split is positional, with the measured grouped-data numbers
- `evolve` / `async_evolve` / `evolve_skill` docstrings; `EvolutionResult.stop_reason`
- CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)