### PR TITLE
test: experiments that measure something, and tests that can fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **The docstring-completeness guard was a substring match.** `test_api_docs.py`
+  exists to keep `evolve` / `async_evolve` honest as their signatures grow, and
+  checked `p not in doc` against the *whole* docstring. Delete `async_evolve`'s
+  entire Parameters section and **20 of its 27 parameters still passed**, because
+  its opening paragraph names them in prose; `evolve` kept 11 of 30 the same way.
+  Substrings made it worse -- `run` matches "running", `agent` matches "agents",
+  `parallel` matches "parallelism". It now parses numpydoc entries, plus a
+  meta-test that fails if stripping the section leaves anything looking
+  documented. `async_evolve`'s 15 cross-referenced parameters got a real entry
+  rather than relying on the prose.
+
+### Changed
+- **The six custom optimizers in `examples/` take a lock.** They were safe only
+  because every `ingest` happened to be a single `list.append`, atomic under the
+  GIL -- which stops holding the moment `ingest` grows a counter or a dedup check,
+  and is already not enough when `evolve(round_timeout=)` abandons a straggler
+  that keeps running and can `ingest` mid-drain. `AggregatorProtocol` now states
+  the contract it always relied on: `ingest` may be called from many worker
+  threads, `step` from one, guard anything both touch.
+
+### Fixed
 - **The published version drifted five minor releases behind the code.**
   `__version__` said `0.7.0`; `pyproject.toml` said `0.2.0`, and the build backend
   reads the latter -- so every wheel, the PyPI page and the README badge were

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -52,7 +52,16 @@ class AggregatorProtocol(Protocol):
     An aggregator is the framework's *optimizer*: it receives evidence cards
     (diffs + evidence) and, on ``step()``, decides what to merge into the shared
     ledger. Implement these two methods (see :class:`Aggregator` for the
-    reference 7-stage pipeline) to swap in your own merge/acceptance logic."""
+    reference 7-stage pipeline) to swap in your own merge/acceptance logic.
+
+    **Threading contract.** ``ingest`` may be called concurrently from many worker
+    threads; ``step`` is called from one. Guard anything both touch. This was
+    unwritten, and the shipped examples all relied on ``list.append`` happening to
+    be atomic under the GIL -- which stops being true the moment ``ingest`` grows a
+    counter, a dict update or a dedup check, and is already not enough when
+    ``evolve(round_timeout=)`` abandons a straggler that keeps running and can
+    ``ingest`` in the middle of a ``step``'s drain. :class:`EvidenceBuffer` is the
+    worked example."""
 
     def ingest(self, card: EvidenceCard) -> None: ...
 

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -102,6 +102,10 @@ def async_evolve(
 
     Parameters
     ----------
+    tasks, reward, agent, run, propose, strategy, initial_state, blast_radius, artifact_id, held_out_frac, repo_path, agg_config, staleness_policy, aggregator_factory, oracle_budget:
+        Exactly as in :func:`~agentdescent.evolution.evolve`, which documents them.
+        (Listed rather than left to the paragraph above: a completeness check that
+        reads prose cannot tell a documented parameter from a mentioned one.)
     n_workers:
         Producer threads (``>= 1``). The train tasks are sharded round-robin
         across them; a worker with an empty shard is not started.

--- a/examples/ace_context_evolution.py
+++ b/examples/ace_context_evolution.py
@@ -44,6 +44,8 @@ AppWorld (a heavy simulator) which this dependency-free example omits.
 
 from __future__ import annotations
 
+import threading
+
 import argparse
 import re
 import sys

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -500,6 +500,7 @@ class MetaSearchAggregator(AggregatorProtocol):
         self.aid = artifact_id
         self.boot_seed = boot_seed
         self.cards: List[EvidenceCard] = []
+        self._lock = threading.Lock()   # ingest: workers; step: one thread
         self._seeded = False
 
     def _fitness(self, head, design: str) -> float:
@@ -519,7 +520,9 @@ class MetaSearchAggregator(AggregatorProtocol):
         return bootstrap_ci(correct, seed=self.boot_seed)[0]
 
     def ingest(self, card: EvidenceCard) -> None:
-        self.cards.append(card)
+        # ingest runs on worker threads, step on one: see AggregatorProtocol.
+        with self._lock:
+            self.cards.append(card)
 
     def _record(self, name, thought, program, fitness):
         agent = {"name": name, "thought": thought, "program": program, "fitness": fitness}
@@ -541,7 +544,8 @@ class MetaSearchAggregator(AggregatorProtocol):
             self.ctx.seed_fitness = self.ctx.best_fitness
             self._seeded = True
 
-        cards, self.cards = self.cards, []
+        with self._lock:
+            cards, self.cards = self.cards, []
         for card in cards:
             design = card.diff.ops["design"]
             self._record(card.diff.ops.get("name", "agent"),

--- a/examples/dgm_self_improve.py
+++ b/examples/dgm_self_improve.py
@@ -51,6 +51,8 @@ escalation, keep-all) is therefore fully runnable and testable offline; the
 
 from __future__ import annotations
 
+import threading
+
 import argparse
 import hashlib
 import math
@@ -290,6 +292,7 @@ class DGMArchiveAggregator(AggregatorProtocol):
         self.ctx = ctx
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
+        self._lock = threading.Lock()   # ingest: workers; step: one thread
         self.head_index = 0
         self._seeded = False
 
@@ -302,7 +305,9 @@ class DGMArchiveAggregator(AggregatorProtocol):
                                insts[:STAGE_SMALL], insts[:STAGE_MEDIUM], insts[:STAGE_BIG])
 
     def ingest(self, card: EvidenceCard) -> None:
-        self.cards.append(card)
+        # ingest runs on worker threads, step on one: see AggregatorProtocol.
+        with self._lock:
+            self.cards.append(card)
 
     def step(self) -> List[MergeReport]:
         snap = self.ledger.snapshot(Ledger.DEV)
@@ -320,7 +325,8 @@ class DGMArchiveAggregator(AggregatorProtocol):
 
         parent_idx = self.head_index
         parent = self.ctx.archive[parent_idx]
-        cards, self.cards = self.cards, []
+        with self._lock:
+            cards, self.cards = self.cards, []
         for card in cards:                                 # each card = a self-modification
             child_caps = _caps_of(card.diff.ops["capabilities"])
             child = Agent(tuple(sorted(child_caps)), parent=parent_idx,

--- a/examples/evoskill_skill_discovery.py
+++ b/examples/evoskill_skill_discovery.py
@@ -432,10 +432,13 @@ class TopKFrontierAggregator(AggregatorProtocol):
         self.ctx = ctx
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
+        self._lock = threading.Lock()   # ingest: workers; step: one thread
         self._seeded = False
 
     def ingest(self, card: EvidenceCard) -> None:
-        self.cards.append(card)
+        # ingest runs on worker threads, step on one: see AggregatorProtocol.
+        with self._lock:
+            self.cards.append(card)
 
     def _eval(self, artifact) -> float:
         """Score an artifact on the held-out (val) set -- **concurrently**, so the
@@ -462,7 +465,8 @@ class TopKFrontierAggregator(AggregatorProtocol):
             self.ctx.frontier.update(dict(head.state), self.ctx.seed_score)
             self._seeded = True
 
-        cards, self.cards = self.cards, []
+        with self._lock:
+            cards, self.cards = self.cards, []
         for card in cards:
             candidate = head.apply(card.diff)
             score = self._eval(candidate)
@@ -507,13 +511,16 @@ class SgdSkillAggregator(AggregatorProtocol):
         self.ctx = ctx
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
+        self._lock = threading.Lock()   # ingest: workers; step: one thread
         self._seeded = False
         self.checkpoint: Dict[str, str] = {}   # last val-confirmed skill library
         self.ckpt_score = 0.0
         self.steps = 0                          # applied updates since last validation
 
     def ingest(self, card: EvidenceCard) -> None:
-        self.cards.append(card)
+        # ingest runs on worker threads, step on one: see AggregatorProtocol.
+        with self._lock:
+            self.cards.append(card)
 
     def _eval(self, artifact) -> float:
         tasks = self.verifier.held_out
@@ -550,7 +557,8 @@ class SgdSkillAggregator(AggregatorProtocol):
             self.checkpoint = dict(head.state)
             self._seeded = True
 
-        cards, self.cards = self.cards, []
+        with self._lock:
+            cards, self.cards = self.cards, []
         if not cards:
             # Always report ckpt_score so the async runtime never falls back to a
             # full held-out re-eval (which would defeat eval-at-end / val_every).

--- a/examples/gepa_prompt_evolution.py
+++ b/examples/gepa_prompt_evolution.py
@@ -40,6 +40,8 @@ instruction module and the minibatch is the per-round worker sample (raise
 
 from __future__ import annotations
 
+import threading
+
 import argparse
 import random
 import re
@@ -196,6 +198,7 @@ class ParetoAggregator(AggregatorProtocol):
         self.artifact_id = artifact_id
         self.rng = random.Random(seed)
         self._cards: List[EvidenceCard] = []
+        self._lock = threading.Lock()   # ingest: workers; step: one thread
         # pool: list of (state_dict, per_instance_scores, avg). Parallel lists so
         # score rows stay aligned for pareto_frontier.
         self.states: List[Dict[str, str]] = []
@@ -233,7 +236,9 @@ class ParetoAggregator(AggregatorProtocol):
     # -- AggregatorProtocol --------------------------------------------------
 
     def ingest(self, card: EvidenceCard) -> None:
-        self._cards.append(card)
+        # ingest runs on worker threads, step on one: see AggregatorProtocol.
+        with self._lock:
+            self._cards.append(card)
 
     def step(self) -> List[MergeReport]:
         snap = self.ledger.snapshot(Ledger.DEV)
@@ -242,7 +247,8 @@ class ParetoAggregator(AggregatorProtocol):
         if not self.states:                       # seed the pool with the base system
             self._admit(head)
 
-        cards, self._cards = self._cards, []
+        with self._lock:
+            cards, self._cards = self._cards, []
         admitted = 0
         for card in cards:
             # GEPA Alg. 1 admits a child whose score on the feedback minibatch is

--- a/examples/skillopt_skill_training.py
+++ b/examples/skillopt_skill_training.py
@@ -338,10 +338,13 @@ class StrictGateAggregator(AggregatorProtocol):
         self.ctx = ctx
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
+        self._lock = threading.Lock()   # ingest: workers; step: one thread
         self.current_em = None
 
     def ingest(self, card: EvidenceCard) -> None:
-        self.cards.append(card)
+        # ingest runs on worker threads, step on one: see AggregatorProtocol.
+        with self._lock:
+            self.cards.append(card)
 
     def step(self) -> List[MergeReport]:
         snap = self.ledger.snapshot(Ledger.DEV)
@@ -351,7 +354,8 @@ class StrictGateAggregator(AggregatorProtocol):
             self.current_em = head.score(self.verifier.held_out)
             self.ctx.seed_em = self.ctx.best_em = self.current_em
 
-        cards, self.cards = self.cards, []
+        with self._lock:
+            cards, self.cards = self.cards, []
         best = None
         for card in cards:                                 # pick the best strict improver
             em = head.apply(card.diff).score(self.verifier.held_out)

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -7,14 +7,46 @@ the docstrings honest as the signatures change.
 """
 
 import inspect
+import re
 
 from agentdescent.async_evolve import async_evolve
 from agentdescent.evolution import evolve
 
 
+def _documented_parameters(fn):
+    """Names with a real entry under ``Parameters``, not merely a mention.
+
+    This used to be ``p not in doc`` -- a substring match against the whole
+    docstring. Delete `async_evolve`'s entire Parameters section and **20 of its
+    27 parameters still passed**, because its opening paragraph lists names in
+    prose ("`tasks`, `reward`, `agent` ... mean exactly what they do in evolve").
+    `evolve` kept 11 of 30 the same way. Substrings made it worse still: `run`
+    matches "running", `agent` matches "agents", `parallel` matches "parallelism".
+
+    Both docstrings are numpydoc, so an entry is a line at a fixed indent ending
+    in a colon, and one line may name several (``run, propose:``).
+    """
+    body = _parameters_section(fn)
+    documented = set()
+    for line in body.splitlines():
+        # `getdoc` dedents against the summary line, so the section body keeps its
+        # own indent. An entry is a name (or comma-separated names) then a colon.
+        m = re.match(r"^\s*(\w[\w, ]*):\s*$", line)
+        if m:
+            documented.update(n.strip() for n in m.group(1).split(","))
+    return documented
+
+
+def _parameters_section(fn) -> str:
+    """Everything after the numpydoc ``Parameters`` underline, or ``""``."""
+    doc = inspect.getdoc(fn) or ""
+    m = re.search(r"^\s*Parameters\s*\n\s*-{3,}\s*\n", doc, re.M)
+    return doc[m.end():] if m else ""
+
+
 def _undocumented(fn):
-    doc = fn.__doc__ or ""
-    return [p for p in inspect.signature(fn).parameters if p not in doc]
+    documented = _documented_parameters(fn)
+    return [p for p in inspect.signature(fn).parameters if p not in documented]
 
 
 def test_evolve_documents_every_parameter():
@@ -23,6 +55,22 @@ def test_evolve_documents_every_parameter():
 
 def test_async_evolve_documents_every_parameter():
     assert _undocumented(async_evolve) == []
+
+
+def test_the_guard_would_notice_an_undocumented_parameter():
+    """Guard the guard: the old substring version could not fail for most names.
+
+    Stripping the Parameters section must make (almost) everything undocumented.
+    If it does not, the check is reading prose somewhere else in the docstring.
+    """
+    for fn in (evolve, async_evolve):
+        params = list(inspect.signature(fn).parameters)
+        body = _parameters_section(fn)
+        stripped = (inspect.getdoc(fn) or "").replace(body, "")
+        survivors = [p for p in params if re.search(rf"^\s*{p}:\s*$", stripped, re.M)]
+        assert not survivors, (
+            f"{fn.__name__}: {survivors} would still look documented with the "
+            "Parameters section removed")
 
 
 def test_public_entry_points_have_docstrings():


### PR DESCRIPTION
Closes #17, closes #19, closes #22, closes #23, closes #26, closes #30.

The last batch: the experiments were reporting a constant, and several tests could not fail.

---

## The experiments had no dynamic range

**`rq2_staleness` swept a parameter the run never reads (#17).** It varied `alpha_head`, which `Aggregator._alpha_for` consults only for an **L1** artifact — and the reference `RouterSkill` is `blast_radius=0.2`. The live knob was `alpha_tail=min(alpha, 1)`, so three of the four published rows were the identical configuration. The README advertises `alpha in {0,1,5,inf}`; two configurations ran.

**Every published sweep reported `dev_acc=1.000` for every setting (#22).** Seven sweeps, 15 configurations, one value — including α=0, i.e. *zero* staleness tolerance. An experiment whose ceiling is reached from every point cannot support or refute the hypothesis it was run to test.

Both now sweep the live band and report **cost**, which does vary:

```
   alpha  dev_acc  rounds_to_1.0  commits  discarded_stale
       0    1.000              7        3                7
       1    1.000              4        3                2
       5    1.000              4        3                1
     inf    1.000              4        3                1
```

```
     policy  dev_acc  commits  rollouts  stale  wasted  refresh   secs
       full    1.000        6      4403      0      0%        6    1.9
    guarded    1.000        3      6557   5962     91%        6    1.6
 reflective    1.000        6      4007    467     12%        6    1.7
```

The default policy discarding **91% of its rollouts** is a finding; `1.000` three times was not. Both scripts now say outright that accuracy saturates and the cost columns are the comparison — the honest interim fix while the domain still has a ceiling the system does not have to work for.

## Tests that could not fail

**The docstring guard was a substring match (#19).** It checked `p not in doc` against the whole docstring. Delete the entire `Parameters` section and **20 of `async_evolve`'s 27 parameters still passed** (11 of `evolve`'s 30), because the opening paragraph names them in prose — including `max_seconds` and `max_iters`, the two that file singles out as *"the ones that silently change cost or bound the run"*. Substrings made it worse: `run` matches "running", `agent` matches "agents".

Now it parses numpydoc entries, plus a **meta-test that fails if stripping the section leaves anything still looking documented**. Running it found `async_evolve`'s 15 prose-only parameters at once; they got a real cross-referencing entry.

**The five fully-offline examples had no test at all (#23).** The coverage was inverted: all six algorithm ports — which need credentials to do anything real — had offline tests of their helpers, while the five that run end-to-end in seconds had none, and CI runs `pytest` only. Three defects found in this repo would have been caught there: `run_demo`'s `stable` stuck at 0.000, `rq2_staleness` sweeping an unread parameter, and the saturation above. `tests/test_offline_examples.py` covers them, including the RQ1 merge-vs-fork advantage that three doc pages quote.

Also: `tests/test_bbh_example.py` tested `examples/skill_evolution.py` — a stale name from a rename, so the test for that example was the one file nobody would look in for it. And `docs/usage.md` said the ports *"run offline with `--dry-run`"*; it still downloads the benchmark and does not run the loop.

## Faults for what actually broke (#30)

`tests/faults.py` is a good idea — *"every resilience bug found so far surfaced only under a real fault, and each was found by a throwaway script that then disappeared"* — with three classes missing, each of which had already caused a bug:

- **`returns_nothing`** — every other primitive *raises*, so "succeeds and returns nothing" could not be injected. It is the failure the codebase itself calls the most insidious (`LLMAgent.propose` has a dedicated counter and warning for it), it bypasses every retry and error-tolerance path, and lands as a clean-looking run. The matrix now pins that a mute backend cannot produce a commit.
- **`flaky_propose`** — faults only ever wrapped `run`, and the matrix paired them with a reflector that never fails. In any real setup `propose` is a *separate* backend call, often to a different model (`reflector(claude(model="claude-haiku-4-5"))` is the documented pattern), so "solver healthy, reflector down" was untested.
- **`ledger_dies_after`** — nothing faulted the sole writer, on the critical path of every round, with no retry anywhere. Its failure escaping as an exception was found only by injecting it by hand, which is the workflow this module exists to replace.

`flaky`'s docstring now also says what "seeded so runs are reproducible" means under concurrency: reproducible **counts**, non-deterministic assignment.

## The custom optimizers relied on the GIL (#26)

`docs/self-evolution-examples.md` claims *"their custom optimizers keep shared state thread-safe"*; none of the six had a lock. They were safe only because every `ingest` was a single `list.append` — which stops holding the moment `ingest` grows a counter or a dedup check, and is already not enough: `step()` opens with a two-step read-modify-write, and `evolve(round_timeout=)` **by design** abandons stragglers that keep running and can `ingest` mid-drain. `AggregatorProtocol` now states the contract it always relied on.

<details>
<summary>A deadlock I introduced and caught before this landed</summary>

Two regex passes both matched the drain line, producing a nested acquisition of a non-reentrant lock:

```python
with self._lock:
    with self._lock:          # deadlock, same thread
        cards, self.cards = self.cards, []
```

`pytest` hung rather than failed. Collapsed in all four affected files.
</details>

## Tests

The affected suites pass locally (`test_fault_matrix`, `test_offline_examples`, `test_worker_resilience`, `test_api_docs`, the six port examples, `test_skill_evolution_example`). `mkdocs build --strict` clean. CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)