### PR TITLE
fix: the public API surface, and a version that could not drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **The published version drifted five minor releases behind the code.**
+  `__version__` said `0.7.0`; `pyproject.toml` said `0.2.0`, and the build backend
+  reads the latter -- so every wheel, the PyPI page and the README badge were
+  wrong. The version is now single-sourced from `agentdescent.__version__` via
+  `dynamic = ["version"]`, and a test refuses a static version in `pyproject.toml`.
+- **The README imported `LLMAgent` from the wrong module** (`agentdescent.agents`;
+  it lives in `agentdescent.evolution`). Found by the new docs-import test the
+  moment it was written, which is the point of it.
+- **Trust-region rejections were counted as `all-stale`.** "My reflector emits
+  500 KB values and every one is dropped" and "my lag budget is too tight" are
+  opposite fixes, and only the second had a name. New `oversized` outcome.
+
+### Added
+- **`MergeOutcome`** -- a declared vocabulary for `MergeReport.category`, the keys
+  of `result.outcomes()`. They were bare string literals written at six different
+  return sites, so learning them meant reading `aggregator.py`; nothing could
+  validate a typo, and a custom aggregator had no contract to meet. Subclasses
+  `str`, so every existing lookup, comparison and format string is unchanged.
+- **`evolve(solved_threshold=)`** and the `SOLVED` constant. `0.999` was written
+  out four times -- twice in the drivers, once in a docstring, once as
+  `DifficultyWeighted`'s default, whose own docstring says it "mirrors the engine".
+  Right for a binary scorer; for a graded one (ROUGE, an LLM judge) nothing ever
+  reaches it, so *every* rollout asks the reflector to fix an answer that scored
+  0.95 and the run reports `below-threshold` as if the reflector were at fault.
+- **`AggregatorConfig.anneal_half_life` and `accept_samples`.** `base_delta` was
+  tunable but the half-life that turns it into the actual acceptance threshold was
+  a default argument buried in `stats.annealed_delta`, unreachable from the object
+  the docs call "tuning for the reference aggregator" -- and it sets the shape of a
+  whole run (the threshold goes 0.505 at v1, 0.875 at v128, floors at 0.99).
+- **A much wider top-level API.** `tasks_from` (documented, but importable only
+  from `agentdescent.evolution`), the whole error hierarchy (`ContractError` and
+  friends -- `evolve()` tells callers to distinguish a caller bug from a backend
+  failure, and the base class was not reachable from the package that says so),
+  the extension primitives `diffs_contradict` / `fuse_diffs` / `stable_hash` /
+  `assign_key_sections`, and `GitError` / `LedgerFailure` / `FAST_MAX` /
+  `FROZEN_IDS`.
+
+### Changed
+- **`domains.router.Task` is now `RouterTask`** (`Task` kept as an alias). It
+  shadowed `agentdescent.Task` -- disjoint fields, no relationship, same name --
+  and `orchestrator.py` and `worker.py` imported the other one, so a reader
+  following `AgentDescent -> Worker -> Task` from the architecture page landed on
+  the wrong class with no signal.
+- **The docs now use the top-level API**: 53 `from agentdescent import ...`
+  against 14 submodule imports, up from 3 against 63. `evolve` was never once
+  shown as `from agentdescent import evolve`, which is why the top-level surface
+  went untested and gaps in it went unnoticed. The remaining submodule imports are
+  the deliberately module-scoped ones (`dataloader`, `rewards`, `backends`,
+  `domains.router`).
+- A new test resolves **every** `from agentdescent... import` across all 70 doc
+  code blocks. 68 of them were executed by nothing at all, so a rename, a typo or
+  an unexported name was invisible.
+
+### Fixed
 - **The DGM port ran a staged-eval rung upstream does not have.** `DGM_outer.py`
   passes exactly two subsets to each self-improve attempt -- `small` (10) and
   `medium` (50), one `test_more_threshold = 0.4` -- and `big.json` (140) belongs

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ your data, how to score it, and which model.
 
 ```python
 from agentdescent import evolve_skill
-from agentdescent.agents import openai_compatible
+from agentdescent import openai_compatible
 from agentdescent.dataloader import hf_rows
 
 rows = hf_rows("hotpotqa/hotpot_qa", "validation", config="distractor", limit=40)
@@ -94,7 +94,7 @@ it does not express.
 <summary>The same thing without the wrapper. Runnable as-is — no API key, no dependencies.</summary>
 
 ```python
-from agentdescent.evolution import Task, evolve
+from agentdescent import Task, evolve
 
 tasks = [Task(id=f"t{i}", prompt=f"item {i}") for i in range(12)]
 
@@ -118,7 +118,7 @@ Swap in a real model or agent by passing `agent=` instead of `run`/`propose` —
 they are all the same contract:
 
 ```python
-from agentdescent.agents import LLMAgent, claude, openai_compatible, claude_code
+from agentdescent import LLMAgent, claude, openai_compatible, claude_code
 
 evolve(tasks, reward, agent=LLMAgent(claude(model="claude-haiku-4-5")))
 evolve(tasks, reward, agent=LLMAgent(openai_compatible(model="deepseek-v4-flash")))
@@ -167,7 +167,7 @@ top: describe **what evolves** (a `Strategy`) and the **rules of evolution**
 (`run` / `reward` / `propose`), and it runs the parallel, merge-based loop.
 
 ```python
-from agentdescent.evolution import evolve, AppendRules
+from agentdescent import evolve, AppendRules
 
 result = evolve(
     tasks, reward,

--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -12,6 +12,8 @@ it implements.
 
 from .evolvable import (
     Contract,
+    ContractError,
+    stable_hash,
     Diff,
     EvidenceCard,
     Evolvable,
@@ -19,7 +21,9 @@ from .evolvable import (
     vv_dominates,
     vv_staleness,
 )
-from .ledger import Ledger, Snapshot, CASConflict, ContractRejected
+from .ledger import (
+    Ledger, Snapshot, CASConflict, ContractRejected, GitError, LedgerFailure,
+)
 from .verifier import ThreeLayerVerifier, VerifierBudget
 from . import backends, dataloader          # submodules: agentdescent.dataloader.hf_rows(...)
 from .dataloader import Dataset, split_dataset
@@ -33,9 +37,17 @@ from .scheduler import (
     fifo_makespan,
     lpt_schedule,
 )
-from .governance import Layer, classify, assert_mutable, GovernanceError, L1SerialGate
+from .governance import (
+    FAST_MAX, FROZEN_IDS, Layer, classify, assert_mutable, GovernanceError,
+    L1SerialGate,
+)
 from .aggregator import (
     Aggregator,
+    AggregatorContractError,
+    MergeOutcome,
+    diffs_conflict,
+    diffs_contradict,
+    fuse_diffs,
     AggregatorConfig,
     AggregatorProtocol,
     AggregatorFactory,
@@ -80,7 +92,10 @@ from .evolution import (
     KeyedRules,
     SingleSlot,
     EvolutionResult,
+    ProposalContractError,
     RewardContractError,
+    SOLVED,
+    tasks_from,
     RoundInfo,
     evolve,
     claude_agent,
@@ -98,6 +113,7 @@ from .parallel import (
     TensorParallelMerge,
     PipelineChain,
     SectionViolation,
+    assign_key_sections,
     assign_sections,
     section_of,
     shard_round_robin,
@@ -107,6 +123,8 @@ __version__ = "0.7.0"
 
 __all__ = [
     "Contract",
+    "ContractError",
+    "stable_hash",
     "Diff",
     "EvidenceCard",
     "Evolvable",
@@ -116,6 +134,8 @@ __all__ = [
     "Ledger",
     "Snapshot",
     "CASConflict",
+    "GitError",
+    "LedgerFailure",
     "ContractRejected",
     "ThreeLayerVerifier",
     "VerifierBudget",
@@ -137,12 +157,19 @@ __all__ = [
     "classify",
     "assert_mutable",
     "GovernanceError",
+    "FAST_MAX",
+    "FROZEN_IDS",
     "L1SerialGate",
     "Aggregator",
     "AggregatorConfig",
     "AggregatorProtocol",
     "AggregatorFactory",
     "MergeReport",
+    "MergeOutcome",
+    "AggregatorContractError",
+    "diffs_conflict",
+    "diffs_contradict",
+    "fuse_diffs",
     "EvidenceBuffer",
     "StaleAction",
     "StalenessPolicy",
@@ -167,6 +194,7 @@ __all__ = [
     "PipelineChain",
     "SectionViolation",
     "assign_sections",
+    "assign_key_sections",
     "section_of",
     "shard_round_robin",
     "Completion",
@@ -193,6 +221,9 @@ __all__ = [
     "SingleSlot",
     "EvolutionResult",
     "RewardContractError",
+    "ProposalContractError",
+    "SOLVED",
+    "tasks_from",
     "RoundInfo",
     "evolve",
     "async_evolve",

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import threading
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import (Callable, Deque, Dict, List, Optional, Protocol, Tuple,
                     runtime_checkable)
 
@@ -80,6 +81,50 @@ class AggregatorConfig:
     #: Real ops in the shipped ports are ~2.5k chars, so this is ~12x headroom.
     trust_region_chars: int = 32_000
     promote_after_k: int = 3        # dev->stable: regression-free ROUNDS (EMA)
+    #: Version half-life of the acceptance risk. `base_delta` is exposed but the
+    #: half-life that turns it into the actual threshold was a default argument
+    #: buried in `stats.annealed_delta`, unreachable from here or from `evolve()` --
+    #: and it sets the shape of the whole run: the threshold `P(delta>0)` must clear
+    #: goes 0.505 at v1, 0.750 at v64, 0.875 at v128, and floors at 0.99. A caller
+    #: wanting a flatter or steeper schedule had to monkeypatch the module.
+    anneal_half_life: int = 64
+    #: Monte-Carlo draws behind each acceptance decision. Also unreachable before.
+    accept_samples: int = 4000
+
+
+class MergeOutcome(str, Enum):
+    """The vocabulary of :attr:`MergeReport.category`.
+
+    ``result.outcomes()`` is the framework's primary diagnostic -- the README, the
+    quickstart and ``docs/evolution.md`` all point at it to answer "why did nothing
+    commit?" -- and its keys were bare string literals with no declared vocabulary
+    anywhere. To learn them you had to read this file and collect the sixth
+    argument of six different ``MergeReport(...)`` constructions.
+
+    Subclasses ``str``, so every existing dict key, comparison and format string
+    keeps working: ``outcomes()["below-threshold"]`` is unchanged.
+    """
+
+    #: The candidate was merged into dev.
+    COMMITTED = "committed"
+    #: Proposals reached the gate and failed to beat the baseline. The reflector is
+    #: the thing to look at.
+    BELOW_THRESHOLD = "below-threshold"
+    #: Nothing survived the staleness filter -- they never reached the gate. The
+    #: lag budget is the thing to look at.
+    ALL_STALE = "all-stale"
+    #: The diff exceeded the trust region (too many ops, or one oversized value).
+    #: Used to be folded into ``all-stale``, which pointed at the opposite fix.
+    OVERSIZED = "oversized"
+    #: The oracle overruled the cheap layer's verdict (see the audit gate).
+    ORACLE_REJECTED = "oracle-rejected"
+    #: Another writer committed first; the diff was re-filed for a later round.
+    CAS_CONFLICT = "cas-conflict"
+    #: The bucket named an artifact the ledger does not have.
+    UNKNOWN_ARTIFACT = "unknown-artifact"
+
+    def __str__(self) -> str:            # so f-strings render the value, not the name
+        return self.value
 
 
 class AggregatorContractError(ContractError, TypeError):
@@ -406,7 +451,7 @@ class Aggregator:
         for aid in set(self._survival) | set(by_id):
             rep = by_id.get(aid)
             if rep is not None and (rep.committed_version is not None
-                                    or rep.category == "oracle-rejected"):
+                                    or rep.category == MergeOutcome.ORACLE_REJECTED):
                 self._survival[aid] = 0        # changed, or measurably worse
                 continue
             self._survival[aid] += 1
@@ -445,7 +490,7 @@ class Aggregator:
         artifact = snap.get(artifact_id)
         if artifact is None:
             return MergeReport(artifact_id, None, False, len(cards), 0, 0, 0, 0.0, None,
-                               "unknown artifact", "unknown-artifact")
+                               "unknown artifact", MergeOutcome.UNKNOWN_ARTIFACT)
         assert_mutable(artifact)  # L0 guard
 
         # trust-region: reject over-large diffs up front. They were previously
@@ -467,9 +512,21 @@ class Aggregator:
         survivors, discarded = self._staleness_filter(artifact, head, cards)
         self.buffer.settle(discarded)
         if not survivors:
+            # Report the reason that dominated, rather than folding oversized
+            # diffs into the staleness count. "my reflector emits 500 KB values and
+            # every one is rejected" and "my lag budget is too tight" are opposite
+            # fixes, and the trust-region case used to be invisible in both
+            # `outcomes()` and the report.
+            if oversized and not discarded:
+                return MergeReport(artifact_id, None, False, n_considered, 0,
+                                   len(oversized), 0, 0.0, None,
+                                   f"{len(oversized)} diff(s) outside the trust "
+                                   f"region ({self.config.trust_region_ops} ops / "
+                                   f"{self.config.trust_region_chars} chars)",
+                                   MergeOutcome.OVERSIZED)
             return MergeReport(artifact_id, None, False, n_considered, 0,
                                len(discarded) + len(oversized), 0, 0.0, None,
-                               "all stale / rejected", "all-stale")
+                               "all stale / rejected", MergeOutcome.ALL_STALE)
 
         kept_cards, conflicts = self._resolve_conflicts(artifact, survivors)
         kept_diffs = [c.diff for c in kept_cards]
@@ -495,14 +552,15 @@ class Aggregator:
             if set(card.diff.ops) & set(best_diff.ops):
                 candidate_post.observe_delta(card.before_after_delta)
 
-        delta = annealed_delta(self.config.base_delta, artifact.version)
+        delta = annealed_delta(self.config.base_delta, artifact.version,
+                               half_life=self.config.anneal_half_life)
         # Seed from (version, candidate) rather than the version alone. A shared
         # seed made the ~0.003 Monte-Carlo error identical for every candidate in
         # the round, so on knife-edge cases the draw decided them as a block --
         # one stream accepted every marginal diff, another rejected all of them.
         # stable_hash keeps this reproducible across processes.
         p_improve = prob_improvement(
-            candidate_post, baseline_post,
+            candidate_post, baseline_post, samples=self.config.accept_samples,
             seed=stable_hash((artifact.version, best_diff.diff_id)) & 0x7FFFFFFF)
 
         # -- audit (section 5.3): the optimizer audits its own decision ------
@@ -535,7 +593,7 @@ class Aggregator:
                 prior.observe_delta(oracle_cand - oracle_base)
                 return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
                                    len(discarded), conflicts, p_improve, None,
-                                   "oracle rejected", "oracle-rejected")
+                                   "oracle rejected", MergeOutcome.ORACLE_REJECTED)
 
         # Not settled, unlike the CAS-conflict path below -- and the asymmetry is
         # deliberate. A CAS-conflicted diff lost a race and was never judged against
@@ -547,7 +605,7 @@ class Aggregator:
             return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
                                len(discarded), conflicts, p_improve, None,
                                f"P(delta>0)={p_improve:.2f} <= {1-delta:.2f}",
-                               "below-threshold")
+                               MergeOutcome.BELOW_THRESHOLD)
 
         # -- commit (section 4.1): CAS on dev --------------------------------
         base_vv = {artifact_id: head.get(artifact_id, 0)}
@@ -560,7 +618,7 @@ class Aggregator:
             self.buffer.settle(survivors)
             return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
                                len(discarded), conflicts, p_improve, None,
-                               "CAS conflict", "cas-conflict")
+                               "CAS conflict", MergeOutcome.CAS_CONFLICT)
 
         prior.update(True, weight=2.0)  # a committed improvement is strong evidence.
 
@@ -570,4 +628,4 @@ class Aggregator:
 
         return MergeReport(artifact_id, best_diff, fused, n_considered, len(survivors),
                            len(discarded), conflicts, p_improve, new_version,
-                           "committed", "committed")
+                           "committed", MergeOutcome.COMMITTED)

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -39,7 +39,7 @@ from typing import Callable, Dict, List, Optional
 from .evolution import (
     _safe_log,
     Agent, EvolutionResult, Propose, Reward, RoundInfo, Run, Strategy, Task, _tally,
-    _build_engine, _checked_proposal, _checked_reward,
+    SOLVED, _build_engine, _checked_proposal, _checked_reward,
 )
 from .aggregator import AggregatorConfig, check_reports
 from .evolvable import ContractError, EvidenceCard, vv_staleness
@@ -74,6 +74,7 @@ def async_evolve(
     aggregator_factory=None,
     oracle_budget: int = 200,
     cheap_eval_tasks: Optional[int] = None,
+    solved_threshold: float = SOLVED,
     shuffle: bool = False,
     seed: int = 0,
     self_verify: bool = True,
@@ -138,6 +139,9 @@ def async_evolve(
     cheap_eval_tasks:
         As in :func:`evolve`: how many held-out tasks the cheap layer scores when
         ranking candidates. ``None`` scores them all.
+    solved_threshold:
+        As in :func:`evolve`: the reward at which a task counts as solved and no
+        proposal is requested. Lower it for a graded scorer.
     shuffle, seed:
         As in :func:`evolve`: shuffle before the positional train/held-out split.
         Off by default.
@@ -250,7 +254,7 @@ def async_evolve(
                 output = eng.run(artifact.render(), task)
                 score = _checked_reward(eng.reward(task, output), task)
                 sampler.record(task.id, score)     # learn which tasks carry signal
-                if score < 0.999:
+                if score < solved_threshold:
                     proposal = _checked_proposal(
                         eng.propose(artifact.render(), task, output, score), task)
                     if proposal:

--- a/agentdescent/domains/router.py
+++ b/agentdescent/domains/router.py
@@ -29,10 +29,22 @@ from ..evolvable import Contract, Diff, EvidenceCard, stable_hash
 
 
 @dataclass(frozen=True)
-class Task:
+class RouterTask:
+    """One item of the reference domain: a text, its gold label, its keyword.
+
+    Named ``Task`` until it collided with :class:`agentdescent.evolution.Task`
+    -- ``Task(id, prompt, meta)``, the one every caller writes against. Disjoint
+    fields, no relationship, same name, and a reader following
+    ``AgentDescent -> Worker -> Task`` from the architecture page landed on this
+    one with no signal. ``Task`` remains as an alias inside this module."""
+
     text: str
     label: str
     keyword: str
+
+
+#: Back-compatible alias. Prefer :class:`RouterTask` in new code.
+Task = RouterTask
 
 
 class RouterSkill:

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -368,6 +368,18 @@ class KeyedRules:
 # healthy. Catch that at the boundary instead.
 _REWARD_TOL = 1e-6
 
+#: A reward at or above this counts as solved: the engine asks for no proposal and
+#: the task sampler counts a pass. It was written out four times -- twice in the
+#: drivers, once in `evolve`'s docstring, and once as `DifficultyWeighted`'s
+#: default, whose own docstring says it "mirrors the engine" (exactly the coupling
+#: a shared constant exists to express). Right for a binary scorer, and wrong in a
+#: way that produces no error for a graded one: a ROUGE or LLM-judge score rarely
+#: reaches 0.999, so *every* rollout requests a proposal, the reflector is asked to
+#: fix an answer that scored 0.95, and the run reports `below-threshold` -- which
+#: reads as "the reflector is useless" when the real cause is that nothing is ever
+#: recognised as solved. `evolve(solved_threshold=)` overrides it.
+SOLVED = 0.999
+
 
 class ProposalContractError(ContractError, TypeError):
     """``propose`` returned something that is not text (or ``None``).
@@ -694,6 +706,16 @@ class EvolutionResult:
         beat the baseline (the reflector is the problem). ``all-stale`` means they
         never reached it (the lag budget is). ``cas-conflict`` means workers raced.
 
+        The keys are :class:`~agentdescent.aggregator.MergeOutcome` values, which
+        subclass ``str`` -- so ``outcomes()["below-threshold"]`` works, and so does
+        ``outcomes()[MergeOutcome.BELOW_THRESHOLD]``:
+
+        ``committed`` · ``below-threshold`` · ``all-stale`` · ``oversized``
+        (outside the trust region -- a runaway reflector, which used to be counted
+        as ``all-stale`` and so pointed at the opposite fix) · ``oracle-rejected``
+        · ``cas-conflict`` · ``unknown-artifact`` · ``section-violation``
+        (tensor-parallel only).
+
         >>> result.outcomes()
         {'below-threshold': 7, 'committed': 2, 'all-stale': 1}
         """
@@ -1003,6 +1025,7 @@ def evolve(
     aggregator_factory: Optional[AggregatorFactory] = None,
     oracle_budget: int = 200,
     cheap_eval_tasks: Optional[int] = None,
+    solved_threshold: float = SOLVED,
     shuffle: bool = False,
     seed: int = 0,
     on_round: Optional[Callable[["RoundInfo"], None]] = None,
@@ -1045,6 +1068,13 @@ def evolve(
         The work the artifact is evaluated on. Split into train / held-out **by
         position** -- the last ``held_out_frac`` of the sequence is held out, in
         the order given. At least 4 are required and ids must be unique.
+    solved_threshold:
+        A reward at or above this counts as solved, so no proposal is requested
+        and the task sampler counts a pass. The default (:data:`SOLVED`, 0.999) is
+        right for a binary scorer. **Lower it for a graded one** -- a ROUGE score
+        or an LLM judge rarely reaches 0.999, so every rollout would ask the
+        reflector to "fix" an answer that scored 0.95, and the run reports
+        ``below-threshold`` as if the reflector were the problem.
     shuffle, seed:
         Shuffle ``tasks`` before that positional split. Off by default, which
         keeps a run reproducible and keeps
@@ -1056,7 +1086,7 @@ def evolve(
         ``target_reward``, ``final_reward``) would then be measured against it.
     reward:
         ``(task, output) -> [0, 1]``. Scores in ``[0, 1]``; the engine treats
-        ``>= 0.999`` as a pass (no proposal is requested).
+``>= solved_threshold`` as a pass (no proposal is requested).
     agent:
         An object with ``solve`` + ``propose``. Provide this **or** ``run`` and
         ``propose``; both signatures are checked before the first rollout.
@@ -1242,6 +1272,7 @@ def evolve(
             repo_path=repo_path, agg_config=agg_config, staleness_policy=staleness_policy,
             aggregator_factory=aggregator_factory, oracle_budget=oracle_budget,
             cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed,
+            solved_threshold=solved_threshold,
             self_verify=self_verify, task_sampler=task_sampler,
             target_reward=target_reward, patience=patience,
             max_worker_errors=max_worker_errors,
@@ -1357,7 +1388,7 @@ def evolve(
             with unit_lock:
                 ok_units[0] += 1
                 any_success[0] = True
-            if score >= 0.999:
+            if score >= solved_threshold:
                 return
             proposal = _checked_proposal(
                 propose(artifact.render(), task, output, score), task)

--- a/agentdescent/sampling.py
+++ b/agentdescent/sampling.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import math
 import threading
 from collections import defaultdict
-from typing import Dict, Protocol, Sequence, Tuple, runtime_checkable
+from typing import Dict, Optional, Protocol, Sequence, Tuple, runtime_checkable
 
 
 @runtime_checkable
@@ -94,10 +94,14 @@ class DifficultyWeighted:
 
     name = "difficulty-weighted"
 
-    def __init__(self, c: float = 0.2, pass_threshold: float = 0.999,
+    def __init__(self, c: float = 0.2, pass_threshold: Optional[float] = None,
                  prior: float = 0.5) -> None:
         self.c = c
-        self.pass_threshold = pass_threshold
+        # Defaults to the engine's own SOLVED rather than repeating the
+        # literal: the docstring says this 'mirrors the engine', which is
+        # exactly the coupling a shared constant should carry.
+        from .evolution import SOLVED
+        self.pass_threshold = SOLVED if pass_threshold is None else pass_threshold
         self.prior = prior
         # task_id -> (passes, trials); untried tasks fall back to the prior.
         self._stats: Dict[str, Tuple[float, float]] = defaultdict(lambda: (0.0, 0.0))

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -21,7 +21,7 @@ completion into whatever task interface they need.
 ## Adapters
 
 ```python
-from agentdescent.agents import claude, from_callable, echo, with_retries
+from agentdescent import claude, from_callable, echo, with_retries
 
 # Claude (needs: pip install anthropic + credentials / `ant auth login`)
 model = claude(model="claude-opus-4-8")           # or claude-haiku-4-5 for cheap runs
@@ -71,7 +71,7 @@ A `Completion` is `prompt -> text`, so the token counts the providers *do* retur
 would be thrown away at the adapter boundary. Pass a `Usage` and they are kept:
 
 ```python
-from agentdescent.agents import Usage, openai_compatible, metered
+from agentdescent import Usage, openai_compatible, metered
 
 usage = Usage()
 model = openai_compatible(model="deepseek-v4-flash", usage=usage)   # or claude(usage=usage)
@@ -104,7 +104,7 @@ def openai_completion(prompt: str) -> str:
         model="gpt-...", messages=[{"role": "user", "content": prompt}])
     return resp.choices[0].message.content
 
-from agentdescent.agents import from_callable
+from agentdescent import from_callable
 model = from_callable(openai_completion)
 ```
 
@@ -113,8 +113,8 @@ model = from_callable(openai_completion)
 `agentdescent.evolution` consumes a completion through `LLMAgent`:
 
 ```python
-from agentdescent.agents import claude
-from agentdescent.evolution import LLMAgent
+from agentdescent import claude
+from agentdescent import LLMAgent
 
 agent = LLMAgent(claude(model="claude-haiku-4-5"))
 ```
@@ -130,7 +130,7 @@ contract is identical**: text in, text out. So they are all `Completion`s, and
 everything that takes a completion takes all of them with no special-casing:
 
 ```python
-from agentdescent.agents import claude, openai_compatible, claude_code, codex, cli_agent
+from agentdescent import claude, openai_compatible, claude_code, codex, cli_agent
 from agentdescent.backends import openhands
 
 claude(model="claude-haiku-4-5")                    # API model
@@ -167,7 +167,7 @@ Feature-detect it rather than assuming — plain API models deliberately do not
 implement it:
 
 ```python
-from agentdescent.agents import WorkspaceAgent
+from agentdescent import WorkspaceAgent
 
 if isinstance(agent, WorkspaceAgent):
     answer = agent.in_workspace(staged_dir)(prompt)   # it can grep real files

--- a/docs/aggregator.md
+++ b/docs/aggregator.md
@@ -35,7 +35,7 @@ Deep dive on the *why*: [concepts §4](concepts.md#4-the-aggregator-a-discrete-s
 Keep the reference pipeline, change its knobs:
 
 ```python
-from agentdescent.aggregator import AggregatorConfig
+from agentdescent import AggregatorConfig
 
 evolve(tasks, reward, agent=agent, agg_config=AggregatorConfig(
     batch_trigger=2,      # fire a merge once this many proposals collect for an artifact
@@ -55,6 +55,24 @@ evolve(tasks, reward, agent=agent, agg_config=AggregatorConfig(
 | `alpha_head` / `alpha_tail` | staleness tolerance `α` (hot vs cold artifacts) |
 | `trust_region_ops` | diff-size cap (the trust region) |
 | `promote_after_k` | dev→stable after this many regression-free rounds (EMA) |
+| `anneal_half_life` | how fast the acceptance threshold tightens with version |
+| `accept_samples` | Monte-Carlo draws behind each acceptance decision |
+
+!!! note "`anneal_half_life` sets the shape of a long run"
+    `base_delta` was exposed; the half-life that turns it into the actual
+    threshold was a default argument inside `stats.annealed_delta`, reachable from
+    nothing a caller touches. It decides how quickly committing gets harder:
+
+    | artifact version | `P(Δ>0)` must exceed |
+    |---|---|
+    | 1 | 0.505 |
+    | 64 | 0.750 |
+    | 128 | 0.875 |
+    | 256 | 0.969 |
+    | 400+ | 0.990 (floor) |
+
+    Version counts *commits*, so a run with many small accepted diffs reaches the
+    floor much sooner than one with a few large ones.
 
 !!! tip "Making the cheap layer actually cheap — `evolve(cheap_eval_tasks=)`"
     The aggregator scores candidates twice for two different reasons, and only one
@@ -88,8 +106,8 @@ contract is two methods:
 
 ```python
 from typing import Protocol, List
-from agentdescent.evolvable import EvidenceCard
-from agentdescent.aggregator import MergeReport
+from agentdescent import EvidenceCard
+from agentdescent import MergeReport
 
 class AggregatorProtocol(Protocol):
     def ingest(self, card: EvidenceCard) -> None: ...     # a worker's diff + evidence
@@ -114,7 +132,7 @@ deps it owns — `(ledger, verifier, audit, config, staleness_policy)` — and
 returns any `AggregatorProtocol`:
 
 ```python
-from agentdescent.aggregator import Aggregator
+from agentdescent import Aggregator
 
 class StrictAggregator(Aggregator):
     def _tournament(self, artifact, diffs):

--- a/docs/duration-scheduling.md
+++ b/docs/duration-scheduling.md
@@ -25,7 +25,7 @@ least squares, as real rollout durations arrive — the constant isn't known a
 priori, so it calibrates itself:
 
 ```python
-from agentdescent.scheduler import DurationEstimator
+from agentdescent import DurationEstimator
 
 est = DurationEstimator()
 est.observe(cost=len(task.prompt), seconds=measured)   # after each rollout
@@ -52,7 +52,7 @@ Given a batch of tasks with estimated durations, dispatch the **longest first**
 *early* keeps one long rollout from defining the whole batch's wall-clock:
 
 ```python
-from agentdescent.scheduler import lpt_schedule, fifo_makespan
+from agentdescent import lpt_schedule, fifo_makespan
 
 weights = [est.estimate(len(t.prompt)) for t in tasks]
 assignment, makespan = lpt_schedule(weights, n_workers)   # near-optimal
@@ -83,8 +83,8 @@ that overruns `duration_timeout_factor × its estimate`** to the `ResumeQueue`
 (partial rollout) instead of letting it block a worker.
 
 ```python
-from agentdescent.async_runtime import AsyncAgentDescent, AsyncConfig
-from agentdescent.scheduler import DurationEstimator
+from agentdescent import AsyncAgentDescent, AsyncConfig
+from agentdescent import DurationEstimator
 
 sys = AsyncAgentDescent(repo, universe,
                      config=AsyncConfig(duration_timeout_factor=3.0),

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -6,8 +6,8 @@ evolves* and *the rules of evolution*, and it runs the parallel, merge-based loo
 is a **plug-in to a single `evolve()` parameter** — this page is the map.
 
 ```python
-from agentdescent.agents import claude
-from agentdescent.evolution import evolve, LLMAgent
+from agentdescent import claude
+from agentdescent import evolve, LLMAgent
 
 result = evolve(
     tasks,                                   # what to work on
@@ -27,8 +27,8 @@ agent, make it better". That needs three lines: adapt it, pick something to
 reflect with, say what evolves.
 
 ```python
-from agentdescent.agents import claude
-from agentdescent.evolution import SingleSlot, evolve, reflector
+from agentdescent import claude
+from agentdescent import SingleSlot, evolve, reflector
 
 def my_agent(system_prompt, question):        # whatever you already have
     ...
@@ -125,8 +125,8 @@ provides the provider-agnostic **completion** (`prompt -> text`); `LLMAgent`
 adapts a completion into the two-method actor.
 
 ```python
-from agentdescent.agents import claude, openai_compatible, from_callable
-from agentdescent.evolution import LLMAgent
+from agentdescent import claude, openai_compatible, from_callable
+from agentdescent import LLMAgent
 
 evolve(tasks, reward, agent=LLMAgent(claude(model="claude-haiku-4-5")))        # Claude
 evolve(tasks, reward, agent=LLMAgent(openai_compatible(model="glm-4.6")))      # GLM / OpenAI-style
@@ -168,7 +168,7 @@ aggregator resolves conflicts and fusion over.
     where you interpolate it.
 
 ```python
-from agentdescent.evolution import AppendRules, KeyedRules
+from agentdescent import AppendRules, KeyedRules
 
 evolve(tasks, reward, agent=agent, strategy=AppendRules())                       # default
 evolve(tasks, reward, agent=agent, strategy=KeyedRules(categories=["route","fmt"]))
@@ -183,7 +183,7 @@ evolve(tasks, reward, agent=agent, strategy=KeyedRules(categories=["route","fmt"
 Write your own by implementing three methods (`initial` / `render` / `to_diff`):
 
 ```python
-from agentdescent.evolvable import Diff
+from agentdescent import Diff
 
 class OneValue:                       # this is `SingleSlot`, written out longhand
     def initial(self): return {}
@@ -220,7 +220,7 @@ each is a real `Strategy` you can read and reuse:
 [`agentdescent.parallel`](parallelism.md).
 
 ```python
-from agentdescent.parallel import DataParallel, TensorParallel
+from agentdescent import DataParallel, TensorParallel
 
 evolve(tasks, reward, agent=agent, parallel=DataParallel())                # default (shard tasks)
 evolve(tasks, reward, agent=agent,                                         # disjoint sections
@@ -243,7 +243,7 @@ attribution live in `agentdescent.parallel.PipelineChain`.
 Or your own — implement `plan(n_workers, round_index, keys) -> [WorkUnit]`:
 
 ```python
-from agentdescent.parallel import WorkUnit
+from agentdescent import WorkUnit
 
 class Blocks:
     name = "block"
@@ -270,7 +270,7 @@ proposal, so no diff. The same is true of a task it can *never* solve. Only task
 somewhere in between carry a usable gradient (the GRPO zero-advantage argument).
 
 ```python
-from agentdescent.sampling import DifficultyWeighted, RoundRobin
+from agentdescent import DifficultyWeighted, RoundRobin
 
 evolve(tasks, reward, agent=agent, task_sampler=RoundRobin())          # default
 evolve(tasks, reward, agent=agent, task_sampler=DifficultyWeighted())  # focus the budget
@@ -344,7 +344,7 @@ resolution → fusion → statistical acceptance → transactional commit). `agg
 tunes the reference pipeline; `aggregator_factory` swaps in your own.
 
 ```python
-from agentdescent.aggregator import AggregatorConfig, Aggregator
+from agentdescent import AggregatorConfig, Aggregator
 
 # tune: keep the pipeline, change the knobs
 evolve(tasks, reward, agent=agent,
@@ -371,7 +371,7 @@ aggregator: **[the aggregator page](aggregator.md)**.
 *Module:* the Full / Guarded / Reflective policies.
 
 ```python
-from agentdescent.staleness import get_policy
+from agentdescent import get_policy
 
 evolve(tasks, reward, agent=agent, staleness_policy=get_policy("reflective"))
 ```
@@ -615,9 +615,9 @@ The one complete, runnable example threads every block above on a real dataset
 with a real LLM:
 
 ```python
-from agentdescent.agents import claude
-from agentdescent.evolution import evolve, LLMAgent, AppendRules
-from agentdescent.parallel import DataParallel
+from agentdescent import claude
+from agentdescent import evolve, LLMAgent, AppendRules
+from agentdescent import DataParallel
 
 result = evolve(
     tasks, reward,

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ Have a dataset? That is the whole input.
 
 ```python
 from agentdescent import evolve_skill
-from agentdescent.agents import openai_compatible
+from agentdescent import openai_compatible
 from agentdescent.dataloader import hf_rows
 
 rows = hf_rows("hotpotqa/hotpot_qa", "validation", config="distractor", limit=40)

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -33,7 +33,7 @@ what?
 
 ```python
 from typing import Protocol, Sequence, List
-from agentdescent.parallel import WorkUnit
+from agentdescent import WorkUnit
 
 class ParallelStrategy(Protocol):
     name: str
@@ -61,7 +61,7 @@ PP/TP, which stage/section) a worker owns that round.
   own section.
 
 ```python
-from agentdescent.parallel import DataParallel, TensorParallel
+from agentdescent import DataParallel, TensorParallel
 
 strategy = TensorParallel(n_sections=4, keys=CATEGORIES, route=category_of)
 plan = strategy.plan(n_workers=4, round_index=0, keys=task_ids)   # TASK ids
@@ -95,7 +95,7 @@ merge a conflict-free union.
 Implement `plan` and you have a new parallelism method — no other change:
 
 ```python
-from agentdescent.parallel import WorkUnit
+from agentdescent import WorkUnit
 
 class BlockParallel:
     """Give each worker a contiguous block of the key-space (good locality)."""

--- a/docs/quickstart-skill.md
+++ b/docs/quickstart-skill.md
@@ -16,7 +16,7 @@ every time.
 
 ```python
 from agentdescent import evolve_skill
-from agentdescent.agents import openai_compatible
+from agentdescent import openai_compatible
 from agentdescent.dataloader import hf_rows
 
 rows = hf_rows("hotpotqa/hotpot_qa", "validation", config="distractor", limit=40)
@@ -119,7 +119,7 @@ result = evolve_skill(rows, model=model, prompt="question", gold="answer",
 The two layers underneath are public, and useful on their own:
 
 ```python
-from agentdescent.evolution import tasks_from
+from agentdescent import tasks_from
 from agentdescent.rewards import last_number
 
 tasks = tasks_from(rows, prompt="question", gold="answer", difficulty="level")

--- a/docs/skill-evolution.md
+++ b/docs/skill-evolution.md
@@ -15,9 +15,9 @@ Source:
 [`examples/skill_evolution.py`](https://github.com/Birfy/agentdescent/blob/main/examples/skill_evolution.py).
 
 ```python
-from agentdescent.agents import claude
-from agentdescent.evolution import evolve, LLMAgent, AppendRules
-from agentdescent.parallel import DataParallel
+from agentdescent import claude
+from agentdescent import evolve, LLMAgent, AppendRules
+from agentdescent import DataParallel
 
 result = evolve(
     tasks, reward,                                   # your dataset + scorer

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,7 +107,7 @@ those experiments, not to evolve your own artifact.
 ```python
 import tempfile
 from agentdescent.domains.router import make_task_universe
-from agentdescent.orchestrator import AgentDescent
+from agentdescent import AgentDescent
 
 universe = make_task_universe(seed=7)
 with tempfile.TemporaryDirectory() as repo:
@@ -118,9 +118,9 @@ with tempfile.TemporaryDirectory() as repo:
 
 ```python
 import tempfile
-from agentdescent.async_runtime import AsyncAgentDescent, AsyncConfig
+from agentdescent import AsyncAgentDescent, AsyncConfig
 from agentdescent.domains.router import make_task_universe
-from agentdescent.staleness import get_policy
+from agentdescent import get_policy
 
 universe = make_task_universe(seed=7)
 cfg = AsyncConfig(n_workers=6, async_ratio=4, target_accuracy=0.98, max_seconds=15.0)
@@ -166,7 +166,7 @@ with tempfile.TemporaryDirectory() as repo:
 ### Staleness policy
 
 ```python
-from agentdescent.staleness import get_policy
+from agentdescent import get_policy
 get_policy("full")        # accept stale diffs directly
 get_policy("guarded")     # version-gated (default)
 get_policy("reflective")  # always rebase + re-verify
@@ -185,7 +185,7 @@ Implement the protocol from `agentdescent/evolvable.py`
 ([reference: `RouterSkill`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/domains/router.py)):
 
 ```python
-from agentdescent.evolvable import Contract, Diff, EvidenceCard
+from agentdescent import Contract, Diff, EvidenceCard
 
 class MyArtifact:
     def __init__(self, id, state, version=1, blast_radius=0.2):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentdescent"
-version = "0.2.0"
+dynamic = ["version"]
 description = "Gradient descent, but the parameters are agents — a parallel, asynchronous framework for self-evolving agents (skills, prompts, harnesses)"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -24,6 +24,12 @@ docs = ["mkdocs-material>=9.5"]
 
 [project.urls]
 Homepage = "https://github.com/Birfy/agentdescent"
+
+[tool.setuptools.dynamic]
+# Single-sourced: agentdescent/__init__.py is the only place the version
+# lives. It used to be duplicated here, and drifted -- __version__ said
+# 0.7.0 while every wheel, the PyPI page and the README badge said 0.2.0.
+version = { attr = "agentdescent.__version__" }
 
 [tool.setuptools.packages.find]
 include = ["agentdescent*"]

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -1,0 +1,158 @@
+"""What `import agentdescent` gives you, and whether the docs agree with it.
+
+`__init__.py` curates a large `__all__`, and the project's own documentation
+almost never used it -- 63 submodule imports against 3 top-level ones, with
+`evolve` never once shown as `from agentdescent import evolve`. So the top-level
+surface was untested by usage, and it showed: a documented helper missing from it
+(`tasks_from`, which the quickstart tells you to import from
+`agentdescent.evolution`), the whole `ContractError` hierarchy unreachable
+although `evolve`'s docstring tells callers to distinguish it from a backend
+failure, and two classes exported that cannot be constructed from the public API.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+import agentdescent
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_every_exported_name_resolves():
+    """The cheapest possible guard, and it did not exist."""
+    missing = [n for n in agentdescent.__all__ if not hasattr(agentdescent, n)]
+    assert not missing, f"__all__ names nothing can import: {missing}"
+
+
+def test_all_is_sorted_free_of_duplicates():
+    dupes = {n for n in agentdescent.__all__ if agentdescent.__all__.count(n) > 1}
+    assert not dupes, f"duplicated in __all__: {sorted(dupes)}"
+
+
+@pytest.mark.parametrize("name", [
+    "evolve", "async_evolve", "evolve_skill", "Task", "tasks_from",
+    "AppendRules", "KeyedRules", "SingleSlot", "EvolutionResult",
+])
+def test_the_things_a_first_run_needs_are_top_level(name):
+    """`tasks_from` was documented as `from agentdescent.evolution import ...`.
+
+    Everything else the quickstart uses was already top-level, so importing the
+    one helper from a submodule made the module layout look like public API.
+    """
+    assert hasattr(agentdescent, name)
+
+
+@pytest.mark.parametrize("name", [
+    "ContractError", "RewardContractError", "ProposalContractError",
+    "AggregatorContractError", "GovernanceError", "GitError", "CASConflict",
+])
+def test_the_error_hierarchy_is_importable(name):
+    """`evolve()` tells callers to tell a *caller* bug from a *backend* failure.
+
+    `ContractError` is the base of that hierarchy and was not reachable from the
+    package that documents it, so `except agentdescent.ContractError:` did not work.
+    """
+    assert hasattr(agentdescent, name)
+
+
+@pytest.mark.parametrize("name", ["diffs_contradict", "fuse_diffs", "stable_hash",
+                                  "assign_key_sections", "MergeOutcome"])
+def test_the_extension_primitives_are_importable(name):
+    """`aggregator_factory=` is advertised as the main extension point, and
+    `diffs_contradict` / `fuse_diffs` are documented as its primitives."""
+    assert hasattr(agentdescent, name)
+
+
+# -- the two Task classes -------------------------------------------------------
+
+
+def test_the_reference_domain_no_longer_shadows_the_engine_s_task():
+    """`Task(id, prompt, meta)` vs `Task(text, label, keyword)` -- disjoint
+    fields, no relationship, same name, and `orchestrator`/`worker` imported the
+    other one."""
+    from agentdescent.domains.router import RouterTask
+
+    assert agentdescent.Task is not RouterTask
+    assert {f for f in RouterTask.__dataclass_fields__} == {"text", "label", "keyword"}
+    assert "id" in agentdescent.Task.__dataclass_fields__
+
+
+def test_the_old_router_task_name_still_works():
+    """An alias, so nothing that imported it breaks."""
+    from agentdescent.domains.router import RouterTask, Task as LegacyTask
+
+    assert LegacyTask is RouterTask
+
+
+# -- the merge-outcome vocabulary (#8) ------------------------------------------
+
+
+def test_merge_outcomes_are_str_so_existing_lookups_keep_working():
+    """`outcomes()["below-threshold"]` must not break."""
+    assert agentdescent.MergeOutcome.BELOW_THRESHOLD == "below-threshold"
+    assert f"{agentdescent.MergeOutcome.COMMITTED}" == "committed"
+    assert {agentdescent.MergeOutcome.COMMITTED: 1}["committed"] == 1
+
+
+def test_every_category_the_aggregator_emits_is_in_the_vocabulary():
+    """The keys of `result.outcomes()` were bare literals written at six
+    different return sites; to learn them you had to read the file."""
+    src = (ROOT / "agentdescent" / "aggregator.py").read_text()
+    emitted = set(re.findall(r"MergeOutcome\.([A-Z_]+)", src))
+    declared = {m.name for m in agentdescent.MergeOutcome}
+    assert emitted <= declared, f"emitted but undeclared: {emitted - declared}"
+    assert "OVERSIZED" in declared, \
+        "trust-region rejections were folded into all-stale, which points at the opposite fix"
+
+
+# -- the docs must import what exists (#20) -------------------------------------
+
+
+def _doc_imports():
+    """Every `from agentdescent... import a, b` across the docs and README."""
+    for path in sorted(list((ROOT / "docs").glob("*.md")) + [ROOT / "README.md"]):
+        for block in re.findall(r"```python\n(.*?)```", path.read_text(), re.DOTALL):
+            for module, names in re.findall(
+                    r"^from (agentdescent[\w.]*) import ([^\n(]+)$", block, re.M):
+                for name in names.split("#")[0].split(","):
+                    name = name.strip()
+                    if name and not name.startswith("*"):
+                        yield path.name, module, name
+
+
+def test_every_name_the_docs_import_actually_exists():
+    """68 of 70 code blocks were never executed by anything.
+
+    A rename, a typo or an unexported name in any of them was invisible. This
+    resolves the imports without needing credentials or a network.
+    """
+    import importlib
+
+    broken = []
+    for doc, module, name in _doc_imports():
+        try:
+            if not hasattr(importlib.import_module(module), name):
+                broken.append(f"{doc}: {module}.{name}")
+        except ImportError as e:
+            broken.append(f"{doc}: cannot import {module} ({e})")
+    assert not broken, "docs import names that do not exist:\n  " + "\n  ".join(broken)
+
+
+def test_the_docs_import_something_at_all():
+    """Guard the premise: the check above is only worth anything if it has input."""
+    assert len(list(_doc_imports())) > 30
+
+
+# -- the version is single-sourced (#10) ----------------------------------------
+
+
+def test_the_packaged_version_cannot_drift_from_the_module():
+    """`__version__` said 0.7.0 while `pyproject.toml` published 0.2.0, so every
+    wheel, the PyPI page and the README badge were five minor versions behind."""
+    cfg = (ROOT / "pyproject.toml").read_text()
+    assert 'dynamic = ["version"]' in cfg, "the version must not be duplicated"
+    assert 'attr = "agentdescent.__version__"' in cfg
+    assert not re.search(r'^version\s*=\s*"', cfg, re.M), \
+        "a static version in pyproject.toml is what drifted"


### PR DESCRIPTION
Closes #6, closes #10, closes #8, closes #15, closes #20.

---

## The published version was five minor releases behind the code (#10)

```
$ python -c "import agentdescent; print(agentdescent.__version__)"
0.7.0
$ grep '^version' pyproject.toml
version = "0.2.0"
```

The build backend reads `pyproject.toml`, so every wheel, the PyPI page and the README badge said `0.2.0`. Single-sourced now:

```toml
dynamic = ["version"]

[tool.setuptools.dynamic]
version = { attr = "agentdescent.__version__" }
```

`python -m build --wheel` produces `agentdescent-0.7.0-py3-none-any.whl`, and a test refuses a static `version =` in `pyproject.toml`.

## `result.outcomes()` had no declared vocabulary (#8)

It is the framework's primary diagnostic — the README, the quickstart and `docs/evolution.md` all point at it to answer "why did nothing commit?" — and its keys were bare string literals written at six different `MergeReport(...)` return sites. To learn them you read `aggregator.py`; nothing could validate a typo; `aggregator_factory=` is advertised as the main extension point and a custom aggregator had no contract to meet.

`MergeOutcome(str, Enum)` declares all of them. Subclassing `str` means `outcomes()["below-threshold"]`, `f"{outcome}"` and dict keys are all unchanged.

It also surfaced a seventh outcome that was being hidden: **trust-region rejections were folded into `all-stale`**. "My reflector emits 500 KB values and every one is dropped" and "my lag budget is too tight" need opposite fixes, and only the second had a name. Now `oversized`.

## Constants that decided the run and could not be set (#15)

**`0.999` was written out four times** — twice in the drivers, once in `evolve`'s docstring, and once as `DifficultyWeighted`'s default, whose own docstring says it *"mirrors the engine"* (exactly the coupling a shared constant exists to express). It is right for a binary scorer and silently wrong for a graded one: a ROUGE score or an LLM judge rarely reaches 0.999, so *every* rollout requests a proposal, the reflector is asked to "fix" an answer that scored 0.95, and the run reports `below-threshold` — which reads as "the reflector is useless" when nothing was ever recognised as solved. Now `SOLVED` in one place, with `evolve(solved_threshold=)`.

**`anneal_half_life` and `accept_samples`** were default arguments inside `stats.annealed_delta` / `prob_improvement`, reachable from nothing a caller touches — though the half-life sets the shape of a whole run:

| version | `P(Δ>0)` must exceed |
|---|---|
| 1 | 0.505 |
| 128 | 0.875 |
| 400+ | 0.990 (floor) |

Version counts *commits*, so a run with many small accepted diffs hits the floor far sooner than one with a few large ones. Both are now `AggregatorConfig` fields.

## The public surface (#6)

`__init__.py` curated a large `__all__` that the project's own docs never used — **3 top-level imports against 63 submodule ones**, and `evolve` was never once shown as `from agentdescent import evolve`. So the surface went untested by usage, and it showed. Now exported:

- **`tasks_from`** — documented in the quickstart, importable only from `agentdescent.evolution`
- **the error hierarchy** — `ContractError`, `ProposalContractError`, `AggregatorContractError`, `GitError`, `LedgerFailure`. `evolve()`'s docstring tells callers to distinguish a *caller* bug from a *backend* failure, and the base class of that hierarchy was not reachable from the package that says so, so `except agentdescent.ContractError:` did not work
- **the extension primitives** the aggregator docs call primitives — `diffs_contradict`, `fuse_diffs`, `stable_hash`, `assign_key_sections`, plus `FAST_MAX` / `FROZEN_IDS`

**`domains.router.Task` → `RouterTask`** (alias kept). It shadowed `agentdescent.Task` — `Task(text, label, keyword)` vs `Task(id, prompt, meta)`, disjoint fields, no relationship, same name — and `orchestrator.py` and `worker.py` import the router one, so a reader following `AgentDescent → Worker → Task` from the architecture page landed on the wrong class with no signal.

## The docs now use it (#20)

**53 top-level imports against 14**, up from 3 against 63. The 14 that remain are the deliberately module-scoped ones (`dataloader`, `rewards`, `backends`, `domains.router`), which their own module docstrings present that way.

More useful than the rewrite: a test that **resolves every `from agentdescent... import` across all 70 doc code blocks**. 68 of those blocks are executed by nothing, so a rename, a typo or an unexported name was invisible. It earned its keep on the first run:

```
AssertionError: docs import names that do not exist:
  README.md: agentdescent.agents.LLMAgent
```

`LLMAgent` lives in `agentdescent.evolution`. That snippet has presumably never worked.

## Tests

`tests/test_public_surface.py`, 30 cases: every `__all__` name resolves and none is duplicated; the quickstart's names are top-level; the error hierarchy and extension primitives are importable; the two `Task` classes are distinct and the old name still aliases; `MergeOutcome` behaves as `str` and covers every category the aggregator emits; every doc import resolves; the version cannot drift.

**464 passed, 1 skipped.** `mkdocs build --strict` clean.

## Docs

- `docs/aggregator.md` — the two new config fields, with the annealing schedule table
- `EvolutionResult.outcomes()` — the full vocabulary, including `oversized` and why it was worth splitting out
- `evolve(solved_threshold=)`, `SOLVED`, `RouterTask`
- README import fix; import style across all doc pages
- CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)