### PR TITLE
fix: one definition of the L1/L2 boundary, and a scheduler that matches its docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **The L1/L2 boundary was defined three times, with two different numbers.**
+  `governance.classify` drew it at `FAST_MAX = 0.30`; the aggregator's staleness
+  tolerance re-derived it as `blast_radius > 0.5` and the audit gate as
+  `blast_radius >= 0.5`. An artifact at 0.4 was therefore **L1 by governance** --
+  the slow, conservative layer -- and treated as L2 by both mechanisms that decide
+  what being L1 means: it got the staleness tolerance meant for a cold L2 skill,
+  and no oracle audit at all. `evolve()`'s docstring papered over the gap by
+  recommending 0.2 and 0.6, the two values where the thresholds happen to agree.
+  Both sites now call `classify`.
+- **A reserved artifact name failed late and blamed the wrong thing.** The L0
+  frozen ids are ordinary words -- `oracle` is a plausible name for an evolving
+  judge prompt -- and `evolve(artifact_id="oracle")` surfaced a `GovernanceError`
+  on the first round that named governance rather than the cause, which is the
+  *name*. Now refused beside the other `artifact_id` rules, before any rollout,
+  with a message that says to rename it. Still a `GovernanceError`: refusing to
+  mutate L0 is the safety claim, and callers are told to catch that type.
+
+### Removed
+- `governance.SLOW_MAX`. It was defined with a comment describing a frozen-layer
+  rule, and `classify` never read it -- so 0.31 and 0.99 classified identically
+  while the comment documented behaviour that did not exist. L0 is reached by id,
+  not by radius, so one threshold is all there is.
+
+### Changed
+- **Documentation now matches the scheduler.** `TaskScheduler` was described as
+  "UCB over (task-cluster x artifact)" in four places -- both `architecture.md`
+  diagrams, `concepts.md` §5 and its own module docstring. There is no artifact
+  dimension: `TaskCluster` has no such field, and both reference runtimes register
+  exactly one artifact, as does `evolve()`. The missing axis is the one L-task is
+  *about* ("head skills flooded, tail skills starved"), so the mechanism operates
+  on clusters while the problem statement is about artifacts. Documented as
+  not-implemented, alongside the tail canary set and partial-rollout resume.
+- **`select_batch` no longer promises distinct leases.** It cycles when asked for
+  more than there are clusters, and `TaskUniverse.clusters` drops empty hash
+  buckets -- so on the default 24-keyword universe distinctness stops holding at
+  12 workers, and at 24 workers 7 of them (29%) duplicate another's cluster,
+  rolling out the same deterministic tasks for no extra evidence.
+  `AgentDescent.__init__` now warns when it has fewer clusters than workers.
+- **`L1SerialGate` is documented as a primitive, not as something in the path.**
+  "At most one L1 diff in evaluation at a time" holds today by construction --
+  every merge decision runs on one thread -- and the gate is what would enforce it
+  once merges run concurrently. `concepts.md` said "implemented", which was only
+  discoverable as untrue by grep.
+
+### Fixed
 - **`openai_compatible` returned `None` on reasoning models.** `Completion` is
   `prompt -> str`, but a model that spends its whole budget on `reasoning_content`
   answers with JSON `null` for `content` -- DeepSeek's reasoner and GLM's thinking

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -284,8 +284,13 @@ class Aggregator:
     def _alpha_for(self, artifact: Evolvable, card: EvidenceCard) -> int:
         if card.diff.contract_breaking:
             return 0  # contract-breaking diffs must be re-proposed, not rebased.
-        # hotter artifacts (bigger blast radius) tolerate more staleness.
-        return self.config.alpha_head if artifact.blast_radius > 0.5 else self.config.alpha_tail
+        # Hotter artifacts (bigger blast radius) tolerate more staleness. The
+        # boundary is `governance.classify`, not a second hand-written threshold:
+        # this used to test `blast_radius > 0.5` while governance drew the line at
+        # 0.30, so an artifact at 0.4 was L1 by governance and got the *cold*
+        # tolerance meant for an L2 skill.
+        return (self.config.alpha_head if classify(artifact) is Layer.L1_SLOW
+                else self.config.alpha_tail)
 
     def _staleness_filter(
         self, artifact: Evolvable, head: VersionVector, cards: List[EvidenceCard]

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -187,7 +187,8 @@ def async_evolve(
     # hardcoding 5/1 here silently ignored agg_config.alpha_head/alpha_tail, so a
     # tightened tolerance was honoured by the aggregator but not by this gate.
     _cfg = agg_config or AggregatorConfig()
-    alpha = _cfg.alpha_head if eng.blast_radius > 0.5 else _cfg.alpha_tail
+    from .governance import FAST_MAX
+    alpha = _cfg.alpha_head if eng.blast_radius > FAST_MAX else _cfg.alpha_tail
 
     # data-parallel: shard the train tasks round-robin across workers.
     shards: List[List[Task]] = [[] for _ in range(n_workers)]

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -43,7 +43,7 @@ from .aggregator import (
     check_reports,
 )
 from .evolvable import Contract, ContractError, Diff, EvidenceCard
-from .governance import assert_mutable
+from .governance import FROZEN_IDS, GovernanceError, assert_mutable
 from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import AuditScheduler
@@ -840,6 +840,22 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     if not re.fullmatch(r"[A-Za-z0-9_.\-]+", artifact_id):
         raise ValueError("artifact_id must match [A-Za-z0-9_.-]+ (it becomes a filename), "
                          f"got {artifact_id!r}")
+    # A handful of names are reserved for the frozen layer, and they are ordinary
+    # words -- "oracle" is a plausible name for an evolving judge prompt. Say so
+    # here, where the other artifact_id rules live, rather than letting it surface
+    # as a GovernanceError on the first round that names governance and not the
+    # actual cause, which is the *name*.
+    if artifact_id in FROZEN_IDS:
+        # GovernanceError, not ValueError: refusing to mutate L0 is the safety
+        # claim, and callers are told to catch that type. What changes is the
+        # *message* -- it now names the cause, which is the name -- and the timing,
+        # since this is checked beside the other artifact_id rules rather than
+        # surfacing on the first round.
+        raise GovernanceError(
+            f"artifact_id={artifact_id!r} is reserved for the L0 frozen layer "
+            f"({', '.join(sorted(FROZEN_IDS))}), which the evolution loop may only "
+            "read -- these are ordinary words, so this is most likely just a name "
+            "collision. Rename the artifact.")
     # Governance is a caller-level constraint, so check it before any rollout.
     # Previously only the reference aggregator's per-merge guard caught an L0
     # target: nothing was mutated, but the async path burned its whole budget

--- a/agentdescent/governance.py
+++ b/agentdescent/governance.py
@@ -8,10 +8,17 @@ frequency (a two-timescale system):
     L1 (slow)   harness / context / learned verifier days    serial + staged rollout
     L0 (frozen) oracle / audit budget / merge perms  human   read-only to the loop
 
-The key design point is that this is *not* a hand-labelled artifact taxonomy: a
-skill triggered by every task is pulled into the slow layer automatically, while
-a harness patch that only touches one task cluster may ride the fast layer
-(design doc, section 3.2).
+The L1/L2 boundary is *not* a hand-labelled taxonomy: a skill triggered by every
+task is pulled into the slow layer automatically by its blast radius, while a
+harness patch that only touches one task cluster may ride the fast layer (design
+doc, section 3.2).
+
+**L0 is the exception, and deliberately so.** Nothing about a blast radius can
+tell you that an artifact is the oracle -- an artifact that can rewrite the thing
+that judges it is a structural fact, not a measured one -- so the frozen set is an
+explicit list of ids (:data:`FROZEN_IDS`). That is a hand-labelled taxonomy, and
+it should be: a verifier that learns to pass itself is exactly what an *estimated*
+layer would fail to catch.
 """
 
 from __future__ import annotations
@@ -30,11 +37,17 @@ class Layer(IntEnum):
     L0_FROZEN = 0
 
 
-# Thresholds on blast_radius (a normalized [0, 1] estimate of task-surface impact).
+#: The one threshold on blast_radius (a normalized [0, 1] estimate of task-surface
+#: impact): at or below it an artifact is L2, above it L1. There used to be a
+#: second constant, ``SLOW_MAX = 0.85``, with a comment describing a frozen-layer
+#: rule -- ``classify`` never read it, so 0.31 and 0.99 classified identically and
+#: the comment documented behaviour that did not exist. L0 is reached by id, not
+#: by radius, so one threshold is all there is.
 FAST_MAX = 0.30
-SLOW_MAX = 0.85
-# Above SLOW_MAX an artifact is a candidate for the frozen layer *only* if it is
-# also declared structural (see ``FROZEN_IDS``); otherwise it stays L1.
+
+#: Artifacts the loop may read but never mutate. An id list rather than a radius,
+#: because "this is the oracle" is structural (see the module docstring). Names
+#: here are reserved: ``evolve(artifact_id="oracle")`` is refused up front.
 FROZEN_IDS = frozenset(
     {
         "oracle",
@@ -46,7 +59,13 @@ FROZEN_IDS = frozenset(
 
 
 def classify(artifact: Evolvable) -> Layer:
-    """Assign an artifact to a governance layer from its blast radius."""
+    """Assign an artifact to a governance layer.
+
+    This is the single definition of the L1/L2 boundary. The aggregator and the
+    audit scheduler used to re-derive it from raw floats with a *different*
+    threshold (``blast_radius > 0.5``), so an artifact at 0.4 was L1 by governance
+    and treated as L2 everywhere it mattered: it got the cold-artifact staleness
+    tolerance and no oracle audit at all."""
     if artifact.id in FROZEN_IDS:
         return Layer.L0_FROZEN
     if artifact.blast_radius <= FAST_MAX:
@@ -61,7 +80,15 @@ class L1SerialGate:
     L2 artifacts are naturally isolated -- only tasks that trigger them are
     affected -- so they merge fully async.  L1 artifacts have no such isolation,
     so their in-flight changes must be serialized in time to keep attribution
-    tractable."""
+    tractable.
+
+    **Not wired into the shipped runtimes, because they already satisfy it.**
+    Every merge decision runs on one thread -- the round barrier in ``evolve()``,
+    the single merger thread in ``async_evolve`` and ``AsyncAgentDescent`` -- so at
+    most one diff of any layer is ever in evaluation. The guarantee holds by
+    construction; this gate is what would enforce it once merges run concurrently
+    (a process or host pool), and it is tested in isolation for that day. Treat it
+    as a primitive, not as something currently in the path."""
 
     _in_flight: Dict[str, str] = None  # artifact_id -> diff_id
     #: try_acquire is a check-then-act, so calling it from several threads could

--- a/agentdescent/orchestrator.py
+++ b/agentdescent/orchestrator.py
@@ -20,6 +20,7 @@ head and the aggregator must rebase or discard (design doc, section 4.2).
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -87,6 +88,16 @@ class AgentDescent:
                                      staleness_policy=staleness_policy)
 
         clusters = universe.clusters(n_clusters=max(2, n_workers))
+        if len(clusters) < n_workers:
+            # `clusters()` buckets by keyword hash and drops the empty buckets, so
+            # asking for n_workers of them can return fewer -- and `select_batch`
+            # then cycles, handing two workers the same cluster. They roll out the
+            # same tasks and propose diffs that content-address to duplicates.
+            warnings.warn(
+                f"{n_workers} workers but only {len(clusters)} non-empty task "
+                f"clusters, so {n_workers - len(clusters)} worker(s) will duplicate "
+                "another's cluster each round and add no new evidence. Use more "
+                "keywords or fewer workers.", RuntimeWarning, stacklevel=2)
         self.task_scheduler = TaskScheduler(
             [TaskCluster(id=f"c{i}", tasks=c) for i, c in enumerate(clusters)]
         )

--- a/agentdescent/scheduler.py
+++ b/agentdescent/scheduler.py
@@ -3,9 +3,14 @@
 AgentDescent treats the long tail as *three* distinct problems, each with its own
 mechanism:
 
-* :class:`TaskScheduler` -- L-task (data layer): UCB over (task-cluster x
-  artifact) so evidence-starved tail artifacts get an exploration bonus and
-  converged head artifacts are down-weighted (design doc, section 5.2).
+* :class:`TaskScheduler` -- L-task (data layer): UCB over **task clusters**, so
+  evidence-starved clusters get an exploration bonus and clusters that carry no
+  learning signal are down-weighted (design doc, section 5.2). The design frames
+  L-task as an *artifact* problem -- head skills flooded, tail skills starved --
+  and the cross-product ``(task-cluster x artifact)`` it calls for is **not**
+  implemented: :class:`TaskCluster` has no artifact dimension, and both reference
+  runtimes register exactly one artifact, as does ``evolve()``, so there is
+  nowhere for the second axis to live yet.
 * :class:`AuditScheduler` -- L-value (signal layer): allocates the scarce oracle
   budget to high-blast-radius, high-uncertainty, low-trust diffs, and audits the
   aggregator's own merges to prevent self-pollution (design doc, section 5.3).
@@ -67,11 +72,22 @@ class TaskScheduler:
             return self._ranked()[0]
 
     def select_batch(self, k: int) -> List[TaskCluster]:
-        """Lease up to ``k`` *distinct* clusters to workers, UCB-ordered.
+        """Lease ``k`` clusters to workers, UCB-ordered, cycling if ``k`` exceeds
+        the number of clusters.
 
-        Data-parallel sharding: distinct leases guarantee coverage across the
-        task long tail while UCB still front-loads the highest-value clusters
-        (design doc, sections 3.1 and 5.2)."""
+        Data-parallel sharding: leases spread coverage across the task long tail
+        while UCB front-loads the highest-value clusters (design doc, sections 3.1
+        and 5.2).
+
+        **Not distinct beyond ``len(clusters)``.** The docstring used to promise
+        distinctness and "guaranteed coverage", which holds only while there are at
+        least ``k`` clusters -- and :meth:`TaskUniverse.clusters` drops empty hash
+        buckets, so on the default 24-keyword universe that stops being true at 12
+        workers, and by 24 workers 7 of them (29%) are handed a cluster another
+        worker already has. Those workers roll out the same deterministic tasks and
+        produce diffs that content-address to duplicates: real budget, no extra
+        evidence. :class:`~agentdescent.orchestrator.AgentDescent` now warns when it
+        has fewer clusters than workers."""
         with self._lock:
             ranked = self._ranked()
             if not ranked:
@@ -170,8 +186,14 @@ class AuditScheduler:
             return priority
 
     def force_oracle(self, blast_radius: float, artifact_id: str) -> bool:
-        """High-impact or low-trust changes are forced through the oracle."""
-        return blast_radius >= 0.5 or self._trust[artifact_id] < 0.75
+        """High-impact or low-trust changes are forced through the oracle.
+
+        "High-impact" means L1, and the boundary belongs to
+        :func:`~agentdescent.governance.classify` -- a third hand-written
+        threshold here (``>= 0.5``) meant an artifact at 0.4 was L1 by governance
+        and audited like an L2 skill: never."""
+        from .governance import FAST_MAX
+        return blast_radius > FAST_MAX or self._trust[artifact_id] < 0.75
 
     def pop(self) -> Optional[_AuditItem]:
         with self._lock:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ resistant to the three long tails.
 
 ```mermaid
 flowchart TD
-    TS["TaskScheduler (UCB)<br/>leases task-cluster × artifact"] -->|lease| W1[Worker 1]
+    TS["TaskScheduler (UCB)<br/>leases task clusters"] -->|lease| W1[Worker 1]
     TS -->|lease| W2[Worker 2]
     TS -->|lease| WN[Worker N]
     W1 -->|diff + evidence + base_version| EB
@@ -54,7 +54,7 @@ The same flow, with the design-doc section numbers annotated:
 ```
                 ┌──────────────────────────────────────────────┐
                 │            TaskScheduler (UCB)                │  §5.2
-                │   leases (task-cluster × artifact) to workers │
+                │   leases task clusters to workers              │
                 └───────────────┬──────────────────────────────┘
                      lease tasks │
         ┌─────────────┬──────────┴────────┬─────────────┐
@@ -108,8 +108,8 @@ the Aggregator calls at steps 1–3 and 5 (cheap) and at step 4 (oracle, budgete
 | **Aggregator** | [`aggregator.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/aggregator.py) | The optimizer. Buckets evidence by artifact and runs the 7-step merge pipeline. Owns the per-artifact Beta posteriors. |
 | **StalenessPolicy** | [`staleness.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/staleness.py) | Full / Guarded / Reflective. Decides `ACCEPT/REBASE/DISCARD` for a stale diff. Swappable without touching the pipeline. |
 | **Verifier** | [`verifier.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/verifier.py) | rule (cheap subset), learned (noisy + uncertainty), oracle (ground truth, budgeted). The cheap subset is **fixed for the run**, so candidates ranked against each other are always scored on the same tasks; `evolve(cheap_eval_tasks=)` sizes it. |
-| **Schedulers** | [`scheduler.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/scheduler.py) | `TaskScheduler` (UCB task leasing), `AuditScheduler` (oracle-budget allocation + trust), `ResumeQueue` (straggler records; nothing resumes them — see §4). |
-| **Governance** | [`governance.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/governance.py) | Sorts artifacts into L0/L1/L2 by blast radius; L0 is read-only to the loop; L1 serial gate. |
+| **Schedulers** | [`scheduler.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/scheduler.py) | `TaskScheduler` (UCB over task **clusters** — the design's `× artifact` axis is not implemented), `AuditScheduler` (oracle-budget allocation + trust; its priority queue has no consumer), `ResumeQueue` (straggler records; nothing resumes them — see §4). |
+| **Governance** | [`governance.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/governance.py) | `classify` is the single definition of the L1/L2 boundary (`FAST_MAX = 0.30`), used by the aggregator's staleness tolerance and the audit gate rather than re-derived. L0 is reached by name, not radius, and is read-only to the loop. `L1SerialGate` is a primitive for concurrent merging, not in the path — the shipped runtimes merge on one thread. |
 | **Worker** | [`worker.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/worker.py) | rollout + propose. Emits evidence cards; never mutates the Ledger directly. |
 | **Sync runtime** | [`orchestrator.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/orchestrator.py) | `AgentDescent`: round-barrier DP loop + fork baseline. |
 | **Async runtime** | [`async_runtime.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/async_runtime.py) | `AsyncAgentDescent`: barrier-free thread pipeline + `async_ratio` + backpressure. |
@@ -150,7 +150,8 @@ A round barrier:
 
 ```
 for round in range(R):
-    leases = scheduler.select_batch(n_workers)   # distinct clusters
+    leases = scheduler.select_batch(n_workers)   # UCB-ordered, cycling if
+                                                 # there are fewer clusters
     for worker, cluster in zip(workers, leases):
         card = worker.run(snapshot, base_version, cluster.tasks)
         aggregator.ingest(card)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -212,11 +212,16 @@ mechanism:
 - **L-task (data layer)** — Zipfian artifact triggering (head skills flooded,
   tail skills starved — a problem parameter space doesn't have, since gradients
   flow to all parameters but diffs only to triggered artifacts). Handled by
-  **UCB over (task-cluster × artifact)** and a difficulty filter (GRPO
-  zero-advantage groups) — both implemented, the latter also reachable from
+  **UCB over task clusters** and a difficulty filter (GRPO zero-advantage
+  groups) — both implemented, the latter also reachable from
   `evolve()` as [`DifficultyWeighted`](evolution.md#task-selection-which-rollout-to-spend)
-  task sampling. The design also calls for a **tail canary set** inside held-out
-  eval; that is **not implemented** — held-out is one undifferentiated split.
+  task sampling. The design's cross-product **(task-cluster × artifact)** is
+  **not implemented**: `TaskCluster` has no artifact dimension, and both reference
+  runtimes register exactly one artifact, as does `evolve()` — so the second axis
+  has nowhere to live yet, and the mechanism operates on clusters while the
+  problem statement is about artifacts. The design also calls for a **tail canary
+  set** inside held-out eval; that is **not implemented** — held-out is one
+  undifferentiated split.
 - **L-value (signal layer)** — most diffs are marginal, a few are high-value
   refactors. The **AuditScheduler** spends the scarce oracle budget by
   `blast_radius × uncertainty / trust`, where *trust* is how often the cheap layer
@@ -251,12 +256,27 @@ system):
 - **L2** is naturally isolated — only tasks that trigger an artifact are affected
   — so it merges fully async.
 - **L1** has no such isolation, so *at most one L1 diff is in evaluation at a
-  time* (the serial gate — implemented). The design's staged rollout beyond that
-  (offline counterfactual replay → canary → full) is **not implemented**.
+  time*. That holds today **by construction, not by the gate**: every merge
+  decision runs on one thread — the round barrier in `evolve()`, the single merger
+  in `async_evolve` and `AsyncAgentDescent` — so at most one diff of any layer is
+  ever in evaluation. `L1SerialGate` is the primitive that would enforce it once
+  merges run concurrently (a process or host pool); it is tested in isolation and
+  is not in the path. The design's staged rollout beyond that (offline
+  counterfactual replay → canary → full) is **not implemented**.
+- The L1/L2 boundary is `FAST_MAX = 0.30`, and `governance.classify` is the only
+  place it is defined. It used to be re-derived twice more from raw floats — the
+  aggregator's staleness tolerance at `> 0.5` and the audit gate at `>= 0.5` — so
+  an artifact at 0.4 was L1 by governance and treated as L2 by both mechanisms
+  that decide what being L1 *means*.
 - **L0** must be frozen: without it, the self-referential loop eventually
   pollutes itself (a verifier that learns to pass itself is undetectable).
   AgentDescent minimizes the frozen set to "audit + permissions", leaving the
-  verifier's learnable part in L1 under audit.
+  verifier's learnable part in L1 under audit. Unlike L1/L2, **L0 is reached by
+  name, not by blast radius** — no measurement can tell you an artifact *is* the
+  oracle, and an estimated layer is exactly what would fail to catch it. The
+  reserved names are ordinary words (`oracle`, `audit_budget`,
+  `merge_permissions`, `safety_constraints`), so `evolve(artifact_id="oracle")` is
+  refused up front with a message saying to rename it.
 
 ---
 

--- a/tests/test_layer_boundary.py
+++ b/tests/test_layer_boundary.py
@@ -1,0 +1,112 @@
+"""One definition of the L1/L2 boundary, used by everything that branches on it.
+
+`governance.classify` drew the line at `FAST_MAX = 0.30`. The aggregator's
+staleness tolerance re-derived it as `blast_radius > 0.5`, and the audit gate as
+`blast_radius >= 0.5`. So an artifact at 0.4 was **L1 by governance** -- the slow,
+conservative layer -- and treated as L2 by both mechanisms that decide what that
+means: it got the staleness tolerance meant for a cold L2 skill, and no oracle
+audit at all.
+
+`evolve()`'s own docstring papered over the gap by recommending 0.2 and 0.6, the
+two values where the thresholds happen to agree.
+"""
+
+import warnings
+
+import pytest
+
+from agentdescent.aggregator import Aggregator, AggregatorConfig
+from agentdescent.evolution import EvolvingArtifact, Task, evolve
+from agentdescent.governance import (
+    FAST_MAX, FROZEN_IDS, GovernanceError, Layer, classify,
+)
+from agentdescent.scheduler import AuditScheduler
+
+
+def _artifact(blast_radius):
+    return EvolvingArtifact("art", {}, blast_radius=blast_radius)
+
+
+class _Card:
+    class diff:
+        contract_breaking = False
+
+
+# -- the boundary is one number, in one place -----------------------------------
+
+
+@pytest.mark.parametrize("blast_radius", [0.31, 0.4, 0.5])
+def test_the_gap_between_the_thresholds_is_treated_as_l1_throughout(blast_radius):
+    """These are exactly the radii the three thresholds used to disagree about."""
+    assert classify(_artifact(blast_radius)) is Layer.L1_SLOW, "premise"
+
+    agg = Aggregator.__new__(Aggregator)
+    agg.config = AggregatorConfig(alpha_head=5, alpha_tail=1)
+    assert agg._alpha_for(_artifact(blast_radius), _Card()) == 5, (
+        "an L1 artifact was given the staleness tolerance meant for a cold L2 one")
+
+    assert AuditScheduler().force_oracle(blast_radius, "art"), (
+        "an L1 artifact was not audited; the gate used its own 0.5 threshold")
+
+
+@pytest.mark.parametrize("blast_radius", [0.0, 0.2, FAST_MAX])
+def test_l2_artifacts_keep_the_cheap_treatment(blast_radius):
+    assert classify(_artifact(blast_radius)) is Layer.L2_FAST
+    agg = Aggregator.__new__(Aggregator)
+    agg.config = AggregatorConfig(alpha_head=5, alpha_tail=1)
+    assert agg._alpha_for(_artifact(blast_radius), _Card()) == 1
+    assert not AuditScheduler().force_oracle(blast_radius, "art"), \
+        "a trusted L2 artifact should not spend oracle budget"
+
+
+def test_there_is_no_second_threshold_constant():
+    """`SLOW_MAX = 0.85` existed with a comment describing frozen-layer behaviour.
+
+    `classify` never read it, so 0.31 and 0.99 classified identically and the
+    comment documented a rule that did not exist.
+    """
+    import agentdescent.governance as gov
+    assert not hasattr(gov, "SLOW_MAX"), \
+        "a threshold nothing reads is worse than no threshold"
+
+
+# -- L0 is reached by name, and the names are ordinary words --------------------
+
+
+def test_a_reserved_name_is_refused_before_any_rollout():
+    """`oracle` is a plausible name for an evolving judge prompt.
+
+    It used to surface as a GovernanceError on the first round, naming governance
+    rather than the actual cause -- the name.
+    """
+    calls = {"n": 0}
+
+    def run(rendered, task):
+        calls["n"] += 1
+        return "x"
+
+    with pytest.raises(GovernanceError) as excinfo:
+        evolve([Task(id=str(i), prompt="q", meta={"gold": "y"}) for i in range(8)],
+               lambda t, o: 0.0, run=run, propose=lambda *a: None,
+               artifact_id="oracle", rounds=3)
+    assert calls["n"] == 0, "no rollout should run against a reserved name"
+    msg = str(excinfo.value)
+    assert "reserved" in msg and "Rename" in msg, \
+        "the error must say the problem is the name"
+
+
+@pytest.mark.parametrize("frozen_id", sorted(FROZEN_IDS))
+def test_every_frozen_id_is_refused(frozen_id):
+    with pytest.raises(GovernanceError):
+        evolve([Task(id=str(i), prompt="q", meta={"gold": "y"}) for i in range(8)],
+               lambda t, o: 0.0, run=lambda r, t: "x", propose=lambda *a: None,
+               artifact_id=frozen_id, rounds=1)
+
+
+def test_a_normal_artifact_id_is_unaffected():
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = evolve([Task(id=str(i), prompt="q", meta={"gold": "y"}) for i in range(8)],
+                     lambda t, o: 1.0, run=lambda r, t: "x", propose=lambda *a: None,
+                     artifact_id="oracle_prompt", rounds=1, held_out_frac=0.5)
+    assert res.error is None


### PR DESCRIPTION
Closes #4, closes #28.

---

## The L1/L2 boundary was defined three times, with two different numbers

| site | test | boundary |
|---|---|---|
| `governance.classify` | `blast_radius <= FAST_MAX` | **0.30** |
| `Aggregator._alpha_for` | `blast_radius > 0.5` | **0.5** |
| `AuditScheduler.force_oracle` | `blast_radius >= 0.5` | **0.5** |

So an artifact at 0.4 was **L1 by governance** — the slow, conservative layer — and treated as L2 by both mechanisms that decide what being L1 *means*: it got `alpha_tail`, the staleness tolerance for a cold L2 skill, and no oracle audit at all. `evolve()`'s docstring papered over the gap by recommending 0.2 and 0.6, the two values where the thresholds happen to agree; anything between 0.30 and 0.5 was classified one way and treated the other.

Both sites now call `classify`. That is a behaviour change for radii in (0.30, 0.5] — they now get the wider staleness tolerance and the oracle audit, which is what every description of L1 already promised.

## `SLOW_MAX` was dead code documenting behaviour that did not exist

```python
FAST_MAX = 0.30
SLOW_MAX = 0.85
# Above SLOW_MAX an artifact is a candidate for the frozen layer *only* if it is
# also declared structural (see ``FROZEN_IDS``); otherwise it stays L1.
```

`grep -rn SLOW_MAX agentdescent/` returned one hit: its own definition. `classify` never read it, so 0.31 and 0.99 classified identically. Removed — L0 is reached by id, not by radius, so one threshold is all there is.

The module docstring also claimed the layering is "*not* a hand-labelled artifact taxonomy" while `FROZEN_IDS` is literally a hardcoded id allowlist. That is now stated as the deliberate exception it should be: no measurement can tell you an artifact *is* the oracle, and an estimated layer is exactly what would fail to catch a verifier that learns to pass itself.

## A reserved name failed late and blamed the wrong thing

```python
>>> evolve(tasks, reward, run=run, propose=propose, artifact_id="oracle")
GovernanceError: oracle is L0-frozen; the evolution loop may only read it
```

`oracle` is a plausible name for an evolving judge prompt, and the error named governance rather than the actual cause — the *name*. Now refused beside the other `artifact_id` rules, before any rollout:

> `artifact_id='oracle'` is reserved for the L0 frozen layer (…), which the evolution loop may only read — these are ordinary words, so this is most likely just a name collision. Rename the artifact.

Still a `GovernanceError`: refusing to mutate L0 is the safety claim and callers are told to catch that type. Only the message and the timing change.

## `L1SerialGate` was documented as implemented; nothing wired it in

`docs/concepts.md` said *"at most one L1 diff is in evaluation at a time (the serial gate — **implemented**)"*, and `grep -rn L1SerialGate agentdescent/` found only the definition and the export.

The guarantee **does** hold — but by construction, not by the gate: every merge decision runs on one thread (the round barrier in `evolve()`, the single merger in `async_evolve` and `AsyncAgentDescent`). So the gate would be a no-op today. Documented as the primitive it is — what enforces this once merges run concurrently across processes or hosts — rather than wiring in something with no effect.

## `TaskScheduler` has no artifact dimension (#28)

Four places said **"UCB over (task-cluster × artifact)"**: both `architecture.md` diagrams, `concepts.md` §5, and the module's own docstring. `TaskCluster` has `id`, `tasks`, `recent_value`, `n_evidence`, `pass_rate` — no artifact field, and `_ranked()` scores clusters only.

The missing axis is the one L-task is *about*. From the same paragraph that claims the mechanism:

> Zipfian **artifact** triggering (head skills flooded, tail skills starved) … Handled by UCB over (task-cluster × artifact)

The exploration bonus and the down-weighting operate on task clusters, so a starved tail *artifact* gets neither. It could not be otherwise today: both reference runtimes register exactly one artifact, as does `evolve()`. Documented as not-implemented, alongside the tail canary set and partial-rollout resume — the precedent this page already sets.

### `select_batch`'s "distinct" guarantee

```python
"""Lease up to ``k`` *distinct* clusters … distinct leases guarantee coverage"""
return [ranked[i % len(ranked)] for i in range(k)]      # cycles
```

`TaskUniverse.clusters` buckets by keyword hash and drops the empty buckets, so asking for `n_workers` can return fewer. On the default 24-keyword universe:

| n_workers | non-empty clusters | workers handed a duplicate |
|---|---|---|
| 2–11 | = n_workers | 0 |
| 13 | 9 | **4** |
| 24 | 17 | **7 (29%)** |

Those workers roll out the same deterministic tasks and produce diffs that content-address to duplicates: real budget, no extra evidence. Invisible today only because every shipped configuration stops before the cliff (`run_demo` uses 6, `efficiency` sweeps 1/2/4/8 — which is also why "near-linear scaling through 8 workers" holds). The docstring is now honest and `AgentDescent.__init__` warns:

```
13 workers but only 9 non-empty task clusters, so 4 worker(s) will duplicate
another's cluster each round and add no new evidence.
```

## Tests

`tests/test_layer_boundary.py`, 13 cases: the (0.30, 0.5] gap is treated as L1 by `classify`, `_alpha_for` **and** `force_oracle`; L2 keeps the cheap treatment; `SLOW_MAX` is gone; a reserved name is refused with zero rollouts; every frozen id is refused; a normal id containing a reserved word (`oracle_prompt`) still works.

**423 passed, 1 skipped.** `mkdocs build --strict` clean.

## Docs

- `docs/concepts.md` §5 and §6 — the single boundary, L0-by-name, `L1SerialGate` as a primitive, the missing `× artifact` axis
- `docs/architecture.md` — both diagrams, the Governance and Schedulers rows, the `select_batch` pseudocode comment
- `governance.py` module docstring and constants, `TaskScheduler` docstring, `select_batch`, `force_oracle`, `_alpha_for`
- CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)