### PR TITLE
fix: stop the two async pipelines diverging in behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **The measured worker-retirement fix existed in only one of the two async
+  pipelines.** `async_evolve` retires a worker only while *no* worker has ever
+  succeeded, with a comment recording why: keyed on a worker's own history, an
+  intermittent backend retires whoever loses its first few rolls, and since every
+  worker shares one backend, shedding workers cannot relieve the throttling and
+  only guarantees the run dies -- measured at a 1-in-3 call failure rate as all
+  three workers retiring in 22s with nothing learned. `AsyncAgentDescent` still
+  had exactly the blanket rule that paragraph describes. Ported, along with
+  `retired_workers` so a run finishing at a fraction of its concurrency is visible.
+- **The reference merger was still a single point of failure.** It ended the run
+  on its first exception -- and it *calls the backend* every sweep, since it scores
+  held-out. `async_evolve` removed that pattern after measuring a run end with 0
+  sweeps while the workers were healthy; the same tolerance now applies here.
+
+### Added
+- **Backpressure on the general async path** (`async_evolve(stall_patience=)`).
+  `concepts.md` documents this guard as what keeps a mismatched `async_ratio > α`
+  from livelocking under Guarded -- workers propose against a snapshot too old for
+  the policy to accept, every card is discarded, head never moves, so the lag
+  budget never triggers a refresh either. It existed only in the reference
+  runtime, which is not the one a real workload reaches. `result.forced_refreshes`
+  counts how often it fired.
+- **Duration-aware straggler detection on the general async path**
+  (`async_evolve(duration_estimator=, straggler_factor=)` →
+  `result.stragglers`). The design's L-traj mechanism was reachable only through
+  `AsyncAgentDescent`, which accepts nothing but a `TaskUniverse`. Detection only:
+  resuming a partial rollout would need it to expose its turns, and
+  `run(rendered, task) -> output` is opaque.
+
+### Fixed
 - **`examples/rq2_staleness` swept a parameter the run never reads.** It varied
   `alpha_head`, which `Aggregator._alpha_for` consults only for an L1 artifact,
   while the reference `RouterSkill` is `blast_radius=0.2` -- so the live knob was

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -45,6 +45,7 @@ from .aggregator import AggregatorConfig, check_reports
 from .evolvable import ContractError, EvidenceCard, vv_staleness
 from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
+from .scheduler import DurationEstimator
 from .staleness import StaleAction, StalenessPolicy, get_policy
 
 
@@ -79,6 +80,9 @@ def async_evolve(
     seed: int = 0,
     self_verify: bool = True,
     shutdown_grace: float = 2.0,
+    stall_patience: int = 50,
+    duration_estimator: Optional["DurationEstimator"] = None,
+    straggler_factor: float = 3.0,
     task_sampler: Optional["TaskSampler"] = None,
     on_round: Optional[Callable[[RoundInfo], None]] = None,
     verbose: bool = False,
@@ -152,6 +156,22 @@ def async_evolve(
     self_verify:
         As in :func:`evolve`. ``False`` skips the extra per-trajectory rollout,
         which is what ports that judge candidates only on held-out want.
+    stall_patience:
+        Merger sweeps that may pass with cards arriving and nothing committing
+        before every worker is forced to resync, regardless of ``async_ratio``.
+        Without it a lag budget larger than the staleness tolerance **livelocks**
+        under the Guarded policy: workers propose against a snapshot too old for
+        the policy to accept, every card is discarded, head never moves, and the
+        lag budget therefore never triggers a refresh either.
+    duration_estimator, straggler_factor:
+        Pass a :class:`~agentdescent.scheduler.DurationEstimator` to fit
+        ``seconds ~ intercept + slope * len(prompt)`` online and count rollouts
+        that overran their own estimate by more than ``straggler_factor``
+        (``result.stragglers``). This is the design's **L-traj** mechanism, which
+        until now lived only in the reference runtime and so was unreachable from
+        the API a real workload uses. Detection only: resuming a partial rollout
+        would need it to expose its turns, and ``run(rendered, task) -> output``
+        is opaque.
     shutdown_grace:
         Total seconds to wait for the worker and merger threads after the budget
         expires -- shared across all of them, not per thread. An in-flight
@@ -219,6 +239,13 @@ def async_evolve(
     died = [False]                            # True only if the run ENDED on failure
     contract_error: List[Optional[BaseException]] = [None]   # caller bug -> re-raise
     stop_reason = ["max_seconds"]             # overwritten by whichever bound fires
+    # Backpressure: bumped when the pipeline stalls (evidence keeps arriving and
+    # nothing commits), which forces every worker to resync regardless of the ratio.
+    epoch = [0]
+    forced_refreshes = [0]
+    no_commit_sweeps = [0]
+    stragglers = [0]
+    estimator = duration_estimator
     n_live = sum(1 for s in shards if s)      # workers that will actually start
     live = [n_live]                           # workers still running
     retired = [0]                             # workers that gave up (diagnostic)
@@ -232,6 +259,7 @@ def async_evolve(
         shard_ids = [t.id for t in shard]          # the sampler works on ids
         by_shard_id = {t.id: t for t in shard}
         i = 0
+        local_epoch = epoch[0]
         consecutive = 0            # consecutive backend failures for this worker
         warned = False
         while not stop.is_set():
@@ -248,12 +276,30 @@ def async_evolve(
                     break
                 time.sleep(0.05)
             head_v = eng.ledger.head_version(Ledger.DEV).get(eng.artifact_id, 0)
-            if head_v - base_v > async_ratio:          # lag budget exceeded -> refresh
+            # Refresh on the lag budget, or when the merger has asked everyone to
+            # sync. `concepts.md` documents that backpressure guard as what keeps a
+            # mismatched `async_ratio > alpha` from livelocking under Guarded --
+            # workers keep proposing against a snapshot too old for the policy to
+            # accept, every card is discarded, head never moves, so the lag budget
+            # never triggers a refresh either. It existed only in the reference
+            # runtime, which is not the one a real workload reaches.
+            if head_v - base_v > async_ratio or epoch[0] != local_epoch:
                 snap = eng.ledger.snapshot(Ledger.DEV)
                 base_v = snap.version.get(eng.artifact_id, 0)
                 artifact = snap.get(eng.artifact_id)
+                local_epoch = epoch[0]
+                with counter_lock:
+                    forced_refreshes[0] += 1
             task = by_shard_id[sampler.pick(shard_ids, i)]
             i += 1
+            # Duration-aware straggler detection (design spec 5.1, L-traj). It
+            # existed only in the reference runtime, which accepts nothing but the
+            # synthetic router domain -- so the whole L-traj mechanism was
+            # unreachable from the API every real workload uses. Cost is the task's
+            # size, which is what correlates with agentic rollout time.
+            cost = float(len(task.prompt))
+            predicted = estimator.estimate(cost) if estimator is not None else 0.0
+            t_start = time.time()
             try:
                 output = eng.run(artifact.render(), task)
                 score = _checked_reward(eng.reward(task, output), task)
@@ -339,6 +385,15 @@ def async_evolve(
                 # asleep and produced no sweeps at all.
                 stop.wait(min(0.25 * 2.0 ** consecutive, 5.0))     # backoff, then retry
                 continue
+            elapsed = time.time() - t_start
+            if estimator is not None:
+                estimator.observe(cost, elapsed)
+                # A rollout that overran its own estimate is a straggler. Counted,
+                # not resumed: `run(rendered, task) -> output` is opaque, so there
+                # is no continuation state to check point (see concepts.md L-traj).
+                if predicted > 0 and elapsed > straggler_factor * predicted:
+                    with counter_lock:
+                        stragglers[0] += 1
             consecutive, warned = 0, False                    # a clean rollout resets
             any_success[0] = True
             with counter_lock:
@@ -382,6 +437,15 @@ def async_evolve(
             best[1] += 1
         history.append(RoundInfo(len(history), r, len(dev.state), committed,
                                  len(reports) - committed, _tally(reports)))
+        # A stalled pipeline: cards keep arriving and none of them commits. Under
+        # Guarded with async_ratio > alpha that is a livelock, not slow progress.
+        if committed:
+            no_commit_sweeps[0] = 0
+        elif batch:
+            no_commit_sweeps[0] += 1
+            if no_commit_sweeps[0] >= stall_patience:
+                epoch[0] += 1                  # every worker resyncs on its next loop
+                no_commit_sweeps[0] = 0
         if verbose:
             print(f"sweep {len(history):>3}  reward={r:.3f}  merged={len(batch)}  "
                   f"+{committed}  pending={len(intake)}")
@@ -526,6 +590,8 @@ def async_evolve(
                              final_reward=final_reward, history=history,
                              ledger_log=_safe_log(eng.ledger),
                              error=run_error, retired_workers=retired[0],
-                             stop_reason="error" if run_error else stop_reason[0])
+                             stop_reason="error" if run_error else stop_reason[0],
+                             forced_refreshes=forced_refreshes[0],
+                             stragglers=stragglers[0])
     eng.cleanup()          # do not hold a scratch git repo for the whole process
     return result

--- a/agentdescent/async_runtime.py
+++ b/agentdescent/async_runtime.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import threading
 import time
+import warnings
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
@@ -82,6 +83,10 @@ class AsyncStats:
     conflicts_dropped: int = 0
     forced_refreshes: int = 0
     stragglers_checkpointed: int = 0
+    #: Workers that gave up after repeated failures *before any worker had ever
+    #: succeeded*. A run can finish cleanly at a fraction of its requested
+    #: concurrency, so `error` stays None while throughput quietly drops.
+    retired_workers: int = 0
     oracle_used: int = 0
     final_dev_accuracy: float = 0.0
     final_stable_accuracy: float = 0.0
@@ -95,6 +100,7 @@ class AsyncStats:
 class AsyncAgentDescent:
 
     _MAX_WORKER_ERRORS = 3
+    _MAX_MERGER_ERRORS = 3
     """Barrier-free, thread-per-worker parallel self-evolution runtime."""
 
     def __init__(
@@ -153,9 +159,10 @@ class AsyncAgentDescent:
         # nothing commits), forcing every worker to sync regardless of the ratio.
         self._refresh_epoch = 0
         self._stats_lock = threading.Lock()
-        # worker resilience: retire a worker after this many consecutive backend
-        # failures; the run ends once every worker has retired.
+        # worker resilience: retire a worker only while NO worker has ever
+        # succeeded (see _worker_loop); the run ends once every worker has retired.
         self._live_workers = len(self.workers)
+        self._any_success = False
 
     # -- shared head bookkeeping (ROLL Flash async ratio) --------------------
 
@@ -215,16 +222,36 @@ class AsyncAgentDescent:
                 with self._stats_lock:
                     if self.stats.error is None:
                         self.stats.error = f"{type(e).__name__}: {str(e)[:200]}"
-                if consecutive >= self._MAX_WORKER_ERRORS:
+                # Two situations wear the same exception and want opposite
+                # responses, and this used to treat them alike -- the blanket rule
+                # `async_evolve` removed after measuring it. Keyed on a worker's own
+                # history, an intermittent backend retires whoever loses its first
+                # few rolls even though nothing is wrong with it; and since every
+                # worker shares one backend, shedding workers cannot relieve the
+                # throttling and only guarantees the run dies. Measured there at a
+                # 1-in-3 call failure rate: all three workers retired in 22s with
+                # nothing learned. The test is global -- while NO worker has ever
+                # completed a rollout the backend is misconfigured, so give up fast;
+                # once any has, it demonstrably works and this is a transient.
+                if not self._any_success and consecutive >= self._MAX_WORKER_ERRORS:
                     with self._stats_lock:
                         self._live_workers -= 1
+                        self.stats.retired_workers += 1
                         all_dead = self._live_workers <= 0
                     if all_dead:
                         self._stop.set()      # nothing can make progress any more
                     return
-                time.sleep(min(2.0 ** consecutive, 5.0))
+                if self._any_success and consecutive == self._MAX_WORKER_ERRORS:
+                    warnings.warn(
+                        f"{worker.worker_id} has failed {consecutive} rollouts in a "
+                        f"row and is backing off, not retiring (it succeeded "
+                        f"earlier, so this reads as transient). Last error: "
+                        f"{type(e).__name__}: {str(e)[:120]}",
+                        RuntimeWarning, stacklevel=2)
+                self._stop.wait(min(2.0 ** consecutive, 5.0))
                 continue
             consecutive = 0
+            self._any_success = True     # the backend demonstrably works
             elapsed = time.time() - t0
             if self.estimator is not None:
                 self.estimator.observe(cost, elapsed)
@@ -252,17 +279,32 @@ class AsyncAgentDescent:
 
     def _aggregator_loop(self) -> None:
         no_commit_streak = 0
+        consecutive = 0
         while not self._stop.is_set():
             try:
                 reports = self.aggregator.step()
-            except Exception as e:  # noqa: BLE001 - the only writer; if it dies the
-                # workers fill a buffer nobody drains and the run spins to its
-                # deadline with no reason given.
+                consecutive = 0
+            except Exception as e:  # noqa: BLE001 - the merger is the only writer,
+                # so if it dies the workers fill a buffer nobody drains. But it also
+                # *calls the backend* every sweep (it scores held-out), so ending
+                # the run on the first exception made it a single point of failure
+                # one transient could take out permanently -- the same mistake
+                # `async_evolve` removed after measuring it end with 0 sweeps while
+                # the workers were still healthy. Tolerate, and let the run's own
+                # budget bound the wait: a truly dead backend retires every worker,
+                # which ends the run anyway.
+                consecutive += 1
                 with self._stats_lock:
                     if self.stats.error is None:
                         self.stats.error = f"{type(e).__name__}: {str(e)[:200]}"
-                self._stop.set()
-                return
+                if consecutive == self._MAX_MERGER_ERRORS:
+                    warnings.warn(
+                        f"the merger has failed {consecutive} sweeps in a row and "
+                        f"is retrying; nothing will merge until it recovers. Last "
+                        f"error: {type(e).__name__}: {str(e)[:120]}",
+                        RuntimeWarning, stacklevel=2)
+                self._stop.wait(min(2.0 ** consecutive, 30.0))
+                continue
             committed = False
             with self._stats_lock:
                 self.stats.sweeps += 1

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -691,6 +691,14 @@ class EvolutionResult:
     #: the sync and async paths. The ``verbose`` print lines always knew the
     #: reason; this makes it available to a non-interactive caller.
     stop_reason: str = "rounds"
+    #: Times a worker was forced to resync because the pipeline stalled -- cards
+    #: arriving, nothing committing (async path only). A non-zero count means the
+    #: lag budget and the staleness tolerance are mismatched.
+    forced_refreshes: int = 0
+    #: Rollouts that overran their own predicted duration by ``straggler_factor``
+    #: (async path, and only when a ``duration_estimator`` was given). The design's
+    #: L-traj signal; detection only, nothing is resumed.
+    stragglers: int = 0
     #: Workers that gave up after repeated backend failures (async path only). A
     #: run can finish *cleanly* at a fraction of its requested concurrency, so
     #: `error` stays `None` while throughput quietly drops -- check this to tell a
@@ -744,6 +752,8 @@ class EvolutionResult:
                 for h in self.history
             ],
             "retired_workers": self.retired_workers,
+            "forced_refreshes": self.forced_refreshes,
+            "stragglers": self.stragglers,
             "stop_reason": self.stop_reason,
             "ledger_log": list(self.ledger_log),
         }
@@ -763,6 +773,8 @@ class EvolutionResult:
             history=[RoundInfo(**h) for h in d.get("history", [])],
             ledger_log=d.get("ledger_log", []), error=d.get("error"),
             retired_workers=d.get("retired_workers", 0),
+            forced_refreshes=d.get("forced_refreshes", 0),
+            stragglers=d.get("stragglers", 0),
             stop_reason=d.get("stop_reason", "rounds"),
         )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,11 +135,23 @@ the Aggregator calls at steps 1–3 and 5 (cheap) and at step 4 (oracle, budgete
     It does its own sharding, keeps its own intake buffer, and selects tasks via a
     [`task_sampler`](evolution.md#task-selection-which-rollout-to-spend).
 
-    So two capabilities described below are, today, reachable **only** through the
-    reference stack: UCB task-cluster leasing (§5.2 / L-task) and partial-rollout
-    resume (§5.1 / L-traj). `evolve()`'s `task_sampler` covers the L-task idea at
-    task granularity; there is no `evolve()`-level resume yet. This split is a
-    known wart, not a design intent — it is tracked for consolidation.
+    They are still **two implementations**, which is a known wart rather than a
+    design intent. What no longer differs is *behaviour*: the worker-retirement
+    heuristic and the merger's error tolerance were measured, fixed in
+    `async_evolve`, and have been ported back — so a resilience bug cannot live in
+    one and not the other. Backpressure (the guard that keeps `async_ratio > α`
+    from livelocking under Guarded) and duration-aware straggler detection (§5.1 /
+    L-traj) are reachable from `async_evolve` too, via `stall_patience=` and
+    `duration_estimator=`, and reported as `result.forced_refreshes` /
+    `result.stragglers`.
+
+    One capability remains reference-only: **UCB task-cluster leasing** (§5.2 /
+    L-task), because it partitions a `TaskUniverse` into clusters and `evolve()`
+    takes a flat task list. `evolve()`'s
+    [`task_sampler`](evolution.md#task-selection-which-rollout-to-spend) covers the
+    same idea at task granularity. Partial-rollout **resume** is unimplemented on
+    both paths — `run(rendered, task) -> output` is opaque, so there is no
+    continuation state to check point; both now *detect* and count stragglers.
 
 AgentDescent separates *what to merge* (the Aggregator, identical in both) from
 *when workers and the aggregator run relative to each other* (the runtime).

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -141,7 +141,10 @@ more than `async_ratio` versions ahead of it.
 
 A **backpressure** guard forces a global sync if the pipeline stalls (evidence
 keeps arriving but nothing commits) — otherwise a mismatched `async_ratio > α`
-would livelock under the Guarded policy.
+would livelock under the Guarded policy: workers keep proposing against a
+snapshot too old for the policy to accept, every card is discarded, head never
+moves, and so the lag budget never triggers a refresh either. `stall_patience=`
+on both async paths; `result.forced_refreshes` counts how often it fired.
 
 Observed trade-off at `async_ratio=4` (all three converge to 1.000):
 
@@ -201,7 +204,10 @@ mechanism:
 
 - **L-traj (system layer)** — heavy-tailed rollout durations. Handled today by
   the duration estimator + LPT dispatch and by **detecting** stragglers: a
-  rollout that overruns its prediction is flagged into `ResumeQueue` and counted.
+  rollout that overruns its prediction is counted. Reachable from `evolve()` /
+  `async_evolve` as `duration_estimator=` → `result.stragglers`; it used to exist
+  only in the reference runtime, which accepts nothing but the synthetic domain,
+  so the mechanism was unreachable from the API a real workload uses.
   **The resume half is not implemented** — nothing pops that queue, and the
   recorded item carries no continuation state, because a resumable rollout would
   have to expose its turns and `run(rendered, task) -> output` is opaque. The

--- a/tests/test_async_parity.py
+++ b/tests/test_async_parity.py
@@ -1,0 +1,190 @@
+"""The two async pipelines must not diverge in behaviour.
+
+`AsyncAgentDescent` (reference stack, synthetic router domain) and `async_evolve`
+(general, and the only one a real workload reaches) implement the same
+barrier-free shape independently and share no code. The cost was that fixes and
+capabilities lived in whichever one they were written for:
+
+* the worker-retirement heuristic was **measured wrong** and fixed in
+  `async_evolve` -- "at a 1-in-3 call failure rate the old blanket rule retired
+  all three workers in 22s with nothing learned" -- while `AsyncAgentDescent` kept
+  the rule that paragraph describes, along with a merger that ended the run on its
+  first exception (the other pattern that measurement removed);
+* backpressure and duration-aware straggler detection existed only in
+  `AsyncAgentDescent`, which accepts nothing but `TaskUniverse` -- so the guard
+  `concepts.md` says prevents a livelock, and the whole L-traj mechanism, were
+  unreachable from the API every real workload uses.
+
+These pin the behaviour on *both* sides rather than the implementation, so they
+keep holding if the two are ever merged into one.
+"""
+
+import tempfile
+import time
+import warnings
+
+import pytest
+
+from agentdescent import AppendRules, Task, async_evolve
+from agentdescent.async_runtime import AsyncAgentDescent, AsyncConfig
+from agentdescent.domains.router import make_task_universe
+from agentdescent.scheduler import DurationEstimator
+
+
+def _tasks(n=12):
+    return [Task(id=str(i), prompt=f"q{i}", meta={"gold": "y"}) for i in range(n)]
+
+
+def _async_evolve(**kw):
+    kw.setdefault("n_workers", 3)
+    kw.setdefault("max_seconds", 3.0)
+    kw.setdefault("self_verify", False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return async_evolve(_tasks(), kw.pop("reward", lambda t, o: 0.0),
+                            strategy=AppendRules(), **kw)
+
+
+# -- the retirement heuristic, on both sides ------------------------------------
+
+
+def test_the_reference_runtime_no_longer_sheds_workers_over_a_transient():
+    """Every worker shares one backend, so shedding workers cannot relieve
+    throttling -- it only guarantees the run dies."""
+    universe = make_task_universe(seed=7)
+    cfg = AsyncConfig(n_workers=4, max_seconds=3.0, seed=1)
+    with tempfile.TemporaryDirectory() as repo:
+        system = AsyncAgentDescent(repo, universe, config=cfg)
+        original = [w.run for w in system.workers]
+        calls = {"n": 0}
+
+        def flaky(w, orig):
+            def run(*a, **kw):
+                calls["n"] += 1
+                if calls["n"] % 3:            # ~2 in 3 fail, after a first success
+                    if calls["n"] > 1:
+                        raise RuntimeError("429 rate limited")
+                return orig(*a, **kw)
+            return run
+
+        for w, orig in zip(system.workers, original):
+            w.run = flaky(w, orig)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            stats = system.run()
+    assert stats.retired_workers == 0, (
+        f"{stats.retired_workers} worker(s) retired over a transient the backend "
+        "recovers from; shedding them cannot relieve a shared throttle")
+
+
+def test_a_misconfigured_backend_still_retires_every_worker_fast():
+    """The other half: while nothing has ever succeeded, give up loudly."""
+    universe = make_task_universe(seed=7)
+    cfg = AsyncConfig(n_workers=3, max_seconds=20.0, seed=1)
+    with tempfile.TemporaryDirectory() as repo:
+        system = AsyncAgentDescent(repo, universe, config=cfg)
+        for w in system.workers:
+            w.run = lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("401 unauthorized"))
+        t0 = time.time()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            stats = system.run()
+    assert stats.error is not None and "401" in stats.error, "ended silently"
+    assert time.time() - t0 < 15.0, "burned the whole budget on a dead backend"
+
+
+def test_the_reference_merger_survives_a_transient():
+    """It scores held-out every sweep, so it is a backend caller like any other.
+
+    Ending the run on its first exception made the merger a single point of
+    failure -- measured in `async_evolve` as 0 sweeps while the workers were fine.
+    """
+    universe = make_task_universe(seed=7)
+    # Generous budget on purpose: the retry backs off 2s after one failure, which
+    # would be half of a short run and would test the clock, not the tolerance.
+    cfg = AsyncConfig(n_workers=2, max_seconds=12.0, target_accuracy=2.0, seed=1)
+    with tempfile.TemporaryDirectory() as repo:
+        system = AsyncAgentDescent(repo, universe, config=cfg)
+        original, calls = system.aggregator.step, {"n": 0}
+
+        def flaky_step():
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise RuntimeError("503 transient")
+            return original()
+
+        system.aggregator.step = flaky_step
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            stats = system.run()
+    assert stats.sweeps > 2, \
+        f"the merger stopped at the first transient ({stats.sweeps} sweeps)"
+
+
+# -- capabilities the general path was missing ----------------------------------
+
+
+def test_backpressure_is_reachable_from_the_general_api():
+    """`concepts.md` says this guard is what keeps `async_ratio > alpha` from
+    livelocking under Guarded. It existed only in the reference runtime."""
+    res = _async_evolve(async_ratio=50, stall_patience=1,
+                        reward=lambda t, o: 0.0,
+                        run=lambda r, t: "no",
+                        propose=lambda r, t, o, s: f"rule {time.time()}")
+    assert res.forced_refreshes >= 0        # the field exists and is reported
+    assert hasattr(res, "forced_refreshes")
+
+
+def test_a_stalled_pipeline_forces_a_resync():
+    """Cards arriving, nothing committing: that is a livelock, not slow progress."""
+    n = [0]
+
+    def propose(rendered, task, output, score):
+        n[0] += 1
+        return f"rule number {n[0]}"
+
+    res = _async_evolve(async_ratio=1000, stall_patience=1, max_seconds=4.0,
+                        reward=lambda t, o: 0.5, run=lambda r, t: "no",
+                        propose=propose)
+    assert res.forced_refreshes > 0, (
+        "the pipeline stalled and no worker was ever told to resync; "
+        "with a lag budget this large nothing would move head on its own")
+
+
+def test_straggler_detection_is_reachable_from_the_general_api():
+    """L-traj lived only in a runtime that accepts nothing but TaskUniverse."""
+    slow_id = "3"
+    tasks = [Task(id=str(i), prompt="q" * (200 if str(i) == slow_id else 20),
+                  meta={"gold": "y"}) for i in range(12)]
+
+    def run(rendered, task):
+        time.sleep(0.35 if task.id == slow_id else 0.01)
+        return "no"
+
+    est = DurationEstimator()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = async_evolve(tasks, lambda t, o: 0.0, run=run,
+                           propose=lambda r, t, o, s: f"rule {time.time()}",
+                           strategy=AppendRules(), n_workers=3, max_seconds=4.0,
+                           duration_estimator=est, self_verify=False)
+    assert res.stragglers > 0, "the one deliberately slow rollout was not detected"
+    intercept, slope = est.params
+    assert slope != 0.0, "the estimator never fitted a cost law"
+
+
+def test_no_estimator_means_no_straggler_accounting():
+    """Opt-in: timing every rollout against a fitted law is not free."""
+    res = _async_evolve(run=lambda r, t: "no", propose=lambda *a: None)
+    assert res.stragglers == 0
+
+
+def test_the_new_diagnostics_survive_save_and_load(tmp_path):
+    from agentdescent import EvolutionResult
+
+    res = _async_evolve(run=lambda r, t: "no", propose=lambda *a: None)
+    path = tmp_path / "r.json"
+    res.save(str(path))
+    loaded = EvolutionResult.load(str(path))
+    assert loaded.forced_refreshes == res.forced_refreshes
+    assert loaded.stragglers == res.stragglers


### PR DESCRIPTION
Closes #13.

`AsyncAgentDescent` (reference stack, router-only) and `async_evolve` (general, and the only one a real workload reaches) implement the same barrier-free shape independently and share no code. The cost was that fixes and capabilities lived in whichever one they were written for.

**Scope note.** This closes the divergence in *behaviour*, not the duplication. Merging them into one implementation means unifying two different actor contracts — `Worker.run(skill, base_version, tasks) -> EvidenceCard` against `evolve`'s `run`/`propose` pair — and the efficiency numbers the docs quote are measured on `AsyncAgentDescent`'s exact behaviour. That is a rewrite with a real chance of silently changing published results, and it wants your call on direction, not mine. What this PR guarantees is that **a resilience bug cannot live in one and not the other**, and that nothing useful is reachable from only the runtime a real workload cannot use.

---

## Two measured fixes existed in only one

`async_evolve` retires a worker only while **no** worker has ever succeeded, and the comment records why:

> The test is deliberately global … every worker shares one backend, so shedding workers cannot relieve the throttling and only guarantees the run dies. **Measured: at a 1-in-3 call failure rate (~56% per rollout, an ordinary 429 storm) the old blanket rule retired all three workers in 22s with nothing learned.**

`AsyncAgentDescent._worker_loop` still had exactly the rule that paragraph describes — no `any_success` guard, no distinction between "misconfigured" and "transient". Ported, along with `retired_workers` so a run finishing at a fraction of its requested concurrency is visible rather than looking merely fast.

Its merger had the mirror problem: `except Exception: self._stop.set(); return` on the first failure — and the merger *calls the backend every sweep*, since it scores held-out. That is the single-point-of-failure pattern `async_evolve` removed after measuring a run end with **0 sweeps while the workers were still healthy**. Same tolerance now.

## Two capabilities were unreachable from the general API

**Backpressure.** `concepts.md` documents it as the guard that keeps a mismatched `async_ratio > α` from livelocking under Guarded: workers keep proposing against a snapshot too old for the policy to accept, every card is discarded, head never moves — so the lag budget never triggers a refresh either, and the run spins out its whole budget. It existed only in the reference runtime. Now `async_evolve(stall_patience=)`, with `result.forced_refreshes` counting how often it fired.

**Duration-aware straggler detection (L-traj).** `DurationEstimator` → straggler counting lived only in `AsyncAgentDescent`, which accepts nothing but a `TaskUniverse`, so the entire mechanism was unreachable from `evolve()`. Now `async_evolve(duration_estimator=, straggler_factor=)` → `result.stragglers`:

```
stragglers=1  forced_refreshes=0  estimator params=(-0.0259, 0.0019)
```

— one deliberately slow rollout among twelve, detected, with the cost law fitted online. Detection only, and the docs say so: resuming a partial rollout would need it to expose its turns, and `run(rendered, task) -> output` is opaque.

## What is still reference-only, and why

**UCB task-cluster leasing** (§5.2 / L-task). It partitions a `TaskUniverse` into clusters; `evolve()` takes a flat task list, so there is nothing to cluster over without inventing a grouping the caller did not ask for. `task_sampler=` ([`DifficultyWeighted`](docs/evolution.md)) covers the same idea at task granularity, which is the honest mapping.

**Partial-rollout resume** is unimplemented on *both* paths, for the reason above. Both now detect and count.

## Tests

`tests/test_async_parity.py`, 8 cases, asserting behaviour on **both** sides so they keep holding if the two are ever merged: the reference runtime no longer sheds workers over a transient; a genuinely misconfigured backend still retires everything fast and loudly; its merger survives a transient; backpressure and straggler detection are reachable from `async_evolve`; a stalled pipeline forces a resync; no estimator means no straggler accounting; the new diagnostics survive `save()`/`load()`.

`test_async.py`, `test_async_evolve.py`, `test_async_semantics.py` and `test_api_docs.py` pass. `mkdocs build --strict` clean. CI runs the full suite.

## Docs

- `docs/architecture.md` §4 — the "known wart" warning now says precisely what does and does not still differ, instead of "tracked for consolidation"
- `docs/concepts.md` — L-traj and the backpressure guard, both now reachable from the general path
- `async_evolve` docstrings for `stall_patience`, `duration_estimator`, `straggler_factor`; `EvolutionResult.forced_refreshes` / `.stragglers`
- CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)