### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,28 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-08-01
+
+A measurement pass. 0.2.0 made the framework's claims honest; this release makes
+the numbers behind them readable, and fixes the ports and engine paths where a
+run could look like it had measured something when it had not.
+
+The headline is that a silent failure mode ran through everything: on a reasoning
+model, too small a token budget returns **empty visible content**, which does not
+raise — it scores as a wrong answer. A starved run therefore reports a low
+accuracy indistinguishable from a model that cannot do the task. ADAS's
+meta-agent hit this on every call, so its search proposed nothing and the docs
+recorded "no lift demonstrated" for a cause that was never the algorithm.
+
 ### Fixed
+- **The single-sourced version was single-sourced onto the wrong number.**
+  0.2.0 removed the duplicate version from `pyproject.toml` so it could not
+  drift again — correctly — but pointed it at `agentdescent.__version__`, which
+  had said `0.7.0` since the Concordia → AgentDescent rename while every wheel,
+  the PyPI page and the badge said 0.2.0. Nothing surfaced it, because the value
+  is only read at build time: the next GitHub Release would have published
+  **0.7.0** to PyPI, and PyPI version numbers cannot be reused, so 0.3.0 through
+  0.7.0 would have been unusable forever. Now `0.3.0`.
 - **ADAS's meta-agent returned empty content on every call, so the search
   proposed nothing.** `deepseek-v4-flash` is a reasoning model: the token budget
   is spent on hidden reasoning first and the visible content is what is left. The

--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -119,7 +119,7 @@ from .parallel import (
     shard_round_robin,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "Contract",


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.3.0]` — and fixes the version number itself, which
would otherwise have shipped wrong.

## The version was single-sourced onto the wrong number

| | |
|---|---|
| PyPI latest | **0.2.0** |
| git tags | `v0.1.0`, `v0.2.0` |
| `agentdescent/__init__.py` before this PR | **`__version__ = "0.7.0"`** |
| `pyproject.toml` | `version = { attr = "agentdescent.__version__" }` |

0.2.0 removed the duplicate version from `pyproject.toml` so it could not drift
again — correctly — but pointed the single source at `agentdescent.__version__`,
which had said `0.7.0` since the Concordia → AgentDescent rename. Its own comment
records the symptom it was fixing: *"`__version__` said 0.7.0 while every wheel,
the PyPI page and the README badge said 0.2.0."* The duplication went away; the
wrong value stayed, and became the authoritative one.

Nothing surfaces it outside a build, so `publish.yml` — which triggers on a
published GitHub Release and takes the version from the built artifact — would
have **published 0.7.0 to PyPI**. PyPI version numbers cannot be reused, so
0.3.0 through 0.7.0 would have been burned permanently on the next release.

Now `0.3.0`.

## Verified, not assumed

```
$ python -m build
Successfully built agentdescent-0.3.0.tar.gz and agentdescent-0.3.0-py3-none-any.whl

$ twine check dist/*
Checking agentdescent-0.3.0-py3-none-any.whl: PASSED
Checking agentdescent-0.3.0.tar.gz: PASSED

$ mkdocs build --clean --strict          # what docs.yml runs
Documentation built in 0.62 seconds
```

The strict docs build covers the new cross-page anchor from `algo-adas.md` into
`agents.md#configuring-your-provider-and-key`, confirmed present in the built
HTML. The README's PyPI badge is a shields.io endpoint that reads PyPI directly,
so it needs no manual bump.

## What is in 0.3.0

A measurement pass over 0.2.0's honesty pass. The thread running through it: on a
reasoning model, too small a token budget returns **empty visible content**, which
does not raise — it scores as a wrong answer, so a starved run reports a low
accuracy indistinguishable from a model that cannot do the task. ADAS's
meta-agent hit this on every call, which is why its docs recorded *"no lift
demonstrated"* for a cause that was never the algorithm.

Also in the release: port fidelity against the upstream repos (#42), the public
API surface and this version fix (#43, this PR), test rigour and experiments that
measure something (#44, #45), one async pipeline instead of two divergent ones
(#46), and the ADAS measurement work (#47).

## Not claimed

ADAS's searched-vs-seed lift is still unmeasured — `docs/algo-adas.md` shows the
comparison table with that row explicitly empty. The run that would fill it did
not finish. Everything else in `docs/results.md` is a completed before → after.

## Release steps left to a human

This PR stops before the irreversible part. After merge:

1. **PyPI** — create a GitHub Release tagged `v0.3.0`; `publish.yml` builds and
   publishes via Trusted Publishing (OIDC, no stored token).
2. **Docs** — run the `docs` workflow manually (`workflow_dispatch`); it only
   deploys to Pages on a manual trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
