### PR TITLE
fix: ADAS measured nothing, and the biggest reason was empty model replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **ADAS reported "no lift demonstrated", and most of the reasons were not the
+  algorithm.** The recorded run spent 791 calls to report `test accuracy 0.000`
+  on three items. Fixed across the measurement, the search and the accounting:
+    - The hard subset came from a 600-item sample of four languages, leaving 47
+      items to split three ways. Full MGSM is 2750 items over 11 languages and
+      `deepseek-v4-flash` answers 0.919 of it directly — a 222-item hard pool.
+    - The split was 50/25/25, but the train half only ever *triggers* proposals:
+      the meta-agent conditions on the archive, not on the task `evolve()` hands
+      it, so a generation consumes two items and ignores the rest. `--train-frac`
+      / `--test-frac` now default to 15/50/35, and splits are stratified by
+      language (MGSM languages differ by 8 points of baseline accuracy, so an
+      unstratified draw can hand val one mixture and test another — and that
+      difference reads as a lift).
+    - The run reported only the searched agent's test accuracy, which on a
+      `--hard` subset cannot say whether searching helped: the structure-free
+      baseline is 0.000 there by construction. It now scores the best seed on the
+      same split and prints both rows and the delta.
+    - The `--hard` baseline was scored with a digit-concatenating extractor while
+      the agents used `_extract_int`, so "hard" partly meant "the two extractors
+      disagree". One extractor for both sides. The printed direct accuracy was
+      also derived from the subset size, so a pool `select_hard` had *topped up*
+      reported the top-up as model error.
+    - The seed archive was scored inside the first `step()` — after generation 0
+      had already proposed — so the first generation designed against seven
+      entries all reading `unevaluated`. Seeded before round 0 instead.
+    - `propose_agent` returned whatever the last Reflexion round emitted,
+      discarding a valid draft from an earlier round; `_parse_agent`'s greedy
+      `\{.*\}` spanned first brace to last brace in the whole reply, so one brace
+      in the closing prose threw the proposal away. A generation produces one
+      proposal, so each of these costs a whole generation.
+    - Nothing bounded a proposal's cost, which is multiplicative in this DSL (an
+      ensemble of two 2-round debates is 14 calls per question against a
+      most-expensive-seed of 5). Now capped, and the cap is in the meta-prompt.
+    - `self_verify` ran an extra multi-step rollout per proposal for a delta the
+      archive never reads; `--eval-concurrency` never reached `evolve()`; and
+      `--hard` re-ran its entire baseline pass every invocation (2750 calls at
+      full size), now cached per (model, question).
+    - The budget line was computed *before* `--hard` narrowed the split, so it
+      advertised ~9009 calls for a run that made 791. It is now derived from the
+      real program costs, after the split, and reports a range.
+    - `MetaSearchAggregator` left `MergeReport.accepted`/`category` empty while it
+      was committing, so an unchanged best design printed `+0/-1` and
+      `outcomes()` bucketed every generation as `unknown`.
+- **The evaluation cache keyed on state the artifact does not render.**
+  `_EvalCache` used the whole state dict, but `eval_one` only ever passes
+  `render()` to `run` — so two states that render identically cannot score
+  differently. ADAS keeps a design's name and rationale beside the design itself,
+  and committing a candidate the aggregator had just scored therefore re-ran the
+  entire held-out set because a label changed: a duplicate sweep of real model
+  calls per committing round.
+- **`RoundInfo.n_items` is the artifact's key count, not the sample size.** The
+  verbose line printed it as `items=` directly beside the reward, where it reads
+  as "measured on this many" — a 110-item measurement announced itself as 3. Now
+  `size=`, with the held-out count printed next to the reward it belongs to.
 - **The L1/L2 boundary was defined three times, with two different numbers.**
   `governance.classify` drew it at `FAST_MAX = 0.30`; the aggregator's staleness
   tolerance re-derived it as `blast_radius > 0.5` and the audit gate as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **ADAS's meta-agent returned empty content on every call, so the search
+  proposed nothing.** `deepseek-v4-flash` is a reasoning model: the token budget
+  is spent on hidden reasoning first and the visible content is what is left. The
+  example took the library default of 4096 — sized for "answer with the final
+  number" — and used one completion for both the multi-step agent programs and
+  the meta-agent, whose prompt is far longer. At 4096, **0 of 4** meta-agent
+  calls returned anything at all; at 16384, 4 of 4 returned a well-formed design.
+  The solver is affected too (blank replies 13/40 → 2/40), though the accuracy
+  difference at n=40 is inside the noise. The defect is that it is *silent*: an
+  empty completion does not raise, `_extract_int("")` is `None`, and `score_mgsm`
+  scores `None` as a wrong answer — so a starved run reports a low accuracy
+  indistinguishable from a model that cannot do the problems. Now `--max-tokens`
+  (default 16384) and `--timeout` (300 s), blank replies are counted and warned
+  about, and the pre-flight check sends a *reasoning* prompt and aborts if it
+  comes back empty ("Reply with the single word: ok" passes at any budget, which
+  is why it never caught this).
+- **A design's identity ignored key order.** Every dedup in the search is string
+  equality on the program's JSON, and a proposal's key order is whatever the
+  model emitted, so two orderings of the same program were two designs. The
+  duplicate passed the dedup, cost a full evaluation sweep, tied what it
+  duplicated, and failed the acceptance test. Now `json.dumps(..., sort_keys=True)`.
+- **A run that finished its search printed nothing if the test split failed.**
+  The test split is scored after the search is over and paid for; letting a
+  backend failure there escape discarded every validation number the run had
+  produced. Test accuracy now degrades to `n/a` and the rest still prints.
 - **ADAS reported "no lift demonstrated", and most of the reasons were not the
   algorithm.** The recorded run spent 791 calls to report `test accuracy 0.000`
   on three items. Fixed across the measurement, the search and the accounting:

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -456,7 +456,19 @@ class EvolvingArtifact:
                                 self._rt, self._strategy)
 
     def _signature(self):
-        return tuple(sorted(self.state.items()))
+        """The evaluation-cache key: what the artifact *renders to*.
+
+        It used to be the whole state, which is a finer key than evaluation
+        actually depends on -- ``eval_one`` only ever passes ``render()`` to
+        ``run``, so two states that render identically cannot score differently.
+        Any state a strategy carries for bookkeeping rather than for rendering
+        (ADAS keeps the design's name and rationale beside the design itself)
+        therefore invalidated the cache for free: the aggregator scored a
+        candidate on the full held-out set, the round committed it, and the
+        driver's own held-out measurement re-ran every one of those rollouts
+        because a label had changed. On an LLM workload that is a duplicate sweep
+        of real model calls per committing round."""
+        return self.render()
 
     def score(self, tasks: Sequence[Task]) -> float:
         """Mean reward over ``tasks``, evaluated concurrently.
@@ -644,6 +656,11 @@ def _tally(reports) -> Dict[str, int]:
 class RoundInfo:
     round: int
     held_out_reward: float
+    #: How many **keys the artifact holds** -- its size (rules for `AppendRules`,
+    #: slots for `KeyedRules`), not how many tasks `held_out_reward` was measured
+    #: on. The verbose line prints it as ``size=`` for that reason: sitting beside
+    #: the reward under the name ``items`` it reads as the sample size, and a
+    #: reader who takes it that way concludes a 108-item measurement rested on 3.
     n_items: int
     committed: int
     rejected: int
@@ -1533,8 +1550,8 @@ def evolve(
         else:
             stalled += 1
         if verbose:
-            print(f"round {r:>3}  reward={info.held_out_reward:.3f}  "
-                  f"items={info.n_items}  +{committed}/-{rejected}")
+            print(f"round {r:>3}  reward={info.held_out_reward:.3f} on "
+                  f"{len(held_out)}  size={info.n_items}  +{committed}/-{rejected}")
         if target_reward is not None and info.held_out_reward >= target_reward:
             stop_reason = "target_reward"
             if verbose:

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,6 +18,80 @@ Anything that maps a prompt to text is a completion — an LLM call, a tool-usin
 agent loop, a canned stub. Adapters build completions; higher layers turn a
 completion into whatever task interface they need.
 
+## Configuring your provider and key
+
+Credentials are read from the **environment at call time** — they never pass
+through code, arguments, or a config file the repo owns. Two variables decide
+everything:
+
+| variable | used by | value |
+|---|---|---|
+| `OPENAI_BASE_URL` | `openai_compatible` | the endpoint's root, e.g. `https://api.deepseek.com` |
+| `OPENAI_API_KEY` | `openai_compatible` | your key for that endpoint |
+| `ANTHROPIC_API_KEY` | `claude` | your Anthropic key (or run `ant auth login`) |
+
+**DeepSeek**
+
+```bash
+export OPENAI_BASE_URL=https://api.deepseek.com
+export OPENAI_API_KEY=sk-...
+python -m examples.adas_meta_agent_search --provider openai --model deepseek-v4-flash
+```
+
+**GLM / Zhipu**
+
+```bash
+export OPENAI_BASE_URL=https://open.bigmodel.cn/api/paas/v4
+export OPENAI_API_KEY=...
+python -m examples.adas_meta_agent_search --provider openai --model glm-4.6
+```
+
+**OpenAI** — `OPENAI_BASE_URL` is the default here and may be omitted
+
+```bash
+export OPENAI_BASE_URL=https://api.openai.com/v1
+export OPENAI_API_KEY=sk-...
+python -m examples.adas_meta_agent_search --provider openai --model gpt-4.1-mini
+```
+
+**A local server** (vLLM, Ollama, LM Studio) — the key is unused but must be set
+
+```bash
+export OPENAI_BASE_URL=http://localhost:8000/v1
+export OPENAI_API_KEY=not-used
+python -m examples.adas_meta_agent_search --provider openai --model my-local-model
+```
+
+**Claude** — a different variable, and `ant auth login` works instead
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+python -m examples.adas_meta_agent_search --provider claude --model claude-haiku-4-5
+```
+
+Put the `export` lines in your shell profile to keep them across sessions. Every
+example also takes `--dry-run`, which loads the dataset and prints the plan
+**without a single API call** — the cheapest way to confirm your setup before
+paying for a run:
+
+```bash
+python -m examples.adas_meta_agent_search --dry-run
+```
+
+!!! tip "Check the endpoint before a long run"
+    `--provider openai` talks to whatever `OPENAI_BASE_URL` points at, so a typo
+    surfaces as an HTTP error rather than a wrong answer. To see what a key can
+    reach:
+
+    ```bash
+    curl -s "$OPENAI_BASE_URL/models" -H "Authorization: Bearer $OPENAI_API_KEY"
+    ```
+
+    Common replies: `401` — the key is wrong for this base URL; `402` /
+    `Insufficient Balance` — the account is out of credit; `404` on
+    `/chat/completions` — the base URL is missing or has an extra path segment
+    (most gateways want the version prefix, e.g. `/v1`).
+
 ## Adapters
 
 ```python
@@ -64,6 +138,15 @@ instance, and forwards extra kwargs to `messages.create`.
     Both adapters default to **4096**. You are billed for tokens *generated*, not
     for the cap, so a generous limit costs nothing — and an empty reflection emits
     a `RuntimeWarning` naming this as the likely cause.
+
+    **4096 is not always enough.** That figure was measured on a short reflection
+    prompt; the budget a model needs scales with how much it has to think about.
+    On ADAS's meta-agent prompt — a whole archive of designs and their fitness —
+    `deepseek-v4-flash` at 4096 returned empty content on **every** call, burning
+    the full budget on reasoning each time; at 16384 it answered every time, with
+    a reply of only ~250 tokens. If a caller's prompts are long or its task is
+    hard, raise the cap and check: an empty completion scores as a wrong answer,
+    it does not raise.
 
 ## What did the run cost? — `Usage`
 

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -139,6 +139,18 @@ empty. You are billed for tokens generated, not for the cap.
 
 ## Run it
 
+Point the example at your own endpoint with two environment variables — they are
+read at call time and never stored by the repo (full list, including Claude and
+local servers: [Configuring your provider and key](agents.md#configuring-your-provider-and-key)):
+
+```bash
+export OPENAI_BASE_URL=https://api.deepseek.com     # or your gateway
+export OPENAI_API_KEY=sk-...
+```
+
+Then confirm the setup costs nothing before it costs something — `--dry-run`
+loads MGSM, prints the plan and the budget, and makes **no API calls**:
+
 ```bash
 python -m examples.adas_meta_agent_search --dry-run
 python -m examples.adas_meta_agent_search --select dgm --langs en,es

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -59,63 +59,101 @@ In [`examples/adas_meta_agent_search.py`](https://github.com/Birfy/agentdescent/
 
 ## Measured — MGSM with DeepSeek
 
-**This is the one shipped port where I could not demonstrate a lift**, and the
-reason is worth stating rather than hiding.
+MGSM is saturated for a strong model, so the search has no gradient without
+`--hard`. Measured with `deepseek-v4-flash` over the **whole benchmark** — all 11
+languages, 250 items each:
 
-At the default settings MGSM is saturated: the seed archive already scores 1.000
-on the sampled items, so Meta Agent Search has no gradient and the archive merge
-accepts nothing. `--hard` is the lever — but MGSM resists it from both sides:
-
-| pool | items a single structure-free call gets **wrong** |
+| | |
 |---|---|
-| `--per-lang 40` on `bn,sw,te,th` (160) | fewer than 12 — `select_hard` warns and tops up |
-| `--per-lang 150` (600) | **47** (23 train / 12 val / 11 test) |
+| pool | 2750 items |
+| direct, structure-free single call | **0.919** |
+| items it answers incorrectly | **222** (8.1%) |
 
-So a subset with real signal exists, but it is ~8% of a large pool. The bind is
-cost: with 23 training items a three-generation run is ~9000 model calls and takes
-hours. Shrinking it to fit a budget shrinks the *measurement* with it — at
-`--hard-keep 12` the split is 6 train / 3 val / 3 test, and a 3-item validation set
-cannot separate anything:
+Those 222 are what the search runs on, split 15 / 50 / 35:
 
 ```
-round 0  reward=0.400  +0/-1
-round 1  reward=0.400  +0/-1
-test accuracy (held out): 0.000        # 3 items
-791 calls, 5653 s in the model, 24 min wall-clock
+Split    : 34 trigger / 110 val (fitness) / 78 test
 ```
 
-The archive rejected every candidate. On this evidence that is neither a working
-demonstration nor a bug — it is a measurement too small to read. What the run
-*does* show is that the loop, the archive, the selection rule and the gate all
-execute against a real dataset.
+The train share only *triggers* proposals — the meta-agent conditions on the
+archive, not on the task `evolve()` hands it, so a generation consumes `--workers`
+items and ignores the rest. Everything else measures. Splits are stratified by
+language, because MGSM's languages differ by 8 points of baseline accuracy (`en`
+0.964, `ja` 0.880) and an unstratified draw hands validation one mixture and test
+another.
 
-To get a number you can trust here, budget for `--per-lang 150` with no
-`--hard-keep` and expect hours, or use a weaker base model so the plain benchmark
-has headroom.
+On a `--hard` subset the structure-free baseline is 0.000 by construction, so the
+searched agent's test accuracy on its own says nothing. The run scores the best
+hand-designed seed on the same split and reports both:
+
+```
+                                  val (search)   test (held out)
+  best hand-designed seed              ?.???           ?.???
+  best searched design                 ?.???           ?.???
+  lift                                +?.???          +?.???
+```
+
+!!! note "The lift row is not filled in yet"
+    A run over the split above is ~2 hours and 6k–17k model calls. One has not
+    been completed against the current code, so this page does not claim a
+    demonstrated lift — the table is the shape of the answer, not the answer.
+
+### Give a reasoning model a real token budget
+
+`deepseek-v4-flash` spends its budget on hidden reasoning first; visible content
+is what is left. At the library default of 4096 the meta-agent returns **empty
+content on every call**, so no design ever reaches the archive:
+
+| `--max-tokens` | meta-agent replies | solver blank rate | solver CoT |
+|---|---|---|---|
+| 4096 | **0 / 4** | 13 / 40 | 0.275 |
+| 16384 (default here) | **4 / 4** | 2 / 40 | 0.325 |
+
+An empty completion does not raise — `_extract_int("")` is `None` and that scores
+as a wrong answer, so a starved run reports a low accuracy indistinguishable from
+a model that cannot do the problems. The run counts blank replies and warns, and
+the pre-flight check sends a *reasoning* prompt and aborts if it comes back
+empty. You are billed for tokens generated, not for the cap.
 
 !!! warning "This is by far the most expensive example"
-    Every candidate is scored on every training item, and each score is a
-    *multi-step* program — self-consistency and debate make several model calls per
-    question. One generation over 23 items is on the order of a thousand calls, so
-    a three-generation run takes hours even fully parallel.
+    Every candidate is scored on every validation item, and each score is a
+    *multi-step* program. Wall-clock is set by the **serial** chains, not by
+    fan-out, so past `--eval-concurrency >= |val|` more concurrency buys nothing:
 
-    Two knobs control the cost directly:
-
-    | | |
+    | chain | length |
     |---|---|
-    | `--hard-keep N` | cap the hard subset. Evaluation is *candidates × items × multi-step calls*, so this is the strongest lever |
-    | `--eval-concurrency N` | how many examples are scored at once (default 16). Purely I/O bound |
+    | seed archive | 19 sequential calls per item (7 seeds) |
+    | `propose` | 3 Reflexion rounds, ~84 s |
+    | candidate evaluation | `program_cost` calls per item, candidates run one after another |
 
-    `--hard-keep` caps the **pool**, which is then split 50/25/25 — so
-    `--hard-keep 12` leaves only 6 training items, and the fan-out cannot exceed
-    that. Ask for roughly four times the training set you want.
+    A proposed design may cost up to `MAX_PROGRAM_CALLS` (10) calls per question
+    against a seed average of 2.7, which is what dominates a generation. The
+    budget line reports both ends of the range for exactly this reason.
+
+    | knob | effect |
+    |---|---|
+    | `--generations`, `--workers` | candidates searched |
+    | `--hard-keep N` | caps the pool, and with it every sweep |
+    | `--eval-concurrency N` | set it to at least `|val|` |
+    | `--max-tokens`, `--timeout` | see above |
 
 ## Run it
 
 ```bash
 python -m examples.adas_meta_agent_search --dry-run
-python -m examples.adas_meta_agent_search --model claude-haiku-4-5 --generations 6
 python -m examples.adas_meta_agent_search --select dgm --langs en,es
+```
+
+The settings the numbers above come from — the whole benchmark, hard subset, a
+split that leaves something to measure. The baseline pass is cached per
+(model, question), so only the first run pays for it:
+
+```bash
+python -m examples.adas_meta_agent_search \
+    --provider openai --model deepseek-v4-flash \
+    --hard --langs bn,de,en,es,fr,ja,ru,sw,te,th,zh --per-lang 250 \
+    --generations 4 --workers 3 --eval-concurrency 128 \
+    --train-frac 0.15 --test-frac 0.35 --yes
 ```
 
 Offline tests: `tests/test_adas_example.py`.

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -110,7 +110,7 @@ has headroom.
     `--hard-keep 12` leaves only 6 training items, and the fan-out cannot exceed
     that. Ask for roughly four times the training set you want.
 
-## Run it## Run it
+## Run it
 
 ```bash
 python -m examples.adas_meta_agent_search --dry-run

--- a/docs/results.md
+++ b/docs/results.md
@@ -13,16 +13,22 @@ so you can reproduce it.
 | **[SkillOpt](algo-skillopt.md)** | SearchQA | `--hard --steps 6` | val hard-EM **0.250 → 0.500**; test **0.450** | 6 steps |
 | **[EvoSkill](algo-evoskill.md)** | FinQA | `--dataset finqa --iterations 5` | val **0.487 → 0.573**; test **0.617**, 1 skill | 115 calls, 4 min |
 | **[DGM](algo-dgm.md)** | surrogate | `--generations 4` | resolve-rate **0.000 → 0.300**; test 0.200 | offline |
-| **[ADAS](algo-adas.md)** | MGSM | `--hard --langs bn,sw,te,th` | **no lift demonstrated** — see below | 791 calls, 24 min |
+| **[ADAS](algo-adas.md)** | MGSM | `--hard`, all 11 languages | direct **0.919** → 222-item hard subset; lift **not yet measured** | ~2 h, 6k–17k calls |
 
-!!! warning "ADAS is the exception, and the reason is cost"
-    MGSM is saturated at the default settings, and `select_hard` does find a real
-    subset (47 of 600 items) — but evaluating one candidate there is a *multi-step
-    program per item*, so a three-generation run is ~9000 calls and hours long.
-    Shrinking it to fit a budget shrinks the measurement too: at 6 train / 3 val /
-    3 test the archive rejected every candidate and held-out test was 0.000 on
-    three items. That is a measurement too small to read, not a demonstration and
-    not a bug. [Details](algo-adas.md#measured-mgsm-with-deepseek).
+!!! warning "ADAS is the exception: the lift row is still empty"
+    Everything else in this table is a completed before → after. ADAS is not, and
+    the honest reason is that no run against the current code has finished.
+
+    What *is* measured: over the whole benchmark (2750 items, 11 languages)
+    `deepseek-v4-flash` answers **0.919** directly, leaving **222** items with
+    real signal — enough for a 34 / 110 / 78 split, where the previous attempt had
+    47 items and split them 23 / 12 / 11.
+
+    One thing to know before running it: this example needs `--max-tokens` set for
+    a reasoning model. At the library default the meta-agent returns empty content
+    on every call and no design reaches the archive — and an empty completion
+    scores as a wrong answer rather than raising.
+    [Details](algo-adas.md#measured-mgsm-with-deepseek).
 
 Each learned something specific to the failure it was shown:
 

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -805,6 +805,17 @@ class SearchResult:
     #: `--hard` subset the direct baseline is 0.000 by construction, so the only
     #: comparison that says anything about the search is searched-vs-seed.
     best_seed: dict = field(default_factory=dict)
+    #: ``EvolutionResult.outcomes()`` -- why each generation went as it did.
+    #: The driver's own ``+0/-1`` line cannot distinguish "candidates reached the
+    #: archive and none beat the incumbent" (`already-best`) from "no candidate
+    #: was ever produced" (`no-candidates`, i.e. every trigger rollout passed, so
+    #: `evolve()` never asked for a proposal). Those need opposite fixes -- a
+    #: better meta-prompt versus a harder trigger split -- and the recorded run
+    #: that concluded "the archive rejected every candidate" had no way to tell
+    #: which of the two it had actually observed.
+    outcomes: dict = field(default_factory=dict)
+    stop_reason: str = "rounds"
+    error: Optional[str] = None
 
 
 def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
@@ -834,7 +845,7 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
         agg.seed()             # score the seed archive BEFORE round 0 proposes
         return agg
 
-    evolve(tasks, reward, run=run, propose=make_propose(ctx, complete),
+    out = evolve(tasks, reward, run=run, propose=make_propose(ctx, complete),
            strategy=AgentDesignStrategy(), blast_radius=0.6, artifact_id="agentic_system",
            rounds=generations, n_workers=n_workers,
            max_concurrency=1 if asynchronous else n_workers,
@@ -849,7 +860,8 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
            eval_concurrency=EVAL_CONCURRENCY,
            held_out_frac=held_out_frac, aggregator_factory=factory, verbose=verbose)
     return SearchResult(ctx.archive, ctx.best_agent or {}, ctx.seed_fitness,
-                        ctx.best_fitness, ctx.best_seed or {})
+                        ctx.best_fitness, ctx.best_seed or {},
+                        out.outcomes(), out.stop_reason, out.error)
 
 
 # ===========================================================================
@@ -1042,6 +1054,14 @@ def main() -> None:
     print(f"\narchive: {len(result.archive)} designs "
           f"({sum(1 for a in result.archive if a.get('seed'))} seeds + "
           f"{sum(1 for a in result.archive if not a.get('seed'))} searched)")
+    # Why the generations went as they did. `already-best` and `no-candidates`
+    # both print as `+0/-1` on the driver's line and need opposite fixes.
+    if result.outcomes:
+        print("generations: " + ", ".join(f"{k}={v}" for k, v in
+                                          sorted(result.outcomes.items()))
+              + f"  (stopped: {result.stop_reason})")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print("\n                                  val (search)   test (held out)")
     print(f"  best hand-designed seed         {result.seed_fitness:>9.3f}   "
           f"{seed_test:>13.3f}   ({result.best_seed.get('name', '?')})")

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -107,6 +107,41 @@ def validate_program(program: dict, depth: int = 0) -> bool:
     return True
 
 
+#: Ceiling on model calls per question for a *proposed* program. The DSL nests,
+#: so cost is multiplicative: an `ensemble` of five 2-round/4-role `debate`s is 45
+#: calls per question, and evaluation is candidates x items x this number. One
+#: such proposal costs more than the entire rest of the search, and the meta-agent
+#: has no reason not to make it -- "compose more blocks" is exactly what it is
+#: asked to do. The most expensive *seed* is 5, so this leaves real headroom.
+MAX_PROGRAM_CALLS = 10
+
+
+def program_cost(program: dict, depth: int = 0) -> int:
+    """Model calls this program makes per question -- the unit of the run's budget.
+
+    Used for two things: the pre-run budget estimate, and the cap that keeps one
+    proposal from eating the whole search (:data:`MAX_PROGRAM_CALLS`)."""
+    if depth > 4 or not isinstance(program, dict):
+        return 0
+    block = program.get("block")
+    if block == "cot":
+        return 1
+    if block == "cot_sc":
+        return max(1, min(int(program.get("k", 3) or 3), Interpreter.max_samples))
+    if block == "reflexion":
+        return 1 + max(0, int(program.get("n", 1) or 0))
+    if block == "step_back":
+        return 2
+    if block == "debate":
+        roles = program.get("roles") or ["a", "b", "c"]
+        return len(roles) * max(1, int(program.get("rounds", 1) or 1)) + 1
+    if block == "role_assignment":
+        return 2
+    if block == "ensemble":
+        return sum(program_cost(c, depth + 1) for c in program.get("children", []))
+    return 0
+
+
 @dataclass
 class Interpreter:
     """Runs a DSL agent program over one MGSM question via LLM calls."""
@@ -275,6 +310,14 @@ You may compose ONLY these building blocks into a `program` tree:
 Design the NEXT agent: it should be interesting, novel versus the archive, and
 likely to improve fitness. Output ONLY a JSON object with keys "thought",
 "name", and "program". The "program" must use only the blocks above.
+
+Two constraints on the design:
+- It may make at most {max_calls} model calls per question (`cot`=1, `cot_sc`=k,
+  `reflexion`=1+n, `step_back`=2, `role_assignment`=2, `debate`=roles*rounds+1,
+  `ensemble`=the sum of its children). A costlier proposal is discarded unrun.
+- The fitness intervals overlap heavily at this validation-set size. Prefer a
+  design that is structurally different from the archive over one that adds a
+  refinement step to whichever entry happens to lead.
 {reflexion}"""
 
 _REFLEXION_1 = ("\nReflect: is this genuinely novel versus the archive and "
@@ -284,48 +327,108 @@ _REFLEXION_2 = ("\nReflect again: is the program valid (only allowed blocks) and
 
 
 def _render_archive(archive: List[dict]) -> str:
+    """The meta-agent's whole view of the search so far.
+
+    Shows the 95% bootstrap CI beside the mean, as ADAS's own archive does. The
+    mean alone reads as an exact ranking, so a meta-agent conditioned on it chases
+    gaps that are pure sampling noise on a validation set this size -- and then
+    proposes a *more elaborate* version of whatever happened to win. The interval
+    is already computed by :func:`bootstrap_ci`; it was just being discarded."""
     lines = []
     for i, a in enumerate(archive):
         fit = a.get("fitness")
-        fit_s = f"{fit:.3f}" if isinstance(fit, (int, float)) else "unevaluated"
-        lines.append(f"[{i}] {a['name']} (fitness={fit_s})\n"
+        if isinstance(fit, (int, float)):
+            ci = a.get("ci")
+            fit_s = f"{fit:.3f}"
+            if ci:
+                fit_s += f", 95% CI [{ci[0]:.3f}, {ci[1]:.3f}]"
+        else:
+            fit_s = "unevaluated"
+        lines.append(f"[{i}] {a['name']} (fitness={fit_s}; "
+                     f"{program_cost(a['program'])} model calls per question)\n"
                      f"    thought: {a.get('thought','')}\n"
                      f"    program: {json.dumps(a['program'])}")
     return "\n".join(lines)
 
 
-def _parse_agent(text: str) -> Optional[dict]:
-    m = re.search(r"\{.*\}", text, re.DOTALL)
-    if not m:
-        return None
-    try:
-        obj = json.loads(m.group(0))
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(obj, dict) or "program" not in obj:
-        return None
-    if not validate_program(obj["program"]):
-        return None
-    obj.setdefault("name", "Unnamed Agent")
-    obj.setdefault("thought", "")
-    return obj
+def _json_objects(text: str):
+    """Every balanced ``{...}`` span in ``text``, outermost first.
+
+    The single greedy ``\\{.*\\}`` this replaces spans from the first brace to the
+    last one in the whole reply, so any prose containing a brace after the JSON --
+    a closing note, a second worked example, a ```json fence followed by
+    commentary -- made the match unparseable and threw the proposal away. A
+    balanced scan gives each candidate span its own chance."""
+    starts = [i for i, c in enumerate(text) if c == "{"]
+    for start in starts:
+        depth, in_str, esc = 0, False, False
+        for i in range(start, len(text)):
+            c = text[i]
+            if in_str:
+                if esc:
+                    esc = False
+                elif c == "\\":
+                    esc = True
+                elif c == '"':
+                    in_str = False
+                continue
+            if c == '"':
+                in_str = True
+            elif c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    yield text[start:i + 1]
+                    break
+
+
+def _parse_agent(text: str, max_calls: int = MAX_PROGRAM_CALLS) -> Optional[dict]:
+    """The first balanced JSON span that is a well-formed, affordable agent."""
+    for span in _json_objects(text or ""):
+        try:
+            obj = json.loads(span)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict) or "program" not in obj:
+            continue
+        if not validate_program(obj["program"]):
+            continue
+        if max_calls and program_cost(obj["program"]) > max_calls:
+            continue                       # affordable is part of well-formed here
+        obj.setdefault("name", "Unnamed Agent")
+        obj.setdefault("thought", "")
+        return obj
+    return None
 
 
 def propose_agent(complete: Completion, archive: List[dict], debug_max: int = 3
                   ) -> Optional[dict]:
-    """Meta-agent proposes a new agent, with two Reflexion refinement rounds."""
+    """Meta-agent proposes a new agent, with two Reflexion refinement rounds.
+
+    The refinement rounds are *revisions*, so the last one is normally the answer
+    -- but only if it parsed. This used to return ``_parse_agent(text)`` on
+    whatever the final round happened to emit, which throws away a perfectly good
+    agent from round 0 or 1 whenever round 2 exhausts its retries on malformed
+    output. A generation produces one proposal, so that is a whole generation
+    spent for nothing. Keep the newest valid draft instead, and carry it forward
+    as the draft the next round refines."""
     reflexions = ["", _REFLEXION_1, _REFLEXION_2]
-    text = ""
+    best: Optional[dict] = None
+    draft = ""
     for i, refl in enumerate(reflexions):
         prompt = f"{_META_SYSTEM}\n\n" + _META_TMPL.format(
-            archive=_render_archive(archive), reflexion=(refl if i else ""))
-        if i and text:
-            prompt += f"\n\nYour current draft:\n{text}"
+            archive=_render_archive(archive), max_calls=MAX_PROGRAM_CALLS,
+            reflexion=(refl if i else ""))
+        if i and draft:
+            prompt += f"\n\nYour current draft:\n{draft}"
         for _ in range(debug_max):
             text = complete(prompt)
-            if _parse_agent(text) is not None:
+            agent = _parse_agent(text)
+            if agent is not None:
+                best, draft = agent, json.dumps(agent)
                 break
-    return _parse_agent(text)
+    return best
 
 
 # ===========================================================================
@@ -355,6 +458,20 @@ def build_examples(langs: List[str], per_lang: int, seed: int = 0
         pool.extend(rows[:per_lang])
     rng.shuffle(pool)
     return pool
+
+
+def language_of(langs: List[str], per_lang: int, seed: int = 0) -> dict:
+    """``question -> language`` for the same pool :func:`build_examples` returns.
+
+    MGSM's languages are not equally hard (measured with ``deepseek-v4-flash``:
+    ``en`` 0.964, ``ja`` 0.880), so a hard subset drawn from several of them is a
+    mixture -- and an unstratified split can hand validation one mix and test
+    another. That difference then shows up as a lift, or hides one."""
+    out = {}
+    for lang in langs:
+        for q, _ in download_mgsm(lang):
+            out[q] = lang
+    return out
 
 
 def score_mgsm(target: str, prediction: Optional[str]) -> bool:
@@ -399,6 +516,77 @@ def load_dataset(langs: List[str], per_lang: int, seed: int = 0,
 EVAL_CONCURRENCY = 16          # set from --eval-concurrency; I/O bound, so high
 
 
+def estimate_calls(generations: int, n_train: int, n_val: int, n_test: int,
+                   n_workers: int = 2) -> int:
+    """Model calls a run of this shape costs, from the actual program costs.
+
+    The old estimate was ``(7 + generations) * (n_val + n_test) * 3`` computed
+    *before* ``--hard`` narrowed the split, so it reported the cost of a run over
+    the full pool for a run that would actually happen on 8% of it. The recorded
+    figure was ~9009 calls for a run that made 791 -- an order of magnitude, on
+    the number a caller uses to decide whether they can afford this at all."""
+    seeds = seed_archive()
+    seed_calls = sum(program_cost(s["program"]) for s in seeds) * n_val
+    # Three Reflexion rounds per meta-agent, and a candidate costs at most
+    # MAX_PROGRAM_CALLS per item -- which is the cap, so this is an upper bound.
+    propose = generations * n_workers * 3
+    trigger = generations * n_workers * MAX_PROGRAM_CALLS
+    candidates = generations * n_workers * n_val * MAX_PROGRAM_CALLS
+    test = 2 * n_test * MAX_PROGRAM_CALLS          # best seed + best searched
+    return int(seed_calls + propose + trigger + candidates + test)
+
+
+class _HardCache:
+    """Per-question verdicts from the ``--hard`` baseline pass, kept on disk.
+
+    The pass is one cheap call per item, but it is *every* item: at
+    ``--langs`` all ``--per-lang 250`` that is 2750 calls thrown away and paid
+    again on the next run, which is more than a three-generation search costs.
+    The verdict depends only on (model, question), so it caches cleanly -- and
+    caching it is what makes the hard subset reproducible across runs rather than
+    re-drawn from a fresh sample of the model each time."""
+
+    def __init__(self, model: str, enabled: bool = True) -> None:
+        import hashlib
+        import os
+        self.enabled = enabled
+        key = hashlib.sha256(model.encode()).hexdigest()[:12]
+        root = os.path.join(os.path.expanduser("~/.cache/agentdescent"), "mgsm", "hard")
+        self.path = os.path.join(root, f"direct_{key}.json")
+        self._d = {}
+        self._dirty = False
+        self._lock = threading.Lock()
+        if enabled:
+            os.makedirs(root, exist_ok=True)
+            try:
+                with open(self.path, encoding="utf-8") as fh:
+                    self._d = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                self._d = {}
+
+    def count(self, questions) -> int:
+        return sum(1 for q in questions if q in self._d)
+
+    def get(self, question: str) -> Optional[float]:
+        return self._d.get(question) if self.enabled else None
+
+    def put(self, question: str, score: float) -> None:
+        if not self.enabled:
+            return
+        with self._lock:
+            self._d[question] = score
+            self._dirty = True
+
+    def flush(self) -> None:
+        if not (self.enabled and self._dirty):
+            return
+        try:
+            with open(self.path, "w", encoding="utf-8") as fh:
+                json.dump(self._d, fh, ensure_ascii=False)
+        except OSError:
+            pass                          # a cache miss is not a run failure
+
+
 def evaluate(complete: Completion, program: dict,
              examples: List[Tuple[str, str]]) -> float:
     """Mean MGSM accuracy of an agent program on a held-out split."""
@@ -439,6 +627,10 @@ class AdasContext:
     seed_fitness: float = 0.0
     best_fitness: float = 0.0
     best_agent: dict = field(default_factory=dict)
+    #: The best *hand-designed* seed, kept so the run can report the lift that
+    #: matters -- searched-vs-seed on the test split. Reporting only the searched
+    #: agent's test accuracy says nothing about whether the search helped.
+    best_seed: dict = field(default_factory=dict)
     lock: threading.Lock = field(default_factory=threading.Lock)   # workers run concurrently
 
 
@@ -496,7 +688,7 @@ class MetaSearchAggregator(AggregatorProtocol):
         self.cards: List[EvidenceCard] = []
         self._seeded = False
 
-    def _fitness(self, head, design: str) -> float:
+    def _fitness(self, head, design: str) -> Tuple[float, Tuple[float, float]]:
         art = head.apply(Diff(diff_id="eval", target=self.aid,
                               ops={"design": design}, author="adas"))
         # Per-instance 0/1, because the bootstrap CI needs the individual outcomes --
@@ -510,13 +702,35 @@ class MetaSearchAggregator(AggregatorProtocol):
                 correct = list(pool.map(lambda t: art.score([t]), held))
         else:
             correct = []
-        return bootstrap_ci(correct, seed=self.boot_seed)[0]
+        mean, lo, hi = bootstrap_ci(correct, seed=self.boot_seed)
+        return mean, (lo, hi)
+
+    def seed(self) -> None:
+        """Score the seven hand-designed seeds -- once, and *before* round 0.
+
+        This ran inside the first ``step()``, which is after the first round's
+        meta-agents have already proposed. Their whole conditioning signal is the
+        archive, so the first generation was designed against seven entries all
+        reading ``unevaluated``: it could not know that Debate beats CoT here,
+        because nothing had been measured yet. With ``--generations 3`` that is a
+        third of the search spent blind. The aggregator is built before round 0,
+        so this belongs in construction."""
+        if self._seeded:
+            return
+        self._seeded = True
+        head = self.ledger.snapshot(Ledger.DEV).get(self.aid)
+        for a in seed_archive():
+            mean, ci = self._fitness(head, json.dumps(a["program"]))
+            self._record(a["name"], a["thought"], a["program"], mean, ci, seed=True)
+        self.ctx.seed_fitness = self.ctx.best_fitness
+        self.ctx.best_seed = dict(self.ctx.best_agent)
 
     def ingest(self, card: EvidenceCard) -> None:
         self.cards.append(card)
 
-    def _record(self, name, thought, program, fitness):
-        agent = {"name": name, "thought": thought, "program": program, "fitness": fitness}
+    def _record(self, name, thought, program, fitness, ci=None, seed=False):
+        agent = {"name": name, "thought": thought, "program": program,
+                 "fitness": fitness, "ci": ci, "seed": seed}
         self.ctx.archive.append(agent)
         self.ctx.children.append(0)
         if fitness > self.ctx.best_fitness or not self.ctx.best_agent:
@@ -525,39 +739,50 @@ class MetaSearchAggregator(AggregatorProtocol):
         return agent
 
     def step(self) -> List[MergeReport]:
+        self.seed()                                        # no-op after construction
         snap = self.ledger.snapshot(Ledger.DEV)
         head = snap.get(self.aid)
         base_vv = {self.aid: snap.version.get(self.aid, 0)}
-        if not self._seeded:                               # ADAS: seed archive first
-            for a in seed_archive():
-                self._record(a["name"], a["thought"], a["program"],
-                             self._fitness(head, json.dumps(a["program"])))
-            self.ctx.seed_fitness = self.ctx.best_fitness
-            self._seeded = True
 
         cards, self.cards = self.cards, []
         for card in cards:
             design = card.diff.ops["design"]
+            mean, ci = self._fitness(head, design)
             self._record(card.diff.ops.get("name", "agent"),
                          card.diff.ops.get("thought", ""),
-                         json.loads(design), self._fitness(head, design))
+                         json.loads(design), mean, ci)
 
         best_design = json.dumps(self.ctx.best_agent["program"])
-        committed = None
+        diff = Diff(diff_id="best", target=self.aid,
+                    ops={"design": best_design,
+                         "name": self.ctx.best_agent["name"],
+                         "thought": self.ctx.best_agent.get("thought", "")},
+                    author="adas")
+        committed, category = None, "already-best"
+        if not cards:
+            category = "no-candidates"
         if best_design != head.state.get("design"):        # keep the best design as head
             try:
                 _, committed = self.ledger.commit(
-                    head.apply(Diff(diff_id="best", target=self.aid,
-                                    ops={"design": best_design,
-                                         "name": self.ctx.best_agent["name"],
-                                         "thought": self.ctx.best_agent.get("thought", "")},
-                                    author="adas")),
-                    base_vv, branch=Ledger.DEV, message="adas: keep best design")
+                    head.apply(diff), base_vv, branch=Ledger.DEV,
+                    message="adas: keep best design")
+                category = "committed"
             except CASConflict:
-                committed = None
-        return [MergeReport(self.aid, None, False, len(cards), len(cards), 0, 0,
+                category = "cas-conflict"
+        # `accepted` and `category` were left at None/"" while the archive was in
+        # fact committing, so the driver's own tally -- which reads
+        # `committed_version` -- printed `+0/-1` for a generation whose best design
+        # was simply unchanged, and `outcomes()` bucketed every generation as
+        # "unknown". The three outcomes need opposite responses: "already-best"
+        # means the search found nothing better, "no-candidates" means nothing
+        # reached the archive at all (the trigger rollouts all passed, so evolve()
+        # never asked for a proposal), and "committed" means it did improve.
+        return [MergeReport(self.aid, diff if committed is not None else None, False,
+                            len(cards), len(cards), 0, 0,
                             self.ctx.best_fitness, committed,
-                            f"archive={len(self.ctx.archive)} best={self.ctx.best_fitness:.3f}")]
+                            f"archive={len(self.ctx.archive)} "
+                            f"best={self.ctx.best_fitness:.3f} ({category})",
+                            category)]
 
 
 @dataclass
@@ -566,12 +791,17 @@ class SearchResult:
     best: dict
     seed_fitness: float
     best_fitness: float
+    #: The best hand-designed seed, so the caller can score *it* on test too. On a
+    #: `--hard` subset the direct baseline is 0.000 by construction, so the only
+    #: comparison that says anything about the search is searched-vs-seed.
+    best_seed: dict = field(default_factory=dict)
 
 
 def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
                           generations: int, select: str = "adas", seed: int = 0,
                           asynchronous: bool = False, async_ratio: int = 3,
-                          max_seconds: float = 45.0, verbose: bool = False) -> SearchResult:
+                          max_seconds: float = 45.0, held_out_frac: float = 0.5,
+                          n_workers: int = 2, verbose: bool = False) -> SearchResult:
     """Drive Meta Agent Search through `evolve()` (val split into trigger/held-out)."""
     tasks = [Task(id=f"mgsm{i}", prompt=q, meta={"answer": a})
              for i, (q, a) in enumerate(val)]
@@ -589,17 +819,27 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
         return 1.0 if score_mgsm(task.meta["answer"], output) else 0.0
 
     def factory(ledger, verifier, audit, config, policy):
-        return MetaSearchAggregator(ledger, verifier, ctx,
-                                    artifact_id="agentic_system", boot_seed=seed)
+        agg = MetaSearchAggregator(ledger, verifier, ctx,
+                                   artifact_id="agentic_system", boot_seed=seed)
+        agg.seed()             # score the seed archive BEFORE round 0 proposes
+        return agg
 
     evolve(tasks, reward, run=run, propose=make_propose(ctx, complete),
            strategy=AgentDesignStrategy(), blast_radius=0.6, artifact_id="agentic_system",
-           rounds=generations, n_workers=2,
-           max_concurrency=1 if asynchronous else 2,
+           rounds=generations, n_workers=n_workers,
+           max_concurrency=1 if asynchronous else n_workers,
            asynchronous=asynchronous, async_ratio=async_ratio,
            max_seconds=max_seconds if asynchronous else None,
-           held_out_frac=0.5, aggregator_factory=factory, verbose=verbose)
-    return SearchResult(ctx.archive, ctx.best_agent or {}, ctx.seed_fitness, ctx.best_fitness)
+           # The archive judges a candidate by its own bootstrap fitness over the
+           # whole held-out set and never reads `before_after_delta`, so the
+           # self-verify rollout each proposal triggers is a multi-step program run
+           # for a number nothing consumes -- pure cost on the most expensive
+           # example in the repo.
+           self_verify=False,
+           eval_concurrency=EVAL_CONCURRENCY,
+           held_out_frac=held_out_frac, aggregator_factory=factory, verbose=verbose)
+    return SearchResult(ctx.archive, ctx.best_agent or {}, ctx.seed_fitness,
+                        ctx.best_fitness, ctx.best_seed or {})
 
 
 # ===========================================================================
@@ -629,40 +869,60 @@ def main() -> None:
                         "on how long a run takes")
     p.add_argument("--eval-concurrency", type=int, default=16,
                    help="how many examples to score at once (I/O bound)")
+    p.add_argument("--workers", type=int, default=2,
+                   help="meta-agents proposing per generation. A proposal is only "
+                        "requested when the generation's trigger rollout FAILS, so "
+                        "on a hard subset roughly half of them fire -- raising this "
+                        "buys candidates per generation at the same cost each")
     p.add_argument("--hard", action="store_true",
                    help="keep only items a plain single call gets wrong -- MGSM is "
-                        "already ~1.000 for a strong model, so the search has no "
+                        "already ~0.92 for a strong model, so the search has no "
                         "gradient. Those are exactly the items where agentic "
                         "structure (CoT, debate, self-refine) can help")
+    p.add_argument("--no-hard-cache", dest="hard_cache", action="store_false",
+                   help="re-run the --hard baseline pass instead of reusing the "
+                        "cached per-question verdicts")
+    p.add_argument("--train-frac", type=float, default=0.15,
+                   help="share of the pool used only to TRIGGER proposals. The "
+                        "meta-agent conditions on the archive, not on the task it "
+                        "is handed, so a round consumes 2 of these and nothing "
+                        "else -- everything left over measures fitness instead")
+    p.add_argument("--test-frac", type=float, default=0.35,
+                   help="share of the pool held out for the final number")
     p.add_argument("--dry-run", action="store_true")
     p.add_argument("--yes", action="store_true")
     args = p.parse_args()
 
     langs = [l.strip() for l in args.langs.split(",") if l.strip() in ALL_LANGUAGES]
+    if not 0.0 < args.train_frac and 0.0 < args.test_frac and args.train_frac + args.test_frac < 1.0:
+        p.error("--train-frac and --test-frac must be positive and sum to < 1")
+    ratios = (args.train_frac, 1.0 - args.train_frac - args.test_frac, args.test_frac)
     print("Algorithm: ADAS Meta Agent Search -- harness (agentic-system) self-evolution")
     print("Dataset  : MGSM (Multilingual Grade-School Math)")
-    ds = load_dataset(langs, args.per_lang, seed=args.seed)
+    langmap = language_of(langs, args.per_lang, seed=args.seed)
+    pool = build_examples(langs, args.per_lang, seed=args.seed)
+    ds = split_dataset(pool, ratios=ratios, seed=args.seed, name="MGSM",
+                       stratify_key=lambda ex: langmap.get(ex[0], "?"))
     harness = EvolvingArtifact("agentic_system", blast_radius=0.6)
-    ntr, nva, nte = ds.sizes()
     print(f"Governance: harness artifact blast_radius={harness.blast_radius} "
           f"-> {classify(harness).name} (harness changes are high-blast-radius)")
-    print(f"Loaded   : langs={langs}; {ntr} train / {nva} val (search) / {nte} test")
+    print(f"Loaded   : langs={langs}; {len(pool)} items")
     print(f"Seeds    : {', '.join(a['name'] for a in seed_archive())}")
     print("\nExample problem:")
     print("  Q:", ds.train[0][0][:150])
     print("  A:", ds.train[0][1])
-
-    calls = args.generations * 3 + (len(seed_archive()) + args.generations) * (nva + nte) * 3
     print(f"\nPlan     : model={args.model}, generations={args.generations}, select={args.select}")
     if args.asynchronous:
-        print(f"Async    : 2 meta-agents, barrier-free (async_ratio={args.async_ratio}, "
-              f"max {args.max_seconds:.0f}s); the archive rebases/discards stale designs")
+        print(f"Async    : {args.workers} meta-agents, barrier-free "
+              f"(async_ratio={args.async_ratio}, max {args.max_seconds:.0f}s); "
+              f"the archive rebases/discards stale designs")
     else:
-        print("Parallel : 2 meta-agents propose concurrently each generation "
-              "(synchronous DP; the archive merge is the barrier)")
-    print(f"Budget   : up to ~{calls} model calls (multi-step agents call the model many times)")
+        print(f"Parallel : {args.workers} meta-agents propose concurrently each "
+              "generation (synchronous DP; the archive merge is the barrier)")
 
     if args.dry_run:
+        print(f"\nBudget   : ~{estimate_calls(args.generations, *ds.sizes(), args.workers)} "
+              f"model calls on this (unfiltered) split")
         print("\n[dry-run] not calling the API. Drop --dry-run to run Meta Agent Search.")
         return
 
@@ -675,47 +935,113 @@ def main() -> None:
     completion = (openai_compatible(model=args.model, usage=usage) if args.provider in ("openai", "glm")
                   else claude(model=args.model, usage=usage))
     globals()["EVAL_CONCURRENCY"] = args.eval_concurrency
+    try:
+        completion("Reply with the single word: ok")
+    except Exception as e:  # noqa: BLE001
+        print(f"\nCould not reach the model ({type(e).__name__}: {e}).")
+        print("For --provider openai set OPENAI_BASE_URL + OPENAI_API_KEY; "
+              "for claude set ANTHROPIC_API_KEY (or `ant auth login`).")
+        return
+
     if args.hard:
         # A plain, structure-free call is the right baseline here: what ADAS
         # searches over IS structure, so the items worth keeping are the ones a
         # single call cannot already do.
         from agentdescent.dataloader import select_hard
 
+        cache = _HardCache(args.model, enabled=args.hard_cache)
+        verdicts = {}                     # this run's view, cache on or off
+
         def _direct(ex):
             q, a = ex
+            hit = cache.get(q)
+            if hit is not None:
+                verdicts[q] = hit
+                return hit
             out = completion(f"{q}\n\nAnswer with the final number only.")
-            digits = "".join(c for c in (out or "") if c.isdigit() or c in ".-")
-            return 1.0 if score_mgsm(a, digits.strip(".-") or None) else 0.0
+            # The agents are scored with `_extract_int`; scoring the baseline with
+            # a different, cruder extractor (concatenating every digit character in
+            # the reply) means "hard" partly meant "the two extractors disagree" --
+            # and the run then measures the agents against items they were never
+            # actually wrong about. One extractor for both sides, so the subset
+            # means what it says.
+            score = 1.0 if score_mgsm(a, _extract_int(out or "")) else 0.0
+            cache.put(q, score)
+            verdicts[q] = score
+            return score
 
-        pool = select_hard(build_examples(langs, args.per_lang, seed=args.seed),
-                           _direct, keep=args.hard_keep,
+        n_cached = cache.count(q for q, _ in pool)
+        if n_cached:
+            print(f"\nBaseline : {n_cached}/{len(pool)} verdicts reused from "
+                  f"{cache.path}")
+        hard = select_hard(pool, _direct, keep=args.hard_keep,
                            concurrency=args.eval_concurrency)
-        ds = split_dataset(pool, ratios=(0.5, 0.25, 0.25), seed=args.seed, name="MGSM")
-        ntr, nva, nte = ds.sizes()
-        print(f"Hard mode: {ntr} train / {nva} val / {nte} test  "
-              f"(items a single call answers incorrectly)")
-    try:
-        completion("Reply with the single word: ok")
-    except Exception as e:  # noqa: BLE001
-        print(f"\nCould not reach the model ({type(e).__name__}: {e}).")
-        print("For --provider glm set OPENAI_BASE_URL + OPENAI_API_KEY; "
-              "for claude set ANTHROPIC_API_KEY (or `ant auth login`).")
-        return
+        cache.flush()
+        ds = split_dataset(hard, ratios=ratios, seed=args.seed, name="MGSM",
+                           stratify_key=lambda ex: langmap.get(ex[0], "?"))
+        # From the verdicts, not from len(hard): `select_hard` tops a thin result
+        # up with items the baseline SOLVED, and `--hard-keep` truncates. Deriving
+        # the baseline from the subset size therefore reports the top-up as model
+        # error -- on a 30-item English pool it printed 0.600 for a model that had
+        # in fact answered 29 of 30.
+        n_wrong = sum(1 for q, _ in pool if verdicts.get(q) == 0.0)
+        kept_hard = sum(1 for q, _ in hard if verdicts.get(q) == 0.0)
+        print(f"Hard mode: {n_wrong}/{len(pool)} items a single call answers "
+              f"incorrectly (direct accuracy {1 - n_wrong/len(pool):.3f})")
+        if kept_hard < len(hard):
+            print(f"           subset is {len(hard)} items, of which {kept_hard} are "
+                  f"hard -- select_hard topped up a pool too thin to split")
+
+    ntr, nva, nte = ds.sizes()
+    print(f"Split    : {ntr} trigger / {nva} val (fitness) / {nte} test")
+    print(f"Budget   : ~{estimate_calls(args.generations, ntr, nva, nte, args.workers)} "
+          f"model calls (each candidate is a multi-step program, run on every val item)")
+    if nva < 20 or nte < 20:
+        print("WARNING  : fewer than 20 items on a split -- at this size a single "
+              "rollout moves the number by 5%+ and no lift is readable. "
+              "Raise --per-lang / --langs, or drop --hard-keep.")
 
     print("\nSearching agentic systems (Meta Agent Search, L1 harness)...\n")
     result = run_meta_agent_search(completion, ds.trainval, args.generations,
                                    select=args.select, seed=args.seed,
                                    asynchronous=args.asynchronous, async_ratio=args.async_ratio,
-                                   max_seconds=args.max_seconds, verbose=True)
+                                   max_seconds=args.max_seconds, n_workers=args.workers,
+                                   # the engine's held-out split IS ds.val
+                                   held_out_frac=ds.val_frac, verbose=True)
 
-    test_acc = evaluate(completion, result.best.get("program", {}), ds.test)
+    # Both numbers on the SAME held-out split. Reporting only the searched agent's
+    # test accuracy cannot answer the question the run exists to answer -- on a
+    # `--hard` subset the structure-free baseline is 0.000 by construction, so
+    # "0.4 on test" is not evidence that searching did anything. The comparison is
+    # searched-vs-best-seed, and it costs one extra evaluation of one program.
+    seed_prog = result.best_seed.get("program", {})
+    best_prog = result.best.get("program", {})
+    if not validate_program(best_prog):        # the run died before the archive filled
+        print("\nNo agentic system was evaluated -- see the error above.")
+        print(f"model usage: {usage.summary()}")
+        return
+    seed_test = evaluate(completion, seed_prog, ds.test)
+    test_acc = (seed_test if seed_prog == best_prog
+                else evaluate(completion, best_prog, ds.test))
+
     print("\n=== best discovered agentic system ===")
     print(f"name   : {result.best.get('name', '?')}")
-    print(f"program: {json.dumps(result.best.get('program', {}), indent=2)}")
-    print(f"\nseed fitness (best hand-designed): {result.seed_fitness:.3f}")
-    print(f"searched fitness (best on val)   : {result.best_fitness:.3f}")
-    print(f"test accuracy (held out)         : {test_acc:.3f}")
-    print(f"model usage: {usage.summary()}")
+    print(f"program: {json.dumps(best_prog, indent=2)}")
+    print(f"         ({program_cost(best_prog)} model calls per question)")
+    print(f"\narchive: {len(result.archive)} designs "
+          f"({sum(1 for a in result.archive if a.get('seed'))} seeds + "
+          f"{sum(1 for a in result.archive if not a.get('seed'))} searched)")
+    print("\n                                  val (search)   test (held out)")
+    print(f"  best hand-designed seed         {result.seed_fitness:>9.3f}   "
+          f"{seed_test:>13.3f}   ({result.best_seed.get('name', '?')})")
+    print(f"  best searched design            {result.best_fitness:>9.3f}   "
+          f"{test_acc:>13.3f}   ({result.best.get('name', '?')})")
+    print(f"  lift                            {result.best_fitness - result.seed_fitness:>+9.3f}   "
+          f"{test_acc - seed_test:>+13.3f}")
+    if args.hard:
+        print("\n  (a structure-free single call scores 0.000 on this subset by "
+              "construction -- the seed row is the baseline that matters)")
+    print(f"\nmodel usage: {usage.summary()}")
 
 
 if __name__ == "__main__":

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -94,6 +94,24 @@ def _majority(answers: List[Optional[str]]) -> Optional[str]:
     return votes.most_common(1)[0][0] if votes else None
 
 
+def canonical(program: dict) -> str:
+    """A design's identity: its JSON with **sorted keys**.
+
+    Every dedup in the search is string equality on this -- `to_diff` drops a
+    proposal identical to the head, `step()` commits only when the best design
+    differs from it, and the evaluation cache keys on it (an artifact's cache key
+    is what it renders to, and a design IS what this artifact renders). Plain
+    `json.dumps` preserves *insertion* order, which for a proposal is whatever
+    key order the model happened to emit -- so `{"block":"cot_sc","k":3}` and
+    `{"k":3,"block":"cot_sc"}` were two different designs. The duplicate passed
+    the dedup, was scored on every val item (~330 model calls at this size),
+    landed the same fitness as the design it duplicated, failed the strict
+    `>` test, and showed up as one more `+0/-1`. Sorted, the duplicate is
+    recognised for free -- and if one slips through anyway it now hits the
+    evaluation cache instead of being re-run."""
+    return json.dumps(program, sort_keys=True)
+
+
 def validate_program(program: dict, depth: int = 0) -> bool:
     """Reject any program that is not built purely from known DSL blocks."""
     if depth > 4 or not isinstance(program, dict):
@@ -515,6 +533,52 @@ def load_dataset(langs: List[str], per_lang: int, seed: int = 0,
 
 EVAL_CONCURRENCY = 16          # set from --eval-concurrency; I/O bound, so high
 
+#: Token budget per model call. Far above what any single reply here needs -- the
+#: meta-agent's JSON is ~250 tokens and an answer is a handful -- because on a
+#: *reasoning* model the budget is spent on hidden reasoning first and the visible
+#: content is what is left. Measured on ``deepseek-v4-flash`` at the library
+#: default of 4096: **0 of 4** meta-agent calls returned anything at all, each
+#: burning its entire 4096 on reasoning; at 16384 all 4 returned a well-formed
+#: 740-1068 character design. You are billed for tokens generated, not for the
+#: cap, so the headroom is free.
+MAX_TOKENS = 16384
+
+
+class EmptyCompletionGuard:
+    """Wraps a completion and counts the replies that come back blank.
+
+    An empty completion is the most dangerous failure mode this example has,
+    because it is *silent*: `_extract_int("")` is `None`, `score_mgsm` scores that
+    as a wrong answer, and a starved run therefore reports a low accuracy that
+    looks exactly like a model that cannot do the problems. Nothing raises, so
+    every gate downstream -- fitness, the archive, the lift -- is computed over
+    answers that were never generated. Counting them turns a corrupted
+    measurement into a visible one."""
+
+    def __init__(self, complete: Completion) -> None:
+        self._complete = complete
+        self.blank = 0
+        self.total = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, prompt: str) -> str:
+        out = self._complete(prompt)
+        if not (out or "").strip():
+            with self._lock:
+                self.blank += 1
+        with self._lock:
+            self.total += 1
+        return out
+
+    def report(self) -> Optional[str]:
+        if not self.blank:
+            return None
+        return (f"{self.blank}/{self.total} model calls returned EMPTY content "
+                f"({self.blank / self.total:.1%}). On a reasoning model that means "
+                f"the token budget was spent on hidden reasoning -- raise "
+                f"--max-tokens. Every blank reply was scored as a wrong answer, so "
+                f"the numbers below understate the agents by an unknown amount.")
+
 
 def estimate_calls(generations: int, n_train: int, n_val: int, n_test: int,
                    n_workers: int = 2) -> Tuple[int, int]:
@@ -649,7 +713,7 @@ class AgentDesignStrategy:
 
     def initial(self):
         seed = seed_archive()[0]                            # start from Chain-of-Thought
-        return {"design": json.dumps(seed["program"]),
+        return {"design": canonical(seed["program"]),
                 "name": seed["name"], "thought": seed["thought"]}
 
     def render(self, state):
@@ -659,7 +723,7 @@ class AgentDesignStrategy:
         agent = _parse_agent(proposal)
         if agent is None:
             return None
-        design = json.dumps(agent["program"])
+        design = canonical(agent["program"])
         if design == state.get("design"):
             return None
         return Diff(diff_id=f"{author}:{rule_id(design)}:{base_version}", target=target,
@@ -730,7 +794,7 @@ class MetaSearchAggregator(AggregatorProtocol):
         self._seeded = True
         head = self.ledger.snapshot(Ledger.DEV).get(self.aid)
         for a in seed_archive():
-            mean, ci = self._fitness(head, json.dumps(a["program"]))
+            mean, ci = self._fitness(head, canonical(a["program"]))
             self._record(a["name"], a["thought"], a["program"], mean, ci, seed=True)
         self.ctx.seed_fitness = self.ctx.best_fitness
         self.ctx.best_seed = dict(self.ctx.best_agent)
@@ -762,7 +826,7 @@ class MetaSearchAggregator(AggregatorProtocol):
                          card.diff.ops.get("thought", ""),
                          json.loads(design), mean, ci)
 
-        best_design = json.dumps(self.ctx.best_agent["program"])
+        best_design = canonical(self.ctx.best_agent["program"])
         diff = Diff(diff_id="best", target=self.aid,
                     ops={"design": best_design,
                          "name": self.ctx.best_agent["name"],
@@ -891,6 +955,11 @@ def main() -> None:
                         "on how long a run takes")
     p.add_argument("--eval-concurrency", type=int, default=16,
                    help="how many examples to score at once (I/O bound)")
+    p.add_argument("--max-tokens", type=int, default=MAX_TOKENS,
+                   help="token budget per model call. On a reasoning model the "
+                        "budget is spent on hidden reasoning first, so too small a "
+                        "cap returns EMPTY content -- which scores as a wrong "
+                        "answer and silently understates every agent")
     p.add_argument("--workers", type=int, default=2,
                    help="meta-agents proposing per generation. A proposal is only "
                         "requested when the generation's trigger rollout FAILS, so "
@@ -954,15 +1023,28 @@ def main() -> None:
             return
 
     usage = Usage()                       # what the run actually costs
-    completion = (openai_compatible(model=args.model, usage=usage) if args.provider in ("openai", "glm")
-                  else claude(model=args.model, usage=usage))
+    raw = (openai_compatible(model=args.model, usage=usage, max_tokens=args.max_tokens)
+           if args.provider in ("openai", "glm")
+           else claude(model=args.model, usage=usage, max_tokens=args.max_tokens))
+    guard = EmptyCompletionGuard(raw)
+    completion = guard
     globals()["EVAL_CONCURRENCY"] = args.eval_concurrency
     try:
-        completion("Reply with the single word: ok")
+        probe = completion("Solve: what is 17 * 23? Think step by step, then end "
+                           "with `Answer: <integer>`.")
     except Exception as e:  # noqa: BLE001
         print(f"\nCould not reach the model ({type(e).__name__}: {e}).")
         print("For --provider openai set OPENAI_BASE_URL + OPENAI_API_KEY; "
               "for claude set ANTHROPIC_API_KEY (or `ant auth login`).")
+        return
+    # A *reasoning* prompt, not "reply with ok": the cheap probe passes at any
+    # budget, and the whole run is reasoning prompts. An empty reply here means
+    # every rollout will be blank and score as wrong, with nothing raising.
+    if not (probe or "").strip():
+        print(f"\nThe model returned EMPTY content for a reasoning prompt at "
+              f"--max-tokens {args.max_tokens}. On a reasoning model the budget is "
+              f"spent on hidden reasoning first, so every rollout would come back "
+              f"blank and be scored as a wrong answer. Raise --max-tokens.")
         return
 
     if args.hard:
@@ -1072,6 +1154,9 @@ def main() -> None:
     if args.hard:
         print("\n  (a structure-free single call scores 0.000 on this subset by "
               "construction -- the seed row is the baseline that matters)")
+    blank = guard.report()
+    if blank:
+        print(f"\nWARNING: {blank}")
     print(f"\nmodel usage: {usage.summary()}")
 
 

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -580,6 +580,15 @@ class EmptyCompletionGuard:
                 f"the numbers below understate the agents by an unknown amount.")
 
 
+def fmt_score(x: Optional[float]) -> str:
+    """A score, or ``n/a`` when it could not be measured.
+
+    A missing number must print as missing. Formatting `None` with `:.3f` raises,
+    which would turn "we could not score the test split" into a traceback that
+    also discards the validation numbers the run *did* produce."""
+    return "     n/a" if x is None else f"{x:>8.3f}"
+
+
 def estimate_calls(generations: int, n_train: int, n_val: int, n_test: int,
                    n_workers: int = 2) -> Tuple[int, int]:
     """``(typical, ceiling)`` model calls for a run of this shape.
@@ -955,6 +964,11 @@ def main() -> None:
                         "on how long a run takes")
     p.add_argument("--eval-concurrency", type=int, default=16,
                    help="how many examples to score at once (I/O bound)")
+    p.add_argument("--timeout", type=float, default=300.0,
+                   help="per-call timeout. A reasoning model given a large "
+                        "--max-tokens can spend minutes on one call, and the "
+                        "library default of 120s then turns a working run into "
+                        "retries and lost rounds")
     p.add_argument("--max-tokens", type=int, default=MAX_TOKENS,
                    help="token budget per model call. On a reasoning model the "
                         "budget is spent on hidden reasoning first, so too small a "
@@ -1023,7 +1037,8 @@ def main() -> None:
             return
 
     usage = Usage()                       # what the run actually costs
-    raw = (openai_compatible(model=args.model, usage=usage, max_tokens=args.max_tokens)
+    raw = (openai_compatible(model=args.model, usage=usage,
+                             max_tokens=args.max_tokens, timeout=args.timeout)
            if args.provider in ("openai", "glm")
            else claude(model=args.model, usage=usage, max_tokens=args.max_tokens))
     guard = EmptyCompletionGuard(raw)
@@ -1125,9 +1140,28 @@ def main() -> None:
         print("\nNo agentic system was evaluated -- see the error above.")
         print(f"model usage: {usage.summary()}")
         return
-    seed_test = evaluate(completion, seed_prog, ds.test)
+    # The search is already done and paid for at this point: the archive holds
+    # every design's validation fitness. Letting a backend failure *here* escape
+    # throws all of it away and prints nothing -- which is how a run that had
+    # completed its seeding and its generations reported a bare traceback. It
+    # happened: an account ran out of credit during this very call, after 79
+    # minutes of work. Test accuracy is the one thing that becomes unavailable;
+    # everything measured on val survives, so report that and say which number is
+    # missing rather than losing both.
+    def _on_test(program) -> Optional[float]:
+        try:
+            return evaluate(completion, program, ds.test)
+        except Exception as e:  # noqa: BLE001 - a backend failure, not a caller bug
+            print(f"\nWARNING: could not score the test split "
+                  f"({type(e).__name__}: {str(e)[:160]}).")
+            print("         The validation numbers below are complete; the test "
+                  "column is not available for this run.")
+            return None
+
+    seed_test = _on_test(seed_prog)
     test_acc = (seed_test if seed_prog == best_prog
-                else evaluate(completion, best_prog, ds.test))
+                else _on_test(best_prog) if seed_test is not None else None)
+
 
     print("\n=== best discovered agentic system ===")
     print(f"name   : {result.best.get('name', '?')}")
@@ -1144,13 +1178,15 @@ def main() -> None:
               + f"  (stopped: {result.stop_reason})")
     if result.error:
         print(f"WARNING: the run did not finish cleanly -- {result.error}")
+    lift_test = (None if seed_test is None or test_acc is None
+                 else test_acc - seed_test)
     print("\n                                  val (search)   test (held out)")
     print(f"  best hand-designed seed         {result.seed_fitness:>9.3f}   "
-          f"{seed_test:>13.3f}   ({result.best_seed.get('name', '?')})")
+          f"{fmt_score(seed_test):>13}   ({result.best_seed.get('name', '?')})")
     print(f"  best searched design            {result.best_fitness:>9.3f}   "
-          f"{test_acc:>13.3f}   ({result.best.get('name', '?')})")
+          f"{fmt_score(test_acc):>13}   ({result.best.get('name', '?')})")
     print(f"  lift                            {result.best_fitness - result.seed_fitness:>+9.3f}   "
-          f"{test_acc - seed_test:>+13.3f}")
+          f"{('     n/a' if lift_test is None else f'{lift_test:>+8.3f}'):>13}")
     if args.hard:
         print("\n  (a structure-free single call scores 0.000 on this subset by "
               "construction -- the seed row is the baseline that matters)")

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -517,23 +517,33 @@ EVAL_CONCURRENCY = 16          # set from --eval-concurrency; I/O bound, so high
 
 
 def estimate_calls(generations: int, n_train: int, n_val: int, n_test: int,
-                   n_workers: int = 2) -> int:
-    """Model calls a run of this shape costs, from the actual program costs.
+                   n_workers: int = 2) -> Tuple[int, int]:
+    """``(typical, ceiling)`` model calls for a run of this shape.
 
     The old estimate was ``(7 + generations) * (n_val + n_test) * 3`` computed
     *before* ``--hard`` narrowed the split, so it reported the cost of a run over
     the full pool for a run that would actually happen on 8% of it. The recorded
     figure was ~9009 calls for a run that made 791 -- an order of magnitude, on
-    the number a caller uses to decide whether they can afford this at all."""
+    the number a caller uses to decide whether they can afford this at all.
+
+    A single number cannot be honest here either, because a candidate's cost is
+    whatever the meta-agent proposes: anywhere from 1 call per question (`cot`) to
+    :data:`MAX_PROGRAM_CALLS`. So both ends are given -- the typical figure prices
+    a candidate at the mean seed cost, the ceiling at the cap. Not every
+    generation yields a candidate either (a proposal is only requested when the
+    trigger rollout fails), so even the low end is an over-estimate."""
     seeds = seed_archive()
-    seed_calls = sum(program_cost(s["program"]) for s in seeds) * n_val
-    # Three Reflexion rounds per meta-agent, and a candidate costs at most
-    # MAX_PROGRAM_CALLS per item -- which is the cap, so this is an upper bound.
-    propose = generations * n_workers * 3
-    trigger = generations * n_workers * MAX_PROGRAM_CALLS
-    candidates = generations * n_workers * n_val * MAX_PROGRAM_CALLS
-    test = 2 * n_test * MAX_PROGRAM_CALLS          # best seed + best searched
-    return int(seed_calls + propose + trigger + candidates + test)
+    costs = [program_cost(s["program"]) for s in seeds]
+    seed_calls = sum(costs) * n_val
+    typical_cost = sum(costs) / len(costs)
+    propose = generations * n_workers * 3          # three Reflexion rounds each
+    out = []
+    for per_item in (typical_cost, float(MAX_PROGRAM_CALLS)):
+        trigger = generations * n_workers * per_item
+        candidates = generations * n_workers * n_val * per_item
+        test = 2 * n_test * per_item               # best seed + best searched
+        out.append(int(seed_calls + propose + trigger + candidates + test))
+    return out[0], out[1]
 
 
 class _HardCache:
@@ -921,8 +931,8 @@ def main() -> None:
               "generation (synchronous DP; the archive merge is the barrier)")
 
     if args.dry_run:
-        print(f"\nBudget   : ~{estimate_calls(args.generations, *ds.sizes(), args.workers)} "
-              f"model calls on this (unfiltered) split")
+        lo, hi = estimate_calls(args.generations, *ds.sizes(), args.workers)
+        print(f"\nBudget   : ~{lo}-{hi} model calls on this (unfiltered) split")
         print("\n[dry-run] not calling the API. Drop --dry-run to run Meta Agent Search.")
         return
 
@@ -994,8 +1004,9 @@ def main() -> None:
 
     ntr, nva, nte = ds.sizes()
     print(f"Split    : {ntr} trigger / {nva} val (fitness) / {nte} test")
-    print(f"Budget   : ~{estimate_calls(args.generations, ntr, nva, nte, args.workers)} "
-          f"model calls (each candidate is a multi-step program, run on every val item)")
+    lo, hi = estimate_calls(args.generations, ntr, nva, nte, args.workers)
+    print(f"Budget   : ~{lo}-{hi} model calls (each candidate is a multi-step "
+          f"program, run on every val item)")
     if nva < 20 or nte < 20:
         print("WARNING  : fewer than 20 items on a split -- at this size a single "
               "rollout moves the number by 5%+ and no lift is readable. "

--- a/tests/test_adas_example.py
+++ b/tests/test_adas_example.py
@@ -328,3 +328,15 @@ def test_design_identity_ignores_key_order():
     assert head_prog == {"block": "cot"}
     resend = json.dumps({"name": "N", "thought": "t", "program": {"block": "cot"}})
     assert strat.to_diff(state, resend, "w0", 1, "agentic_system") is None
+
+
+def test_a_missing_score_prints_as_missing():
+    """The test split is scored *after* the search is finished and paid for. When
+    that call fails -- an account ran out of credit inside it, 79 minutes in --
+    the validation numbers are still in hand, so they must still print. Formatting
+    `None` with `:.3f` raises, which would discard them along with the failure."""
+    from examples.adas_meta_agent_search import fmt_score
+
+    assert fmt_score(0.4375).strip() == "0.438"
+    assert fmt_score(None).strip() == "n/a"
+    assert len(fmt_score(None)) == len(fmt_score(0.5))    # column stays aligned

--- a/tests/test_adas_example.py
+++ b/tests/test_adas_example.py
@@ -273,3 +273,58 @@ def test_search_surfaces_why_each_generation_went_as_it_did():
     r = run_meta_agent_search(lambda p: "Answer: 42", val, generations=2, seed=0)
     assert r.outcomes == {"no-candidates": 2}, r.outcomes
     assert r.stop_reason == "rounds" and r.error is None
+
+
+def test_empty_completions_are_counted_not_silently_scored_wrong():
+    """The most dangerous failure this example has is silent: a reasoning model
+    that spends its whole token budget on hidden reasoning returns EMPTY visible
+    content, `_extract_int("")` is None, and `score_mgsm` scores that as a wrong
+    answer. Nothing raises, so a starved run reports a low accuracy that looks
+    exactly like a model which cannot do the problems. Measured on
+    deepseek-v4-flash at the library default of 4096: 0 of 4 meta-agent calls
+    returned anything at all."""
+    from examples.adas_meta_agent_search import EmptyCompletionGuard
+
+    replies = iter(["", "Answer: 42", "   ", "Answer: 7"])
+    guard = EmptyCompletionGuard(lambda p: next(replies))
+    assert [guard(f"p{i}") for i in range(4)] == ["", "Answer: 42", "   ", "Answer: 7"]
+    assert guard.blank == 2 and guard.total == 4
+    msg = guard.report()
+    assert msg and "EMPTY" in msg and "50.0%" in msg
+
+    quiet = EmptyCompletionGuard(lambda p: "Answer: 1")
+    quiet("p")
+    assert quiet.report() is None      # silent when there is nothing to report
+
+
+def test_an_empty_completion_scores_as_a_wrong_answer():
+    """Why the guard has to exist: this is indistinguishable from being wrong."""
+    from examples.adas_meta_agent_search import evaluate_agent
+
+    scores = evaluate_agent(Interpreter(lambda p: ""), {"block": "cot"},
+                            [("q", "42"), ("q2", "7")])
+    assert scores == [0.0, 0.0]        # no error, no warning -- just "wrong"
+
+
+def test_design_identity_ignores_key_order():
+    """Every dedup in the search is string equality on the design's JSON, and a
+    proposal's key order is whatever the model emitted. Unsorted, a semantically
+    identical design counted as new: it passed `to_diff`, was scored on every val
+    item, tied the design it duplicated, failed the strict `>` test, and appeared
+    as one more `+0/-1` -- having spent a full evaluation sweep to learn nothing."""
+    from examples.adas_meta_agent_search import AgentDesignStrategy, canonical
+
+    a = {"block": "cot_sc", "k": 3}
+    b = {"k": 3, "block": "cot_sc"}
+    assert canonical(a) == canonical(b)
+    assert json.dumps(a) != json.dumps(b)      # why this function has to exist
+
+    # the head is stored canonically, so a re-proposal of it is dropped, not scored
+    strat = AgentDesignStrategy()
+    state = strat.initial()
+    same = json.dumps({"name": "N", "thought": "t",
+                       "program": {"k": 3, "block": "cot"}})   # CoT, reordered+extra
+    head_prog = json.loads(state["design"])
+    assert head_prog == {"block": "cot"}
+    resend = json.dumps({"name": "N", "thought": "t", "program": {"block": "cot"}})
+    assert strat.to_diff(state, resend, "w0", 1, "agentic_system") is None

--- a/tests/test_adas_example.py
+++ b/tests/test_adas_example.py
@@ -261,3 +261,15 @@ def test_merge_reports_name_the_outcome():
     assert set(out.outcomes()) <= {"committed", "already-best", "no-candidates",
                                    "cas-conflict"}
     assert "unknown" not in out.outcomes()
+
+
+def test_search_surfaces_why_each_generation_went_as_it_did():
+    """`already-best` and `no-candidates` both print as `+0/-1` on the driver's
+    line, and they need opposite fixes. The run that concluded "the archive
+    rejected every candidate" had no way to tell which one it had seen."""
+    # a stub that answers every task correctly -> no trigger rollout ever fails,
+    # so evolve() never asks for a proposal and nothing reaches the archive.
+    val = [(f"q{i}", "42") for i in range(12)]
+    r = run_meta_agent_search(lambda p: "Answer: 42", val, generations=2, seed=0)
+    assert r.outcomes == {"no-candidates": 2}, r.outcomes
+    assert r.stop_reason == "rounds" and r.error is None

--- a/tests/test_adas_example.py
+++ b/tests/test_adas_example.py
@@ -4,6 +4,8 @@ Exercise the safe DSL validation + interpreter, MGSM scoring, bootstrap fitness,
 the DGM parent-selection formula, and the search loop. No network or LLM calls.
 """
 
+import json
+
 from examples.adas_meta_agent_search import (
     Interpreter,
     _extract_int,
@@ -147,3 +149,115 @@ def test_hard_mode_keeps_items_a_single_call_gets_wrong():
     # a "baseline" that only gets the even ones right
     kept = select_hard(pool, lambda ex: 1.0 if int(ex[1]) % 2 == 0 else 0.0)
     assert kept == [ex for ex in pool if int(ex[1]) % 2]
+
+
+# --- measurability: the fixes that turned "no lift demonstrated" into a number --
+
+def test_parse_agent_survives_prose_around_the_json():
+    """The meta-agent wraps its JSON in a fence and a closing remark. A single
+    greedy `\\{.*\\}` spans from the first brace to the last one anywhere in the
+    reply, so one stray brace in the prose discarded the whole proposal -- and a
+    generation produces one proposal."""
+    reply = ('Here is my design:\n```json\n'
+             '{"thought":"t","name":"N","program":{"block":"cot_sc","k":3}}\n'
+             '```\nNote: {this} composes two ideas.')
+    assert _parse_agent(reply)["name"] == "N"
+
+
+def test_parse_agent_rejects_a_program_it_cannot_afford():
+    """Cost is multiplicative in this DSL and evaluation is candidates x items x
+    cost, so one unbounded proposal outweighs the rest of the search."""
+    from examples.adas_meta_agent_search import MAX_PROGRAM_CALLS, program_cost
+
+    greedy = {"block": "ensemble", "children": [
+        {"block": "debate", "roles": ["a", "b", "c"], "rounds": 2},
+        {"block": "debate", "roles": ["a", "b", "c"], "rounds": 2}]}
+    assert program_cost(greedy) > MAX_PROGRAM_CALLS
+    assert _parse_agent(json.dumps({"program": greedy})) is None
+    # ... and every shipped seed stays comfortably inside the cap
+    assert all(program_cost(s["program"]) <= MAX_PROGRAM_CALLS for s in seed_archive())
+
+
+def test_program_cost_counts_the_calls_the_interpreter_makes():
+    """The budget line and the cap both read this, so it has to match the
+    interpreter rather than approximate it."""
+    from examples.adas_meta_agent_search import program_cost
+
+    for program in ([s["program"] for s in seed_archive()] +
+                    [{"block": "debate", "roles": ["x", "y"], "rounds": 2}]):
+        calls = [0]
+
+        def count(prompt):
+            calls[0] += 1
+            return "Answer: 42"
+
+        Interpreter(count).run(program, "q")
+        assert calls[0] == program_cost(program), program
+
+
+def test_propose_keeps_a_valid_draft_when_a_later_round_degrades():
+    """Two Reflexion rounds refine the draft; returning whatever the *last* round
+    emitted throws away a good agent whenever the last one is malformed."""
+    from examples.adas_meta_agent_search import propose_agent
+
+    good = '{"thought":"t","name":"Good","program":{"block":"step_back"}}'
+    replies = iter([good] + ["not json"] * 6)
+
+    agent = propose_agent(lambda prompt: next(replies), seed_archive())
+    assert agent is not None and agent["name"] == "Good"
+
+
+def test_seed_archive_is_scored_before_the_first_proposal():
+    """The meta-agent's only conditioning signal is the archive. Scoring the seeds
+    inside the first `step()` means generation 0 designs against seven entries all
+    reading `unevaluated`."""
+    seen = []
+
+    def stub(prompt):
+        if "archive of agents discovered so far" in prompt:
+            seen.append(prompt)
+        return "Answer: 42"
+
+    val = [(f"q{i}", "42" if i % 2 else "7") for i in range(8)]
+    run_meta_agent_search(stub, val, generations=1, seed=0)
+    assert seen, "the meta-agent was never asked for a design"
+    assert "unevaluated" not in seen[0], (
+        "the first proposal was conditioned on an unscored archive")
+
+
+def test_search_reports_the_best_seed_for_comparison():
+    """On a `--hard` subset the structure-free baseline is 0.000 by construction,
+    so searched-vs-seed is the only comparison that carries information."""
+    val = [(f"q{i}", "42" if i % 2 else "7") for i in range(8)]
+    result = run_meta_agent_search(lambda p: "Answer: 42", val, generations=1, seed=0)
+    assert validate_program(result.best_seed.get("program", {}))
+    assert any(a.get("seed") for a in result.archive)
+    assert result.best_fitness >= result.seed_fitness
+
+
+def test_merge_reports_name_the_outcome():
+    """`committed_version is None` is the driver's whole tally, so an archive whose
+    best design simply did not change was reported identically to a rejection."""
+    from agentdescent.evolution import Task, evolve
+
+    from examples.adas_meta_agent_search import (AdasContext, AgentDesignStrategy,
+                                                 MetaSearchAggregator, make_propose)
+
+    ctx = AdasContext()
+    interp = Interpreter(lambda p: "Answer: 42")
+    tasks = [Task(id=f"t{i}", prompt="q", meta={"answer": "42"}) for i in range(8)]
+
+    def factory(ledger, verifier, audit, config, policy):
+        agg = MetaSearchAggregator(ledger, verifier, ctx, artifact_id="agentic_system")
+        agg.seed()
+        return agg
+
+    out = evolve(tasks, lambda t, o: 1.0 if o == "42" else 0.0,
+                 run=lambda r, t: interp.run(json.loads(r), t.prompt) or "",
+                 propose=make_propose(ctx, lambda p: "Answer: 42"),
+                 strategy=AgentDesignStrategy(), artifact_id="agentic_system",
+                 blast_radius=0.6, rounds=1, n_workers=1, self_verify=False,
+                 held_out_frac=0.5, aggregator_factory=factory)
+    assert set(out.outcomes()) <= {"committed", "already-best", "no-candidates",
+                                   "cas-conflict"}
+    assert "unknown" not in out.outcomes()


### PR DESCRIPTION
ADAS is the one shipped port whose docs say **"no lift demonstrated"**. The run
behind that line spent 791 calls to report `test accuracy 0.000` on three items.
Almost none of the reasons were the algorithm.

## The root cause

`deepseek-v4-flash` is a reasoning model: the token budget is spent on hidden
reasoning first, and the visible content is whatever is left. The example took
the library default of 4096 — sized for *"answer with the final number"* — and
used **one completion** for both the multi-step agent programs and the
meta-agent, whose prompt carries the entire archive.

| `--max-tokens` | meta-agent replies | solver blank rate | solver CoT |
|---|---|---|---|
| 4096 | **0 / 4** | 13 / 40 | 0.275 |
| 16384 | **4 / 4** | 2 / 40 | 0.325 |

At 4096 the meta-agent returned **empty content on every call**, so no design
ever reached the archive and every generation reported `+0/-1`. The reply it
eventually produces is ~250 tokens — the length was never the problem, the
*thinking* was.

This is dangerous because it is **silent**. An empty completion does not raise:
`_extract_int("")` is `None`, and `score_mgsm` scores `None` as a wrong answer.
A starved run reports a low accuracy indistinguishable from a model that cannot
do the problems.

Fixed with `--max-tokens` (16384) and `--timeout` (300 s); blank replies are now
counted and warned about; and the pre-flight check sends a *reasoning* prompt and
aborts if it comes back empty — `"Reply with the single word: ok"` passes at any
budget, which is exactly why it never caught this.

## Measurement

The old setup could not have read a lift even with a working search.

| | before | after |
|---|---|---|
| pool | 600 items, 4 languages | **2750**, all 11 |
| hard subset | 47 | **222** |
| split | 23 / 12 / 11 | **34 / 110 / 78** |

- The train share only *triggers* proposals — the meta-agent conditions on the
  archive, not on the task `evolve()` hands it — so 50/25/25 spent half the hard
  items on rollouts nothing reads. Now 15/50/35 via `--train-frac`/`--test-frac`.
- Splits are **stratified by language**: MGSM languages differ by 8 points of
  baseline accuracy (`en` 0.964, `ja` 0.880), so an unstratified draw hands
  validation one mixture and test another — and that difference reads as a lift.
- The run reported **only the searched agent's** test accuracy, which on a
  `--hard` subset says nothing: the structure-free baseline is 0.000 there by
  construction. It now scores the best seed on the same split and prints both
  rows plus the delta.
- The `--hard` baseline used a digit-concatenating extractor while the agents
  used `_extract_int`, so "hard" partly meant *"the two extractors disagree"*.
  One extractor for both sides. The printed direct accuracy was derived from the
  subset size, so a pool `select_hard` had **topped up** reported the top-up as
  model error (0.600 for a model that had answered 29 of 30).

## Search

- The **seed archive was scored inside the first `step()`** — after generation 0
  had already proposed — so the first generation designed against seven entries
  all reading `unevaluated`. Now seeded before round 0.
- `propose_agent` returned whatever the **last** Reflexion round emitted,
  discarding a valid draft from an earlier round.
- `_parse_agent`'s greedy `\{.*\}` spanned first brace to last brace in the whole
  reply, so one brace in the closing prose threw the proposal away.
- A design's identity ignored **key order**, so two orderings of the same program
  were two designs — the duplicate cost a full evaluation sweep (~330 calls) to
  tie what it duplicated.
- Nothing bounded a proposal's cost, which is multiplicative in this DSL (an
  ensemble of two 2-round debates is 14 calls/question against a most-expensive
  seed of 5). Capped, and the cap is in the meta-prompt.

Each of the first three costs a **whole generation**, since a generation produces
one proposal.

## Accounting

- The budget line was computed **before** `--hard` narrowed the split, advertising
  ~9009 calls for a run that made 791 — this is where the docs' "hours, ~9000
  calls" claim came from. Now derived from real `program_cost`s, after the split,
  as a range.
- `MetaSearchAggregator` left `MergeReport.accepted`/`category` empty while it was
  committing, so an unchanged best design printed `+0/-1` and `outcomes()`
  bucketed everything as `unknown`. The categories were then **thrown away** by
  `run_meta_agent_search`, which discarded the `EvolutionResult` — so
  `already-best` and `no-candidates`, which need opposite fixes, stayed
  indistinguishable.
- `--hard` re-ran its entire baseline pass every invocation (2750 calls at full
  size). Cached per (model, question).
- `--eval-concurrency` never reached `evolve()`; `self_verify` ran an extra
  multi-step rollout per proposal for a delta the archive never reads.
- A run that finished its search printed **nothing** if scoring the test split
  failed. Observed: an account ran out of credit inside that call, 79 minutes in,
  after seeding had completed. Test accuracy now degrades to `n/a`.

## Engine

- `_EvalCache` keyed on the whole state, but `eval_one` only passes `render()` to
  `run` — two states that render identically cannot score differently. ADAS keeps
  a design's name beside the design, so committing a candidate the aggregator had
  just scored re-ran the entire held-out set because a label changed.
- `RoundInfo.n_items` is the artifact's key count, printed as `items=` beside the
  reward where it reads as the sample size — a 110-item measurement announced
  itself as 3. Now `size=`, with the held-out count next to the reward.

## Docs

`agents.md` gains **"Configuring your provider and key"** — the two variables,
ready-to-run blocks for DeepSeek / GLM / OpenAI / local vLLM-or-Ollama / Claude,
and how to read 401 / 402 / 404. It also corrects the "give a reasoning model
room" tip, which measured 4096 on a short prompt and left that reading as general.

## What this PR does *not* claim

**The searched-vs-seed lift is not measured.** The run that would produce it did
not finish — the account ran out of credit 79 minutes in, during the final test
scoring. `docs/algo-adas.md` shows the comparison table with the row explicitly
unfilled rather than presenting a number that does not exist, and `results.md`
says the same. Everything above *is* measured.

To fill it in, one run of the command in `algo-adas.md` (~2 h, 6k–17k calls) —
the baseline pass is cached, so those 2750 calls are already paid for.

## Tests

459 pass. `tests/test_adas_example.py` grows from 13 to 24, covering the
empty-completion guard, the cost model against the interpreter's real call count,
draft retention across Reflexion rounds, prose-wrapped JSON, key-order identity,
seeding order, and the merge categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
