### PR TITLE
ADAS evaluated candidates serially, so it never used its workers

### DIFF
--- a/adas.txt
+++ b/adas.txt
@@ -1,0 +1,17 @@
+Algorithm: ADAS Meta Agent Search -- harness (agentic-system) self-evolution
+Dataset  : MGSM (Multilingual Grade-School Math)
+Governance: harness artifact blast_radius=0.6 -> L1_SLOW (harness changes are high-blast-radius)
+Loaded   : langs=['bn', 'sw', 'te', 'th']; 300 train / 150 val (search) / 150 test
+Seeds    : Chain-of-Thought, Self-Consistency with CoT, Self-Refine (Reflexion), LLM Debate, Step-back Abstraction, Quality-Diversity, Dynamic Assignment of Roles
+
+Example problem:
+  Q: ริชาร์ดอาศัยอยู่ในอาคารอพาร์ตเมนต์สูง 15 ชั้น แต่ละชั้นมีห้อง 8 ยูนิต และมีผู้อาศัยอยู่ 3/4 ของยูนิตทั้งหมด จำนวนยูนิตทั้งหมดที่ไม่มีผู้อาศัยคือกี่ยูน
+  A: 30
+
+Plan     : model=deepseek-v4-flash, generations=3, select=adas
+Parallel : 2 meta-agents propose concurrently each generation (synchronous DP; the archive merge is the barrier)
+Budget   : up to ~9009 model calls (multi-step agents call the model many times)
+Hard mode: 23 train / 12 val / 11 test  (items a single call answers incorrectly)
+
+Searching agentic systems (Meta Agent Search, L1 harness)...
+

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -59,27 +59,33 @@ In [`examples/adas_meta_agent_search.py`](https://github.com/Birfy/agentdescent/
 
 ## Measured — MGSM with DeepSeek
 
-MGSM is grade-school arithmetic, and a strong model answers it directly: at the
-default `--langs en,es,fr` the seed archive already scores **1.000**, so the
-search has no gradient and the archive merge accepts nothing.
+At the default settings MGSM is **saturated**: the seed archive already scores
+1.000 on the sampled items, so Meta Agent Search has no gradient and the archive
+merge accepts nothing.
 
-Two settings give it room, and MGSM's own difficulty axis is language:
+`--hard` is the lever, and MGSM needs both of the difficulty knobs at once. Even
+restricted to its low-resource languages, `deepseek-v4-flash` answers ~95% of
+items correctly with a single structure-free call, so finding a subset with signal
+takes a large pool:
+
+| pool | items a single call gets wrong |
+|---|---|
+| `--per-lang 40` on `bn,sw,te,th` (160) | fewer than 12 — `select_hard` warns and tops up |
+| `--per-lang 150` on `bn,sw,te,th` (600) | **47** (23 train / 12 val / 11 test) |
 
 ```bash
 python -m examples.adas_meta_agent_search --hard --langs bn,sw,te,th \
-    --per-lang 150 --provider openai --model deepseek-v4-flash --generations 4 --yes
+    --per-lang 150 --generations 3 --provider openai --model deepseek-v4-flash --yes
 ```
 
-`--hard` keeps the items a **plain single call** answers incorrectly, which is the
-right filter here: what ADAS searches over *is* structure, so the items worth
-keeping are the ones a structure-free call cannot already do. Over a 600-item
-low-resource pool that leaves 47 genuinely hard questions (24 train / 12 val /
-11 test).
+!!! warning "This is by far the most expensive example"
+    Every candidate is scored on every training item, and each score is a
+    *multi-step* program — self-consistency and debate make several model calls per
+    question. One generation over 23 items is on the order of a thousand calls, so
+    a three-generation run takes hours even fully parallel. Start with a small
+    `--per-lang` and `--generations 1` to see the loop work.
 
-ADAS is also the most expensive example — the searched agents are multi-step, so
-one generation is hundreds of model calls.
-
-## Run it
+## Run it## Run it
 
 ```bash
 python -m examples.adas_meta_agent_search --dry-run

--- a/docs/results.md
+++ b/docs/results.md
@@ -13,7 +13,7 @@ so you can reproduce it.
 | **[SkillOpt](algo-skillopt.md)** | SearchQA | `--hard --steps 6` | val hard-EM **0.250 → 0.500**; test **0.450** | 6 steps |
 | **[EvoSkill](algo-evoskill.md)** | FinQA | `--dataset finqa --iterations 5` | val **0.487 → 0.573**; test **0.617**, 1 skill | 115 calls, 4 min |
 | **[DGM](algo-dgm.md)** | surrogate | `--generations 4` | resolve-rate **0.000 → 0.300**; test 0.200 | offline |
-| **[ADAS](algo-adas.md)** | MGSM | `--hard --langs bn,sw,te,th` | *pending* | — |
+| **[ADAS](algo-adas.md)** | MGSM | `--hard --langs bn,sw,te,th --per-lang 150` | *see page — the run takes hours* | ~9000 calls |
 
 Each learned something specific to the failure it was shown:
 

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -366,9 +366,27 @@ def score_mgsm(target: str, prediction: Optional[str]) -> bool:
     return target.replace(",", "") == prediction.replace(",", "")
 
 
-def evaluate_agent(interp: Interpreter, program: dict,
-                   examples: List[Tuple[str, str]]) -> List[float]:
-    return [1.0 if score_mgsm(a, interp.run(program, q)) else 0.0 for q, a in examples]
+def evaluate_agent(interp: Interpreter, program: dict, examples: List[Tuple[str, str]],
+                   concurrency: int = 8) -> List[float]:
+    """Score a program on each example, concurrently.
+
+    This was a sequential list comprehension, and it is the whole run: every
+    candidate is scored on every example, and each score is a *multi-step* program
+    (debate and self-consistency make several model calls per question). Serially
+    that made ADAS's effective concurrency ~1 no matter how many workers the
+    engine was given -- measured, a 6-example generation had not finished after 25
+    minutes. `Interpreter` holds only a completion, so the runs are independent.
+    """
+    if not examples:
+        return []
+    from concurrent.futures import ThreadPoolExecutor
+
+    def one(ex):
+        q, a = ex
+        return 1.0 if score_mgsm(a, interp.run(program, q)) else 0.0
+
+    with ThreadPoolExecutor(max(1, min(concurrency, len(examples)))) as pool:
+        return list(pool.map(one, examples))
 
 
 def load_dataset(langs: List[str], per_lang: int, seed: int = 0,
@@ -477,7 +495,17 @@ class MetaSearchAggregator(AggregatorProtocol):
     def _fitness(self, head, design: str) -> float:
         art = head.apply(Diff(diff_id="eval", target=self.aid,
                               ops={"design": design}, author="adas"))
-        correct = [art.score([t]) for t in self.verifier.held_out]   # 0/1 per instance
+        # Per-instance 0/1, because the bootstrap CI needs the individual outcomes --
+        # but scored concurrently. One task per `score()` call sidesteps the
+        # engine's own fan-out (it short-circuits at a single task), so this loop
+        # was serial even though everything under it is not.
+        from concurrent.futures import ThreadPoolExecutor
+        held = list(self.verifier.held_out)
+        if held:
+            with ThreadPoolExecutor(max(1, min(8, len(held)))) as pool:
+                correct = list(pool.map(lambda t: art.score([t]), held))
+        else:
+            correct = []
         return bootstrap_ci(correct, seed=self.boot_seed)[0]
 
     def ingest(self, card: EvidenceCard) -> None:

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+source ~/.zshrc >/dev/null 2>&1
+cd /tmp/ad-adas
+export PYTHONPATH=.
+{ time python3 -u -m examples.adas_meta_agent_search --provider openai --model deepseek-v4-flash \
+    --hard --langs bn,sw,te,th --per-lang 150 --generations 3 --yes ; } > /tmp/ad-adas/adas.txt 2>&1
+echo DONE >> /tmp/ad-adas/status

--- a/tests/test_adas_example.py
+++ b/tests/test_adas_example.py
@@ -89,3 +89,61 @@ def test_search_evaluates_seed_archive():
     assert len(result.archive) >= len(seed_archive())
     assert 0.0 <= result.seed_fitness <= 1.0
     assert result.best_fitness >= result.seed_fitness
+
+
+# --- concurrency: ADAS is the most expensive example, and it was serial --------
+
+def test_evaluate_agent_scores_examples_concurrently():
+    """This loop *is* the run: every candidate is scored on every example, and
+    each score is a multi-step program. Serially, ADAS's effective concurrency was
+    ~1 no matter how many workers the engine was given -- measured, a 6-example
+    generation had not finished after 25 minutes.
+    """
+    import threading
+    import time
+
+    from examples.adas_meta_agent_search import evaluate_agent
+
+    live, peak, lock = [0], [0], threading.Lock()
+
+    def slow(prompt):
+        with lock:
+            live[0] += 1
+            peak[0] = max(peak[0], live[0])
+        time.sleep(0.05)
+        with lock:
+            live[0] -= 1
+        return "Answer: 42"
+
+    examples = [(f"q{i}", "42") for i in range(8)]
+    scores = evaluate_agent(Interpreter(slow), {"block": "cot"}, examples)
+    assert scores == [1.0] * 8
+    assert peak[0] > 1, "evaluate_agent scored the examples serially"
+
+
+def test_evaluate_agent_handles_an_empty_split():
+    from examples.adas_meta_agent_search import evaluate_agent
+    assert evaluate_agent(Interpreter(lambda p: "Answer: 1"), {"block": "cot"}, []) == []
+
+
+def test_evaluate_agent_preserves_order():
+    """Concurrency must not scramble the per-instance outcomes -- the bootstrap
+    CI is computed over them."""
+    from examples.adas_meta_agent_search import evaluate_agent
+
+    def echo(prompt):
+        return f"Answer: {prompt.count('#')}"
+
+    examples = [("#" * i, str(i)) for i in range(1, 7)]
+    assert evaluate_agent(Interpreter(echo), {"block": "cot"}, examples) == [1.0] * 6
+
+
+def test_hard_mode_keeps_items_a_single_call_gets_wrong():
+    """`--hard` exists because MGSM is ~95% solved by one call, so the search has
+    no gradient. The filter is `select_hard` over a structure-free baseline."""
+    from agentdescent.dataloader import select_hard
+
+    pool = [(f"q{i}", str(i)) for i in range(40)]
+    # a "baseline" that only gets the even ones right
+    kept = select_hard(pool, lambda ex: 1.0 if int(ex[1]) % 2 == 0 else 0.0)
+    assert kept == [ex for ex in pool if int(ex[1]) % 2]


### PR DESCRIPTION
ADAS is the most expensive shipped example, and it was pinned at an **effective concurrency of ~1**. Two sequential loops — both the same mistake already fixed in the library's own `score()`.

## The two loops

**`evaluate_agent()`** scored a candidate on each example in a list comprehension. That loop *is* the run: every candidate is scored on every training item, and each score is a multi-step program (debate and self-consistency make several model calls per question).

**The archive optimizer's fitness** computed `[art.score([t]) for t in held_out]` — one task per call. That sidesteps the engine's own fan-out, which short-circuits at a single task, so the loop stayed serial even though everything under it is not. It has to stay per-instance (the bootstrap CI needs the individual outcomes), but not serial.

## Measured

| | before | after |
|---|---|---|
| established connections to the provider | **1** | **8** |
| a generation over 6 items | not finished after 25 min | progresses |

## Tests

Four new, covering what actually broke:

- peak concurrency > 1 (the fix itself)
- **order preservation** — concurrency must not scramble the per-instance outcomes, since the bootstrap CI is computed over them
- empty split
- the `--hard` selection

## Docs

MGSM needs both difficulty levers at once. Even restricted to its low-resource languages, `deepseek-v4-flash` answers ~95% of items with a single structure-free call:

| pool | items a single call gets wrong |
|---|---|
| `--per-lang 40` on `bn,sw,te,th` (160) | fewer than 12 — `select_hard` warns and tops up |
| `--per-lang 150` (600) | **47** (23 train / 12 val / 11 test) |

The full three-generation run is ~9000 model calls and takes hours. The results row says that rather than carrying a number I did not measure — the run is still going and I will add the figure when it lands.

420 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)