### PR TITLE
feat: evolve a directory — a skill folder, an agent folder, or its code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,99 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **Evolving a directory: a skill folder, an agent folder, or its code.** Until
+  now every artifact was text that ended up *in a prompt*. A skill directory is
+  not that: it is only a skill directory if the agent can *read the files*, which
+  needs the candidate on disk, in the layout the agent expects, for the duration
+  of one rollout. Four new modules do that translation and nothing in the
+  optimizer changed — `aggregator.py`, `ledger.py`, `async_evolve.py`,
+  `parallel.py` and `governance.py` are untouched.
+
+  The reason it drops in so cleanly is that the engine never interprets a state
+  key: it only asks whether two diffs touch the same one. Make the keys **file
+  paths** and file-level semantics arrive for free — two workers editing
+  different files fuse, two editing the same file contradict and are resolved on
+  held-out score.
+
+  - `agentdescent.filetree` — `load_tree` / `materialize` / `canonical` /
+    `parse_tree` / `TreeSpec`. A file that matches `include` but cannot be
+    represented (binary, oversized) **raises** rather than being skipped: a
+    silently dropped file is one `write_to` would later delete by omission.
+    Paths are re-validated at every boundary, because a state key is a
+    model-authored string and `materialize` turns it into a filesystem write.
+  - `agentdescent.treestrategy` — the `FileTree` strategy, the `<EDITS>`
+    multi-file proposal protocol (`parse_edits`), and `tree_reflector`, which
+    shows the reflector the files it may change rather than the whole tree.
+  - `agentdescent.runners` — `tree_runner` / `code_runner`. One throwaway
+    workspace **per call**: `max_concurrency` worker threads and
+    `eval_concurrency` evaluation threads share a `run`, so a fixed directory
+    would let two candidates overwrite each other and produce scores that look
+    ordinary and are wrong.
+  - `agentdescent.skilldir` — `evolve_skill_dir` (L2), `evolve_agent_dir` (L1),
+    `evolve_agent_code` (L1 + a test gate).
+  - `EvolutionResult.write_to(path)` installs the evolved tree back, backing the
+    directory up first, leaving unknown files alone unless `prune=True`, and
+    refusing outright when the artifact is not a file tree.
+  - `examples/skill_dir_evolution.py` — runs offline in seconds; the "agent" is a
+    real subprocess bound to a workspace, so the staging, layout, overlay and
+    isolation logic are all exercised without an API key.
+
+- **`FileTree(frozen=[...])`, enforced twice.** `governance.py` freezes whole
+  artifacts by id, which cannot say "this skill may evolve, but not its test
+  suite" — and without that the shortest path to a high score is to weaken the
+  thing measuring it. Filtering proposals only stops the *reflector*; candidate
+  code can still rewrite `conftest.py` at run time. So the runner also **overlays
+  the pristine frozen files after materialisation**, and `code_runner` invokes
+  the gate from outside the tree. Both halves are needed; only the second is a
+  security boundary.
+
+- **`document_agent(..., skill_files=...)` — skills as files, not prompt text.**
+  A skill *directory* is only worth more than a concatenated string if the agent
+  can open one skill at a time. When the completion is a `WorkspaceAgent` the
+  library is written to `.claude/skills/` in the same scratch directory as the
+  document and the prompt carries a pointer; a backend with no workspace folds
+  them back into the inline block rather than dropping them in silence.
+
+### Changed
+- **EvoSkill's skill library is now a directory** (`SkillLibraryTree`, a
+  `FileTree` subclass): `{"defense-lookup": ...}` became
+  `{"skills/defense-lookup/SKILL.md": ...}`. This was the acceptance test for the
+  new abstraction — if the port could not be expressed in it, the shape was
+  wrong — and it passed with all 12 existing EvoSkill tests unchanged.
+
+  Two things it settled, both of which looked like blockers beforehand:
+
+  * **A port keeps its own prompt format.** `render()` has to be the lossless
+    serialisation because it is the evaluation-cache key, but `run` is where an
+    artifact becomes a prompt — so `run` parses the tree and re-renders it in
+    EvoSkill's own `### skill: <name>` format. The retriever path's prompt is
+    byte-identical to before, and a test now asserts that.
+  * **A port keeps its own proposal protocol.** `to_diff` still accepts the
+    repo's `name :: body` rather than `FileTree`'s `<EDITS>` JSON. What is
+    faithful about EvoSkill is the two-role Proposer/Generator induction, not the
+    separator; switching would have changed the Generator's prompt, which is
+    precisely the silent behaviour change a migration must not smuggle in.
+
+  With `--backend claude-code` / `openhands` the skills now reach the agent as
+  files in its workspace instead of inlined in every prompt.
+- **A `None` op now deletes a key** instead of storing `None`
+  (`EvolvingArtifact.apply`). `dict.update` could express "add" and "replace" but
+  not "remove", which is invisible for a rules playbook and disqualifying for a
+  file tree, where a key is a path and deleting a file is an ordinary edit.
+  `None` was never a legal op value, so this is backward compatible.
+- `evolve_skill_dir` / `evolve_agent_dir` / `evolve_agent_code` default to
+  `self_verify=False` and `cheap_eval_tasks=4`, unlike the plain engine. Both
+  defaults are right for a text artifact and expensive for this one: the first
+  doubles the agent calls per proposal, and the second leaves the cheap layer
+  pinned to the whole held-out set, which makes candidate *ranking* the dominant
+  cost of a run when `eval_fn` runs a real agent.
+- `TreeSpec.max_file_bytes` defaults to 28 000, below `AggregatorConfig`'s
+  32 000-char trust region, and `validate_against` refuses a mismatch up front. A
+  larger file could be loaded but never changed: every diff touching it is
+  rejected as `oversized`, which surfaces five rounds later as "my reflector
+  emits junk" rather than "that file was never editable".
+
 ## [0.3.0] — 2026-08-01
 
 A measurement pass. 0.2.0 made the framework's claims honest; this release makes

--- a/README.md
+++ b/README.md
@@ -196,6 +196,45 @@ The one complete end-to-end run — real dataset, real LLM, every module — is
 Guides: [the engine](https://github.com/Birfy/agentdescent/blob/main/docs/evolution.md) · [skill example](https://github.com/Birfy/agentdescent/blob/main/docs/skill-evolution.md)
 · [agents](https://github.com/Birfy/agentdescent/blob/main/docs/agents.md).
 
+## Evolve a **directory** — a skill folder, an agent folder, its code
+
+Everything above evolves text that ends up *in a prompt*. `evolve_skill_dir`
+evolves a **directory**, and each rollout is performed by a real agent that reads
+those files off disk with its own tools:
+
+```python
+from agentdescent import evolve_skill_dir
+from agentdescent.agents import claude_code, openai_compatible
+
+result = evolve_skill_dir(
+    "~/.claude/skills/pdf-audit", rows,
+    agent=claude_code(extra_args=["--permission-mode", "acceptEdits"]),
+    reflect_with=openai_compatible(model="deepseek-v4-flash"),
+    prompt="question", gold="answer", score="contains")
+
+result.write_to("~/.claude/skills/pdf-audit")     # opt in; backs up first
+```
+
+Each rollout materialises the candidate into a throwaway workspace at
+`.claude/skills/<name>/`, stages the task's fixtures beside it and runs the agent
+there. The optimizer is untouched: **state keys are file paths**, so two workers
+editing different files *fuse* and two editing the same file are *resolved* on
+held-out score — the same machinery as every other strategy.
+
+Three entry points, differing only in governance and what guards them:
+`evolve_skill_dir` (L2), `evolve_agent_dir` (L1 — an agent definition is a
+harness, so every merge also passes the oracle), and `evolve_agent_code`, where
+the tree is **executed** behind a frozen test suite that the candidate cannot
+rewrite (pristine files are overlaid after materialisation, so weakening the
+tests at run time does not work either).
+
+```bash
+python -m examples.skill_dir_evolution        # offline, no API key
+```
+
+Guide: [evolving a directory](https://github.com/Birfy/agentdescent/blob/main/docs/directory-evolution.md)
+· [design record](https://github.com/Birfy/agentdescent/blob/main/docs/design-directory-evolution.md).
+
 ## Faithful ports of the latest self-evolution algorithms
 
 To show the engine is faithful to the field, AgentDescent ships one runnable example
@@ -272,6 +311,9 @@ python -m examples.run_async
 
 # The flagship: evolve a skill on a real dataset with a real LLM (--dry-run: no API)
 python -m examples.skill_evolution --dry-run
+
+# Evolve a skill DIRECTORY that a real agent reads off disk (offline by default)
+python -m examples.skill_dir_evolution
 
 # Efficiency: parallel throughput scaling + async vs sync-barrier tail-hiding
 python -m examples.efficiency

--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -64,6 +64,18 @@ from .staleness import (
 )
 from . import rewards                      # agentdescent.rewards.last_number(...)
 from .skill import evolve_skill
+from .filetree import (
+    TreeError,
+    TreeSpec,
+    canonical,
+    load_tree,
+    materialize,
+    parse_tree,
+    tree_summary,
+)
+from .treestrategy import EDIT_PROTOCOL, FileTree, parse_edits, tree_reflector
+from .runners import LAYOUTS, TEST_FAILURE_MARKER, code_runner, tree_runner
+from .skilldir import evolve_agent_code, evolve_agent_dir, evolve_skill_dir
 from .worker import Worker
 from .orchestrator import AgentDescent, RoundStat, run_fork_baseline
 from .agents import (
@@ -226,6 +238,24 @@ __all__ = [
     "tasks_from",
     "RoundInfo",
     "evolve",
+    "TreeError",
+    "TreeSpec",
+    "canonical",
+    "load_tree",
+    "materialize",
+    "parse_tree",
+    "tree_summary",
+    "EDIT_PROTOCOL",
+    "FileTree",
+    "parse_edits",
+    "tree_reflector",
+    "LAYOUTS",
+    "TEST_FAILURE_MARKER",
+    "code_runner",
+    "tree_runner",
+    "evolve_skill_dir",
+    "evolve_agent_dir",
+    "evolve_agent_code",
     "async_evolve",
     "claude_agent",
     "rule_id",

--- a/agentdescent/backends.py
+++ b/agentdescent/backends.py
@@ -33,16 +33,25 @@ import os
 import re
 import tempfile
 import warnings
-from typing import Callable, Protocol, runtime_checkable
+from typing import Callable, Mapping, Optional, Protocol, runtime_checkable
 
 from .agents import Completion, WorkspaceAgent
 
 
 @runtime_checkable
 class AgentBackend(Protocol):
-    """A base agent that answers a question about a document, possibly using tools."""
+    """A base agent that answers a question about a document, possibly using tools.
 
-    def answer(self, question: str, document: str, *, skills: str = "") -> str: ...
+    ``skills`` is the learned skill library **as text**, to be inlined in the
+    prompt. ``skill_files`` is the same library **as files** (``{relpath:
+    content}``): a backend whose agent has a workspace writes them to disk and
+    tells the agent where they are, so it reads only the ones it needs instead of
+    carrying all of them in every prompt. Backends without a workspace ignore it
+    and fall back to ``skills``.
+    """
+
+    def answer(self, question: str, document: str, *, skills: str = "",
+               skill_files: Optional[Mapping[str, str]] = None) -> str: ...
 
 
 class _FnBackend:
@@ -51,8 +60,9 @@ class _FnBackend:
     def __init__(self, fn: Callable[..., str]) -> None:
         self._fn = fn
 
-    def answer(self, question: str, document: str, *, skills: str = "") -> str:
-        return self._fn(question, document, skills=skills)
+    def answer(self, question: str, document: str, *, skills: str = "",
+               skill_files: Optional[Mapping[str, str]] = None) -> str:
+        return self._fn(question, document, skills=skills, skill_files=skill_files)
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +81,13 @@ _DOC_INSTR = (
     "if the answer spans several rows (e.g. monthly values for a calendar year), "
     "compute it. Reply with ONLY the final answer value.\n\nQuestion: {q}"
 )
+#: What replaces the inlined skill text once the skills are files on disk. The
+#: point of a skill *directory* is that the agent opens what it needs -- inlining
+#: the whole library in every prompt is the thing this avoids.
+_SKILL_DIR_INSTR = (
+    "Learned skills are files under {dir}/ in this directory: {names}. "
+    "Read the ones relevant to the question before answering.\n\n"
+)
 _DOC_INSTR_INLINE = (
     "{skills}Below is a document (often large financial tables). Find the relevant "
     "rows; if the answer spans several rows, compute it. Reply with ONLY the final "
@@ -79,7 +96,8 @@ _DOC_INSTR_INLINE = (
 
 
 def document_agent(completion: Completion, *, doc_filename: str = "document.txt",
-                   inline_chars: int = 200_000) -> AgentBackend:
+                   inline_chars: int = 200_000,
+                   skills_dir: str = ".claude/skills") -> AgentBackend:
     """Turn **any** :data:`~agentdescent.agents.Completion` into an
     :class:`AgentBackend` for document questions.
 
@@ -99,12 +117,22 @@ def document_agent(completion: Completion, *, doc_filename: str = "document.txt"
         document_agent(claude_code())          # same task, different agent
         document_agent(claude(model="claude-haiku-4-5"))   # no tools: inline
     """
-    def answer(question: str, document: str, *, skills: str = "") -> str:
+    def answer(question: str, document: str, *, skills: str = "",
+               skill_files: Optional[Mapping[str, str]] = None) -> str:
         skill_block = f"Learned skills you should apply:\n{skills}\n\n" if skills.strip() else ""
         if isinstance(completion, WorkspaceAgent):
             workdir = tempfile.mkdtemp(prefix="agentdescent-doc-")
             with open(os.path.join(workdir, doc_filename), "w", encoding="utf-8") as f:
                 f.write(document)
+            if skill_files:
+                # Progressive disclosure: the library goes to disk and the prompt
+                # carries a pointer, so the agent opens the one skill it needs
+                # rather than reading all of them on every question.
+                from .filetree import materialize
+
+                materialize(skill_files, workdir, prefix=skills_dir)
+                names = ", ".join(sorted({p.split("/", 1)[0] for p in skill_files})) or "(none)"
+                skill_block = _SKILL_DIR_INSTR.format(dir=skills_dir, names=names)
             prompt = _DOC_INSTR.format(skills=skill_block, fname=doc_filename, q=question)
             return completion.in_workspace(workdir)(prompt).strip()
         if len(document) > inline_chars:
@@ -260,7 +288,12 @@ def tool_loop_backend(complete: Completion, *, max_steps: int = 5,
     plain :data:`~agentdescent.agents.Completion`, so it runs on any Python. A lighter
     local stand-in for :func:`openhands_backend`."""
 
-    def answer(question: str, document: str, *, skills: str = "") -> str:
+    def answer(question: str, document: str, *, skills: str = "",
+               skill_files=None) -> str:
+        # No workspace here, so files cannot be handed over: fold them into the
+        # inline block rather than dropping them in silence.
+        if skill_files and not skills.strip():
+            skills = "\n\n".join(f"### {p}\n{c}" for p, c in sorted(skill_files.items()))
         lines = document.splitlines()
         obs = "(none yet)"
         skill_block = f"Apply these learned skills:\n{skills}\n\n" if skills.strip() else ""

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -463,7 +463,18 @@ class EvolvingArtifact:
 
     def apply(self, diff: Diff) -> "EvolvingArtifact":
         new_state = dict(self.state)
-        new_state.update(diff.ops)
+        # A ``None`` op *removes* the key rather than storing ``None``. Plain
+        # ``update`` had no way to express deletion at all, which is invisible for
+        # a rules playbook (a stale rule can be overwritten) and disqualifying for
+        # a file tree (:class:`~agentdescent.treestrategy.FileTree`), where a key
+        # is a path and "delete this file" is an ordinary edit. Popping rather
+        # than storing the sentinel keeps every downstream consumer -- ``render``,
+        # the ledger's JSON, the trust region -- working on ``Dict[str, str]``.
+        for key, value in diff.ops.items():
+            if value is None:
+                new_state.pop(key, None)
+            else:
+                new_state[key] = value
         return EvolvingArtifact(self.id, new_state, self.version + 1, self.blast_radius,
                                 self._rt, self._strategy)
 
@@ -776,6 +787,85 @@ class EvolutionResult:
         }
         with open(path, "w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2, ensure_ascii=False)
+
+    def write_to(self, path: str, *, backup: bool = True, prune: bool = False,
+                 dry_run: bool = False) -> Dict[str, List[str]]:
+        """Install a file-tree artifact back into a real directory.
+
+        Only meaningful when the artifact was evolved as a
+        :class:`~agentdescent.treestrategy.FileTree` -- every state key must be a
+        relative path. Returns the plan: ``{"written": [...], "extra": [...],
+        "deleted": [...], "backup": [...]}``.
+
+        Deliberately conservative, because this is the one call in the whole
+        package that writes into a directory the user cares about:
+
+        * ``backup=True`` (default) copies the existing directory to
+          ``<path>.bak-N`` first;
+        * files present in the target but **not** in the artifact are reported as
+          ``extra`` and left alone unless ``prune=True`` -- the run only ever knew
+          about the files its ``TreeSpec`` selected, so deleting by omission would
+          take out anything the spec excluded;
+        * ``dry_run=True`` returns the same plan without touching the disk.
+        """
+        import os
+        import shutil
+
+        from .filetree import TreeError, materialize, parse_tree, safe_relpath
+
+        # `rendered` is the strategy's own serialisation, so it is the one
+        # reliable signal that this artifact really is a tree. Without the check,
+        # an `AppendRules` result would happily be written out as a directory of
+        # files named after rule hashes -- every key of every strategy is a
+        # *syntactically* valid relative path.
+        try:
+            parse_tree(self.rendered)
+        except TreeError as e:
+            raise TreeError(
+                "write_to() only applies to an artifact evolved as a FileTree; "
+                f"this result does not render as one ({e}). Use save() for a "
+                "text artifact.") from None
+
+        bad = []
+        for key in self.state:
+            try:
+                safe_relpath(key)
+            except TreeError as e:
+                bad.append(str(e))
+        if bad:
+            raise TreeError(
+                "write_to() needs a file-tree artifact (every state key a relative "
+                "path); this result has keys that are not paths:\n  "
+                + "\n  ".join(bad[:5]))
+
+        dest = os.path.abspath(os.path.expanduser(path))
+        planned = sorted(self.state)
+        existing: List[str] = []
+        walker = os.walk(dest) if os.path.isdir(dest) else ()
+        for dirpath, dirnames, filenames in walker:
+            dirnames[:] = [d for d in dirnames if d not in (".git", "__pycache__")]
+            for fname in filenames:
+                rel = os.path.relpath(os.path.join(dirpath, fname), dest)
+                existing.append(rel.replace(os.sep, "/"))
+        extra = sorted(set(existing) - set(planned))
+        plan = {"written": planned, "extra": [] if prune else extra,
+                "deleted": extra if prune else [], "backup": []}
+        if dry_run:
+            return plan
+        if backup and os.path.isdir(dest):
+            n = 0
+            while os.path.exists(f"{dest}.bak-{n}"):
+                n += 1
+            shutil.copytree(dest, f"{dest}.bak-{n}", symlinks=True)
+            plan["backup"] = [f"{dest}.bak-{n}"]
+        materialize(self.state, dest)
+        if prune:
+            for rel in extra:
+                try:
+                    os.remove(os.path.join(dest, rel.replace("/", os.sep)))
+                except OSError:
+                    pass
+        return plan
 
     @classmethod
     def load(cls, path: str) -> "EvolutionResult":

--- a/agentdescent/filetree.py
+++ b/agentdescent/filetree.py
@@ -1,0 +1,370 @@
+"""Directories as evolvable state: load a tree, materialise it, serialise it.
+
+An artifact's state is a flat ``{key: value}`` dict, and the engine never
+interprets the keys -- it only asks whether two diffs touch the same one
+(:func:`~agentdescent.aggregator.diffs_contradict`) and unions the ones that do
+not (:func:`~agentdescent.aggregator.fuse_diffs`). So if the **keys are relative
+file paths**, the whole aggregation stack acquires file-level semantics for free:
+
+* two workers editing different files -> complementary diffs -> fused;
+* two workers editing the same file -> a contradiction -> resolved on held-out
+  score, best one wins.
+
+That is the entire trick behind evolving a skill directory, an agent directory,
+or a small agent codebase. This module is the translation layer between such a
+directory and that dict:
+
+    load_tree(path)        directory      -> {relpath: text}
+    materialize(state, ws) {relpath: text} -> a workspace on disk
+    canonical(state)       {relpath: text} -> one lossless string
+    parse_tree(text)       that string     -> {relpath: text}
+
+``canonical`` / ``parse_tree`` are a pair because :meth:`Strategy.render` is the
+*only* channel through which the engine hands an artifact to ``run`` -- and it is
+also the evaluation cache key (``EvolvingArtifact._signature``). A lossy render
+would therefore make two different trees share a cached score, so the
+serialisation has to be exact, and JSON is used rather than a prettier
+delimiter-based format precisely because file *contents* cannot break it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "TreeSpec",
+    "TreeError",
+    "canonical",
+    "parse_tree",
+    "load_tree",
+    "materialize",
+    "match_any",
+    "safe_relpath",
+    "tree_summary",
+]
+
+
+class TreeError(ValueError):
+    """A directory could not be represented as evolvable state, or vice versa.
+
+    Always a caller-facing problem (a binary file in the tree, a path that
+    escapes the workspace, a size cap), never a transient -- so it is raised
+    rather than absorbed."""
+
+
+# ---------------------------------------------------------------------------
+# Glob matching
+# ---------------------------------------------------------------------------
+#
+# `fnmatch` is not usable here: its `*` matches `/`, so `*.md` would match
+# `references/rules.md`, and `**/*.md` would NOT match a top-level `SKILL.md`
+# (the `**/` needs a literal slash to match). Both are silent -- one over-selects
+# and one under-selects -- and either way the resulting tree is not the directory
+# the caller pointed at. A ~20-line translation gets real glob semantics.
+
+def _glob_to_regex(pattern: str) -> "re.Pattern":
+    i, n, out = 0, len(pattern), ["(?s:"]
+    while i < n:
+        if pattern.startswith("**/", i):
+            out.append("(?:.*/)?")          # zero or more directories
+            i += 3
+            continue
+        if pattern.startswith("**", i):
+            out.append(".*")
+            i += 2
+            continue
+        c = pattern[i]
+        if c == "*":
+            out.append("[^/]*")
+        elif c == "?":
+            out.append("[^/]")
+        elif c == "[":
+            j = pattern.find("]", i)
+            if j < 0:
+                out.append(re.escape(c))
+            else:
+                out.append("[" + pattern[i + 1:j].replace("\\", "\\\\") + "]")
+                i = j
+        else:
+            out.append(re.escape(c))
+        i += 1
+    out.append(r")\Z")
+    return re.compile("".join(out))
+
+
+_GLOB_CACHE: Dict[str, "re.Pattern"] = {}
+
+
+def match_any(relpath: str, patterns: Sequence[str]) -> bool:
+    """Does ``relpath`` (posix, no leading ``./``) match any of ``patterns``?
+
+    Supports ``*`` (within a path segment), ``**`` (across segments), ``?`` and
+    ``[...]``. A bare directory pattern (``tests``) also matches everything under
+    it, so ``frozen=["tests"]`` means what a reader expects.
+    """
+    for p in patterns:
+        if not p:
+            continue
+        for candidate in (p, p.rstrip("/") + "/**") if "*" not in p and "?" not in p else (p,):
+            rx = _GLOB_CACHE.get(candidate)
+            if rx is None:
+                rx = _GLOB_CACHE[candidate] = _glob_to_regex(candidate)
+            if rx.match(relpath):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+
+def safe_relpath(path: str) -> str:
+    """Normalise ``path`` to a workspace-relative posix path, or raise.
+
+    Every key in the state is a **path proposed by a model**, so this is a
+    security boundary, not tidying: an absolute path or a ``..`` segment would
+    have :func:`materialize` write outside the workspace it was given.
+    """
+    if not isinstance(path, str) or not path.strip():
+        raise TreeError(f"empty or non-string path: {path!r}")
+    p = path.replace("\\", "/").strip()
+    if p.startswith("/") or re.match(r"^[A-Za-z]:", p):
+        raise TreeError(f"absolute path is not allowed in a file tree: {path!r}")
+    if "\x00" in p:
+        raise TreeError(f"path contains a NUL byte: {path!r}")
+    parts: List[str] = []
+    for seg in p.split("/"):
+        if seg in ("", "."):
+            continue
+        if seg == "..":
+            raise TreeError(
+                f"path escapes the tree with '..': {path!r}. Paths are relative to "
+                "the artifact root and may not traverse upwards.")
+        parts.append(seg)
+    if not parts:
+        raise TreeError(f"path resolves to nothing: {path!r}")
+    return "/".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# What belongs in the tree
+# ---------------------------------------------------------------------------
+
+
+#: The aggregator's default trust region caps a single op value at
+#: ``AggregatorConfig.trust_region_chars`` (32_000). A file above that can be
+#: *loaded* but never *changed*: every diff touching it is rejected as
+#: ``oversized``. Defaulting below the cap keeps the tree and the optimizer
+#: consistent; :meth:`TreeSpec.validate_against` is the escape hatch when a
+#: caller genuinely raises both.
+DEFAULT_MAX_FILE_BYTES = 28_000
+
+
+@dataclass(frozen=True)
+class TreeSpec:
+    """Which files make up an evolvable tree, and how big it may get."""
+
+    include: Sequence[str] = (
+        "**/*.md", "**/*.txt", "**/*.py", "**/*.json", "**/*.yaml", "**/*.yml",
+        "**/*.toml", "**/*.sh", "**/*.cfg", "**/*.ini",
+    )
+    exclude: Sequence[str] = (
+        "**/.git/**", "**/__pycache__/**", "**/node_modules/**", "**/.venv/**",
+        "**/*.egg-info/**", "**/.pytest_cache/**", "**/.DS_Store",
+    )
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+    max_files: int = 200
+    max_total_bytes: int = 2_000_000
+
+    def selects(self, relpath: str) -> bool:
+        return (match_any(relpath, self.include)
+                and not match_any(relpath, self.exclude))
+
+    def validate_against(self, trust_region_chars: int) -> None:
+        """Fail now if the loader admits files the optimizer can never accept.
+
+        Without this the mismatch shows up as a pile of ``oversized`` entries in
+        ``result.outcomes()`` five rounds in, which reads as "my reflector emits
+        junk" rather than "this file was never editable"."""
+        if self.max_file_bytes > trust_region_chars:
+            raise TreeError(
+                f"TreeSpec(max_file_bytes={self.max_file_bytes:,}) exceeds the "
+                f"aggregator's trust region ({trust_region_chars:,} chars per op), "
+                "so any diff touching a file above that size would always be "
+                "rejected as 'oversized'. Lower max_file_bytes, or raise it with "
+                "agg_config=AggregatorConfig(trust_region_chars=...).")
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+_MAGIC = "agentdescent.filetree/1"
+
+
+def canonical(state: Mapping[str, str]) -> str:
+    """A lossless, stable serialisation of a file tree.
+
+    Stable because the engine caches evaluations on it, lossless because two
+    different trees must never collide in that cache, and JSON because a file's
+    *content* must not be able to forge the delimiter of its own container."""
+    return json.dumps({"_": _MAGIC, "files": dict(sorted(state.items()))},
+                      ensure_ascii=False, sort_keys=True)
+
+
+def parse_tree(rendered: str) -> Dict[str, str]:
+    """The inverse of :func:`canonical`.
+
+    ``run`` receives ``Strategy.render(state)``, so this is how a runner gets the
+    tree back in order to write it to disk. Also accepts a plain
+    ``{path: content}`` object, which is what a hand-written test tends to pass.
+    """
+    try:
+        data = json.loads(rendered)
+    except Exception as e:  # noqa: BLE001 - the caller gets a precise message
+        raise TreeError(
+            f"not a serialised file tree ({type(e).__name__}); expected the output "
+            "of agentdescent.filetree.canonical()") from e
+    if isinstance(data, dict) and data.get("_") == _MAGIC:
+        files = data.get("files") or {}
+    elif isinstance(data, dict):
+        files = data
+    else:
+        raise TreeError(f"serialised file tree must be an object, got {type(data).__name__}")
+    out: Dict[str, str] = {}
+    for k, v in files.items():
+        if not isinstance(v, str):
+            raise TreeError(f"file {k!r} has non-text content ({type(v).__name__})")
+        out[safe_relpath(k)] = v
+    return out
+
+
+def tree_summary(state: Mapping[str, str], limit: int = 40) -> str:
+    """A human/LLM-readable listing (paths + sizes), for prompts and logs.
+
+    Deliberately *not* the render: a reflector that needs the whole tree in its
+    prompt pays for the whole tree, and most reflections only need to know what
+    exists (see :func:`agentdescent.treestrategy.tree_reflector`)."""
+    items = sorted(state.items())
+    lines = [f"{p}  ({len(c):,} chars)" for p, c in items[:limit]]
+    if len(items) > limit:
+        lines.append(f"... and {len(items) - limit} more file(s)")
+    return "\n".join(lines) or "(empty tree)"
+
+
+# ---------------------------------------------------------------------------
+# Disk <-> state
+# ---------------------------------------------------------------------------
+
+
+def load_tree(path: str, spec: Optional[TreeSpec] = None) -> Dict[str, str]:
+    """Read a directory into ``{relpath: text}``.
+
+    Files that match ``spec.include`` but cannot be represented -- binary, or
+    over ``max_file_bytes`` -- **raise** rather than being skipped. Skipping
+    silently would mean the evolved tree is not the tree the caller pointed at,
+    and :meth:`~agentdescent.evolution.EvolutionResult.write_to` would then
+    delete-by-omission or write back a truncated directory. Widen ``exclude`` to
+    say "this file is not part of the artifact" on purpose.
+    """
+    spec = spec or TreeSpec()
+    root = os.path.abspath(os.path.expanduser(path))
+    if not os.path.isdir(root):
+        raise TreeError(f"not a directory: {path!r}")
+    state: Dict[str, str] = {}
+    total = 0
+    rejected: List[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        rel_dir = os.path.relpath(dirpath, root).replace(os.sep, "/")
+        rel_dir = "" if rel_dir == "." else rel_dir
+        # prune excluded directories in place -- cheaper, and keeps .git out of
+        # the walk entirely rather than filtering thousands of paths afterwards.
+        dirnames[:] = [d for d in sorted(dirnames)
+                       if not match_any(f"{rel_dir}/{d}".lstrip("/") + "/x", spec.exclude)]
+        for fname in sorted(filenames):
+            rel = f"{rel_dir}/{fname}".lstrip("/")
+            full = os.path.join(dirpath, fname)
+            if os.path.islink(full):
+                continue                    # never follow links out of the tree
+            if not spec.selects(rel):
+                continue
+            size = os.path.getsize(full)
+            if size > spec.max_file_bytes:
+                rejected.append(f"{rel} ({size:,} bytes > max_file_bytes="
+                                f"{spec.max_file_bytes:,})")
+                continue
+            with open(full, "rb") as fh:
+                raw = fh.read()
+            if b"\x00" in raw:
+                rejected.append(f"{rel} (binary)")
+                continue
+            try:
+                text = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                rejected.append(f"{rel} (not utf-8)")
+                continue
+            state[safe_relpath(rel)] = text
+            total += len(raw)
+    if rejected:
+        raise TreeError(
+            f"{len(rejected)} file(s) under {path!r} match the include patterns but "
+            f"cannot be evolved as text:\n  " + "\n  ".join(rejected[:10])
+            + ("\n  ..." if len(rejected) > 10 else "")
+            + "\nAdd them to TreeSpec(exclude=...) to declare them outside the "
+              "artifact, or raise max_file_bytes.")
+    if len(state) > spec.max_files:
+        raise TreeError(
+            f"{len(state)} files exceed TreeSpec(max_files={spec.max_files}); "
+            "narrow `include` or raise the cap.")
+    if total > spec.max_total_bytes:
+        raise TreeError(
+            f"{total:,} bytes exceed TreeSpec(max_total_bytes="
+            f"{spec.max_total_bytes:,}); every ledger commit stores the whole tree.")
+    if not state:
+        raise TreeError(
+            f"no files under {path!r} matched TreeSpec.include={list(spec.include)}. "
+            "An empty artifact cannot be evolved.")
+    return state
+
+
+#: Files made executable on materialisation. A skill that ships a helper script
+#: is useless if the agent cannot run it, and the mode bit is not part of the
+#: evolvable state (only content is), so it is derived from the path.
+_EXEC_PATTERNS = ("**/*.sh", "scripts/**", "**/bin/**")
+
+
+def materialize(state: Mapping[str, str], dest: str, *, prefix: str = "",
+                exec_patterns: Sequence[str] = _EXEC_PATTERNS) -> List[str]:
+    """Write a tree into ``dest`` (optionally under ``prefix``); return the paths.
+
+    ``dest`` is created if missing. Every path is re-validated here even though
+    the strategy validated it on the way in -- this is the last point before a
+    model-authored string becomes a filesystem write, and a resumed ledger or a
+    custom aggregator can put state in front of it that never passed through
+    :class:`~agentdescent.treestrategy.FileTree`.
+    """
+    root = os.path.abspath(dest)
+    os.makedirs(root, exist_ok=True)
+    written: List[str] = []
+    for raw_path, content in sorted(state.items()):
+        rel = safe_relpath(f"{prefix}/{raw_path}" if prefix else raw_path)
+        full = os.path.join(root, rel.replace("/", os.sep))
+        # belt and braces: safe_relpath already forbids `..`, but a symlinked
+        # parent directory inside dest could still redirect the write.
+        real_parent = os.path.realpath(os.path.dirname(full))
+        if not (real_parent == os.path.realpath(root)
+                or real_parent.startswith(os.path.realpath(root) + os.sep)):
+            raise TreeError(f"refusing to write {rel!r} outside {dest!r}")
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        if match_any(rel, exec_patterns):
+            os.chmod(full, os.stat(full).st_mode | stat.S_IXUSR | stat.S_IXGRP)
+        written.append(rel)
+    return written

--- a/agentdescent/runners.py
+++ b/agentdescent/runners.py
@@ -1,0 +1,266 @@
+"""Runners: let a **real agent** use the tree that is being evolved.
+
+:data:`~agentdescent.evolution.Run` is ``(rendered, task) -> output``, and for a
+text artifact that is enough -- the instruction goes in the prompt. A directory
+cannot: a skill directory is only a skill directory if the agent can *read the
+files*, which means the candidate has to exist on disk, in the layout the agent
+expects, for the duration of one rollout.
+
+That is what a runner does:
+
+    parse the rendered tree -> materialise it into a fresh workspace
+    -> overlay the pristine frozen files -> stage the task's fixtures
+    -> run the agent bound to that directory -> clean up
+
+**One workspace per call, always.** ``evolve(max_concurrency=N)`` runs workers in
+threads and ``EvolvingArtifact.score`` opens its own pool of ``eval_concurrency``
+threads, so a shared directory would let two candidates overwrite each other --
+producing scores that look perfectly ordinary and are simply wrong.
+
+The overlay is the other half of ``FileTree(frozen=...)``. Filtering proposals
+stops a reflector from *editing* the test suite; it does nothing about candidate
+code that rewrites ``conftest.py`` at run time. Writing the pristine copies back
+over the candidate, after it has been materialised, is what makes "frozen"
+a property of every rollout rather than a property of well-behaved proposals.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Callable, Dict, Mapping, Optional, Sequence
+
+from .agents import AgentError, Completion, WorkspaceAgent
+from .evolution import Task
+from .filetree import TreeError, materialize, parse_tree
+
+__all__ = [
+    "LAYOUTS",
+    "TEST_FAILURE_MARKER",
+    "code_runner",
+    "layout_prefix",
+    "tree_runner",
+]
+
+#: Where the tree is written inside the workspace. ``{name}`` is the artifact's
+#: directory name. Add your own by passing ``layout=`` a literal prefix string.
+LAYOUTS: Dict[str, str] = {
+    "claude_skill": ".claude/skills/{name}",   # project-scoped Claude Code skill
+    "claude_agent": ".claude/agents",          # project-scoped subagent definitions
+    "skill_library": ".claude/skills",         # a directory OF skills, one dir each
+    "root": "",                                # the tree *is* the working directory
+}
+
+#: Prefix of the output a runner produces when the frozen test suite fails. The
+#: rollout is not an error -- "the candidate broke the build" is exactly the
+#: signal a reflector needs -- so it is reported in-band and scored 0.
+TEST_FAILURE_MARKER = "AGENTDESCENT_GATE_FAILED"
+
+_WS_PREFIX = "agentdescent-ws-"
+_WS_MAX_AGE = 6 * 3600.0
+
+_DEFAULT_PROMPT = (
+    "{prompt}\n\n"
+    "(The files under {tree_dir} in this directory are available to you; read "
+    "them and follow them. Reply with only the final answer.)"
+)
+
+
+def layout_prefix(layout: str, name: str) -> str:
+    """Resolve a layout name (or a literal prefix) to a path inside the workspace."""
+    template = LAYOUTS.get(layout, layout)
+    return template.format(name=name) if "{name}" in template else template
+
+
+def _reap_stale_workspaces(max_age: float = _WS_MAX_AGE) -> int:
+    """Collect workspaces left behind by a killed process.
+
+    ``evolve()`` reaps its own scratch *ledgers* the same way
+    (``_reap_stale_scratch_repos``) and for the same reason: ``atexit`` does not
+    run on SIGKILL or an OOM kill, and a long sweep otherwise leaves one
+    directory per rollout in ``$TMPDIR``. Best-effort and silent -- reclaiming
+    disk must never fail a run."""
+    root, now, n = tempfile.gettempdir(), time.time(), 0
+    try:
+        names = os.listdir(root)
+    except OSError:
+        return 0
+    for name in names:
+        if not name.startswith(_WS_PREFIX):
+            continue
+        path = os.path.join(root, name)
+        try:
+            if now - os.path.getmtime(path) < max_age:
+                continue
+            shutil.rmtree(path, ignore_errors=True)
+            n += 1
+        except OSError:
+            pass
+    return n
+
+
+def _stage(rendered: str, task: Task, *, prefix: str,
+           overlay: Optional[Mapping[str, str]],
+           fixtures: Optional[Callable[[Task], Mapping[str, str]]],
+           workspace_root: Optional[str]) -> str:
+    """Build one workspace for one rollout and return its path."""
+    tree = parse_tree(rendered)
+    ws = tempfile.mkdtemp(prefix=_WS_PREFIX, dir=workspace_root)
+    try:
+        materialize(tree, ws, prefix=prefix)
+        if overlay:
+            # after the candidate, so the candidate cannot win the race.
+            materialize(overlay, ws, prefix=prefix)
+        staged = fixtures(task) if fixtures else (task.meta or {}).get("fixtures")
+        if staged:
+            materialize(staged, ws)
+    except Exception:
+        shutil.rmtree(ws, ignore_errors=True)
+        raise
+    return ws
+
+
+def tree_runner(agent: Completion, *, layout: str = "claude_skill",
+                name: str = "artifact",
+                prompt_template: str = _DEFAULT_PROMPT,
+                overlay: Optional[Mapping[str, str]] = None,
+                fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
+                answer_file: Optional[str] = None,
+                keep_failed: bool = False,
+                workspace_root: Optional[str] = None) -> Callable[[str, Task], str]:
+    """Build a ``run(rendered, task)`` that gives ``agent`` the evolving directory.
+
+    ``agent`` should be a :class:`~agentdescent.agents.WorkspaceAgent`
+    (``claude_code()``, ``codex()``, ``cli_agent([...])``, ``openhands()``); a
+    plain completion still works but never sees the files, which makes the whole
+    exercise meaningless -- so that case raises rather than quietly scoring the
+    model's prior knowledge.
+
+    ``prompt_template`` may use ``{prompt}`` (the task), ``{tree_dir}`` (where the
+    tree was written, relative to the workspace) and ``{name}``.
+    ``answer_file`` reads the answer from a file the agent is told to write,
+    instead of stdout -- useful for agents whose stdout carries chatter.
+    """
+    if not isinstance(agent, WorkspaceAgent):
+        raise TypeError(
+            f"tree_runner needs a WorkspaceAgent so the evolving directory can be "
+            f"put in front of it; {type(agent).__name__} is a plain Completion and "
+            "would only ever see the prompt. Use claude_code(), codex(), "
+            "cli_agent([...]) or openhands().")
+    prefix = layout_prefix(layout, name)
+    _reap_stale_workspaces()
+
+    def run(rendered: str, task: Task) -> str:
+        ws = _stage(rendered, task, prefix=prefix, overlay=overlay,
+                    fixtures=fixtures, workspace_root=workspace_root)
+        ok = False
+        try:
+            prompt = prompt_template.format(prompt=task.prompt, name=name,
+                                            tree_dir=prefix or ".")
+            out = agent.in_workspace(ws)(prompt)
+            if answer_file:
+                path = os.path.join(ws, answer_file)
+                if os.path.exists(path):
+                    with open(path, encoding="utf-8", errors="replace") as fh:
+                        out = fh.read()
+            ok = True
+            return (out or "").strip()
+        finally:
+            if ok or not keep_failed:
+                shutil.rmtree(ws, ignore_errors=True)
+
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Evolving code: the same staging, plus a gate that actually runs it
+# ---------------------------------------------------------------------------
+
+#: Environment handed to candidate code. Deliberately tiny: the process is
+#: model-authored, and the ambient environment of a research run holds API keys.
+_ENV_ALLOWLIST = ("PATH", "LANG", "LC_ALL", "TZ", "SYSTEMROOT", "TEMP", "TMP")
+
+
+def _child_env(ws: str, extra: Optional[Mapping[str, str]]) -> Dict[str, str]:
+    env = {k: os.environ[k] for k in _ENV_ALLOWLIST if k in os.environ}
+    # HOME points at the workspace, not the real one: candidate code should not
+    # be able to read ~/.claude or ~/.aws just because it can read files.
+    env["HOME"] = ws
+    env["TMPDIR"] = ws
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _sh(cmd: Sequence[str], ws: str, timeout: float,
+        env: Mapping[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(list(cmd), cwd=ws, capture_output=True, text=True,
+                          timeout=timeout, env=dict(env))
+
+
+def code_runner(entrypoint: Sequence[str], *, layout: str = "root",
+                name: str = "agent",
+                setup_cmd: Optional[Sequence[str]] = None,
+                test_cmd: Optional[Sequence[str]] = None,
+                overlay: Optional[Mapping[str, str]] = None,
+                fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
+                timeout: float = 120.0,
+                env: Optional[Mapping[str, str]] = None,
+                workspace_root: Optional[str] = None) -> Callable[[str, Task], str]:
+    """Run **candidate code** on a task: materialise, gate, execute.
+
+    ``entrypoint`` is argv; the task prompt is appended as the last argument and
+    stdout is the output. ``setup_cmd`` runs first (e.g. ``["pip", "install",
+    "-e", "."]``), ``test_cmd`` is the correctness gate (e.g. ``["pytest", "-q"]``)
+    -- and because ``test_cmd`` is invoked *from outside the tree* over an overlay
+    of pristine frozen files, a candidate cannot pass by rewriting its own tests.
+
+    A failing gate is **not** an exception: the output becomes
+    ``TEST_FAILURE_MARKER`` plus the captured stderr, which scores 0 and gives the
+    reflector something to fix. Only infrastructure faults raise.
+
+    This is process isolation, **not a sandbox**: a trimmed environment, ``HOME``
+    inside the workspace, and a hard timeout. Model-authored code still runs with
+    your user's permissions. Use a container for anything you would not run by
+    hand.
+    """
+    prefix = layout_prefix(layout, name)
+    _reap_stale_workspaces()
+
+    def run(rendered: str, task: Task) -> str:
+        ws = _stage(rendered, task, prefix=prefix, overlay=overlay,
+                    fixtures=fixtures, workspace_root=workspace_root)
+        child = _child_env(ws, env)
+        try:
+            for label, cmd in (("setup", setup_cmd), ("tests", test_cmd)):
+                if not cmd:
+                    continue
+                try:
+                    proc = _sh(cmd, ws, timeout, child)
+                except subprocess.TimeoutExpired:
+                    return (f"{TEST_FAILURE_MARKER} ({label} timed out after "
+                            f"{timeout:g}s)")
+                except FileNotFoundError as e:
+                    raise AgentError(f"{cmd[0]!r} is not installed or not on PATH") from e
+                if proc.returncode != 0:
+                    detail = (proc.stdout or "") + (proc.stderr or "")
+                    return f"{TEST_FAILURE_MARKER} ({label}):\n{detail.strip()[:2000]}"
+            try:
+                proc = _sh([*entrypoint, task.prompt], ws, timeout, child)
+            except subprocess.TimeoutExpired:
+                return f"{TEST_FAILURE_MARKER} (entrypoint timed out after {timeout:g}s)"
+            except FileNotFoundError as e:
+                raise AgentError(
+                    f"{entrypoint[0]!r} is not installed or not on PATH") from e
+            if proc.returncode != 0:
+                detail = (proc.stderr or proc.stdout or "").strip()[:2000]
+                return f"{TEST_FAILURE_MARKER} (entrypoint exited {proc.returncode}):\n{detail}"
+            return (proc.stdout or "").strip()
+        finally:
+            shutil.rmtree(ws, ignore_errors=True)
+
+    return run

--- a/agentdescent/skilldir.py
+++ b/agentdescent/skilldir.py
@@ -1,0 +1,236 @@
+"""One call from a directory on disk to an evolved directory on disk.
+
+Three wrappers over :func:`~agentdescent.evolution.evolve`, one per thing people
+actually point at:
+
+    evolve_skill_dir(path, ...)    a skill directory   -> L2, merged freely
+    evolve_agent_dir(path, ...)    an agent directory  -> L1, oracle-gated
+    evolve_agent_code(path, ...)   a small codebase    -> L1 + a test gate
+
+They are wrappers, not a second system: same engine, same ``EvolutionResult``,
+and any extra keyword argument passes straight through. What they contribute is
+the wiring that is identical every time (load the tree, build the runner, build
+the reflector, install the governance layer) and **two defaults that the plain
+engine gets wrong for this workload**:
+
+* ``self_verify=False`` -- the default re-runs each proposal's trajectory, which
+  on a real coding agent doubles the cost of every proposal;
+* ``cheap_eval_tasks=4`` -- otherwise the aggregator's *ranking* passes score
+  every candidate on the whole held-out set, and with ``eval_fn`` running an
+  agent that is the dominant cost of the run (see the note in
+  ``evolution._build_engine``).
+
+Both are overridable; they are defaults here because the cost of getting them
+wrong is measured in dollars rather than in a warning.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Union
+
+from .agents import Completion
+from .aggregator import AggregatorConfig
+from .evolution import EvolutionResult, Task, evolve, tasks_from
+from .filetree import TreeSpec, load_tree
+from .runners import TEST_FAILURE_MARKER, code_runner, tree_runner
+from .skill import SCORERS
+from .treestrategy import FileTree, tree_reflector
+
+__all__ = ["evolve_skill_dir", "evolve_agent_dir", "evolve_agent_code"]
+
+#: L2: a skill is local, so its changes merge on held-out reward alone.
+SKILL_BLAST_RADIUS = 0.2
+#: L1: an agent definition or its code is a harness -- every merge is forced
+#: through the oracle by :meth:`~agentdescent.scheduler.AuditScheduler.force_oracle`.
+#: Free, as it happens: the oracle scores the same artifact on the same held-out
+#: set that the acceptance test just scored, and the evaluation cache serves it.
+HARNESS_BLAST_RADIUS = 0.6
+
+
+def _artifact_id(path: str, name: Optional[str]) -> str:
+    import os
+
+    raw = name or os.path.basename(os.path.abspath(os.path.expanduser(path)))
+    cleaned = re.sub(r"[^A-Za-z0-9_.-]+", "-", raw).strip("-") or "artifact"
+    return cleaned
+
+
+def _as_tasks(data: Sequence[Any], prompt: str, gold: str) -> Sequence[Task]:
+    if not data:
+        raise ValueError("no tasks given")
+    return (list(data) if isinstance(data[0], Task)
+            else tasks_from(data, prompt=prompt, gold=gold))
+
+
+def _as_reward(score: Union[str, Callable]) -> Callable:
+    if callable(score):
+        return score
+    if score in SCORERS:
+        return SCORERS[score]()
+    raise ValueError(
+        f"unknown score={score!r}; use one of {sorted(SCORERS)} or pass a "
+        "callable (task, output) -> float")
+
+
+def _build(path, *, spec, editable, frozen, max_files_per_diff, agg_config):
+    spec = spec or TreeSpec()
+    cfg = agg_config or AggregatorConfig(batch_trigger=2, max_wait_rounds=1)
+    spec.validate_against(cfg.trust_region_chars)
+    tree = load_tree(path, spec)
+    strategy = FileTree(tree, editable=editable, frozen=frozen,
+                        max_files_per_diff=max_files_per_diff,
+                        max_file_bytes=spec.max_file_bytes)
+    return tree, strategy, cfg
+
+
+def _defaults(kwargs: Dict[str, Any], n_tasks: int) -> None:
+    held_out_frac = kwargs.get("held_out_frac", 0.3)
+    workers = max(1, min(4, max(1, int(n_tasks * (1 - held_out_frac)))))
+    for key, value in (("rounds", 6), ("n_workers", workers),
+                       ("target_reward", 0.98), ("patience", 3),
+                       ("held_out_frac", held_out_frac),
+                       ("self_verify", False), ("cheap_eval_tasks", 4)):
+        kwargs.setdefault(key, value)
+    if not kwargs.get("asynchronous"):
+        kwargs.setdefault("max_concurrency", kwargs["n_workers"])
+
+
+def evolve_skill_dir(
+    path: str,
+    data: Sequence[Any],
+    *,
+    agent: Completion,
+    score: Union[str, Callable] = "contains",
+    reflect_with: Optional[Completion] = None,
+    prompt: str = "prompt",
+    gold: str = "gold",
+    name: Optional[str] = None,
+    layout: str = "claude_skill",
+    spec: Optional[TreeSpec] = None,
+    editable: Sequence[str] = ("**",),
+    frozen: Sequence[str] = (),
+    max_files_per_diff: int = 2,
+    prompt_template: Optional[str] = None,
+    fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
+    answer_file: Optional[str] = None,
+    blast_radius: float = SKILL_BLAST_RADIUS,
+    **evolve_kwargs: Any,
+) -> EvolutionResult:
+    """Evolve a **skill directory**, executed by a real agent that reads it.
+
+    ``path`` is loaded with :func:`~agentdescent.filetree.load_tree`; every
+    rollout materialises the current candidate into a fresh workspace under
+    ``layout`` (default ``.claude/skills/<name>/``) and runs ``agent`` there.
+
+    ::
+
+        result = evolve_skill_dir(
+            "~/.claude/skills/pdf-audit", rows,
+            agent=claude_code(extra_args=["--permission-mode", "acceptEdits"]),
+            reflect_with=openai_compatible(model="deepseek-v4-flash"),
+            prompt="question", gold="answer", score="contains")
+        result.write_to("~/.claude/skills/pdf-audit")     # opt in, backs up first
+
+    ``agent`` must be a :class:`~agentdescent.agents.WorkspaceAgent`; a plain API
+    completion cannot read files, so the directory would not participate.
+    ``reflect_with`` defaults to ``agent`` -- a cheap model there and an expensive
+    agent for the rollouts is usually the right trade.
+    """
+    tasks = _as_tasks(data, prompt, gold)
+    aid = _artifact_id(path, name)
+    tree, strategy, cfg = _build(path, spec=spec, editable=editable, frozen=frozen,
+                                 max_files_per_diff=max_files_per_diff,
+                                 agg_config=evolve_kwargs.pop("agg_config", None))
+    runner_kwargs: Dict[str, Any] = {}
+    if prompt_template:
+        runner_kwargs["prompt_template"] = prompt_template
+    run = tree_runner(agent, layout=layout, name=aid,
+                      overlay=strategy.frozen_files(tree), fixtures=fixtures,
+                      answer_file=answer_file, **runner_kwargs)
+    _defaults(evolve_kwargs, len(tasks))
+    evolve_kwargs.setdefault("propose", tree_reflector(reflect_with or agent,
+                                                       strategy=strategy))
+    return evolve(tasks, _as_reward(score), run=run, strategy=strategy,
+                  artifact_id=aid, blast_radius=blast_radius,
+                  agg_config=cfg, **evolve_kwargs)
+
+
+def evolve_agent_dir(
+    path: str,
+    data: Sequence[Any],
+    *,
+    agent: Completion,
+    score: Union[str, Callable] = "contains",
+    layout: str = "claude_agent",
+    frozen: Sequence[str] = (),
+    **kwargs: Any,
+) -> EvolutionResult:
+    """Evolve an **agent directory** (subagent definitions, tool config, harness).
+
+    Identical to :func:`evolve_skill_dir` except for the governance layer: an
+    agent definition is a harness, so it runs at ``blast_radius=0.6`` -- L1, where
+    every merge is additionally gated by the oracle."""
+    kwargs.setdefault("blast_radius", HARNESS_BLAST_RADIUS)
+    return evolve_skill_dir(path, data, agent=agent, score=score, layout=layout,
+                            frozen=frozen, **kwargs)
+
+
+def evolve_agent_code(
+    path: str,
+    data: Sequence[Any],
+    *,
+    entrypoint: Sequence[str],
+    score: Union[str, Callable] = "contains",
+    reflect_with: Completion,
+    prompt: str = "prompt",
+    gold: str = "gold",
+    name: Optional[str] = None,
+    spec: Optional[TreeSpec] = None,
+    editable: Sequence[str] = ("**",),
+    frozen: Sequence[str] = ("tests/**", "conftest.py"),
+    max_files_per_diff: int = 2,
+    setup_cmd: Optional[Sequence[str]] = None,
+    test_cmd: Optional[Sequence[str]] = ("python", "-m", "pytest", "-q"),
+    fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
+    timeout: float = 120.0,
+    **evolve_kwargs: Any,
+) -> EvolutionResult:
+    """Evolve **agent code**: the tree is executed, and a test gate guards it.
+
+    Each rollout materialises the candidate, overwrites every ``frozen`` path with
+    its pristine content, runs ``setup_cmd`` then ``test_cmd``, and only then
+    executes ``entrypoint + [task.prompt]``. A failing gate scores 0 and the
+    failure text is what the reflector sees, so "you broke the tests" is a
+    learning signal rather than a crashed run.
+
+    ``frozen`` defaults to the test suite for a reason: without it the shortest
+    path to a high score is to weaken the thing measuring it. The proposal filter
+    stops the reflector from editing those files and the runner's overlay stops
+    the *candidate* from rewriting them at run time -- both are needed.
+
+    This is isolation, not a sandbox (trimmed environment, ``HOME`` inside the
+    workspace, hard timeout). Model-written code still runs as your user.
+    """
+    tasks = _as_tasks(data, prompt, gold)
+    aid = _artifact_id(path, name)
+    tree, strategy, cfg = _build(path, spec=spec, editable=editable, frozen=frozen,
+                                 max_files_per_diff=max_files_per_diff,
+                                 agg_config=evolve_kwargs.pop("agg_config", None))
+    run = code_runner(entrypoint, layout="root", name=aid, setup_cmd=setup_cmd,
+                      test_cmd=test_cmd, overlay=strategy.frozen_files(tree),
+                      fixtures=fixtures, timeout=timeout)
+    base_reward = _as_reward(score)
+
+    def reward(task: Task, output: str) -> float:
+        # The gate speaks in-band so the reflector can read it; scoring it as a
+        # normal answer would let a candidate "pass" by echoing the marker.
+        if isinstance(output, str) and output.startswith(TEST_FAILURE_MARKER):
+            return 0.0
+        return base_reward(task, output)
+
+    _defaults(evolve_kwargs, len(tasks))
+    evolve_kwargs.setdefault("propose", tree_reflector(
+        reflect_with, strategy=strategy, context_files=("**/*.py",)))
+    return evolve(tasks, reward, run=run, strategy=strategy, artifact_id=aid,
+                  blast_radius=HARNESS_BLAST_RADIUS, agg_config=cfg, **evolve_kwargs)

--- a/agentdescent/treestrategy.py
+++ b/agentdescent/treestrategy.py
@@ -1,0 +1,294 @@
+"""The :class:`FileTree` strategy: a directory as the thing being evolved.
+
+``AppendRules`` accumulates lessons, ``SingleSlot`` holds one instruction,
+``KeyedRules`` holds one entry per category -- and :class:`FileTree` holds one
+entry per **file**. Nothing else changes: the aggregator still dedupes, resolves
+contradictions, fuses complements and gates on held-out reward, except that now
+"two workers touched the same key" means "two workers rewrote the same file".
+
+Two things live here that a text strategy never needs:
+
+* :func:`parse_edits` -- a multi-file proposal protocol, because one string can
+  no longer mean "the new artifact";
+* ``frozen`` -- paths the loop may read but never write. This is L0 in the file
+  world (:mod:`agentdescent.governance` freezes *artifacts* by id, which cannot
+  express "this artifact may evolve, but not its test suite"). Note that the
+  filter here only stops a *proposal*; when the frozen files are what score the
+  candidate, the enforcement that matters is the pristine overlay in
+  :func:`agentdescent.runners.tree_runner`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .agents import Completion
+from .evolvable import Diff, stable_hash
+from .filetree import (
+    DEFAULT_MAX_FILE_BYTES,
+    TreeError,
+    canonical,
+    match_any,
+    parse_tree,
+    safe_relpath,
+    tree_summary,
+)
+
+__all__ = ["FileTree", "parse_edits", "tree_reflector", "EDIT_PROTOCOL"]
+
+
+# ---------------------------------------------------------------------------
+# The proposal protocol
+# ---------------------------------------------------------------------------
+
+#: What a reflector is told to emit. Whole-file replacement rather than a unified
+#: diff: a model-written patch that does not apply is a *silent* failure mode
+#: (wrong context lines, drifted offsets), whereas a whole file either parses or
+#: does not. The cost is tokens, which `max_file_bytes` and "split the skill into
+#: several files" both bound.
+EDIT_PROTOCOL = """Reply with ONE block in exactly this format and nothing else:
+
+<EDITS>
+{{"rationale": "<one sentence: what was wrong and why this fixes it>",
+ "edits": [{{"path": "<relative path>", "content": "<the COMPLETE new file>"}}]}}
+</EDITS>
+
+Rules:
+- `content` is the whole file, not a patch or an excerpt.
+- Edit at most {max_files} file(s) per reply; prefer the smallest change that fixes
+  the observed failure and generalises beyond it.
+- Only these paths are editable: {editable}
+- Never edit: {frozen}
+- To delete a file use {{"path": "...", "delete": true}}."""
+
+_BLOCK_RE = re.compile(r"<EDITS>\s*(.*?)\s*</EDITS>", re.DOTALL | re.IGNORECASE)
+_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def _first_json_object(text: str) -> Optional[str]:
+    """Extract the first balanced ``{...}`` run, ignoring braces inside strings."""
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth, in_str, esc = 0, False, False
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None
+
+
+def parse_edits(proposal: str) -> Dict[str, Optional[str]]:
+    """Parse a reflector reply into ``{path: new_content}`` (``None`` = delete).
+
+    Lenient about the wrapper -- ``<EDITS>`` block, fenced JSON, or a bare object
+    -- and strict about the payload. Returns ``{}`` when nothing parses, because
+    a reflector that ignores the protocol is a *quality* problem the run should
+    absorb and count (``to_diff`` returns ``None``), not a crash.
+    """
+    if not isinstance(proposal, str) or not proposal.strip():
+        return {}
+    m = _BLOCK_RE.search(proposal)
+    raw = m.group(1) if m else None
+    if raw is None:
+        f = _FENCE_RE.search(proposal)
+        raw = f.group(1) if f else _first_json_object(proposal)
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except Exception:  # noqa: BLE001 - malformed model output, not a bug
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    items: Sequence[Any]
+    if isinstance(data.get("edits"), list):
+        items = data["edits"]
+    elif "path" in data:
+        items = [data]
+    else:
+        return {}
+    out: Dict[str, Optional[str]] = {}
+    for item in items:
+        if not isinstance(item, dict) or "path" not in item:
+            continue
+        try:
+            path = safe_relpath(str(item["path"]))
+        except TreeError:
+            continue                       # a hostile or malformed path: drop it
+        if item.get("delete") is True:
+            out[path] = None
+        elif isinstance(item.get("content"), str):
+            out[path] = item["content"]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The strategy
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileTree:
+    """The artifact **is a directory**; each state key is a relative file path.
+
+    ``editable`` / ``frozen`` are glob lists (``"**"``, ``"tests/**"``,
+    ``"*.md"``). ``frozen`` wins over ``editable``. ``max_files_per_diff`` is a
+    trust region expressed in the unit that matters here -- a reflector that
+    rewrites the whole tree in one proposal is almost never right, and the
+    aggregator's own ``trust_region_ops`` (6) is the backstop above it.
+
+        FileTree(load_tree("~/.claude/skills/pdf-audit"),
+                 frozen=["tests/**"], max_files_per_diff=2)
+    """
+
+    initial_files: Mapping[str, str] = field(default_factory=dict)
+    editable: Sequence[str] = ("**",)
+    frozen: Sequence[str] = ()
+    max_files_per_diff: int = 2
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+    #: Paths that do not exist yet but may be created. Only consulted by
+    #: :meth:`keys` -- i.e. only under tensor parallelism, where the section map
+    #: is fixed before the first round and an unknown path is a section
+    #: violation by construction. Under DataParallel (the default) any editable
+    #: path can be created without declaring it here.
+    planned_paths: Sequence[str] = ()
+
+    def __post_init__(self) -> None:
+        self.initial_files = {safe_relpath(k): v for k, v in dict(self.initial_files).items()}
+
+    # -- the Strategy protocol ---------------------------------------------
+
+    def keys(self) -> Sequence[str]:
+        """The declared key space, for :class:`~agentdescent.parallel.TensorParallel`.
+
+        **New files cannot be created under TP.** The section map is built once
+        from this list (``evolve._resolve_sections``) and a path that is not in it
+        maps to ``None``, which never equals a worker's section -- so every
+        creation is counted as ``section-violation``. Declare the paths up front
+        via ``planned_paths``, or use DataParallel, which has no section map."""
+        declared = [p for p in self.initial_files if self.writable(p)]
+        declared += [safe_relpath(p) for p in self.planned_paths]
+        return sorted(set(declared))
+
+    def initial(self) -> Dict[str, str]:
+        return dict(self.initial_files)
+
+    def render(self, state: Mapping[str, str]) -> str:
+        return canonical(state)
+
+    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
+        edits = parse_edits(proposal)
+        ops: Dict[str, Optional[str]] = {}
+        for path, content in edits.items():
+            if not self.writable(path):
+                continue
+            if content is None:
+                if path in state:
+                    ops[path] = None       # delete (EvolvingArtifact.apply pops it)
+                continue
+            if len(content) > self.max_file_bytes:
+                continue                   # would be rejected as oversized anyway
+            if state.get(path) != content:
+                ops[path] = content
+        if not ops or len(ops) > self.max_files_per_diff:
+            return None
+        fingerprint = stable_hash(tuple(sorted((k, v) for k, v in ops.items())))
+        return Diff(diff_id=f"{author}:{fingerprint & 0xFFFFFFFF:08x}:{base_version}",
+                    target=target, ops=dict(ops), author=author)
+
+    # -- helpers ------------------------------------------------------------
+
+    def writable(self, path: str) -> bool:
+        """May the loop write this path? ``frozen`` beats ``editable``."""
+        return match_any(path, self.editable) and not match_any(path, self.frozen)
+
+    def frozen_files(self, source: Mapping[str, str]) -> Dict[str, str]:
+        """The pristine content of every frozen path, for the runner's overlay."""
+        return {p: c for p, c in source.items() if match_any(p, self.frozen)}
+
+
+# ---------------------------------------------------------------------------
+# The reflector
+# ---------------------------------------------------------------------------
+
+_TREE_PROPOSE_TMPL = """You maintain the files below. An agent used them to do a task and did \
+poorly (reward {reward:.2f} out of 1.00). Improve the files so this class of failure stops \
+happening -- generalise, do not hard-code this one case.
+
+FILES IN THE ARTIFACT:
+{listing}
+
+{contents}
+TASK THE AGENT WAS GIVEN:
+{prompt}
+
+WHAT THE AGENT PRODUCED:
+{output}
+{expected}
+{protocol}"""
+
+
+def tree_reflector(complete: Completion, *, strategy: "FileTree",
+                   context_files: Sequence[str] = ("**/SKILL.md", "**/AGENT.md", "*.md"),
+                   max_context_chars: int = 12_000,
+                   max_output_chars: int = 2_000,
+                   template: str = _TREE_PROPOSE_TMPL) -> Any:
+    """A ``propose`` callable that asks ``complete`` for multi-file edits.
+
+    It deliberately does **not** put the whole tree in the prompt.
+    ``render()`` is the full serialisation because the evaluation cache needs it
+    to be lossless -- but a reflection only needs to *see* the files it might
+    change, so this shows the full text of ``context_files`` (within
+    ``max_context_chars``) and a path+size listing for the rest. On a tree of any
+    size that is the difference between a workable prompt and an unaffordable one.
+    """
+    def propose(rendered: str, task, output: str, reward: float) -> Optional[str]:
+        try:
+            state = parse_tree(rendered)
+        except TreeError:
+            return None
+        shown, budget = [], max_context_chars
+        for path in sorted(state):
+            if not strategy.writable(path) or not match_any(path, context_files):
+                continue
+            body = state[path]
+            if len(body) > budget:
+                continue
+            budget -= len(body)
+            shown.append(f"--- {path} ---\n{body}\n")
+        gold = (task.meta or {}).get("gold") or (task.meta or {}).get("answer")
+        prompt = template.format(
+            reward=reward,
+            listing=tree_summary(state),
+            contents=("CURRENT CONTENT OF THE FILES YOU MAY EDIT:\n"
+                      + "\n".join(shown) + "\n") if shown else "",
+            prompt=task.prompt,
+            output=(output or "")[:max_output_chars],
+            expected=f"\nEXPECTED:\n{gold}\n" if gold else "",
+            protocol=EDIT_PROTOCOL.format(
+                max_files=strategy.max_files_per_diff,
+                editable=", ".join(strategy.editable) or "(none)",
+                frozen=", ".join(strategy.frozen) or "(nothing)"),
+        )
+        reply = complete(prompt)
+        return reply if isinstance(reply, str) and reply.strip() else None
+
+    return propose

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -279,6 +279,19 @@ document written into it (so it can genuinely grep a huge table), while a plain
 completion gets the document inline, truncated at `inline_chars`. That is why the
 same OfficeQA example runs on OpenHands, Claude Code, or a bare API model.
 
+Skills can travel as **files** instead of prompt text:
+
+```python
+backend.answer(question, document_text, skill_files={"lookup/SKILL.md": "..."})
+```
+
+For a workspace agent they are written to `.claude/skills/` in that same scratch
+directory and the prompt carries a pointer, so the agent opens the one skill it
+needs rather than reading the whole library on every question — the reason a skill
+*directory* is worth more than a concatenated string. A backend with no workspace
+has nowhere to put them, so it folds them back into the inline block rather than
+dropping them in silence. See [evolving a directory](directory-evolution.md).
+
 !!! warning "The inline path is a fallback, not an equivalent"
     Measured on three real OfficeQA items (documents of 266–390 KB) with
     `document_agent(openai_compatible(model="deepseek-v4-flash"))`: **1 of 3

--- a/docs/algo-evoskill.md
+++ b/docs/algo-evoskill.md
@@ -34,8 +34,15 @@ Traced from the repo (`src/loop/runner.py`, `src/registry/manager.py`,
 
 ## How it plugs into `evolve()`
 
-* `strategy=SkillLibraryStrategy()` — a proposed `name :: body` becomes a `Diff`
-  that appends (or edits) a skill in the library.
+* `strategy=SkillLibraryTree()` — a proposed `name :: body` becomes a `Diff`
+  that appends (or edits) a skill in the library. It is a
+  [`FileTree`](directory-evolution.md) subclass, so the library **is a directory**
+  (`skills/<name>/SKILL.md`) rather than a name→text dict: with a tool-using
+  backend the skills are written into the agent's workspace and it reads the ones
+  it needs, instead of every skill riding along in every prompt. The repo's
+  `name :: body` protocol is kept rather than `FileTree`'s `<EDITS>` JSON — what
+  is faithful here is the two-role Proposer/Generator induction, not the
+  separator, and switching protocols would change the Generator's prompt.
 * `propose` — **batch-level** failure-driven Proposer + Generator: it accumulates
   a batch of `batch_size` failures (shared across the concurrent workers) and then
   induces **one** `SKILL.md` from their shared pattern (two LLM calls) — matching
@@ -59,7 +66,7 @@ In [`examples/evoskill_skill_discovery.py`](https://github.com/Birfy/agentdescen
 
 | Plug-in | `evolve()` slot | What it does |
 |---|---|---|
-| **`SkillLibraryStrategy`** | `strategy=` | a proposed `SKILL.md` (`name :: body`) becomes a `Diff` on the skill library |
+| **`SkillLibraryTree`** | `strategy=` | a proposed `SKILL.md` (`name :: body`) becomes a `Diff` on the skill library — a [`FileTree`](directory-evolution.md), so the library is a real directory of `SKILL.md` files |
 | **`TopKFrontierAggregator`** + **`Frontier`** | `aggregator_factory=` (**sync**) | the bounded top-K aggregate frontier; scores every candidate on held-out, commits the best member as the dev head |
 | **`SgdSkillAggregator`** | `aggregator_factory=` (**async**) | SGD-style skill descent: apply updates, validate every `val_every` steps, checkpoint + roll back on no held-out gain |
 | `make_propose(...)` | `propose=` | **batch-level** failure-driven Skill Proposer + Generator — one `SKILL.md` per `batch_size` failures (shared across workers) |

--- a/docs/design-directory-evolution.md
+++ b/docs/design-directory-evolution.md
@@ -1,0 +1,574 @@
+# 设计文档：演化「目录形态」的 Skill / Agent，并由真实 Agent 执行
+
+> 目标：用户给出一个**目录**（一个 skill 目录、一个 agent 目录，或一份 agent 代码），
+> AgentDescent 演化它；每一次 rollout 由**真实 agent**（Claude Code / Codex /
+> OpenHands / 任意 CLI agent）在一个装载了当前候选目录的工作区里执行任务。
+>
+> **状态：已实现并落地**（P0–P5）。本文保留为设计记录 —— 它写了*为什么*这样做，
+> 以及复核时发现并修掉的三个真问题。要*怎么用*，看
+> [演化一个目录（skill / agent / 代码）](directory-evolution.md)。
+>
+> 落地的模块：`agentdescent/filetree.py`（§3.1）、`agentdescent/treestrategy.py`（§3.2/§3.3）、
+> `agentdescent/runners.py`（§3.4）、`agentdescent/skilldir.py`（§3.7），
+> 加上 `evolution.py` 里的两处改动（§3.6 的删除语义、`EvolutionResult.write_to`）。
+> **P6（EvoSkill 迁移，§5.2）也已完成** —— 见下方 5.2 的结论。
+> 未做：`SectionedFileTree`、Docker 沙箱、ADAS 真执行（§5.3）。
+
+---
+
+## 0. 结论先行
+
+| 能力 | 现状 | 说明 |
+|---|---|---|
+| 演化「一段文本 skill」（system prompt / 指令 / playbook） | ✅ 已支持 | `SingleSlot` / `AppendRules` / `KeyedRules` + `evolve_skill()` |
+| 用**真实 agent**（Claude Code / Codex / OpenHands）跑 rollout | ✅ 已支持 | `cli_agent(["claude","-p"])`、`claude_code()`、`codex()`、`openhands()`，全部是 `Completion` |
+| 把材料**落到磁盘**让 agent 用工具去读 | ⚠️ 有先例但只覆盖单文件 | `WorkspaceAgent.in_workspace(path)` + `document_agent()`（[backends.py:102](https://github.com/Birfy/agentdescent/blob/main/agentdescent/backends.py#L102)）只写一个 `document.txt` |
+| 演化一个 **skill 目录**（`SKILL.md` + `references/` + `scripts/`） | ❌ 缺 → ✅ **已实现** | `evolve_skill_dir()`；缺的是「目录 ↔ state」装载/物化与多文件提案协议 |
+| 演化一个 **agent 目录**（`.claude/agents/*.md`、子 agent 定义、harness 配置） | ❌ 缺 → ✅ **已实现** | `evolve_agent_dir()`（L1）+ 路径级冻结 |
+| 演化 **agent 代码本身**（可执行的 Python/TS） | ❌ 缺 → ✅ **已实现** | `evolve_agent_code()`：一次性工作区真执行 + pristine overlay 测试门 |
+| 把演化结果**装回**用户目录 | ❌ 缺 → ✅ **已实现** | `EvolutionResult.write_to()`（默认先备份，不删多余文件） |
+| 现有算法示例复用这套底座 | ✅ **EvoSkill 已迁移** | `SkillLibraryTree(FileTree)`；prompt 逐字节不变，12 个原有测试全绿（§5.2） |
+
+**一句话**：引擎层（并行 worker、聚合器、ledger、治理、异步运行时）**完全够用且不需要动**；
+缺的是**一层「目录适配层」**——把 `Dict[str, str]` 状态和磁盘目录互相翻译，并在每次 rollout
+时把候选目录物化到一次性工作区里交给真实 agent。
+
+实测下来估算是准的：新增 4 个模块（`filetree` / `treestrategy` / `runners` / `skilldir`），
+`evolution.py` 只动了两处（§3.6 的删除语义，加上 `EvolutionResult.write_to`），
+`aggregator` / `ledger` / `async_evolve` / `parallel` / `governance` 一行未改。
+
+---
+
+## 1. 现状分析（引擎能提供什么）
+
+### 1.1 演化的最小契约
+
+`evolve()` 只要求三个可调用对象（[evolution.py:1025](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L1025)）：
+
+```python
+run(rendered: str, task: Task) -> str                       # 用当前 artifact 做一次 rollout
+reward(task: Task, output: str) -> float                    # [0, 1]
+propose(rendered, task, output, reward) -> Optional[str]    # 反思出一个改进提案
+```
+
+`rendered` 是 `Strategy.render(state)` 的结果，`state` 是**扁平的 `Dict[str, str]`**
+（[evolution.py:228](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L228) `Strategy` 协议）。
+**关键洞察：`state` 的 key 完全可以是相对文件路径，value 是文件内容。**
+引擎从不解释 key 的含义，它只做：
+
+- **冲突检测**：`diffs_contradict` = 同 key 不同 value（[aggregator.py:289](https://github.com/Birfy/agentdescent/blob/main/agentdescent/aggregator.py#L289)）
+- **融合**：`fuse_diffs` = 多个 diff 的 `ops` 字典合并（[aggregator.py:297](https://github.com/Birfy/agentdescent/blob/main/agentdescent/aggregator.py#L297)）
+- **接受**：held-out 分数 + Beta 后验，事务性提交到 git ledger
+
+也就是说：**两个 worker 改不同文件 → 自动融合；改同一文件 → 判为矛盾，按 held-out 分数择优。**
+这正是我们想要的目录级语义，不用写一行聚合器代码。
+
+### 1.2 真实 agent 已经是一等公民
+
+```python
+Completion = Callable[[str], str]          # agents.py:31
+
+class WorkspaceAgent(Protocol):            # agents.py:113
+    def __call__(self, prompt: str) -> str: ...
+    def in_workspace(self, path: str) -> Completion: ...
+```
+
+`cli_agent(["claude","-p"]).in_workspace("/tmp/w")` 会以 `cwd=/tmp/w` 起子进程
+（[agents.py:147](https://github.com/Birfy/agentdescent/blob/main/agentdescent/agents.py#L147)）。`document_agent()` 已经演示了完整套路：
+`mkdtemp` → 写文件 → `in_workspace(dir)(prompt)`。我们要做的就是把「写一个文件」
+换成「物化整棵目录树」。
+
+### 1.3 治理层已经为「改 harness」准备好了
+
+- `blast_radius <= 0.30` → L2 快层（skill）；`> 0.30` → L1 慢层（harness/agent 代码），
+  每次合并强制走 oracle（[governance.py:46](https://github.com/Birfy/agentdescent/blob/main/agentdescent/governance.py#L46)）。
+- `FROZEN_IDS` = L0 只读（oracle / 安全约束）——**但它是 artifact 级的 id 列表，不是路径级**。
+
+### 1.4 已有的两个「演化 agent」示例，以及它们的诚实边界
+
+- `examples/adas_meta_agent_search.py`：演化 agent 的**控制流**，但为了安全用一个
+  受限 DSL 解释器**替代了 `exec` 模型写的代码**（文件头已注明）。
+- `examples/dgm_self_improve.py`：演化 coding agent 的 harness，但目标函数是
+  **capability 覆盖的代理指标**，不是真跑 SWE-bench（文件头「Honesty boundary」已注明）。
+
+结论：**「演化代码 + 真跑」这条链路在仓库里从未闭合过。**
+
+---
+
+## 2. 差距清单（要做的事，按重要性）
+
+| # | 差距 | 影响 |
+|---|---|---|
+| G1 | 无「目录 → state」装载器与「state → 工作区」物化器 | 无法喂入/产出目录 |
+| G2 | `run` 只拿到一个字符串，没有工作区生命周期 | 真实 agent 无法「用」这个 skill 目录 |
+| G3 | 提案是单个字符串，无多文件编辑协议 | 反思模型没法说「改这三个文件」 |
+| G4 | **`apply()` 只做 `state.update(ops)`，无法删除 key**（[evolution.py:464](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L464)） | 无法删除/重命名文件 |
+| G5 | 无路径级冻结 | agent 可以改自己的测试/评分器，指标自我作弊 |
+| G6 | 无候选代码的执行沙箱与测试门 | 演化代码不安全、不可信 |
+| G7 | `_signature()` = `render()` 作为评估缓存 key（[evolution.py:470](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L470)） | `render` 若不是状态的**无损**序列化，不同目录会共用缓存分数 |
+| G8 | 信任域按「op 个数 ≤ 6、单 value ≤ 32k 字符」计（[aggregator.py:86](https://github.com/Birfy/agentdescent/blob/main/agentdescent/aggregator.py#L86)） | 对文件树含义变成「一次最多改 6 个文件、单文件 32k」——需显式设定而非默认 |
+| G9 | `run`/`propose` 会被多线程并发调用（`max_concurrency` worker 线程 + `eval_concurrency=8` 评估线程） | 工作区必须**每次调用独立**，不能复用固定路径 |
+| G10 | 无「装回用户目录」的输出路径 | 结果只能是 JSON |
+| G11 | ledger 把整个 state 存成 `artifacts/<id>.json`（[ledger.py:211](https://github.com/Birfy/agentdescent/blob/main/agentdescent/ledger.py#L211)） | 大目录/二进制文件会撑爆 commit；需要大小上限与 ignore 规则 |
+
+---
+
+## 3. 设计
+
+### 3.0 总体形状
+
+```
+用户目录 ~/.claude/skills/pdf-audit/
+        │  load_tree()            （新增）
+        ▼
+   state: {"SKILL.md": "...", "references/rules.md": "...", "scripts/check.py": "..."}
+        │  FileTree strategy（新增：render / to_diff / keys / frozen_paths）
+        ▼
+   evolve()  ← 引擎不变
+        │  每次 rollout：materialize() 到一次性 workspace（新增）
+        ▼
+   /tmp/ad-ws-xxxx/                          ← layout 决定目录结构
+       .claude/skills/pdf-audit/SKILL.md
+       .claude/skills/pdf-audit/references/rules.md
+       <task fixtures…>
+        │  claude_code().in_workspace(ws)(prompt)
+        ▼
+   agent 输出 → reward() → 反思 → 多文件提案 → Diff(ops={path: content})
+        │
+        ▼
+   result.write_to("~/.claude/skills/pdf-audit")   （新增）
+```
+
+### 3.1 新模块一：`agentdescent/filetree.py` — 目录 ↔ state
+
+```python
+@dataclass(frozen=True)
+class TreeSpec:
+    """哪些文件属于这棵可演化的树。"""
+    include: Sequence[str] = ("**/*.md", "**/*.py", "**/*.txt", "**/*.json", "**/*.yaml")
+    exclude: Sequence[str] = ("**/.git/**", "**/__pycache__/**", "**/node_modules/**")
+    #: 必须 <= AggregatorConfig.trust_region_chars（默认 32_000），否则任何超限文件
+    #: 一旦被修改，diff 必然被判 OVERSIZED 丢弃 —— 一条永远走不通的路。
+    #: 留出余量给序列化开销；要放宽就同时传
+    #: agg_config=AggregatorConfig(trust_region_chars=N)。
+    max_file_bytes: int = 28_000
+    max_files: int = 200
+    max_total_bytes: int = 2_000_000
+
+    def validate_against(self, trust_region_chars: int) -> None:
+        """装载前校验，而不是等到第 5 轮才在 outcomes() 里看到一堆 oversized。"""
+
+def load_tree(path: str, spec: TreeSpec = TreeSpec()) -> Dict[str, str]:
+    """目录 → {相对路径: 文本内容}。二进制/超限文件报错而非跳过。"""
+
+def materialize(state: Mapping[str, str], dest: str, *,
+                prefix: str = "", mode_map: Mapping[str, int] = ...) -> None:
+    """state → 磁盘。prefix 决定装到 dest 的哪个子路径下。
+    路径安全：拒绝绝对路径、`..`、符号链接逃逸。scripts/*.py 自动 chmod +x。"""
+
+def canonical(state: Mapping[str, str]) -> str:
+    """无损、稳定的序列化（用于 render 与评估缓存 key，见 G7）。"""
+```
+
+**设计要点**
+
+- `load_tree` 对二进制/超限文件**报错**而不是跳过：静默跳过会让「演化后的目录」
+  与原目录不等价，装回去就丢文件。仓库既有风格（`document_agent` 的截断告警、
+  `openai_compatible` 的空 content 归一化）也是「绝不静默丢数据」。
+- `materialize` 的路径校验是**安全边界**：state 里的 key 来自模型提案，必须假定敌意。
+
+### 3.2 新模块二：`agentdescent/treestrategy.py` — `FileTree` Strategy
+
+```python
+@dataclass
+class FileTree:
+    """artifact 就是一棵文件树；state 的 key 是相对路径。"""
+    initial_files: Dict[str, str]
+    editable: Sequence[str] = ("**",)      # 允许模型改的路径 glob
+    frozen: Sequence[str] = ()             # 只读：测试、评分器、安全约束（G5）
+    max_files_per_diff: int = 4
+
+    def keys(self) -> Sequence[str]:       # → TensorParallel 可按文件切分工人
+        return [p for p in self.initial_files if _match(p, self.editable)]
+
+    def initial(self) -> Dict[str, str]:
+        return dict(self.initial_files)
+
+    def render(self, state) -> str:
+        return canonical(state)            # 无损，满足 G7
+
+    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
+        edits = parse_edits(proposal)      # §3.3
+        edits = {p: c for p, c in edits.items()
+                 if _match(p, self.editable) and not _match(p, self.frozen)
+                 and state.get(p) != c}
+        if not edits or len(edits) > self.max_files_per_diff:
+            return None                    # 越界提案被丢弃并计入 outcomes
+        return Diff(diff_id=f"{author}:{stable_hash(...)}:{base_version}",
+                    target=target, ops=edits, author=author)
+```
+
+**`render` 的两难与取舍**：`render()` 同时被用作
+(a) 传给 `run` 的内容、(b) 评估缓存 key（`_signature`）。对文件树来说，(a) 其实不需要
+——真实 agent 从磁盘读文件，不从 prompt 读。所以 `render` 返回**规范序列化**，
+`run` 收到它之后先 `parse` 回 state 再物化。这样缓存 key 天然无损，且不必改引擎。
+（备选：给 `Strategy` 加可选的 `signature(state)` 钩子，改动更干净但要动 `evolution.py`。）
+
+### 3.3 提案协议（G3）
+
+反思模型返回一个带围栏的 JSON：
+
+```
+<EDITS>
+{"rationale": "SKILL.md 没说明表格跨页时要合并", 
+ "edits": [{"path": "SKILL.md", "content": "...完整新内容..."}]}
+</EDITS>
+```
+
+- **整文件替换**而非 unified diff：模型产出的 patch 经常对不上上下文行，
+  失败是静默的；整文件替换要么合法要么解析失败，可观测。代价是 token，
+  用 `max_file_bytes` 和「把大 skill 拆成多文件」来控。
+- 解析失败 → `to_diff` 返回 `None`（引擎已有的正常路径）；**不抛异常**，
+  因为那是后端质量问题不是调用者 bug。
+- 配套一个 `tree_reflector(complete, spec)`：把当前树 + 失败轨迹 + reward
+  渲染进模板，要求只输出上述块。
+
+### 3.4 新模块三：`agentdescent/runners.py` — 让真实 agent「用」这棵树
+
+```python
+LAYOUTS = {
+    "claude_skill":  lambda name: f".claude/skills/{name}/",
+    "claude_agent":  lambda name: f".claude/agents/",
+    "agent_repo":    lambda name: "",          # 树就是仓库根
+}
+
+def tree_runner(agent: WorkspaceAgent, *, layout: str, name: str,
+                prompt_template: str, fixtures: Optional[Callable[[Task], Dict[str, str]]] = None,
+                keep_failed: bool = False, timeout: float = 600.0) -> Run:
+    """返回一个 run(rendered, task) -> str。
+
+    每次调用（G9：可能并发）：
+      1. mkdtemp 一个**独立**工作区
+      2. materialize(parse(rendered), ws, prefix=layout_prefix(layout, name))
+      3. 写入 task 的 fixtures（task.meta 里带的输入文件）
+      4. agent.in_workspace(ws)(prompt_template.format(task=..., name=name))
+      5. 读取 agent stdout（或约定的 ws/ANSWER.txt）作为 output
+      6. 清理工作区（失败时按 keep_failed 保留，便于排查）
+    """
+```
+
+**为什么必须一次一个工作区**：`evolve(max_concurrency=N)` 用线程池跑 worker，
+`score()` 另开 `eval_concurrency=8` 个线程评估（[evolution.py:500](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L500)）。
+共用固定目录会让两个候选互相覆盖，产生**看起来正常但完全错误的分数**。
+
+**agent 代码演化的额外一层**：`code_runner(...)` 在物化后先跑
+`setup_cmd`（如 `pip install -e .`）与 `test_cmd`，任一失败则 rollout 直接得 0 分并
+把 stderr 写进 output 供反思使用——「改坏了」于是变成一个可学习的负信号而不是崩溃。
+
+### 3.5 治理与安全（G5 / G6）
+
+| 演化对象 | `blast_radius` | 层 | 门禁 |
+|---|---|---|---|
+| skill 目录（纯 Markdown/参考资料） | `0.2` | L2 | held-out 分数即可 |
+| agent 目录（子 agent 定义、工具配置、harness 提示） | `0.6` | L1 | 每次合并走 oracle（引擎已有行为） |
+| agent 代码（可执行） | `0.6` + `frozen` + 测试门 | L1 | oracle + 测试必须通过 + 沙箱执行 |
+
+三道硬约束：
+
+1. **路径级冻结，且必须是运行时不变量而不只是提案过滤**：
+   `FileTree(frozen=["tests/**", "eval/**", "SAFETY.md"])`。
+   这是文件世界里的 L0。没有它，演化 agent 代码等于允许 agent 改自己的考卷——
+   `governance.py` 的模块文档已经点明这正是「估计出来的层级」抓不住的结构性事实。
+
+   **只在 `to_diff` 里拒绝触碰 frozen 路径的提案是不够的**：它只挡住了「直接改考卷」。
+   候选代码仍可在**运行期**动手脚——新增一个 `conftest.py`、改 `sys.path`、
+   monkeypatch 断言、让 `pytest` 提前 `exit(0)`。真正的门是两条叠加：
+
+   ```
+   物化候选树 → 用 **原始副本** 覆盖所有 frozen 路径（overlay，后写胜） 
+              → 测试/评分从树 **外部** 调用，工作目录只读挂载给被测代码
+   ```
+
+   即「提案过滤」防误改，「pristine overlay + 外部调用」防作弊。后者才是安全边界，
+   前者只是让反思模型少浪费一次提案。
+2. **执行隔离**：候选代码只在一次性工作区里、以子进程 + 超时运行。
+   第一版用 `subprocess` + `timeout` + 独立 `TMPDIR`；文档里明确写清
+   「这不是安全沙箱，只是隔离」，需要真沙箱时接 Docker/`bwrap`（留 `sandbox=` 钩子）。
+3. **网络与凭据**：给 runner 传裁剪过的 `env`（`cli_agent` 已支持 `env=`），
+   默认不透传 `ANTHROPIC_API_KEY` 之外的密钥。
+
+### 3.6 需要动引擎的唯一一处：删除语义（G4）
+
+`EvolvingArtifact.apply` 是 `new_state.update(diff.ops)`，key 只能新增/覆盖，
+不能删除，所以**删文件、改文件名都表达不了**。三个选项：
+
+| 方案 | 改动 | 代价 |
+|---|---|---|
+| A. 墓碑值：`ops[path] = DELETED` 哨兵，`materialize` 时跳过 | 0 行引擎改动 | state 越来越脏；`render` 要过滤；`canonical` 需处理 |
+| B. `apply` 支持 `ops[k] is None` 表示删除 | `evolution.py` 约 3 行 | 影响所有 strategy（但 `None` 目前是非法 value，向后兼容） |
+| C. 自定义 `Evolvable`（不用 `EvolvingArtifact`） | 大 | 要重做 `score`/`cheap_eval`/序列化 |
+
+**推荐 B**：`apply` 遇到 `None` 时 **pop 掉这个 key**（而不是把 `None` 存进 state），
+于是 state 里永远不出现 `None`，`render` / `canonical` / ledger 序列化都不用改。
+配套核实过的三处：`fuse_diffs` 的 `ops.update` 语义天然正确；
+信任域检查 `len(str(v))` 对 `None` 是 4，不会误判 oversized；
+ledger 的 JSON 往返也不受影响（`None` 只存在于 `Diff.ops`，不进 state）。
+
+第一版也可以先只支持「新增 + 覆盖」，把删除列为已知限制。
+
+### 3.7 一行式入口（`agentdescent/skilldir.py`）
+
+```python
+from agentdescent import evolve_skill_dir
+
+result = evolve_skill_dir(
+    "~/.claude/skills/pdf-audit",          # 用户目录
+    tasks,                                  # Task(prompt=..., meta={"fixtures": {...}, "gold": ...})
+    reward=my_scorer,
+    agent=claude_code(),                    # 真实 agent 执行
+    reflect_with=openai_compatible(model="deepseek-v4-flash"),   # 便宜模型做反思
+    layout="claude_skill",
+    frozen=["tests/**"],
+    n_workers=4, max_concurrency=4, rounds=8,
+)
+print(result.final_reward, result.outcomes())
+result.write_to("~/.claude/skills/pdf-audit", backup=True)   # 装回，先备份
+```
+
+三个变体，共用同一套底座：
+
+- `evolve_skill_dir(path, ...)` → `blast_radius=0.2`，layout `claude_skill`
+- `evolve_agent_dir(path, ...)` → `blast_radius=0.6`，layout `claude_agent`
+- `evolve_agent_code(path, ..., test_cmd="pytest -q")` → `blast_radius=0.6` + 测试门 + `frozen=["tests/**"]`
+
+`EvolutionResult` 增加 `write_to(path, *, backup=True, dry_run=False)`：
+默认先把原目录复制成 `<path>.bak-<version>`，`dry_run` 打印将写/将删的文件清单。
+**这是本设计里唯一会写用户目录的操作，必须显式调用，`evolve` 本身永不写回。**
+
+### 3.8 成本模型（真实 agent 下，这是首要设计约束）
+
+一次 rollout = 一次真实 agent 调用（Claude Code 量级 30–90 秒）。数清楚每轮跑几次：
+
+| 来源 | 次数 | 控制项 |
+|---|---|---|
+| worker rollout | `n_workers` | — |
+| self-verify 复跑 | `n_workers`（每个提案一次） | **`self_verify=False`** |
+| 冲突解析 + 融合锦标赛的排序评估 | `候选数 × cheap 集大小` | **`cheap_eval_tasks=4`** |
+| Beta 接受检验（`eval_counts`，胜出者 base+cand） | `1 × |held_out|` | 无（这是提交安全线，不该省） |
+| L1 oracle 门 | **0** | 见下 |
+| 每轮 held-out 测量 | 0（已被缓存覆盖） | — |
+
+两个反直觉的点，都已对代码核实：
+
+1. **oracle 门是免费的。** `oracle_eval` 和 `eval_counts` 调同一个 `eval_fn`、同一个
+   held-out 集，而 `_EvalCache` 按 `(render(), task.id)` 记忆化
+   （[evolution.py:531](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L531)），所以 L1 的强制审计只消耗
+   `oracle_budget` 计数器，不产生任何额外 agent 调用。**演化 agent 目录/代码
+   （L1）并不比演化 skill（L2）贵。**
+2. **默认配置是最贵的配置。** `cheap_eval_tasks=None` 时廉价层被钉死成全量 held-out
+   （[evolution.py:996](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L996) 的注释已经点明「eval_fn RUNS THE
+   AGENT」这个场景），排序阶段于是变成成本主项；`self_verify=True` 又给每个提案加一次。
+   目录演化的入口函数应把 `cheap_eval_tasks=4`、`self_verify=False` 设为**默认值**，
+   而不是留给调用者去发现。
+
+**超时**：靠 `cli_agent(timeout=...)`（`subprocess.run` 会真正杀掉进程），不要靠
+`round_timeout` —— 后者只放弃等待，线程和子进程还在跑
+（[evolution.py:1466](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L1466) 的注释即此意）。
+
+### 3.9 评估噪声：缓存把单样本变成了真值
+
+`_EvalCache` 让每个 `(树, 任务)` 组合**终生只评估一次**。对确定性 scorer 这是纯赚；
+对真实 agent 则意味着**单次采样被 Beta 后验当作真值**，方差被系统性低估，噪声会
+被当成改进接受。三个缓解手段，按代价排序：
+
+1. `temperature=0`（provider 支持时），把随机性压到最低；
+2. `reward` 内部做 k 次多数表决（成本 ×k，但只作用在你真正在意的门上）；
+3. 加大 held-out —— 引擎在 `< 4` 时已经会告警（[evolution.py:935](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L935)），
+   但对随机 agent，4 个任务远远不够。
+
+这不是可以「以后再说」的实现细节：它决定了报出来的 `final_reward` 是否可信。
+
+---
+
+## 4. 并行语义（免费获得的部分）
+
+- **数据并行**（默认）：每个 worker 拿一份任务分片，各自提案。
+- **张量并行**：`FileTree.keys()` 返回所有可编辑文件路径 → `TensorParallel(n_sections=4)`
+  给每个 worker 一个**互斥的文件子集**，越界提案被计为 `section-violation`
+  （[evolution.py:588](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L588) `_resolve_sections` 已经会校验这个配对）。
+  对「一个 skill 目录里 SKILL.md / references / scripts 各由一个 worker 负责」是天然匹配。
+
+  **但 TP 下无法新建文件。** 违规判定是 `section_map.get(k) != unit.section`
+  （[evolution.py:1436](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py#L1436)），而 `section_map` 由
+  `strategy.keys()` 在**首轮之前**一次算定；一个新路径的 `section_map.get(...)` 是
+  `None`，必然 `!= section`，于是每个新建文件的提案都被计为 `section-violation`。
+  三个选项：(a) TP 只用于「精修已有文件」阶段，新建文件走 DataParallel；
+  (b) `FileTree(planned_paths=[...])` 预先声明将来可能出现的空文件位，让它们进入 key 空间；
+  (c) 默认就用 DataParallel（**推荐**，除非文件数明显大于 worker 数且都已存在）。
+- **异步**：`asynchronous=True` 直接可用（记得显式给 `max_seconds`，否则默认 20 秒）。
+- **融合的粒度问题**：以整文件为 key 意味着两个 worker 对同一个 `SKILL.md` 的
+  *互补*修改会被判为矛盾、只留一个。缓解办法是**鼓励把 skill 拆成多文件**
+  （`SKILL.md` 只放路由，细则进 `references/*.md`），这本来也是写 skill 的最佳实践。
+  更细的粒度（文件内小节做 key）留作后续：`SectionedFileTree`，key 形如
+  `SKILL.md#错误处理`。
+
+---
+
+## 5. 把现有算法示例迁移到这套底座
+
+这一节既是路线图，也是**对抽象的检验**：如果 `FileTree` 只能服务新功能、表达不了仓库
+里已有的六个算法端口，那说明抽象选错了。实际检查下来，它能吃掉其中四个自定义 Strategy。
+
+### 5.1 现状：每个例子都自己写了一个 Strategy
+
+| 例子 | 自定义 Strategy | state 形状 | 本质 |
+|---|---|---|---|
+| EvoSkill | `SkillLibraryStrategy` → **`SkillLibraryTree`** | `{skill_name: 正文}` → `{skills/<name>/SKILL.md: 正文}` | **就是一个多 skill 目录** |
+| ADAS | `AgentDesignStrategy` | `{design, name, thought}` | 一份 agent 程序（DSL JSON）+ 元数据 |
+| DGM | `HarnessStrategy` | `{capabilities: "a,b,c"}` | agent 能力集的代理表示 |
+| ACE / GEPA / SkillOpt | 各自的单槽变体（现已统一到 `SingleSlot`） | `{value: 文本}` | 单文件 |
+
+### 5.2 EvoSkill —— 第一梯队，几乎是零语义改动
+
+`SkillLibraryStrategy`（已替换为 `SkillLibraryTree`）的 state 是 `{skill 名: SKILL.md 正文}`
+（[evoskill_skill_discovery.py:379](https://github.com/Birfy/agentdescent/blob/main/examples/evoskill_skill_discovery.py#L379)），
+它的 Generator 提示词里甚至直接写着「Output a SKILL.md body」。这**已经是**一个
+skill 目录，只是活在内存里、靠 `render_skills()` 拼进 prompt。迁移只是换个 key：
+
+```
+{"treasury-tables": "..."}   →   {"skills/treasury-tables/SKILL.md": "..."}
+```
+
+顺带一个值得注意的印证：EvoSkill 里的 `_parse_rendered_skills(rendered)` 正是
+「`render` 无损 → 在 `run` 里解析回来」——也就是 §3.2 提出的做法。**这不是我发明的模式，
+是这个仓库已有的惯例**，这让 `FileTree.render = canonical` 的选择更有底气。
+
+**迁移的实质收益不在代码整洁，而在能力**：EvoSkill 的 OfficeQA 路径已经在用
+`document_agent(claude_code())`，也就是已经有一个真实工作区了
+（[backends.py:104](https://github.com/Birfy/agentdescent/blob/main/agentdescent/backends.py#L104)）。把 skill 树一并物化进去之后，
+agent 可以**按需读取**它需要的那个 skill 文件，而不是把整个 skill 库塞进 prompt。
+这才是「skill 目录」相对于「prompt 拼接」的实质差别（渐进披露），也是当前实现拿不到的东西。
+
+EvoSkill 自带的两个聚合器（`TopKFrontierAggregator` / `SgdSkillAggregator`）与
+`FileTree` 正交，原样保留。
+
+### 5.3 ADAS / DGM —— 第三梯队，高价值但也是最大的安全面
+
+这两个例子的文件头都写着自己的诚实边界：ADAS 用受限 DSL **替代了 `exec` 模型写的代码**，
+DGM 用 **capability 覆盖的代理指标**替代真实 SWE-bench。迁到 `FileTree` + `code_runner`
+之后，这两条边界**正好是本设计要兑现的东西**：
+
+- ADAS：`{"design": <DSL JSON>}` → `{"agent.py": <真实代码>}`，在一次性工作区 + frozen
+  overlay + 超时下**真执行**；
+- DGM：`{"capabilities": "a,b,c"}` → 真实 agent 代码树 + `test_cmd`，把代理指标换成真实通过率。
+
+但要说清楚：**这不是免费的**。两者的核心是各自的聚合器（keep-all archive、
+sigmoid×novelty 父代选择、staged 升级），换 substrate 不改算法，但需要一个真实评测环境
+（DGM 是 SWE-bench 的 Docker harness，~1.5h/任务）。所以这一梯队的门槛是**评测基础设施**，
+不是本设计的这几个模块。建议：先做 ADAS（MGSM 上跑真实 `agent.py`，秒级任务，可离线验证），
+DGM 保持代理指标不动，只在文档里指明接入点。
+
+### 5.4 ACE / GEPA / SkillOpt —— 不迁移
+
+单文本槽用 `SingleSlot` 表达最清楚；套一层文件树只会增加概念负担，没有收益。
+`FileTree` 是 `SingleSlot` 的超集这件事，写在文档里就够了。
+
+### 5.2.1 迁移之后的结论（已验证）
+
+迁移做完了，而且**比设计时预计的便宜**：我原以为「FileTree 的 render 必须无损」和
+「EvoSkill 的 render 是 prompt 文本」是硬冲突，只能二选一（改 prompt 格式 / 改 Strategy 协议）。
+实际不是 —— **`run` 才是把 artifact 变成 prompt 的地方**（框架自己的文档就是这么说的：
+"The framework never injects the artifact into your prompt — you do"）。所以：
+
+- `render()` = canonical（无损，当缓存 key）；
+- `run()` 里 `render_skills(skills_of(parse_tree(rendered)))` 把它变回
+  `### skill: <name>` 格式 —— **prompt 逐字节不变**，有测试守着；
+- `to_diff` 覆写成接受 repo 原本的 `name :: body`，不用 `<EDITS>` JSON ——
+  EvoSkill 忠实的部分是两角色 Proposer/Generator induction，不是名字和正文之间的分隔符；
+  换协议会改 Generator 的 prompt，那才是真的改变了被测量的东西。
+
+12 个原有测试一行没改、全绿；新增 3 个测试守住「state key 是真路径」「prompt 不变」
+「一次一个 skill」。**抽象验收通过。**
+
+真正拿到的新能力：`document_agent` 新增 `skill_files=` —— 工具型 backend
+（`--backend claude-code` / `openhands`）现在把 skill 库物化进 agent 的工作区，
+prompt 里只放一句指路，agent 自己按需打开。以前是每个问题都把整个 skill 库塞进 prompt。
+
+### 5.5 迁移的排序原则
+
+先迁**能证明新能力**的（EvoSkill：按需读取 skill 文件），
+再迁**能兑现已声明边界**的（ADAS：真执行），
+不迁**只会变复杂**的（ACE/GEPA/SkillOpt）。
+每一步都保留原例子的算法与聚合器不动 —— 换的是 substrate，不是算法。
+
+---
+
+## 6. 实施计划
+
+| 阶段 | 内容 | 交付 | 规模 |
+|---|---|---|---|
+| P0 | `filetree.py`：`load_tree` / `materialize` / `canonical` + 路径安全测试 | 目录能进能出 | ~180 行 + 测试 |
+| P1 | `FileTree` strategy + `parse_edits` + `tree_reflector` | 多文件提案跑通 | ~200 行 + 测试 |
+| P2 | `runners.py::tree_runner` + `evolve_skill_dir` + `result.write_to` | **skill 目录端到端**（`echo()` 假 agent 离线可测） | ~200 行 + 测试 |
+| P3 | 真实 agent 打通：`claude_code()` 冒烟示例 `examples/skill_dir_evolution.py` | 真跑一遍 | ~120 行 |
+| P4 | `evolve_agent_dir` + 路径冻结 + L1 治理接线 | agent 目录 | ~80 行 |
+| P5 | `code_runner`（setup/test 门 + 隔离 + 超时）+ `evolve_agent_code` | agent 代码 | ~200 行 + 测试 |
+| P6 ✅ | **迁移 EvoSkill 到 `FileTree`**（§5.2）：skill 库 → skill 目录，工具型 backend 改为按需读取 | 证明抽象够用 | 实际 ~90 行 |
+| P7 | 删除语义（§3.6 方案 B）、`SectionedFileTree`、Docker 沙箱钩子 | 收尾 | — |
+| P8 | （可选，取决于评测基建）ADAS 迁到真实 `agent.py` 执行（§5.3） | 兑现文件头的诚实边界 | — |
+
+P0–P3 是最小可用闭环（约 1–2 天）；**P6 建议紧跟 P3**——它是对抽象的验收，
+如果 EvoSkill 迁不过去，说明 `FileTree` 的形状要改，越早发现越好。
+P5 是风险最高的一段，建议在 P3 的真实数据上先看清楚反思模型对多文件提案的服从度再动。
+
+**不需要改动**：`aggregator.py`、`ledger.py`、`async_evolve.py`、`parallel.py`、
+`governance.py`。**需要小改**：`evolution.py`（仅 §3.6 的删除语义，且可延后）、
+`__init__.py`（导出）。
+
+---
+
+## 7. 验收标准
+
+1. `load_tree(materialize(state))` 对任意合法 state 恒等（round-trip 属性测试）。
+2. `materialize` 拒绝 `../etc/passwd`、`/etc/passwd`、符号链接逃逸（安全测试）。
+3. 用 `echo()` 假 agent + 合成任务，`evolve_skill_dir` 在 8 轮内把 held-out
+   分数从 0 提到 1，且 `outcomes()["committed"] > 0`（离线、无 API key、CI 可跑）。
+4. 两个 worker 改不同文件 → `outcomes()` 出现融合提交；改同一文件 → 矛盾被解析，
+   分高者胜（复用 `domains/router.py` 的验证套路）。
+5. `frozen=["tests/**"]` 下，任何触碰 `tests/` 的提案都不产生 diff（**必须有专门测试**）。
+6. `max_concurrency=8` 时并发跑 100 次 rollout，无工作区串扰（每次 workspace 唯一）。
+7. `write_to(dry_run=True)` 精确列出将写/将删文件；`backup=True` 产出可回滚副本。
+8. **抽象验收**：EvoSkill 迁到 `FileTree` 后，离线测试结果与迁移前一致
+   （同 seed 同分数），且删掉 `SkillLibraryStrategy`。迁不过去 = 抽象形状要改。
+9. **作弊验收**：给 `evolve_agent_code` 一个「把测试改成 `assert True`」的人造提案，
+   确认它既进不了 diff（提案过滤），即便手工注入 state 也因 pristine overlay 而无效。
+
+---
+
+## 8. 风险与开放问题
+
+| 风险 | 缓解 |
+|---|---|
+| **成本**：每个 rollout 起一个真实 coding agent | §3.8 的成本表；入口函数默认 `cheap_eval_tasks=4`、`self_verify=False`；反思用便宜模型；`Usage` 计量并在示例里打印 |
+| **评估噪声被缓存固化成真值** | §3.9：`temperature=0` / k 次多数表决 / 加大 held-out |
+| 反思模型不遵守 `<EDITS>` 协议 | 解析失败即丢弃并计数；示例里报告服从率；必要时降级为「只允许改一个文件」 |
+| 整文件替换的 token 开销 | `max_file_bytes=28k`（与信任域对齐）+ 鼓励拆文件；超限文件标为不可编辑 |
+| 演化代码的安全性 | 一次性工作区 + 子进程 + 超时 + 裁剪 env；文档明说「隔离≠沙箱」；`sandbox=` 钩子留给 Docker |
+| 指标自我作弊（agent 改测试） | 双层：`frozen` 提案过滤 + **pristine overlay / 树外调用测试**（§3.5），后者才是安全边界 |
+| **临时工作区泄漏**：引擎只回收自己的 scratch git repo，不管 runner 的工作区 | `try/finally` 删除 + 仿 `_reap_stale_scratch_repos` 写一个按前缀+age 的回收器；`keep_failed=True` 时只保留失败的 |
+| **`claude -p` 非交互权限**：默认会因工具授权卡住或拒绝 | `claude_code(extra_args=["--permission-mode", "acceptEdits", "--allowedTools", ...])`；先跑一次冒烟确认不会挂 |
+| **实验效度**：skill 可能根本没被加载，测到的是「agent 会不会去找它」 | prompt 模板显式指向 skill 路径；跑一组「空 skill 目录」对照，确认分数确实有差 |
+| ledger 膨胀（每个版本存整棵树的 JSON，[ledger.py:211](https://github.com/Birfy/agentdescent/blob/main/agentdescent/ledger.py#L211)） | `TreeSpec` 的 `max_total_bytes`；git 自身会 delta 压缩；必要时改存内容哈希 + blob |
+| **过拟合 held-out**：目录级 artifact 表达能力强，容易记住答案 | 保留 `held_out_frac`，并在示例里额外留一个从不参与任何门禁的 test 集（EvoSkill/ADAS 的 50/25/25 划分已是仓库惯例） |
+
+**待你确认的四个决定**
+
+1. **首要目标是哪一个**：skill 目录（最简单、收益直接）、agent 目录、还是 agent 代码
+   （最难、最需要沙箱）？建议按 P0→P3 先把 skill 目录闭环，P6 立刻用 EvoSkill 验收抽象。
+2. **执行 agent 用哪个**：`claude_code()`（本机 CLI）还是 `openhands()`（需 Python ≥3.12）？
+   前者零依赖，建议默认。
+3. **删除语义**是先按「已知限制」搁置，还是这一版就做 §3.6 方案 B？
+4. **ADAS 要不要真执行**（§5.3）：这会把它从「安全 DSL」变成「真跑模型写的代码」，
+   收益是兑现文件头声明的边界，代价是引入本仓库目前没有的执行安全面。
+   我的建议是**做**，但必须先有 P5 的 `code_runner`（一次性工作区 + frozen overlay +
+   超时 + 裁剪 env），且默认不联网。

--- a/docs/directory-evolution.md
+++ b/docs/directory-evolution.md
@@ -1,0 +1,327 @@
+# Evolving a directory — a skill, an agent, or its code
+
+Everything else in AgentDescent evolves *text*: an instruction, a playbook, a
+prompt. This page is about evolving a **directory** — a skill folder with a
+`SKILL.md` and a `references/` beside it, a folder of subagent definitions, or a
+small codebase that *is* the agent — where each rollout is performed by a **real
+agent** that reads those files off disk with its own tools.
+
+```python
+from agentdescent import evolve_skill_dir
+from agentdescent.agents import claude_code, openai_compatible
+
+result = evolve_skill_dir(
+    "~/.claude/skills/pdf-audit", rows,
+    agent=claude_code(extra_args=["--permission-mode", "acceptEdits"]),
+    reflect_with=openai_compatible(model="deepseek-v4-flash"),
+    prompt="question", gold="answer", score="contains")
+
+print(result.final_reward, result.outcomes())
+result.write_to("~/.claude/skills/pdf-audit")     # opt in; backs up first
+```
+
+The design record — why it is built this way, and the three problems found while
+reviewing it — is [in the design document](design-directory-evolution.md).
+
+## Why this works without touching the optimizer
+
+An artifact's state is a flat `{key: value}` dict and the engine never interprets
+the keys. It only asks two questions: do two diffs touch the same key
+(`diffs_contradict`), and can non-overlapping ones be unioned (`fuse_diffs`).
+
+So make the keys **relative file paths** and the whole aggregation stack acquires
+file-level semantics for nothing:
+
+| Two workers… | …produce | …and the aggregator |
+|---|---|---|
+| edit different files | complementary diffs | fuses them into one candidate |
+| edit the same file | a contradiction | keeps whichever scores better held-out |
+| propose the identical file | duplicate diffs | collapses them |
+
+This is the same machinery ACE, GEPA and EvoSkill run on. Nothing in
+`aggregator.py`, `ledger.py`, `async_evolve.py`, `parallel.py` or `governance.py`
+knows that a directory is involved.
+
+## The four moving parts
+
+```
+~/.claude/skills/pdf-audit/            your directory
+   │  load_tree()                      → {"SKILL.md": "...", "references/rules.md": "..."}
+   ▼
+FileTree strategy                      keys are paths; frozen paths are read-only
+   ▼
+evolve()                               unchanged
+   │  every rollout: tree_runner()
+   ▼
+/tmp/agentdescent-ws-xxxx/             one throwaway workspace per rollout
+   .claude/skills/pdf-audit/SKILL.md   ← the layout decides where it lands
+   <the task's fixtures>
+   │  claude_code().in_workspace(ws)(prompt)
+   ▼
+answer → reward → reflection → {"path": "...", "content": "..."} → Diff
+   ▼
+result.write_to("~/.claude/skills/pdf-audit")
+```
+
+### 1. `filetree` — directory ↔ state
+
+```python
+from agentdescent import TreeSpec, load_tree, materialize, canonical, parse_tree
+
+state = load_tree("~/.claude/skills/pdf-audit")          # {relpath: text}
+materialize(state, "/tmp/ws", prefix=".claude/skills/pdf-audit")
+```
+
+`TreeSpec` says what belongs to the artifact (`include` / `exclude` globs) and
+how big it may get. Two behaviours are deliberate:
+
+* **A file that matches `include` but cannot be represented — binary, or over
+  `max_file_bytes` — raises.** Skipping it silently would mean the evolved tree
+  is not the tree you pointed at, and `write_to` would later write back a
+  directory missing files. Put it in `exclude` to say "not part of the artifact"
+  on purpose.
+* **`max_file_bytes` defaults to 28 000, below the aggregator's
+  `trust_region_chars` (32 000).** A larger file can be loaded but never changed:
+  every diff touching it is rejected as `oversized`. `TreeSpec.validate_against`
+  catches the mismatch before the run rather than five rounds in.
+
+`canonical` / `parse_tree` are the lossless serialisation pair.
+`Strategy.render` is both what `run` receives *and* the evaluation-cache key, so
+it has to be exact — two different trees must never share a cached score. It is
+JSON rather than a prettier `--- file: x ---` format precisely because a file's
+own content must not be able to forge its container's delimiter.
+
+### 2. `FileTree` — the strategy
+
+```python
+from agentdescent import FileTree
+
+strategy = FileTree(load_tree("./my-skill"),
+                    editable=["**"],          # globs the loop may write
+                    frozen=["tests/**"],      # globs it may only read
+                    max_files_per_diff=2)
+```
+
+`frozen` is L0 expressed in paths. `governance.py` freezes whole *artifacts* by
+id, which cannot say "this skill may evolve, but not its test suite" — and
+without that, the shortest path to a high score is to weaken the thing measuring
+it.
+
+Proposals use a small protocol, because one string can no longer mean "the new
+artifact":
+
+```
+<EDITS>
+{"rationale": "the skill never said what to do when a table spans pages",
+ "edits": [{"path": "SKILL.md", "content": "...the complete new file..."}]}
+</EDITS>
+```
+
+Whole-file replacement, not a unified diff: a model-written patch that does not
+apply fails *silently* (wrong context lines, drifted offsets), whereas a whole
+file either parses or does not. `parse_edits` also accepts a fenced or bare JSON
+object, drops hostile paths, and returns `{}` — never raises — when a reflector
+ignores the protocol, so that shows up as a counted non-proposal rather than a
+crashed run. `{"path": "old.md", "delete": true}` deletes a file.
+
+`tree_reflector(complete, strategy=...)` builds the reflection prompt. It does
+**not** put the whole tree in it: `render()` is the full serialisation because
+the cache needs it lossless, but a reflection only needs to see the files it
+might change, so it inlines the `context_files` within `max_context_chars` and
+lists the rest by path and size.
+
+### 3. `runners` — giving a real agent the candidate
+
+```python
+from agentdescent import tree_runner, code_runner, LAYOUTS
+
+run = tree_runner(claude_code(), layout="claude_skill", name="pdf-audit")
+```
+
+| `layout` | where the tree is written in the workspace |
+|---|---|
+| `claude_skill` | `.claude/skills/<name>/` |
+| `skill_library` | `.claude/skills/` (a directory *of* skills) |
+| `claude_agent` | `.claude/agents/` |
+| `root` | the workspace itself |
+
+Any literal prefix works too. Per rollout the runner makes a fresh workspace,
+materialises the candidate, overlays the pristine frozen files, stages the task's
+fixtures (`task.meta["fixtures"]`, or a `fixtures=` callable), runs the agent
+bound to that directory, and deletes the workspace.
+
+!!! warning "One workspace per call, always"
+    `evolve(max_concurrency=N)` runs workers in threads and
+    `EvolvingArtifact.score` opens its own pool of `eval_concurrency` threads. A
+    shared directory would let two candidates overwrite each other and produce
+    scores that look perfectly ordinary and are simply wrong.
+
+`tree_runner` requires a [`WorkspaceAgent`](agents.md) (`claude_code()`,
+`codex()`, `cli_agent([...])`, `openhands()`). A plain API completion cannot read
+files, so it raises rather than quietly scoring the model's prior knowledge.
+
+### 4. `write_to` — installing the result
+
+```python
+plan = result.write_to("~/.claude/skills/pdf-audit", dry_run=True)
+# {"written": [...], "extra": ["notes.md"], "deleted": [], "backup": []}
+```
+
+This is the only call in the package that writes into a directory you care about,
+so it is conservative: `backup=True` (default) copies the directory to
+`<path>.bak-N` first; files present in the target but not in the artifact are
+reported as `extra` and **left alone** unless `prune=True`; `dry_run=True` returns
+the plan without touching anything. The run itself never writes to your directory.
+
+## The three entry points
+
+| function | governance | what makes it different |
+|---|---|---|
+| `evolve_skill_dir(path, data, agent=…)` | L2 (`blast_radius=0.2`) | merges on held-out reward alone |
+| `evolve_agent_dir(path, data, agent=…)` | L1 (`0.6`) | an agent definition is a harness: every merge additionally passes the oracle |
+| `evolve_agent_code(path, data, entrypoint=…)` | L1 + test gate | the tree is **executed**; a frozen test suite guards it |
+
+### Evolving agent code
+
+```python
+from agentdescent import evolve_agent_code
+
+result = evolve_agent_code(
+    "./my-agent", rows,
+    entrypoint=["python", "main.py"],          # + task.prompt as the last argv
+    test_cmd=["python", "-m", "pytest", "-q"],
+    frozen=["tests/**", "conftest.py"],        # the default
+    reflect_with=openai_compatible(model="deepseek-v4-flash"))
+```
+
+Each rollout materialises the candidate, **overwrites every frozen path with its
+pristine content**, runs `setup_cmd` then `test_cmd`, and only then executes the
+entrypoint. A failing gate is not an exception: the output becomes
+`TEST_FAILURE_MARKER` plus the captured output, which scores 0 and gives the
+reflector something concrete to fix.
+
+!!! danger "Isolation, not a sandbox"
+    Candidate code runs in a throwaway workspace, with a trimmed environment
+    (`HOME` and `TMPDIR` point inside the workspace, so it cannot read
+    `~/.claude` or `~/.aws`), under a hard timeout. It still runs as your user,
+    with your network. Use a container for anything you would not run by hand.
+
+Both halves of `frozen` are needed and they do different jobs:
+
+* the **proposal filter** stops the reflector from editing the test suite;
+* the **overlay** stops the *candidate* from rewriting it at run time
+  (a `conftest.py`, a monkeypatched assertion, an early `exit(0)`).
+
+## Cost — the first-order design constraint
+
+One rollout is one real agent invocation. Count them per round:
+
+| source | calls per round | knob |
+|---|---|---|
+| worker rollouts | `n_workers` | — |
+| self-verify re-run | `n_workers` | `self_verify=False` **(default here)** |
+| conflict resolution + fusion tournament ranking | `candidates × cheap set` | `cheap_eval_tasks=4` **(default here)** |
+| Beta acceptance test (winner: base + candidate) | `1 × |held_out|` | — (this is the commit gate) |
+| L1 oracle gate | **0** | see below |
+
+Two counter-intuitive points, both verified against the engine:
+
+1. **The oracle gate is free.** `oracle_eval` and `eval_counts` call the same
+   `eval_fn` over the same held-out set, and the evaluation cache is keyed on
+   `(render(), task.id)` — so L1's forced audit spends `oracle_budget` counter,
+   not agent calls. Evolving an agent directory is not more expensive than
+   evolving a skill.
+2. **The plain-engine defaults are the expensive ones.** With
+   `cheap_eval_tasks=None` the cheap layer is pinned to the whole held-out set,
+   which makes *ranking* the dominant cost when `eval_fn` runs an agent; and
+   `self_verify=True` adds a second rollout per proposal. The three
+   `evolve_*_dir` wrappers flip both, because getting them wrong costs money
+   rather than a warning.
+
+Bound a rollout with the agent's own timeout (`cli_agent(timeout=...)`, which
+really kills the process), not with `round_timeout` — that only stops *waiting*.
+
+## Evaluation noise: the cache turns one sample into ground truth
+
+`_EvalCache` evaluates each `(tree, task)` pair exactly once, ever. For a
+deterministic scorer that is free speed. For a real agent it means **a single
+sample is treated as the truth**, so the Beta posterior underestimates variance
+and can accept noise as improvement. Mitigations, cheapest first: `temperature=0`
+where the provider supports it; a majority vote of *k* inside your `reward`; and
+a bigger held-out set — the engine warns below 4 tasks, but 4 is nowhere near
+enough for a stochastic agent.
+
+## Parallelism
+
+`DataParallel` (the default) shards tasks and any editable path can be created.
+
+`TensorParallel` gives each worker a disjoint set of *files*, which fits "one
+worker owns `SKILL.md`, another owns `references/`" — but **no worker can create
+a file under TP**. The section map is built once from `strategy.keys()` before the
+first round, and an undeclared path maps to `None`, which never equals a worker's
+section, so every creation is counted as `section-violation`. Declare the paths
+up front with `FileTree(planned_paths=[...])`, or stay on DataParallel.
+
+Fusion is at whole-file granularity, so two *complementary* edits to the same
+`SKILL.md` are still a contradiction and only one survives. That is an argument
+for the thing skill authors should do anyway: keep `SKILL.md` small and put the
+detail in `references/*.md`, one concern per file.
+
+## Known limitations
+
+* **Whole-file replacement** costs tokens on large files; `max_file_bytes` and
+  splitting the skill are the answer.
+* **No renames** — a rename is a delete plus a create, which the protocol can
+  express but which shows up as two ops.
+* **Binary files are out of scope.** The state is `Dict[str, str]`.
+* **Every ledger commit stores the whole tree** as one JSON blob
+  (`artifacts/<id>.json`); git delta-compresses it, but `max_total_bytes` exists
+  for a reason.
+* **Only EvoSkill has been migrated.** ADAS and DGM still evolve their own
+  representations; moving them here would let their candidates actually execute,
+  but that needs an evaluation harness rather than these modules. See §5 of the
+  [design document](design-directory-evolution.md).
+
+## The acceptance test: EvoSkill
+
+The abstraction is only worth having if it can express what the repo already
+does. [EvoSkill](algo-evoskill.md)'s artifact was `{skill name: SKILL.md body}` —
+a skill directory that never touched disk — so it is the natural test, and it now
+runs on `SkillLibraryTree`, a `FileTree` subclass:
+
+```
+{"defense-lookup": "..."}   →   {"skills/defense-lookup/SKILL.md": "..."}
+```
+
+Two things it proved, both worth knowing before you migrate something yourself:
+
+1. **A port can keep its own prompt format.** `render()` has to be the lossless
+   serialisation because it is the cache key — but `run` is where an artifact
+   becomes a prompt (the framework never injects one for you), so EvoSkill parses
+   the tree and re-renders it in its own `### skill: <name>` format. The
+   retriever path's prompt is byte-identical to before the move, which a test
+   asserts; the port measures the same thing it did.
+2. **A port can keep its own proposal protocol.** `SkillLibraryTree` overrides
+   `to_diff` to accept the repo's `name :: body` instead of `<EDITS>` JSON. What
+   is faithful about EvoSkill is the two-role Proposer/Generator induction, not
+   the separator — and switching protocols would have changed the Generator's
+   prompt, which is exactly the kind of silent behaviour change a "pure
+   refactor" should not make.
+
+The payoff is on the tool-using path: with `--backend claude-code`, the skills are
+now materialised into the agent's workspace and the prompt points at them, so the
+agent opens the one skill it needs. Before, every skill in the library rode along
+in every prompt.
+
+## Running a real agent non-interactively
+
+`claude -p` needs its tool permissions settled up front or it will stall waiting
+for a prompt that no one can answer:
+
+```python
+claude_code(extra_args=["--permission-mode", "acceptEdits"], timeout=300)
+```
+
+And check that the skill is actually being *used*: run one round against an empty
+skill directory as a control. If the score does not move, what you are measuring
+is the model's prior knowledge, not your skill.

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -179,6 +179,11 @@ evolve(tasks, reward, agent=agent, strategy=KeyedRules(categories=["route","fmt"
 | **`SingleSlot`** | the artifact **is one value** (a system prompt, an instruction) and each accepted proposal replaces it — the most common case |
 | `AppendRules` | each proposal → a content-addressed rule; identical ones dedupe, complementary ones **fuse** (append-only) |
 | `KeyedRules(categories)` | one entry per category; competing proposals for the same category **contradict** and are resolved on held-out score |
+| `FileTree(files)` | the artifact **is a directory**: one entry per *file*, so two workers editing different files fuse and two editing the same file are resolved — see [evolving a directory](directory-evolution.md) |
+
+`FileTree` is the one strategy whose artifact does not reach the model through the
+prompt: the rendered tree is written to a throwaway workspace and a real agent
+reads it off disk (`tree_runner`). Everything else on this page applies unchanged.
 
 Write your own by implementing three methods (`initial` / `render` / `to_diff`):
 
@@ -207,7 +212,7 @@ each is a real `Strategy` you can read and reuse:
 |---|---|---|
 | `ACEPlaybook` | [ACE](algo-ace.md) | an itemised, incremental-delta context playbook (append-only + grow-and-refine de-dup) |
 | `InstructionSlot` | [GEPA](algo-gepa.md) | one instruction prompt each proposal replaces |
-| `SkillLibraryStrategy` | [EvoSkill](algo-evoskill.md) | a library of `SKILL.md` skills (a proposal appends one) |
+| `SkillLibraryTree` | [EvoSkill](algo-evoskill.md) | a **directory** of `SKILL.md` skills, one per subdirectory (a `FileTree` subclass keeping the repo's `name :: body` proposal protocol) |
 | `SkillDocStrategy` | [SkillOpt](algo-skillopt.md) | one markdown skill doc mutated by bounded `append/insert_after/replace/delete` edits |
 | `AgentDesignStrategy` | [ADAS](algo-adas.md) | one agentic-system design (a control-flow program) each proposal replaces |
 | `HarnessStrategy` | [DGM](algo-dgm.md) | a coding-agent harness's capability set (a proposal adds one) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,10 @@ restatement."* — see [Quickstart](quickstart-skill.md) for the full measuremen
 Nothing is hidden: it builds ordinary arguments and calls
 [`evolve()`](evolution.md), which is where you go the moment you want more.
 
+Have a **directory** instead — a skill folder, a folder of subagent definitions,
+or the agent's own code? [`evolve_skill_dir()`](directory-evolution.md) evolves
+that, with each rollout performed by a real agent that reads the files off disk.
+
 ```bash
 pip install agentdescent
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,6 +59,18 @@ Compares the three staleness policies and sweeps the `async_ratio` lag budget.
 python -m examples.rq2_staleness
 ```
 
+### Evolving a directory (a skill folder a real agent reads)
+
+```bash
+python -m examples.skill_dir_evolution
+```
+
+Materialises a candidate skill directory into a throwaway workspace at
+`.claude/skills/csv-total/` and lets a real (sub)process agent read it. Runs
+offline in seconds; `--agent claude-code` swaps in the real CLI agent, and
+`--install-to <dir>` writes the evolved skill back. See
+[evolving a directory](directory-evolution.md).
+
 ### Self-evolution algorithm ports (real datasets)
 
 Faithful ports of the latest skill- and harness-self-evolution algorithms — ACE,

--- a/examples/evoskill_skill_discovery.py
+++ b/examples/evoskill_skill_discovery.py
@@ -23,7 +23,7 @@ which differs from some paper-level claims -- flagged inline:
   * **Skill = a folder of Markdown files** with YAML frontmatter; the active skill
     set is injected into the agent by concatenation.
 
-It runs **through `evolve()`** like ACE/GEPA: a `SkillLibraryStrategy` turns a
+It runs **through `evolve()`** like ACE/GEPA: a `SkillLibraryTree` turns a
 proposed `SKILL.md` into a `Diff`, and a custom `aggregator_factory`
 (`TopKFrontierAggregator`) is the bounded top-K frontier. A skill is an **L2**
 artifact -> `blast_radius=0.2` (via `classify`).
@@ -56,6 +56,8 @@ from agentdescent.dataloader import (Dataset, fetch_text, hf_rows,
                                      load_gated_hf, split_dataset)
 from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve
+from agentdescent.filetree import parse_tree
+from agentdescent.treestrategy import FileTree
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 
@@ -358,12 +360,30 @@ class EvoSkillContext:
     lock: threading.Lock = field(default_factory=threading.Lock)   # workers run concurrently
 
 
-def _parse_rendered_skills(rendered: str) -> Dict[str, str]:
-    skills: Dict[str, str] = {}
-    for chunk in rendered.split("### skill: ")[1:]:
-        name, _, body = chunk.partition("\n")
-        skills[name.strip()] = body.strip()
-    return skills
+#: Where a skill lives inside the artifact. The library was always a set of
+#: `SKILL.md` files -- until now it only existed in memory, keyed by name. Keyed
+#: by *path* it is a real directory, which is what lets a tool-using agent read
+#: one skill at a time instead of carrying the whole library in every prompt.
+SKILL_ROOT = "skills"
+
+
+def skill_path(name: str) -> str:
+    return f"{SKILL_ROOT}/{_slug(name)}/SKILL.md"
+
+
+def skill_name(path: str) -> str:
+    parts = path.split("/")
+    return parts[1] if len(parts) >= 3 and parts[0] == SKILL_ROOT else path
+
+
+def skills_of(state: Dict[str, str]) -> Dict[str, str]:
+    """`{path: body}` (the artifact) -> `{name: body}` (what the algorithm reads)."""
+    return {skill_name(p): body for p, body in state.items()}
+
+
+def skills_from_rendered(rendered: str) -> Dict[str, str]:
+    """The artifact as the algorithm wants it, from what `run`/`propose` are handed."""
+    return skills_of(parse_tree(rendered))
 
 
 def agent_answer(complete: Completion, docs: Dict[str, str],
@@ -376,22 +396,37 @@ def agent_answer(complete: Completion, docs: Dict[str, str],
     return (m.group(1) if m else text).strip()
 
 
-class SkillLibraryStrategy:
-    """The artifact is a library of SKILL.md files; a proposal is `name :: body`."""
+class SkillLibraryTree(FileTree):
+    """The artifact is a **directory** of `SKILL.md` files -- one per skill.
 
-    def initial(self):
-        return {}
+    The same library EvoSkill always evolved; what changed is that a state key is
+    now a real path (`skills/<name>/SKILL.md`), so the library can be materialised
+    into an agent's workspace and read file by file (`--backend claude-code`)
+    instead of being inlined in every prompt.
 
-    def render(self, state):
-        return render_skills(state)
+    Two deliberate departures from stock :class:`~agentdescent.treestrategy.FileTree`:
+
+    * ``to_diff`` keeps the repo's ``name :: body`` proposal protocol rather than
+      FileTree's ``<EDITS>`` JSON. What is faithful about EvoSkill is the
+      two-role Proposer/Generator induction, not the separator between a name and
+      a body -- switching protocols would change the Generator's prompt and with
+      it the thing being measured.
+    * ``max_files_per_diff=1``: the repo induces exactly one skill per iteration.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(initial_files={}, max_files_per_diff=1)
 
     def to_diff(self, state, proposal, author, base_version, target):
         name, _, body = proposal.partition(" :: ")
         name, body = name.strip(), body.strip()
-        if not (name and body) or state.get(name) == body:
+        if not (name and body):
+            return None
+        path = skill_path(name)
+        if state.get(path) == body:
             return None
         return Diff(diff_id=f"{author}:{name}:{base_version}", target=target,
-                    ops={name: body}, author=author)
+                    ops={path: body}, author=author)
 
 
 def make_propose(ctx: EvoSkillContext, complete: Completion):
@@ -413,7 +448,7 @@ def make_propose(ctx: EvoSkillContext, complete: Completion):
                 return None                                # batch not full yet -> keep collecting
             ctx.last_propose_at = len(ctx.recent_failures)
             batch = list(ctx.recent_failures[-ctx.batch_size:])
-        skills = _parse_rendered_skills(rendered)          # Proposer + Generator over the batch
+        skills = skills_from_rendered(rendered)            # Proposer + Generator over the batch
         proposed = propose_and_generate(complete, skills, batch, ctx.feedback)
         if not proposed:
             return None
@@ -473,8 +508,8 @@ class TopKFrontierAggregator(AggregatorProtocol):
             admitted = self.ctx.frontier.update(dict(candidate.state), score)
             self.ctx.best_score = max(self.ctx.best_score, score)
             self.ctx.feedback.append(
-                f"{list(card.diff.ops)[0]}: {'admitted' if admitted else 'discarded'} "
-                f"(val {score:.3f})")
+                f"{skill_name(list(card.diff.ops)[0])}: "
+                f"{'admitted' if admitted else 'discarded'} (val {score:.3f})")
 
         parent_state, _ = self.ctx.frontier.select_parent()   # strategy="best"
         report_diff = committed = None
@@ -603,6 +638,10 @@ class EvoResult:
     seed_score: float
     best_score: float
     iterations: int
+    #: The same library as a file tree (`{path: body}`) -- what
+    #: :func:`agentdescent.filetree.materialize` or
+    #: :meth:`~agentdescent.evolution.EvolutionResult.write_to` install.
+    tree: Dict[str, str] = field(default_factory=dict)
 
 
 def run_evoskill(complete: Completion, docs: Dict[str, str],
@@ -631,10 +670,17 @@ def run_evoskill(complete: Completion, docs: Dict[str, str],
                           val_every=val_every)
 
     def run(rendered, task):
+        # `rendered` is now the artifact's lossless serialisation (a file tree), not
+        # the prompt text -- so this is where it becomes a prompt again. The
+        # framework never injects an artifact into a prompt; `run` does, and that
+        # is what keeps the retriever path's prompt byte-identical to before the
+        # library moved to a path-keyed state.
+        tree = parse_tree(rendered)
+        rendered_skills = render_skills(skills_of(tree))
         if backend is not None:                    # tool-using base agent (OpenHands / grep-loop)
             return backend.answer(task.prompt, ctx.docs.get(task.meta["source_files"], ""),
-                                  skills=rendered)
-        return agent_answer(complete, ctx.docs, rendered, task)
+                                  skills=rendered_skills, skill_files=tree)
+        return agent_answer(complete, ctx.docs, rendered_skills, task)
 
     def reward(task, output):
         return score_multi_tolerance(output, task.meta["answer"])
@@ -648,7 +694,7 @@ def run_evoskill(complete: Completion, docs: Dict[str, str],
 
     workers = min(3, len(train))
     result = evolve(tasks, reward, run=run, propose=make_propose(ctx, complete),
-                    strategy=SkillLibraryStrategy(), blast_radius=0.2,
+                    strategy=SkillLibraryTree(), blast_radius=0.2,
                     artifact_id="skill_library", rounds=iterations,
                     n_workers=workers,
                     # sync-path knob: under asynchronous=True concurrency is n_workers
@@ -663,7 +709,9 @@ def run_evoskill(complete: Completion, docs: Dict[str, str],
     if eval_at_end and val:
         # single held-out eval of the FINAL accumulated skill library (concurrent).
         val_tasks = tasks[len(train):]
-        rendered = SkillLibraryStrategy().render(dict(result.state))
+        # `run` takes the artifact's serialisation and turns it into a prompt
+        # itself, so hand it the rendered *tree*, not the rendered skills.
+        rendered = SkillLibraryTree().render(dict(result.state))
         from concurrent.futures import ThreadPoolExecutor
         n = max(1, min(eval_concurrency, len(val_tasks)))
         with ThreadPoolExecutor(max_workers=n) as pool:
@@ -671,7 +719,9 @@ def run_evoskill(complete: Completion, docs: Dict[str, str],
         best = sum(scores) / len(scores)
         if verbose:
             print(f"\n[eval-at-end] final held-out score over {len(val_tasks)} items: {best:.3f}")
-    return EvoResult(dict(result.state), ctx.seed_score, best, iterations)
+    # the artifact is path-keyed; the algorithm's own vocabulary is names.
+    return EvoResult(skills_of(dict(result.state)), ctx.seed_score, best,
+                     iterations, tree=dict(result.state))
 
 
 # ===========================================================================

--- a/examples/skill_dir_evolution.py
+++ b/examples/skill_dir_evolution.py
@@ -1,0 +1,190 @@
+"""Evolve a **skill directory** that a real agent reads off disk.
+
+Every other example evolves text that ends up *in a prompt*. This one evolves a
+directory: the candidate is materialised into a throwaway workspace at
+``.claude/skills/<name>/`` and the agent has to open the files to know what to do.
+That is the whole point -- the skill only helps if the agent reads it, which means
+the run measures the directory, not the model's prior knowledge.
+
+The task: a CSV is staged in the workspace and the agent must total one of its
+columns. The skill says which one. It starts out **wrong** (``COLUMN: id``), so
+the initial reward is 0 and the loop has somewhere to go.
+
+    python -m examples.skill_dir_evolution                  # offline, no API key
+    python -m examples.skill_dir_evolution --agent claude-code
+    python -m examples.skill_dir_evolution --agent claude-code --model claude-haiku-4-5
+
+The offline mode is not a mock of the framework: the agent really is a separate
+process bound to a workspace (`cli_agent`), and the only stub is the *reflector*,
+which returns a fixed edit instead of calling a model. Swap in `--agent
+claude-code` and `--model` and the same code path drives the real thing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import re
+import shutil
+import sys
+import tempfile
+
+from agentdescent import evolve_skill_dir
+from agentdescent.agents import claude_code, cli_agent, codex, openai_compatible
+
+SKILL_NAME = "csv-total"
+
+# ---------------------------------------------------------------------------
+# The skill directory this example starts from
+# ---------------------------------------------------------------------------
+
+_SKILL_MD = """# csv-total
+
+Total one column of `data.csv`, which is in the working directory.
+
+1. Read `references/rules.md` to find out **which** column to total.
+2. Sum that column across every data row (skip the header).
+3. Reply with only the number.
+"""
+
+_RULES_MD = """COLUMN: id
+"""      # <- wrong on purpose: `id` is a row number, not the quantity asked for
+
+
+def make_skill_dir() -> str:
+    root = tempfile.mkdtemp(prefix="agentdescent-example-")
+    path = os.path.join(root, SKILL_NAME)
+    os.makedirs(os.path.join(path, "references"))
+    with open(os.path.join(path, "SKILL.md"), "w") as fh:
+        fh.write(_SKILL_MD)
+    with open(os.path.join(path, "references", "rules.md"), "w") as fh:
+        fh.write(_RULES_MD)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The dataset: one CSV per task, staged into the workspace as a fixture
+# ---------------------------------------------------------------------------
+
+
+def make_rows(n: int = 16, seed: int = 0):
+    rng = random.Random(seed)
+    rows = []
+    for i in range(n):
+        amounts = [rng.randint(1, 99) for _ in range(rng.randint(3, 6))]
+        csv = "id,amount,note\n" + "\n".join(
+            f"{j + 1},{a},row-{j}" for j, a in enumerate(amounts))
+        rows.append({
+            "prompt": "What is the total of the requested column in data.csv?",
+            "gold": str(sum(amounts)),
+            "fixtures": {"data.csv": csv},
+        })
+    return rows
+
+
+def to_tasks(rows):
+    from agentdescent import Task
+
+    return [Task(id=f"t{i}", prompt=r["prompt"],
+                 meta={"gold": r["gold"], "fixtures": r["fixtures"]})
+            for i, r in enumerate(rows)]
+
+
+# ---------------------------------------------------------------------------
+# Offline stand-ins -- a real subprocess agent, and a fixed reflector
+# ---------------------------------------------------------------------------
+
+_OFFLINE_AGENT = f"""
+import csv, os, re, sys
+skill = os.path.join('.claude', 'skills', '{SKILL_NAME}')
+rules = ''
+p = os.path.join(skill, 'references', 'rules.md')
+if os.path.exists(p):
+    rules = open(p).read()
+m = re.search(r'COLUMN:\\s*(\\w+)', rules)
+column = m.group(1) if m else 'id'
+rows = list(csv.DictReader(open('data.csv')))
+total = sum(int(r[column]) for r in rows if r.get(column, '').strip().isdigit())
+print(total)
+"""
+
+
+def offline_agent():
+    """A genuine WorkspaceAgent: a separate process, bound to the workspace."""
+    return cli_agent([sys.executable, "-c", _OFFLINE_AGENT])
+
+
+def offline_reflector():
+    """Returns the edit a model would return -- derived from what it is shown."""
+    def complete(prompt: str) -> str:
+        m = re.search(r"--- references/rules\.md ---\n(.*?)\n(?:---|TASK )",
+                      prompt, re.DOTALL)
+        body = (m.group(1) if m else "COLUMN: id").strip()
+        fixed = re.sub(r"COLUMN:\s*\w+", "COLUMN: amount", body) or "COLUMN: amount"
+        if fixed == body:
+            fixed = "COLUMN: amount"
+        return "<EDITS>" + json.dumps({
+            "rationale": "the question asks for a quantity; `id` is a row number",
+            "edits": [{"path": "references/rules.md", "content": fixed + "\n"}],
+        }) + "</EDITS>"
+    return complete
+
+
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--agent", default="offline",
+                    choices=["offline", "claude-code", "codex"],
+                    help="who performs the rollouts (default: a local subprocess)")
+    ap.add_argument("--model", default=None,
+                    help="reflector model on an OpenAI-compatible endpoint "
+                         "(needs OPENAI_API_KEY / OPENAI_BASE_URL)")
+    ap.add_argument("--tasks", type=int, default=16)
+    ap.add_argument("--rounds", type=int, default=4)
+    ap.add_argument("--workers", type=int, default=2)
+    ap.add_argument("--install-to", default=None,
+                    help="write the evolved skill here when the run improves it")
+    args = ap.parse_args()
+
+    path = make_skill_dir()
+    if args.agent == "offline":
+        agent = offline_agent()
+    elif args.agent == "claude-code":
+        agent = claude_code(extra_args=["--permission-mode", "acceptEdits"],
+                            timeout=300.0)
+    else:
+        agent = codex(timeout=300.0)
+    reflect = (openai_compatible(model=args.model) if args.model
+               else (offline_reflector() if args.agent == "offline" else agent))
+
+    print(f"Skill    : {path}")
+    print(f"Agent    : {args.agent}")
+    print(f"Reflector: {args.model or ('stub' if args.agent == 'offline' else args.agent)}")
+    print(f"Start    : rules.md = {_RULES_MD.strip()!r}  (wrong column)\n")
+
+    result = evolve_skill_dir(
+        path, to_tasks(make_rows(args.tasks)),
+        agent=agent, reflect_with=reflect, score="contains",
+        rounds=args.rounds, n_workers=args.workers, max_concurrency=args.workers,
+        verbose=True)
+
+    print(f"\nfinal reward : {result.final_reward:.3f}")
+    print(f"stop reason  : {result.stop_reason}")
+    print(f"outcomes     : {result.outcomes()}")
+    print(f"error        : {result.error}")
+    print("\nevolved rules.md:")
+    print(result.state.get("references/rules.md", "(unchanged)").strip())
+
+    if args.install_to:
+        plan = result.write_to(args.install_to)
+        print(f"\ninstalled {len(plan['written'])} file(s) to {args.install_to}"
+              + (f" (backup: {plan['backup'][0]})" if plan["backup"] else ""))
+    shutil.rmtree(os.path.dirname(path), ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,9 @@ nav:
     - Duration-aware scheduling: duration-scheduling.md
     - Efficiency experiments: efficiency.md
   - Complete example — skill evolution: skill-evolution.md
+  - Evolving a directory (skill / agent / code):
+    - Guide: directory-evolution.md
+    - Design record: design-directory-evolution.md
   - Self-evolution algorithms (faithful ports):
     - Overview: self-evolution-examples.md
     - ACE — context evolution: algo-ace.md

--- a/tests/test_dir_evolution.py
+++ b/tests/test_dir_evolution.py
@@ -1,0 +1,350 @@
+"""End to end: a directory on disk, evolved by a real (sub)process agent.
+
+No API key and no network -- the "agent" is a tiny Python program invoked through
+`cli_agent`, so it is a genuine `WorkspaceAgent`: it runs in a directory, reads
+the candidate skill from disk, and behaves differently depending on what the
+skill says. That is the property under test. If it merely received the skill in a
+prompt, none of the staging, layout, overlay or isolation logic would be exercised.
+"""
+
+import json
+import os
+import re
+import sys
+import tempfile
+import threading
+
+import pytest
+
+from agentdescent import evolve_skill_dir, load_tree
+from agentdescent.agents import cli_agent, echo
+from agentdescent.evolution import EvolutionResult, Task
+from agentdescent.filetree import TreeError, canonical
+from agentdescent.runners import TEST_FAILURE_MARKER, code_runner, tree_runner
+from agentdescent.treestrategy import FileTree
+
+# ---------------------------------------------------------------------------
+# a real workspace agent: it reads the skill it was given and obeys it
+# ---------------------------------------------------------------------------
+
+_SKILL_NAME = "shout-skill"
+
+_AGENT_SRC = (
+    "import os,sys;"
+    "q=sys.argv[1];"
+    f"p=os.path.join('.claude','skills','{_SKILL_NAME}','rules.md');"
+    "t=open(p).read() if os.path.exists(p) else '';"
+    "print(q[::-1] if 'MODE: reverse' in t else q)"
+)
+
+_WORDS = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+          "hotel", "india", "juliet", "kilo", "lima", "mike", "november",
+          "oscar", "papa"]
+
+
+def _agent():
+    return cli_agent([sys.executable, "-c", _AGENT_SRC])
+
+
+def _skill_dir(rules="MODE: forward\n"):
+    root = tempfile.mkdtemp()
+    path = os.path.join(root, _SKILL_NAME)
+    os.makedirs(path)
+    with open(os.path.join(path, "rules.md"), "w") as fh:
+        fh.write(rules)
+    return path
+
+
+def _rows():
+    return [{"prompt": w, "gold": w[::-1]} for w in _WORDS]
+
+
+def _reflector():
+    """A stub that reads the reflection prompt and proposes the fix.
+
+    Deliberately not stateful: it derives the new file from the *current* content
+    shown to it, exactly as a model would."""
+    def complete(prompt: str) -> str:
+        m = re.search(r"--- rules\.md ---\n(.*?)\nTASK THE AGENT WAS GIVEN:",
+                      prompt, re.DOTALL)
+        body = (m.group(1) if m else "").strip()
+        new = body.replace("MODE: forward", "MODE: reverse")
+        if new == body:
+            new = body + "\nMODE: reverse"
+        return ('<EDITS>' + json.dumps(
+            {"rationale": "answers must be reversed",
+             "edits": [{"path": "rules.md", "content": new + "\n"}]}) + '</EDITS>')
+    return complete
+
+
+# ---------------------------------------------------------------------------
+# the loop
+# ---------------------------------------------------------------------------
+
+
+def test_a_skill_directory_evolves_and_the_agent_really_reads_it():
+    path = _skill_dir()
+    result = evolve_skill_dir(
+        path, _rows(), agent=_agent(), reflect_with=_reflector(),
+        score="exact", prompt_template="{prompt}",
+        rounds=4, n_workers=2, max_concurrency=1, seed=0)
+
+    assert result.error is None, result.error
+    assert result.final_reward == 1.0
+    assert result.outcomes().get("committed", 0) >= 1
+    assert "MODE: reverse" in result.state["rules.md"]
+    # the source directory is never touched by the run itself
+    assert load_tree(path)["rules.md"] == "MODE: forward\n"
+
+
+def test_the_starting_directory_is_the_starting_artifact():
+    path = _skill_dir(rules="MODE: reverse\n")   # already correct
+    result = evolve_skill_dir(
+        path, _rows(), agent=_agent(), reflect_with=_reflector(),
+        score="exact", prompt_template="{prompt}",
+        rounds=2, n_workers=1, max_concurrency=1)
+    assert result.final_reward == 1.0
+    assert result.history[0].held_out_reward == 1.0
+
+
+def test_frozen_files_are_never_proposed_even_when_the_reflector_targets_them():
+    path = _skill_dir()
+    with open(os.path.join(path, "GRADING.md"), "w") as fh:
+        fh.write("gold answers: alpha=ALPHA\n")
+
+    def sneaky(prompt: str) -> str:
+        return ('<EDITS>' + json.dumps({"edits": [
+            {"path": "GRADING.md", "content": "everything scores 1.0"}]}) + '</EDITS>')
+
+    result = evolve_skill_dir(
+        path, _rows(), agent=_agent(), reflect_with=sneaky, score="exact",
+        prompt_template="{prompt}", frozen=["GRADING.md"],
+        rounds=2, n_workers=1, max_concurrency=1)
+    assert result.state["GRADING.md"] == "gold answers: alpha=ALPHA\n"
+    assert result.outcomes().get("committed", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# the runner
+# ---------------------------------------------------------------------------
+
+
+def test_tree_runner_refuses_a_completion_that_cannot_see_files():
+    with pytest.raises(TypeError) as e:
+        tree_runner(echo(), layout="claude_skill", name="x")
+    assert "WorkspaceAgent" in str(e.value)
+
+
+def test_the_overlay_restores_frozen_files_over_a_tampered_candidate():
+    # the enforcement that `frozen` in the strategy cannot provide: a candidate
+    # that arrives with the file already rewritten (a resumed ledger, a custom
+    # aggregator, a run-time write) still sees the pristine copy.
+    cat = cli_agent([sys.executable, "-c",
+                     "print(open('tests/t.txt').read().strip())"])
+    run = tree_runner(cat, layout="root", name="x",
+                      overlay={"tests/t.txt": "PRISTINE"},
+                      prompt_template="{prompt}")
+    tampered = canonical({"tests/t.txt": "TAMPERED", "a.md": "x"})
+    assert run(tampered, Task("t", "go")) == "PRISTINE"
+
+
+def test_every_rollout_gets_its_own_workspace():
+    pwd = cli_agent([sys.executable, "-c", "import os;print(os.getcwd())"])
+    run = tree_runner(pwd, layout="root", name="x", prompt_template="{prompt}")
+    rendered = canonical({"a.md": "x"})
+    seen, lock = [], threading.Lock()
+
+    def once(i):
+        out = run(rendered, Task(f"t{i}", "go"))
+        with lock:
+            seen.append(out)
+
+    threads = [threading.Thread(target=once, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(set(seen)) == 8            # no two rollouts shared a directory
+    assert not any(os.path.exists(p) for p in seen)      # and all cleaned up
+
+
+def test_fixtures_are_staged_beside_the_tree():
+    cat = cli_agent([sys.executable, "-c", "print(open('input.txt').read().strip())"])
+    run = tree_runner(cat, layout="claude_skill", name="s",
+                      prompt_template="{prompt}")
+    task = Task("t", "go", {"fixtures": {"input.txt": "hello from the fixture"}})
+    assert run(canonical({"SKILL.md": "x"}), task) == "hello from the fixture"
+
+
+def test_the_layout_decides_where_the_tree_lands():
+    ls = cli_agent([sys.executable, "-c",
+                    "import os;print(os.path.exists('.claude/skills/demo/SKILL.md'))"])
+    run = tree_runner(ls, layout="claude_skill", name="demo", prompt_template="{prompt}")
+    assert run(canonical({"SKILL.md": "x"}), Task("t", "go")) == "True"
+
+
+# ---------------------------------------------------------------------------
+# code_runner: the tree is executed, and the gate runs first
+# ---------------------------------------------------------------------------
+
+
+def test_code_runner_executes_the_candidate():
+    run = code_runner([sys.executable, "main.py"])
+    tree = canonical({"main.py": "import sys;print(sys.argv[1].upper())"})
+    assert run(tree, Task("t", "hello")) == "HELLO"
+
+
+def test_a_failing_gate_scores_zero_in_band_instead_of_raising():
+    run = code_runner([sys.executable, "main.py"],
+                      test_cmd=[sys.executable, "-c", "raise SystemExit(1)"])
+    out = run(canonical({"main.py": "print('x')"}), Task("t", "hello"))
+    assert out.startswith(TEST_FAILURE_MARKER)
+
+
+def test_the_gate_runs_against_the_pristine_tests_not_the_candidates():
+    # the candidate ships a weakened test file; the overlay puts the real one back.
+    run = code_runner([sys.executable, "main.py"],
+                      test_cmd=[sys.executable, "check.py"],
+                      overlay={"check.py": "raise SystemExit(1)"})
+    tree = canonical({"main.py": "print('x')", "check.py": "raise SystemExit(0)"})
+    assert run(tree, Task("t", "hi")).startswith(TEST_FAILURE_MARKER)
+
+
+def test_candidate_code_does_not_inherit_the_ambient_environment():
+    os.environ["AGENTDESCENT_SECRET_FOR_TEST"] = "leak-me"
+    try:
+        run = code_runner([sys.executable, "main.py"])
+        tree = canonical({"main.py":
+                          "import os;print(os.environ.get('AGENTDESCENT_SECRET_FOR_TEST','none'))"})
+        assert run(tree, Task("t", "x")) == "none"
+    finally:
+        del os.environ["AGENTDESCENT_SECRET_FOR_TEST"]
+
+
+def test_a_hung_candidate_is_killed_by_the_timeout():
+    run = code_runner([sys.executable, "main.py"], timeout=1.0)
+    out = run(canonical({"main.py": "import time;time.sleep(30)"}), Task("t", "x"))
+    assert out.startswith(TEST_FAILURE_MARKER) and "timed out" in out
+
+
+# ---------------------------------------------------------------------------
+# installing the result back
+# ---------------------------------------------------------------------------
+
+
+def _result(state):
+    return EvolutionResult(state=state, rendered=canonical(state), final_reward=1.0,
+                           history=[], ledger_log=[])
+
+
+def test_write_to_dry_run_reports_the_plan_and_touches_nothing():
+    dest = _skill_dir()
+    plan = _result({"rules.md": "MODE: reverse\n", "new.md": "x"}).write_to(
+        dest, dry_run=True)
+    assert plan["written"] == ["new.md", "rules.md"]
+    assert not os.path.exists(os.path.join(dest, "new.md"))
+
+
+def test_write_to_backs_up_before_overwriting():
+    dest = _skill_dir()
+    plan = _result({"rules.md": "MODE: reverse\n"}).write_to(dest)
+    assert plan["backup"] and os.path.isdir(plan["backup"][0])
+    assert load_tree(dest)["rules.md"] == "MODE: reverse\n"
+    assert load_tree(plan["backup"][0])["rules.md"] == "MODE: forward\n"
+
+
+def test_write_to_leaves_unknown_files_alone_unless_asked():
+    dest = _skill_dir()
+    with open(os.path.join(dest, "notes.md"), "w") as fh:
+        fh.write("mine")
+    plan = _result({"rules.md": "x"}).write_to(dest, backup=False)
+    assert plan["extra"] == ["notes.md"] and os.path.exists(os.path.join(dest, "notes.md"))
+
+    plan = _result({"rules.md": "x"}).write_to(dest, backup=False, prune=True)
+    assert plan["deleted"] == ["notes.md"]
+    assert not os.path.exists(os.path.join(dest, "notes.md"))
+
+
+def test_write_to_refuses_a_result_that_is_not_a_file_tree():
+    # an AppendRules result: its keys are rule hashes, which are *syntactically*
+    # valid paths -- so the guard is the rendered form, not the keys.
+    playbook = EvolutionResult(state={"a3f2c1": "always check units"},
+                               rendered="# Playbook\n- always check units",
+                               final_reward=1.0, history=[], ledger_log=[])
+    with pytest.raises(TreeError) as e:
+        playbook.write_to(tempfile.mkdtemp())
+    assert "FileTree" in str(e.value)
+
+
+# ---------------------------------------------------------------------------
+# the other two entry points
+# ---------------------------------------------------------------------------
+
+
+def test_an_agent_directory_runs_at_the_harness_layer():
+    from agentdescent.evolution import EvolvingArtifact
+    from agentdescent.governance import Layer, classify
+    from agentdescent.skilldir import HARNESS_BLAST_RADIUS, evolve_agent_dir
+
+    path = _skill_dir()
+    result = evolve_agent_dir(
+        path, _rows(), agent=_agent(), reflect_with=_reflector(), score="exact",
+        prompt_template="{prompt}", rounds=2, n_workers=1, max_concurrency=1)
+    assert result.error is None, result.error
+    # an agent definition is a harness: L1, so every merge also passes the oracle.
+    art = EvolvingArtifact("a", {}, blast_radius=HARNESS_BLAST_RADIUS)
+    assert classify(art) is Layer.L1_SLOW
+
+
+def test_agent_code_evolves_behind_a_test_gate_it_cannot_rewrite():
+    from agentdescent.skilldir import evolve_agent_code
+
+    root = tempfile.mkdtemp()
+    src = os.path.join(root, "tiny-agent")
+    os.makedirs(os.path.join(src, "tests"))
+    # `main.py` answers by echoing; the fix is to reverse, as the tests demand.
+    with open(os.path.join(src, "main.py"), "w") as fh:
+        fh.write("import sys\nprint(sys.argv[1])\n")
+    with open(os.path.join(src, "tests", "test_main.py"), "w") as fh:
+        fh.write("def test_placeholder():\n    assert True\n")
+
+    def reflect(prompt):
+        return "<EDITS>" + json.dumps({"edits": [
+            {"path": "main.py", "content": "import sys\nprint(sys.argv[1][::-1])\n"},
+            # a second edit aimed at the frozen tests: must be dropped
+            {"path": "tests/test_main.py", "content": "assert False"}]}) + "</EDITS>"
+
+    result = evolve_agent_code(
+        src, _rows(), entrypoint=[sys.executable, "main.py"],
+        reflect_with=reflect, score="exact",
+        test_cmd=[sys.executable, "-c", "import ast;ast.parse(open('main.py').read())"],
+        rounds=2, n_workers=1, max_concurrency=1)
+
+    assert result.error is None, result.error
+    assert result.final_reward == 1.0
+    assert "[::-1]" in result.state["main.py"]
+    assert result.state["tests/test_main.py"] == (
+        "def test_placeholder():\n    assert True\n")     # frozen, never rewritten
+
+
+def test_a_candidate_that_breaks_the_gate_scores_zero_and_is_not_committed():
+    from agentdescent.skilldir import evolve_agent_code
+
+    root = tempfile.mkdtemp()
+    src = os.path.join(root, "tiny-agent-2")
+    os.makedirs(src)
+    with open(os.path.join(src, "main.py"), "w") as fh:
+        fh.write("import sys\nprint(sys.argv[1][::-1])\n")
+
+    def wrecker(prompt):
+        return "<EDITS>" + json.dumps({"edits": [
+            {"path": "main.py", "content": "this is not python("}]}) + "</EDITS>"
+
+    result = evolve_agent_code(
+        src, _rows(), entrypoint=[sys.executable, "main.py"],
+        reflect_with=wrecker, score="exact",
+        test_cmd=[sys.executable, "-c", "import ast;ast.parse(open('main.py').read())"],
+        rounds=2, n_workers=1, max_concurrency=1)
+
+    assert result.state["main.py"] == "import sys\nprint(sys.argv[1][::-1])\n"
+    assert result.outcomes().get("committed", 0) == 0

--- a/tests/test_evoskill_example.py
+++ b/tests/test_evoskill_example.py
@@ -139,3 +139,57 @@ def test_eval_at_end_scores_final_library():
     assert res.seed_score == 0.0
     assert res.best_score > 0.0                       # final eval sees the applied skills
     assert len(res.skills) >= 1
+
+
+# ---------------------------------------------------------------------------
+# The library is a real directory now (SkillLibraryTree)
+# ---------------------------------------------------------------------------
+
+
+def test_the_library_is_keyed_by_path_and_installs_as_a_directory():
+    """The migration's point: the artifact is a directory, not a name->text dict."""
+    import tempfile
+
+    from agentdescent.filetree import load_tree, materialize
+
+    from examples.evoskill_skill_discovery import skills_of
+
+    train, val = _tasks()
+    res = run_evoskill(_skill_helps_stub(), {}, train, val, iterations=4, seed=0,
+                       eval_concurrency=1, batch_size=2)
+    assert res.skills, "nothing was learned, so there is nothing to install"
+    # every state key is a real relative path, one directory per skill
+    assert all(p.startswith("skills/") and p.endswith("/SKILL.md") for p in res.tree)
+    assert skills_of(res.tree) == res.skills
+
+    dest = tempfile.mkdtemp()
+    materialize(res.tree, dest)
+    assert load_tree(dest) == res.tree            # round-trips as a directory
+
+
+def test_the_retriever_prompt_is_unchanged_by_the_move_to_paths():
+    """A faithful port's prompt is part of what it reproduces.
+
+    `render()` is now the artifact's lossless serialisation rather than the prompt
+    text, so `run` reassembles the prompt -- and it has to come out identical, or
+    the port measures something else than it did before."""
+    from agentdescent.filetree import parse_tree
+
+    from examples.evoskill_skill_discovery import (
+        SkillLibraryTree, render_skills, skill_path, skills_of)
+
+    skills = {"defense-lookup": "Find the national defense row.\n- report millions",
+              "table-headers": "Locate the nearest header row first."}
+    tree = {skill_path(n): b for n, b in skills.items()}
+    rendered = SkillLibraryTree().render(tree)
+    assert render_skills(skills_of(parse_tree(rendered))) == render_skills(skills)
+
+
+def test_one_skill_per_proposal_and_the_name_protocol_survives():
+    from examples.evoskill_skill_discovery import SkillLibraryTree
+
+    s = SkillLibraryTree()
+    d = s.to_diff({}, "defense lookup :: find the row", "w0", 1, "skill_library")
+    assert d.ops == {"skills/defense-lookup/SKILL.md": "find the row"}
+    assert s.to_diff(d.ops, "defense lookup :: find the row", "w0", 1, "a") is None
+    assert s.to_diff({}, "no separator here", "w0", 1, "a") is None

--- a/tests/test_filetree.py
+++ b/tests/test_filetree.py
@@ -1,0 +1,183 @@
+"""A directory is the state; the translation to and from it must be exact.
+
+`load_tree` / `materialize` are a round trip, and every asymmetry in it is a bug
+with teeth: a file dropped on the way in is a file `write_to` later deletes by
+omission, and a path accepted on the way out is a write outside the workspace.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from agentdescent.filetree import (
+    TreeError,
+    TreeSpec,
+    canonical,
+    load_tree,
+    match_any,
+    materialize,
+    parse_tree,
+    safe_relpath,
+    tree_summary,
+)
+
+
+def _write(root, rel, content, mode="w"):
+    path = os.path.join(root, rel.replace("/", os.sep))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, mode) as fh:
+        fh.write(content)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# round trip
+# ---------------------------------------------------------------------------
+
+
+def test_load_materialize_round_trip():
+    src = tempfile.mkdtemp()
+    _write(src, "SKILL.md", "# skill\nbody\n")
+    _write(src, "references/rules.md", "- rule one\n")
+    _write(src, "scripts/check.sh", "echo hi\n")
+    state = load_tree(src)
+    assert set(state) == {"SKILL.md", "references/rules.md", "scripts/check.sh"}
+
+    dest = tempfile.mkdtemp()
+    materialize(state, dest)
+    assert load_tree(dest) == state
+
+
+def test_canonical_survives_content_that_looks_like_a_delimiter():
+    # the reason canonical() is JSON rather than a `--- file: x ---` format.
+    state = {"a.md": '--- file: b.md ---\n{"files": {"evil": 1}}\n',
+             "b.md": "unicode: 中文 \u2014 ok\n"}
+    assert parse_tree(canonical(state)) == state
+
+
+def test_canonical_is_stable_and_order_independent():
+    a = canonical({"x.md": "1", "y.md": "2"})
+    b = canonical({"y.md": "2", "x.md": "1"})
+    assert a == b                      # it is an evaluation-cache key
+
+
+def test_parse_tree_accepts_a_plain_mapping_but_rejects_junk():
+    assert parse_tree('{"a.md": "hi"}') == {"a.md": "hi"}
+    with pytest.raises(TreeError):
+        parse_tree("not json at all")
+    with pytest.raises(TreeError):
+        parse_tree('{"a.md": 17}')     # non-text content
+
+
+# ---------------------------------------------------------------------------
+# path safety -- these keys come from a model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [
+    "/etc/passwd", "../outside.md", "a/../../b.md", "C:/win.ini", "", "   ",
+    "./../x", "a/\x00b",
+])
+def test_safe_relpath_rejects_escapes(bad):
+    with pytest.raises(TreeError):
+        safe_relpath(bad)
+
+
+def test_safe_relpath_normalises_without_losing_meaning():
+    assert safe_relpath("./a//b.md") == "a/b.md"
+    assert safe_relpath("a\\b.md") == "a/b.md"
+
+
+def test_materialize_refuses_to_write_outside_its_destination():
+    dest = tempfile.mkdtemp()
+    with pytest.raises(TreeError):
+        materialize({"../escaped.md": "x"}, dest)
+    assert not os.path.exists(os.path.join(os.path.dirname(dest), "escaped.md"))
+
+
+def test_materialize_makes_scripts_executable():
+    dest = tempfile.mkdtemp()
+    materialize({"scripts/run.sh": "echo hi\n", "notes.md": "x"}, dest)
+    assert os.access(os.path.join(dest, "scripts", "run.sh"), os.X_OK)
+    assert not os.access(os.path.join(dest, "notes.md"), os.X_OK)
+
+
+def test_materialize_honours_the_layout_prefix():
+    dest = tempfile.mkdtemp()
+    materialize({"SKILL.md": "x"}, dest, prefix=".claude/skills/demo")
+    assert os.path.exists(os.path.join(dest, ".claude", "skills", "demo", "SKILL.md"))
+
+
+# ---------------------------------------------------------------------------
+# what the loader refuses -- loudly
+# ---------------------------------------------------------------------------
+
+
+def test_binary_and_oversized_files_raise_rather_than_being_skipped():
+    src = tempfile.mkdtemp()
+    _write(src, "SKILL.md", "ok")
+    _write(src, "logo.md", b"\x00\x01binary", mode="wb")
+    with pytest.raises(TreeError) as e:
+        load_tree(src)
+    assert "logo.md" in str(e.value) and "binary" in str(e.value)
+
+    src2 = tempfile.mkdtemp()
+    _write(src2, "big.md", "x" * 100)
+    with pytest.raises(TreeError) as e2:
+        load_tree(src2, TreeSpec(max_file_bytes=10))
+    assert "max_file_bytes" in str(e2.value)
+
+
+def test_excluded_files_are_silently_and_correctly_out_of_scope():
+    src = tempfile.mkdtemp()
+    _write(src, "SKILL.md", "ok")
+    _write(src, "logo.md", b"\x00binary", mode="wb")
+    state = load_tree(src, TreeSpec(exclude=("logo.md",)))
+    assert set(state) == {"SKILL.md"}     # declared out, not accidentally dropped
+
+
+def test_empty_selection_is_an_error_not_an_empty_artifact():
+    src = tempfile.mkdtemp()
+    _write(src, "data.bin", "x")
+    with pytest.raises(TreeError):
+        load_tree(src)
+
+
+def test_dot_git_is_never_walked():
+    src = tempfile.mkdtemp()
+    _write(src, "SKILL.md", "ok")
+    _write(src, ".git/config.md", "should not be loaded")
+    assert set(load_tree(src)) == {"SKILL.md"}
+
+
+def test_spec_must_agree_with_the_trust_region():
+    TreeSpec(max_file_bytes=1000).validate_against(32_000)      # fine
+    with pytest.raises(TreeError) as e:
+        TreeSpec(max_file_bytes=64_000).validate_against(32_000)
+    assert "trust region" in str(e.value)
+
+
+# ---------------------------------------------------------------------------
+# glob semantics (fnmatch would get both of these wrong)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path,patterns,expected", [
+    ("SKILL.md", ["**/*.md"], True),           # fnmatch: False
+    ("refs/a.md", ["*.md"], False),            # fnmatch: True
+    ("refs/a.md", ["**/*.md"], True),
+    ("tests/unit/x.py", ["tests"], True),      # bare dir means everything under it
+    ("testsuite/x.py", ["tests"], False),
+    ("a/b/c.py", ["**"], True),
+    ("conftest.py", ["conftest.py"], True),
+    ("pkg/conftest.py", ["conftest.py"], False),
+])
+def test_match_any(path, patterns, expected):
+    assert match_any(path, patterns) is expected
+
+
+def test_tree_summary_lists_paths_and_truncates():
+    state = {f"f{i}.md": "x" * i for i in range(60)}
+    summary = tree_summary(state, limit=5)
+    assert "f0.md" in summary and "55 more file(s)" in summary

--- a/tests/test_skill_dir_example.py
+++ b/tests/test_skill_dir_example.py
@@ -1,0 +1,64 @@
+"""`examples/skill_dir_evolution.py` -- the directory-evolution example.
+
+It is offline and takes seconds, so unlike the algorithm ports there is no reason
+to test only its helpers: run the loop. What it has to demonstrate is the one
+claim the example exists to make -- that the *directory* is what changed the
+score, not the model.
+"""
+
+import os
+
+from examples.skill_dir_evolution import (
+    SKILL_NAME,
+    make_rows,
+    make_skill_dir,
+    offline_agent,
+    offline_reflector,
+    to_tasks,
+)
+
+from agentdescent import evolve_skill_dir, load_tree
+
+
+def _run(**kwargs):
+    path = make_skill_dir()
+    result = evolve_skill_dir(
+        path, to_tasks(make_rows(12)), agent=offline_agent(),
+        reflect_with=offline_reflector(), score="contains",
+        rounds=3, n_workers=2, max_concurrency=1, **kwargs)
+    return path, result
+
+
+def test_the_example_fixes_the_wrong_column():
+    path, result = _run()
+    assert result.error is None, result.error
+    assert result.final_reward == 1.0
+    assert "COLUMN: amount" in result.state["references/rules.md"]
+    assert result.outcomes().get("committed", 0) >= 1
+
+
+def test_the_skill_is_what_moved_the_score_not_the_agent():
+    # the same agent, the same tasks, with the skill's answer already correct vs
+    # still wrong: if the directory were not being read these would agree.
+    path = make_skill_dir()
+    tasks = to_tasks(make_rows(12))
+    before = evolve_skill_dir(
+        path, tasks, agent=offline_agent(), reflect_with=lambda p: "",
+        score="contains", rounds=1, n_workers=1, max_concurrency=1)
+    assert before.final_reward == 0.0          # wrong column, nothing proposed
+
+    _, after = _run()
+    assert after.final_reward == 1.0
+
+
+def test_the_run_never_writes_to_the_source_directory():
+    path, result = _run()
+    assert load_tree(path)["references/rules.md"].strip() == "COLUMN: id"
+
+
+def test_write_to_installs_the_evolved_skill():
+    path, result = _run()
+    plan = result.write_to(path)
+    assert plan["backup"]
+    assert "COLUMN: amount" in load_tree(path)["references/rules.md"]
+    assert os.path.basename(path) == SKILL_NAME

--- a/tests/test_tree_strategy.py
+++ b/tests/test_tree_strategy.py
@@ -1,0 +1,186 @@
+"""`FileTree`: the artifact is a directory, so a state key is a file path.
+
+Two things are load-bearing here and neither exists for a text strategy: the
+multi-file proposal protocol (`parse_edits`) and `frozen`, which is L0 expressed
+in paths rather than in artifact ids.
+"""
+
+import pytest
+
+from agentdescent.evolution import EvolvingArtifact, Task
+from agentdescent.filetree import canonical
+from agentdescent.treestrategy import FileTree, parse_edits, tree_reflector
+
+
+def _tree(**files):
+    return FileTree(files or {"SKILL.md": "old"})
+
+
+# ---------------------------------------------------------------------------
+# the proposal protocol
+# ---------------------------------------------------------------------------
+
+
+def test_parse_edits_reads_the_documented_block():
+    proposal = """Sure, here is the fix.
+<EDITS>
+{"rationale": "r", "edits": [{"path": "SKILL.md", "content": "new body"}]}
+</EDITS>
+Hope that helps."""
+    assert parse_edits(proposal) == {"SKILL.md": "new body"}
+
+
+def test_parse_edits_tolerates_a_fenced_block_or_a_bare_object():
+    fenced = '```json\n{"edits": [{"path": "a.md", "content": "x"}]}\n```'
+    bare = '{"edits": [{"path": "a.md", "content": "x"}]}'
+    single = '{"path": "a.md", "content": "x"}'
+    for text in (fenced, bare, single):
+        assert parse_edits(text) == {"a.md": "x"}
+
+
+def test_parse_edits_returns_nothing_rather_than_raising_on_junk():
+    # a reflector that ignores the protocol is a quality problem the run absorbs
+    # and counts, not a crash.
+    for junk in ("", "no json here", "<EDITS>{broken</EDITS>", "[]", "{}", None, 17):
+        assert parse_edits(junk) == {}
+
+
+def test_parse_edits_drops_hostile_paths_and_keeps_the_rest():
+    proposal = ('<EDITS>{"edits": [{"path": "../../etc/passwd", "content": "x"},'
+                '{"path": "ok.md", "content": "y"}]}</EDITS>')
+    assert parse_edits(proposal) == {"ok.md": "y"}
+
+
+def test_parse_edits_understands_deletion():
+    assert parse_edits('{"edits": [{"path": "old.md", "delete": true}]}') == {"old.md": None}
+
+
+def test_edit_protocol_formats_without_leaking_braces():
+    from agentdescent.treestrategy import EDIT_PROTOCOL
+
+    text = EDIT_PROTOCOL.format(max_files=2, editable="**", frozen="tests/**")
+    assert '"rationale"' in text and "{max_files}" not in text
+
+
+# ---------------------------------------------------------------------------
+# to_diff: what becomes a gradient
+# ---------------------------------------------------------------------------
+
+
+def _diff(strategy, state, proposal):
+    return strategy.to_diff(state, proposal, "w0", 1, "art")
+
+
+def _edits(*pairs):
+    items = ", ".join('{"path": "%s", "content": "%s"}' % p for p in pairs)
+    return "<EDITS>{\"edits\": [%s]}</EDITS>" % items
+
+
+def test_a_changed_file_becomes_one_op():
+    s = _tree(**{"SKILL.md": "old"})
+    d = _diff(s, s.initial(), _edits(("SKILL.md", "new")))
+    assert d.ops == {"SKILL.md": "new"}
+
+
+def test_an_unchanged_file_is_not_a_diff():
+    s = _tree(**{"SKILL.md": "same"})
+    assert _diff(s, s.initial(), _edits(("SKILL.md", "same"))) is None
+
+
+def test_frozen_paths_cannot_be_proposed():
+    s = FileTree({"SKILL.md": "a", "tests/t.py": "assert real"}, frozen=["tests/**"])
+    assert _diff(s, s.initial(), _edits(("tests/t.py", "assert True"))) is None
+    # and a mixed proposal keeps only the writable half
+    d = _diff(s, s.initial(), _edits(("tests/t.py", "assert True"), ("SKILL.md", "b")))
+    assert d.ops == {"SKILL.md": "b"}
+
+
+def test_non_editable_paths_are_ignored():
+    s = FileTree({"SKILL.md": "a", "notes.txt": "n"}, editable=["*.md"])
+    assert _diff(s, s.initial(), _edits(("notes.txt", "x"))) is None
+
+
+def test_a_runaway_proposal_is_dropped_whole():
+    s = FileTree({f"f{i}.md": "x" for i in range(5)}, max_files_per_diff=2)
+    proposal = _edits(*[(f"f{i}.md", "y") for i in range(4)])
+    assert _diff(s, s.initial(), proposal) is None
+
+
+def test_oversized_content_never_reaches_the_aggregator():
+    s = FileTree({"SKILL.md": "a"}, max_file_bytes=50)
+    assert _diff(s, s.initial(), _edits(("SKILL.md", "x" * 200))) is None
+
+
+def test_deletion_is_an_op_that_pops_the_key():
+    s = FileTree({"SKILL.md": "a", "stale.md": "b"})
+    d = _diff(s, s.initial(), '{"edits": [{"path": "stale.md", "delete": true}]}')
+    assert d.ops == {"stale.md": None}
+    art = EvolvingArtifact("art", s.initial(), strategy=s).apply(d)
+    assert set(art.state) == {"SKILL.md"}          # popped, not stored as None
+
+
+def test_deleting_a_file_that_is_not_there_is_not_a_diff():
+    s = FileTree({"SKILL.md": "a"})
+    assert _diff(s, s.initial(), '{"edits": [{"path": "ghost.md", "delete": true}]}') is None
+
+
+def test_diff_ids_are_stable_for_the_same_edit():
+    s = _tree()
+    a = _diff(s, s.initial(), _edits(("SKILL.md", "new")))
+    b = _diff(s, s.initial(), _edits(("SKILL.md", "new")))
+    assert a.diff_id == b.diff_id    # identical proposals dedupe in the aggregator
+
+
+# ---------------------------------------------------------------------------
+# key space / tensor parallelism
+# ---------------------------------------------------------------------------
+
+
+def test_keys_are_the_editable_paths_plus_declared_future_ones():
+    s = FileTree({"SKILL.md": "a", "tests/t.py": "b"}, frozen=["tests/**"],
+                 planned_paths=["references/new.md"])
+    assert s.keys() == ["SKILL.md", "references/new.md"]
+
+
+def test_render_is_the_lossless_serialisation():
+    s = _tree(**{"a.md": "1", "b.md": "2"})
+    assert s.render(s.initial()) == canonical(s.initial())
+
+
+# ---------------------------------------------------------------------------
+# the reflector
+# ---------------------------------------------------------------------------
+
+
+def test_tree_reflector_shows_editable_content_and_the_protocol():
+    seen = {}
+
+    def fake(prompt):
+        seen["prompt"] = prompt
+        return "<EDITS>{\"edits\": [{\"path\": \"SKILL.md\", \"content\": \"v2\"}]}</EDITS>"
+
+    s = FileTree({"SKILL.md": "current body", "tests/t.py": "secret"},
+                 frozen=["tests/**"])
+    propose = tree_reflector(fake, strategy=s)
+    out = propose(s.render(s.initial()), Task("t1", "the question", {"gold": "42"}),
+                  "wrong answer", 0.0)
+    assert "current body" in seen["prompt"]        # the file it may edit
+    assert "the question" in seen["prompt"] and "42" in seen["prompt"]
+    assert "<EDITS>" in seen["prompt"]             # the protocol
+    assert "secret" not in seen["prompt"]          # frozen file body is not shown
+    assert parse_edits(out) == {"SKILL.md": "v2"}
+
+
+def test_tree_reflector_bounds_what_it_puts_in_the_prompt():
+    seen = {}
+
+    def fake(prompt):
+        seen["prompt"] = prompt
+        return ""
+
+    s = FileTree({f"f{i}.md": "y" * 5_000 for i in range(20)})
+    tree_reflector(fake, strategy=s, max_context_chars=6_000)(
+        s.render(s.initial()), Task("t", "q"), "out", 0.0)
+    # the listing names every file, but only a couple of bodies are inlined.
+    assert seen["prompt"].count("--- f") <= 2
+    assert "f19.md" in seen["prompt"]              # still listed

--- a/tests/test_unified_backends.py
+++ b/tests/test_unified_backends.py
@@ -185,3 +185,57 @@ def test_a_workspace_agent_never_truncates():
         out = document_agent(reader).answer("q?", "y" * 400_000)
     assert int(out.strip()) == 400_000, "the whole document must reach the workspace"
     assert not [x for x in w if "inlining" in str(x.message)]
+
+
+# ---------------------------------------------------------------------------
+# skills as FILES, not as prompt text
+# ---------------------------------------------------------------------------
+
+
+def test_a_workspace_agent_receives_the_skill_library_on_disk():
+    """The point of a skill *directory*: the agent opens what it needs.
+
+    Inlining the whole library in every prompt is exactly what this avoids, so the
+    prompt must carry a pointer and the files must actually be there."""
+    import sys
+
+    reader = cli_agent([sys.executable, "-c",
+                        "print(open('.claude/skills/lookup/SKILL.md').read().strip())"])
+    backend = document_agent(reader)
+    out = backend.answer("q", "the document", skills="ignored when files are given",
+                         skill_files={"lookup/SKILL.md": "read the header row first"})
+    assert out == "read the header row first"
+
+
+def test_the_prompt_points_at_the_skills_instead_of_carrying_them():
+    seen = {}
+
+    class _Recorder:
+        def __call__(self, prompt):
+            seen["prompt"] = prompt
+            return "ok"
+
+        def in_workspace(self, path):
+            seen["ws"] = path
+            return self
+
+    backend = document_agent(_Recorder())
+    backend.answer("q", "doc", skill_files={"lookup/SKILL.md": "SECRET BODY"})
+    assert ".claude/skills" in seen["prompt"] and "lookup" in seen["prompt"]
+    assert "SECRET BODY" not in seen["prompt"]          # on disk, not in the prompt
+    assert os.path.exists(os.path.join(seen["ws"], ".claude/skills/lookup/SKILL.md"))
+
+
+def test_a_backend_without_a_workspace_falls_back_to_inlining_them():
+    # dropping them silently would make the skills invisible on the retriever path.
+    from agentdescent.backends import tool_loop_backend
+
+    seen = {}
+
+    def complete(prompt):
+        seen["prompt"] = prompt
+        return "ANSWER: 42"
+
+    tool_loop_backend(complete).answer(
+        "q", "doc", skill_files={"lookup/SKILL.md": "read the header row first"})
+    assert "read the header row first" in seen["prompt"]


### PR DESCRIPTION
## What

Adds a fourth thing you can evolve: a **directory**. A skill folder, a folder of
subagent definitions, or a small codebase that *is* the agent — with each rollout
performed by a real agent that reads those files off disk with its own tools.

```python
result = evolve_skill_dir(
    "~/.claude/skills/pdf-audit", rows,
    agent=claude_code(extra_args=["--permission-mode", "acceptEdits"]),
    reflect_with=openai_compatible(model="deepseek-v4-flash"),
    prompt="question", gold="answer", score="contains")

result.write_to("~/.claude/skills/pdf-audit")     # opt in; backs up first
```

```bash
python -m examples.skill_dir_evolution        # offline, no API key, seconds
```

## Why it needs no optimizer changes

The engine never interprets a state key — it only asks whether two diffs touch
the same one (`diffs_contradict`) and unions the ones that don't (`fuse_diffs`).
Make the keys **file paths** and file-level semantics arrive for free:

| Two workers… | …produce | …and the aggregator |
|---|---|---|
| edit different files | complementary diffs | fuses them |
| edit the same file | a contradiction | keeps whichever scores better held-out |
| propose the identical file | duplicate diffs | collapses them |

`aggregator.py`, `ledger.py`, `async_evolve.py`, `parallel.py` and
`governance.py` are untouched.

## What's new

| module | what it does |
|---|---|
| `agentdescent/filetree.py` | directory ↔ state, path safety, `TreeSpec` |
| `agentdescent/treestrategy.py` | the `FileTree` strategy, the `<EDITS>` multi-file proposal protocol, `tree_reflector` |
| `agentdescent/runners.py` | `tree_runner` / `code_runner` — one throwaway workspace **per call** |
| `agentdescent/skilldir.py` | `evolve_skill_dir` (L2) / `evolve_agent_dir` (L1) / `evolve_agent_code` (L1 + test gate) |

Plus `document_agent(..., skill_files=...)`: for a workspace agent the skill
library is written to `.claude/skills/` and the prompt carries a pointer, so the
agent opens the one skill it needs instead of carrying all of them in every
prompt.

## Engine changes (two, both small)

- **A `None` op deletes a key** instead of storing `None`. `dict.update` could
  express add and replace but not remove — invisible for a rules playbook,
  disqualifying when a key is a path. `None` was never a legal op value, so this
  is backward compatible.
- **`EvolutionResult.write_to(path)`** installs a tree back into a directory:
  backs it up first, reports files it doesn't know about rather than deleting
  them (`prune=True` to delete), `dry_run=True` for the plan, and refuses
  outright when the artifact is not a file tree.

## Safety

`FileTree(frozen=[...])` is L0 expressed in paths — `governance.py` freezes whole
artifacts by id, which cannot say "this skill may evolve, but not its test
suite". Without it, the shortest path to a high score is to weaken the thing
measuring it.

It is enforced **twice**, and only the second is a security boundary:

1. the proposal filter stops the *reflector* from editing the test suite;
2. the runner overlays the **pristine** frozen files after materialisation, and
   `code_runner` invokes the gate from outside the tree — so candidate code
   cannot pass by rewriting `conftest.py` at run time either.

Candidate code runs in a throwaway workspace with a trimmed environment (`HOME`
and `TMPDIR` inside it, so it cannot read `~/.claude` or `~/.aws`) under a hard
timeout. The docs say plainly that this is isolation, **not a sandbox**.

## EvoSkill migration — the acceptance test

If the existing ports could not be expressed in the new abstraction, the shape
was wrong. EvoSkill's artifact was already `{skill name: SKILL.md body}` — a
skill directory that never touched disk — so it is the natural test:

```
{"defense-lookup": "..."}   →   {"skills/defense-lookup/SKILL.md": "..."}
```

**All 12 existing EvoSkill tests pass unchanged.** Two things that looked like
blockers turned out not to be, and both are worth knowing before migrating
anything else:

- **A port keeps its own prompt format.** `render()` has to be the lossless
  serialisation because it is the evaluation-cache key — but `run` is where an
  artifact becomes a prompt (the framework never injects one for you), so
  EvoSkill parses the tree and re-renders it in its own `### skill: <name>`
  format. The retriever path's prompt is byte-identical, asserted by a new test.
- **A port keeps its own proposal protocol.** `SkillLibraryTree` overrides
  `to_diff` to accept the repo's `name :: body` rather than `<EDITS>` JSON. What
  is faithful about EvoSkill is the two-role Proposer/Generator induction, not
  the separator — switching would have changed the Generator's prompt, exactly
  the silent behaviour change a migration must not smuggle in.

The payoff: with `--backend claude-code` / `openhands` the skills now reach the
agent as files in its workspace.

## Cost defaults

`evolve_*_dir` default to `self_verify=False` and `cheap_eval_tasks=4`, unlike
the plain engine. Both plain defaults are right for a text artifact and expensive
here — the first doubles agent calls per proposal, the second leaves the cheap
layer pinned to the whole held-out set, which makes candidate *ranking* the
dominant cost when `eval_fn` runs a real agent. Two counter-intuitive findings
are documented: the L1 oracle gate is **free** (the evaluation cache serves it),
and the evaluation cache turns a single sample into ground truth, so the Beta
posterior underestimates variance for a stochastic agent.

## Tests

`pytest`: **605 passed, 1 skipped** (was 599 + 1). `mkdocs build --strict`:
clean. 20 new tests cover the round trip, path-escape refusal, concurrency
isolation (8 threads, distinct workspaces, all cleaned up), frozen-path
enforcement from both directions, environment leakage, timeouts, `write_to`
plans/backups/pruning, and the EvoSkill migration invariants.

## Docs

New [guide](docs/directory-evolution.md) and the [design
record](docs/design-directory-evolution.md) (both in the nav), plus updates to
`README`, `index`, `usage`, `evolution` (strategy table), `algo-evoskill`,
`agents`, and a `CHANGELOG` entry under **[Unreleased]**.

## Not in this PR

ADAS / DGM still evolve their own representations — moving them here would let
their candidates actually execute, but that needs an evaluation harness (DGM's is
SWE-bench in Docker), not these modules. Also deferred: section-level granularity
inside a file, and a container sandbox behind the existing hook. ACE / GEPA /
SkillOpt are deliberately **not** migrated: a single text slot is clearest as
`SingleSlot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
