### PR TITLE
fix: a review of the whole codebase, and of the docs written against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,85 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **`cheap_eval_tasks` could veto a commit, while four places promised it could
+  not.** The aggregator's acceptance step refuses a candidate that scores worse
+  than the incumbent — a guard worth having — but it read the *cheap* layer,
+  which `cheap_eval_tasks` sub-samples. So a four-task sample could overturn a
+  decision the full held-out Beta test had just approved, and the three
+  `evolve()` entry points for directories default that knob to 4. The guard now
+  reads the full-set rates `eval_counts` has already computed, which is what it
+  meant all along; two source comments, one docstring and two doc pages that
+  asserted the opposite are corrected.
+
+  Its rejection message is also honest now. Both gates reported
+  `P(delta>0)=… <= …`, so a regression rejection printed something like
+  `P(delta>0)=0.97 <= 0.50` — self-contradictory to anyone reading `outcomes()`
+  to find out why nothing committed, which is that method's only job.
+
+- **`EvolvingArtifact.diff()` could not express a deletion**, so
+  `a.apply(a.diff(b))` differed from `b` whenever `b` had dropped a key —
+  silently, and for exactly the case a file tree cares about, where a key is a
+  path. `apply` learned the `None` sentinel last release; `diff` now emits it.
+
+- **The contract mechanism was declared and never enforced.** `Contract`,
+  `Contract.is_compatible_with` and `ContractRejected` all existed, nothing
+  called any of them, and the docstrings described the enforcement as if it were
+  there. `Ledger.register` now records an artifact's contract and `commit`
+  refuses a state whose major disagrees.
+
+- **`domains.router.Task`** — the alias colliding with `evolution.Task` — is no
+  longer used inside the package (`worker.py` takes `RouterTask`). The alias
+  stays, marked deprecated.
+
+### Changed
+- **The two barrier-free runtimes share their policies.** `async_evolve` and
+  `AsyncAgentDescent` implemented the same shape independently; a previous
+  release had to hand-port two measured fixes between them. The parts that are
+  *policy* rather than plumbing now live in `agentdescent.pipeline`
+  (`WorkerHealth`, `StallGuard`) and both call them, so the next fix lands in
+  both. The runtimes themselves are still separate — unifying them would move
+  every measured result's reproduction path, which is a decision, not a cleanup.
+- **One difficulty-weight formula.** `4·p·(1−p)` was written out in both
+  `sampling.DifficultyWeighted` (over tasks) and `scheduler.TaskScheduler` (over
+  clusters); it now lives in `stats.difficulty_weight`. The exploration constants
+  still differ (0.2 vs 1.4) and the docstring says why: the sweep that produced
+  0.2 was measured at task granularity and has not been repeated at cluster
+  granularity.
+- **One definition of which section owns a key.** `TensorParallelMerge` used the
+  `section_of` hash bucket while `TensorParallel` and `evolve()` used the
+  `assign_key_sections` partition — two answers to the same question, so a diff
+  legal on one path could be rejected on the other. `TensorParallelMerge(keys=…)`
+  now uses the same partition.
+- **`AuditScheduler` queues only when asked** (`collect=True`). Nothing in the
+  shipped runtimes calls `pop()`, so every `submit` was a heap push plus a
+  periodic rebuild — once per merge decision — for a queue no one reads. The
+  priority is still computed and returned; `force_oracle` and the trust update
+  are unaffected.
+- **`Evolvable` requires one method fewer.** `full_eval` was in the protocol and
+  called by nothing: ground truth reaches the aggregator through the verifier's
+  `eval_fn`, which the domain supplies. Implementations keep theirs.
+- **`Evolvable.cheap_eval` is now `evidence_eval`**, because it collided with
+  `ThreeLayerVerifier.cheap_eval` — different argument, different meaning, both
+  called from the same forty lines of the aggregator. `cheap_eval` remains an
+  alias.
+- **The text strategies moved out of the engine** into `agentdescent.strategies`,
+  so the rule is now "one module per strategy family, none of them in
+  `evolution.py`" — `FileTree` already had its own. All three import paths still
+  work.
+- `parallel.py` no longer imports `RouterSkill`: a general primitive was typed to
+  the reference domain.
+
+### Documentation
+- A consistency pass over the new site found 14 problems and fixed them. The ones
+  worth naming: `staleness.md` had the `alpha` tolerance **backwards** (it widens
+  for L1/hot artifacts, not cold) and contradicted `concepts.md`; `sampling.md`
+  had dropped the caveat `evolution.md` carried, that the difficulty-weighted
+  numbers are a *targeting* measurement and not an accuracy claim; `evolution.md`
+  kept full copies of sections that now have their own pages while linking away
+  to them; and the `AggregatorConfig` reference omitted `trust_region_chars`,
+  which is the per-file cap a `FileTree` caller has to know about.
+
 ### Documentation
 - **The documentation site was rebuilt as a reference, not a tour.** It had 23
   pages covering 7 of 21 modules and no API reference at all: a reader who wanted

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Full docs live in [`docs/`](https://github.com/Birfy/agentdescent/tree/main/docs
 | **[Measured results](https://github.com/Birfy/agentdescent/blob/main/docs/results.md)** | Every empirical claim with the setup that produced it — including where there was nothing to learn |
 | [Architecture](https://github.com/Birfy/agentdescent/blob/main/docs/architecture.md) | Components, data-flow diagram, the two runtimes, concurrency model |
 | [Concepts](https://github.com/Birfy/agentdescent/blob/main/docs/concepts.md) | The training↔RSI analogy, staleness, the aggregator, the three long tails, governance |
-|  [Install, run, extend](https://github.com/Birfy/agentdescent/blob/main/docs/usage.md) | Running the demos, config reference, **plugging in your own `Evolvable` domain** |
+|  [Run everything, and extend it](https://github.com/Birfy/agentdescent/blob/main/docs/usage.md) | Every demo with its output, config reference, **plugging in your own `Evolvable` domain** |
 | [Evolving anything](https://github.com/Birfy/agentdescent/blob/main/docs/evolution.md) | The general engine — evolve any artifact by writing its `Strategy` + `run`/`reward`/`propose` |
 | [Connecting agents & LLMs](https://github.com/Birfy/agentdescent/blob/main/docs/agents.md) | The provider-agnostic completion layer |
 | [Loading datasets](https://github.com/Birfy/agentdescent/blob/main/docs/dataloader.md) | The `agentdescent.dataloader` data layer — HF datasets-server + raw-file fetch, cached, dependency-free |

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -366,7 +366,7 @@ class Aggregator:
             elif action is StaleAction.REBASE:
                 # cheaply re-verify the delta still holds on the current head.
                 candidate = artifact.apply(card.diff)
-                if artifact.cheap_eval(card) <= candidate.cheap_eval(card):
+                if artifact.evidence_eval(card) <= candidate.evidence_eval(card):
                     survivors.append(card.rebased_onto(head))
                 else:
                     discarded.append(card)
@@ -553,6 +553,16 @@ class Aggregator:
         base_score = self.verifier.cheap_eval(artifact)
         cand_score = self.verifier.cheap_eval(best_state)
 
+        # The full held-out rates. The regression guard below must use *these*
+        # rather than `cand_score`/`base_score`: those come from the cheap layer,
+        # which `cheap_eval_tasks` sub-samples -- so a 4-task sample could veto a
+        # commit the full-set Beta test had just approved, while three comments and
+        # two doc pages promised sub-sampling "never affects commit safety". It was
+        # the promise that was wrong, not the intent; the guard is meant to stop a
+        # measured regression, and ground truth is what measures one.
+        base_full = base_s / max(1e-9, base_s + base_f)
+        cand_full = cand_s / max(1e-9, cand_s + cand_f)
+
         baseline_post = BetaPosterior(prior.successes + base_s, prior.failures + base_f)
         candidate_post = BetaPosterior(prior.successes + cand_s, prior.failures + cand_f)
         # fold each contributing worker's local before/after delta as extra
@@ -588,8 +598,6 @@ class Aggregator:
         # The signal is free here: `eval_counts` already scored base and candidate
         # on the full held-out set for the Beta test above, so comparing its verdict
         # with the cheap layer's costs nothing and happens on every merge.
-        base_full = base_s / max(1e-9, base_s + base_f)
-        cand_full = cand_s / max(1e-9, cand_s + cand_f)
         if cand_full != base_full or cand_score != base_score:
             self.audit.update_trust(
                 artifact_id, (cand_full > base_full) == (cand_score > base_score))
@@ -609,11 +617,18 @@ class Aggregator:
         # the new head, so it deserves another look; one rejected here was judged and
         # lost, and its tournament rivals scored below it on the same held-out set.
         # Re-filing them would just buy the same rejection again.
-        if p_improve <= 1.0 - delta or cand_score < base_score:
-            prior.observe_delta(cand_score - base_score)
+        regressed = cand_full < base_full
+        if p_improve <= 1.0 - delta or regressed:
+            prior.observe_delta(cand_full - base_full)
+            # Name the gate that actually fired. Reporting the posterior either way
+            # printed lines like `P(delta>0)=0.97 <= 0.50` when the regression guard
+            # was the real cause -- self-contradictory to anyone reading `outcomes()`
+            # to find out why nothing committed, which is the one job it has.
+            reason = (f"held-out regression {base_full:.3f} -> {cand_full:.3f}"
+                      if regressed else
+                      f"P(delta>0)={p_improve:.2f} <= {1-delta:.2f}")
             return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
-                               len(discarded), conflicts, p_improve, None,
-                               f"P(delta>0)={p_improve:.2f} <= {1-delta:.2f}",
+                               len(discarded), conflicts, p_improve, None, reason,
                                MergeOutcome.BELOW_THRESHOLD)
 
         # -- commit (section 4.1): CAS on dev --------------------------------

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -46,6 +46,7 @@ from .evolvable import ContractError, EvidenceCard, vv_staleness
 from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import DurationEstimator
+from .pipeline import WorkerHealth
 from .staleness import StaleAction, StalenessPolicy, get_policy
 
 
@@ -249,7 +250,9 @@ def async_evolve(
     n_live = sum(1 for s in shards if s)      # workers that will actually start
     live = [n_live]                           # workers still running
     retired = [0]                             # workers that gave up (diagnostic)
-    any_success = [False]                     # has ANY worker ever completed one?
+    # Retirement policy is shared with AsyncAgentDescent (`pipeline.WorkerHealth`),
+    # which is what keeps the two barrier-free runtimes from drifting apart again.
+    health = WorkerHealth(max_errors=max_worker_errors)
     max_merger_errors = max(3, max_worker_errors)   # sweeps it may fail in a row
 
     def _worker(wid: int, shard: List[Task]) -> None:
@@ -361,7 +364,7 @@ def async_evolve(
                 # only guarantees the run dies. Measured: at a 1-in-3 call failure
                 # rate (~56% per rollout, an ordinary 429 storm) the old blanket
                 # rule retired all three workers in 22s with nothing learned.
-                if not any_success[0] and consecutive >= max_worker_errors:
+                if health.should_retire(consecutive):
                     with counter_lock:
                         retired[0] += 1
                         live[0] -= 1
@@ -369,7 +372,7 @@ def async_evolve(
                             died[0] = True
                             stop.set()
                     return
-                if any_success[0] and consecutive >= max_worker_errors and not warned:
+                if health.should_warn(consecutive) and not warned:
                     warned = True   # a backend that dies mid-run must not look idle
                     warnings.warn(
                         f"async_evolve: worker {wid} has failed {consecutive} "
@@ -395,7 +398,7 @@ def async_evolve(
                     with counter_lock:
                         stragglers[0] += 1
             consecutive, warned = 0, False                    # a clean rollout resets
-            any_success[0] = True
+            health.record_success()
             with counter_lock:
                 counter[0] += 1
                 if max_iters is not None and counter[0] >= max_iters:
@@ -418,7 +421,7 @@ def async_evolve(
                 eng.aggregator.ingest(card if eta == 0 else card.rebased_onto(head_vv))
             elif action is StaleAction.REBASE:
                 cand = head_art.apply(card.diff)         # cheap re-verify on current head
-                if head_art.cheap_eval(card) <= cand.cheap_eval(card):
+                if head_art.evidence_eval(card) <= cand.evidence_eval(card):
                     eng.aggregator.ingest(card.rebased_onto(head_vv))
             # DISCARD -> drop the card
         reports = check_reports(eng.aggregator.step(), eng.aggregator)

--- a/agentdescent/async_runtime.py
+++ b/agentdescent/async_runtime.py
@@ -49,6 +49,7 @@ from .scheduler import (
     TaskCluster,
     TaskScheduler,
 )
+from .pipeline import WorkerHealth
 from .staleness import StalenessPolicy, get_policy
 from .verifier import ThreeLayerVerifier, VerifierBudget
 from .worker import Worker
@@ -159,10 +160,10 @@ class AsyncAgentDescent:
         # nothing commits), forcing every worker to sync regardless of the ratio.
         self._refresh_epoch = 0
         self._stats_lock = threading.Lock()
-        # worker resilience: retire a worker only while NO worker has ever
-        # succeeded (see _worker_loop); the run ends once every worker has retired.
+        # Worker resilience, shared with the general pipeline so the two cannot
+        # drift apart again: the run ends once every worker has retired.
         self._live_workers = len(self.workers)
-        self._any_success = False
+        self._health = WorkerHealth(max_errors=self._MAX_WORKER_ERRORS)
 
     # -- shared head bookkeeping (ROLL Flash async ratio) --------------------
 
@@ -222,18 +223,10 @@ class AsyncAgentDescent:
                 with self._stats_lock:
                     if self.stats.error is None:
                         self.stats.error = f"{type(e).__name__}: {str(e)[:200]}"
-                # Two situations wear the same exception and want opposite
-                # responses, and this used to treat them alike -- the blanket rule
-                # `async_evolve` removed after measuring it. Keyed on a worker's own
-                # history, an intermittent backend retires whoever loses its first
-                # few rolls even though nothing is wrong with it; and since every
-                # worker shares one backend, shedding workers cannot relieve the
-                # throttling and only guarantees the run dies. Measured there at a
-                # 1-in-3 call failure rate: all three workers retired in 22s with
-                # nothing learned. The test is global -- while NO worker has ever
-                # completed a rollout the backend is misconfigured, so give up fast;
-                # once any has, it demonstrably works and this is a transient.
-                if not self._any_success and consecutive >= self._MAX_WORKER_ERRORS:
+                # Retirement policy is shared with `async_evolve` -- see
+                # `agentdescent.pipeline.WorkerHealth` for why it is global rather
+                # than per-worker, and what was measured when it was not.
+                if self._health.should_retire(consecutive):
                     with self._stats_lock:
                         self._live_workers -= 1
                         self.stats.retired_workers += 1
@@ -241,17 +234,17 @@ class AsyncAgentDescent:
                     if all_dead:
                         self._stop.set()      # nothing can make progress any more
                     return
-                if self._any_success and consecutive == self._MAX_WORKER_ERRORS:
+                if self._health.should_warn(consecutive):
                     warnings.warn(
                         f"{worker.worker_id} has failed {consecutive} rollouts in a "
                         f"row and is backing off, not retiring (it succeeded "
                         f"earlier, so this reads as transient). Last error: "
                         f"{type(e).__name__}: {str(e)[:120]}",
                         RuntimeWarning, stacklevel=2)
-                self._stop.wait(min(2.0 ** consecutive, 5.0))
+                self._stop.wait(self._health.backoff(consecutive))
                 continue
             consecutive = 0
-            self._any_success = True     # the backend demonstrably works
+            self._health.record_success()   # the backend demonstrably works
             elapsed = time.time() - t0
             if self.estimator is not None:
                 self.estimator.observe(cost, elapsed)

--- a/agentdescent/domains/router.py
+++ b/agentdescent/domains/router.py
@@ -43,7 +43,11 @@ class RouterTask:
     keyword: str
 
 
-#: Back-compatible alias. Prefer :class:`RouterTask` in new code.
+#: Back-compatible alias, kept only because it is a published name. It collides
+#: with :class:`agentdescent.evolution.Task` -- the one every caller writes
+#: against -- and the two share no fields and no relationship, so a reader who
+#: followed `AgentDescent -> Worker -> Task` landed on the wrong class with no
+#: signal. Nothing inside the package uses it any more; prefer `RouterTask`.
 Task = RouterTask
 
 
@@ -89,7 +93,7 @@ class RouterSkill:
         new_table.update(diff.ops)
         return RouterSkill(self.id, new_table, self.version + 1, self.blast_radius)
 
-    def cheap_eval(self, evidence: EvidenceCard) -> float:
+    def evidence_eval(self, evidence: EvidenceCard) -> float:
         """Accuracy on the tasks the evidence card carries.
 
         The card's ``trajectory_refs`` hold the failing :class:`Task` objects
@@ -97,6 +101,11 @@ class RouterSkill:
         (design doc, section 4.2)."""
         tasks = [t for t in evidence.trajectory_refs if isinstance(t, Task)]
         return self.accuracy(tasks)
+
+
+    #: Back-compatible alias for :meth:`evidence_eval`, which it was called until
+    #: the name collided with the verifier's `cheap_eval(artifact)`.
+    cheap_eval = evidence_eval
 
     def full_eval(self, task_set: Sequence[Task]) -> Mapping[str, float]:
         return {"accuracy": self.accuracy(task_set)}

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -217,144 +217,18 @@ def claude_agent(model: str = "claude-opus-4-8", max_tokens: int = 1024) -> LLMA
 # ---------------------------------------------------------------------------
 # Strategy: what evolves and how a proposal becomes a change
 # ---------------------------------------------------------------------------
+# Strategies -- what evolves. They live in their own modules, one per family:
+# `strategies` (text) and `treestrategy` (a directory). Re-exported here because
+# `from agentdescent.evolution import AppendRules` is a published import path.
+# ---------------------------------------------------------------------------
 
-
-def rule_id(text: str) -> str:
-    """Content-address a proposal so identical proposals dedupe automatically."""
-    return "r" + hashlib.sha1(text.strip().lower().encode()).hexdigest()[:10]
-
-
-@runtime_checkable
-class Strategy(Protocol):
-    """Defines *what evolves and how* -- the representation and the merge rule.
-
-    An artifact's state is a flat ``{key: value}`` dict (the diff op-space the
-    aggregator resolves conflicts and fusion over). A strategy decides the
-    initial state, how it renders, and how a proposal becomes a :class:`Diff`."""
-
-    def initial(self) -> Dict[str, str]: ...
-
-    def render(self, state: Dict[str, str]) -> str: ...
-
-    def to_diff(self, state: Dict[str, str], proposal: str, author: str,
-                base_version: int, target: str) -> Optional[Diff]: ...
-
-    # Optional. A strategy that knows, ahead of time, every key it can write should
-    # say so: that declared space is what tensor parallelism partitions into
-    # sections. A strategy that content-addresses its keys (AppendRules) has no
-    # such space, so it simply does not implement this -- and `evolve()` refuses to
-    # pair it with TP rather than silently dropping most of its proposals.
-    # def keys(self) -> Sequence[str]: ...
-
-
-@dataclass
-class AppendRules:
-    """Accumulate a deduped list of rules/lessons (append-only, content-addressed).
-
-    Identical proposals from different workers collapse to one; complementary
-    rules are *fused* by the aggregator."""
-
-    title: str = "# Playbook"
-
-    def initial(self) -> Dict[str, str]:
-        return {}
-
-    def render(self, state: Dict[str, str]) -> str:
-        if not state:
-            return f"{self.title}\n(empty)"
-        return "\n".join([self.title] + [f"- {state[k]}" for k in sorted(state)])
-
-    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
-        rid = rule_id(proposal)
-        if rid in state:
-            return None
-        return Diff(diff_id=f"{author}:{rid}:{base_version}", target=target,
-                    ops={rid: proposal}, author=author)
-
-
-@dataclass
-class SingleSlot:
-    """The artifact **is one value**, and each accepted proposal replaces it.
-
-    The most common thing anyone evolves -- a system prompt, an instruction, one
-    document -- and until now every caller wrote this themselves (three of the
-    shipped algorithm ports each rolled their own variant). Competing proposals
-    contradict on the same key, so the aggregator resolves them on held-out score
-    and the best replacement wins:
-
-        evolve(tasks, reward, agent=agent,
-               strategy=SingleSlot(initial_value="Answer concisely."))
-
-    ``key`` names the slot in the artifact state and ``initial_value`` seeds it.
-    ``min_chars`` is the shortest proposal worth taking, which guards against a
-    reflector that replies with a terse non-answer; ``empty_render`` is what the
-    artifact renders as before anything has been accepted."""
-
-    initial_value: str = ""
-    key: str = "value"
-    empty_render: str = "(no instruction yet)"
-    min_chars: int = 1
-
-    def keys(self) -> Sequence[str]:
-        """The artifact is one slot, so the key space has exactly one member.
-
-        Declared so ``evolve()`` can reject ``TensorParallel`` up front: a single
-        key cannot be split into disjoint sections, so every worker but one would
-        be authorised for nothing."""
-        return [self.key]
-
-    def initial(self) -> Dict[str, str]:
-        return {self.key: self.initial_value} if self.initial_value else {}
-
-    def render(self, state: Dict[str, str]) -> str:
-        return state.get(self.key) or self.empty_render
-
-    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
-        text = (proposal or "").strip()
-        if len(text) < self.min_chars or state.get(self.key) == text:
-            return None
-        return Diff(diff_id=f"{author}:{self.key}:{base_version}", target=target,
-                    ops={self.key: text}, author=author)
-
-
-@dataclass
-class KeyedRules:
-    """One entry per *category*: competing proposals contradict and are resolved.
-
-    Proposals look like ``"category: text"``. A new proposal for an existing
-    category **overwrites** it, so two workers proposing different text for the
-    same category produce a contradiction the aggregator resolves (keeping the
-    one that scores better). Unknown categories fall back to append behaviour."""
-
-    categories: Sequence[str]
-    title: str = "# Config (by category)"
-
-    def keys(self) -> Sequence[str]:
-        """The declared categories -- the key space tensor parallelism partitions.
-
-        Note that an *unrecognised* proposal still falls back to a content-addressed
-        key, which is outside this space; under TP those are reported as
-        ``section-violation`` rather than silently dropped."""
-        return list(self.categories)
-
-    def initial(self) -> Dict[str, str]:
-        return {}
-
-    def render(self, state: Dict[str, str]) -> str:
-        if not state:
-            return f"{self.title}\n(empty)"
-        return "\n".join([self.title] + [f"## {k}\n{state[k]}" for k in sorted(state)])
-
-    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
-        m = re.match(r"\s*([\w\- ]+?)\s*:\s*(.+)", proposal, re.DOTALL)
-        if m and m.group(1).strip().lower() in {c.lower() for c in self.categories}:
-            key, value = m.group(1).strip().lower(), m.group(2).strip()
-        else:
-            key, value = rule_id(proposal), proposal.strip()
-        if state.get(key) == value:
-            return None
-        return Diff(diff_id=f"{author}:{key}:{base_version}", target=target,
-                    ops={key: value}, author=author)
+from .strategies import (  # noqa: E402
+    AppendRules,
+    KeyedRules,
+    SingleSlot,
+    Strategy,
+    rule_id,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -458,7 +332,13 @@ class EvolvingArtifact:
         return self._strategy.render(self.state)
 
     def diff(self, other: "EvolvingArtifact") -> Diff:
-        ops = {k: v for k, v in other.state.items() if self.state.get(k) != v}
+        ops: Dict[str, Optional[str]] = {
+            k: v for k, v in other.state.items() if self.state.get(k) != v}
+        # A key `other` no longer has is a *deletion*, and leaving it out made
+        # `a.apply(a.diff(b))` differ from `b` -- silently, and only for the case
+        # that matters most to a file tree, where a key is a path. `apply` learned
+        # the `None` sentinel; this is the other half of it.
+        ops.update({k: None for k in self.state if k not in other.state})
         return Diff(diff_id=f"{self.id}:diff", target=self.id, ops=ops)
 
     def apply(self, diff: Diff) -> "EvolvingArtifact":
@@ -514,11 +394,19 @@ class EvolvingArtifact:
             scores = list(pool.map(lambda t: self._rt.eval_one(self, t), tasks))
         return sum(scores) / len(scores)
 
-    def cheap_eval(self, evidence: EvidenceCard) -> float:
+    def evidence_eval(self, evidence: EvidenceCard) -> float:
         return self.score([t for t in evidence.trajectory_refs if isinstance(t, Task)])
 
     def full_eval(self, task_set: Sequence[Task]) -> Dict[str, float]:
+        """Score on a task set. No longer part of the `Evolvable` protocol -- the
+        engine reaches ground truth through the verifier's `eval_fn` -- and kept
+        because it is a convenient thing for a caller to have."""
         return {"reward": self.score(task_set)}
+
+    #: Back-compatible alias for :meth:`evidence_eval`, which it was called until
+    #: the name collided with the verifier's `cheap_eval(artifact)`.
+    cheap_eval = evidence_eval
+
 
 
 @dataclass
@@ -1078,9 +966,11 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     # `oracle_budget` capped nothing (its documented fallback, `rule_eval`, returned
     # the same value it was trying to avoid buying).
     #
-    # Ranking is what the cheap layer is for; committing is not. `eval_counts` --
-    # the Beta-posterior acceptance test -- still uses the whole held-out set, so
-    # sub-sampling trades tournament precision, never commit safety. Noise stays at
+    # Ranking is what the cheap layer is for; committing is not. Both gates that
+    # decide a commit -- the Beta-posterior test and the regression guard beside it
+    # -- read the FULL held-out set via `eval_counts`, so sub-sampling trades
+    # tournament precision and nothing else. (The guard used to read the cheap
+    # layer, which made that claim false; see `Aggregator._process`.) Noise stays at
     # zero: `eval_fn` is deterministic, so the sub-sample is the only approximation
     # and inventing more would just make the ranking worse.
     cheap = (len(held_out) if cheap_eval_tasks is None
@@ -1313,10 +1203,12 @@ def evolve(
         tournament, which run once per candidate. ``None`` (default) scores the
         whole held-out set, which is exact but means a full sweep of real agent
         calls per candidate. Set it to trade ranking precision for cost; the
-        acceptance test always scores the full set, so this never affects whether
-        a change is safe to commit, only which candidate is put forward. The
+        commit gates always score the full set, so this never affects whether a
+        change is safe to commit, only which candidate is put forward. The
         sample is fixed for the run, so candidates are always compared
-        like-for-like.
+        like-for-like. Both commit gates -- the acceptance test and the regression
+        guard -- score the full set, so this never decides whether a change is
+        committed, only which candidate is put forward.
     on_round:
         Called with each :class:`RoundInfo` as the round completes -- progress
         for a long run, which otherwise reports nothing until it returns. An

--- a/agentdescent/evolvable.py
+++ b/agentdescent/evolvable.py
@@ -51,7 +51,10 @@ VersionVector = Dict[str, int]
 
 
 def vv_dominates(a: VersionVector, b: VersionVector) -> bool:
-    """Return True if ``a`` is at least as new as ``b`` on every shared key."""
+    """Return True if ``a`` is at least as new as ``b`` on every shared key.
+
+    A primitive, not part of a path: the engines compare versions through
+    :func:`vv_staleness`, which answers *how* stale rather than *whether*."""
     return all(a.get(k, 0) >= v for k, v in b.items())
 
 
@@ -149,6 +152,13 @@ class Evolvable(Protocol):
     Anything implementing this protocol can be registered into the evolution
     loop.  ``blast_radius`` drives automatic layering into L0/L1/L2 (design
     doc, section 6) -- it is *estimated*, not human-annotated.
+
+    ``evidence_eval`` scores this artifact against the trajectories an evidence
+    card carries. It was called ``cheap_eval`` until it collided with
+    :meth:`~agentdescent.verifier.ThreeLayerVerifier.cheap_eval`, which takes an
+    *artifact* and means something else -- and both are called from the same forty
+    lines of the aggregator. ``cheap_eval`` remains as an alias on the shipped
+    implementations so existing code keeps working.
     """
 
     id: str
@@ -158,8 +168,14 @@ class Evolvable(Protocol):
 
     def diff(self, other: "Evolvable") -> Diff: ...
     def apply(self, diff: Diff) -> "Evolvable": ...
-    def cheap_eval(self, evidence: EvidenceCard) -> float: ...
-    def full_eval(self, task_set: Any) -> Mapping[str, float]: ...
+    def evidence_eval(self, evidence: EvidenceCard) -> float: ...
+
+    # `full_eval(task_set) -> Mapping[str, float]` used to sit here as a fourth
+    # requirement. Nothing ever called it: ground truth reaches the aggregator
+    # through the verifier's `eval_fn`, which the *domain* supplies, so the
+    # artifact never had to know how to score itself on a task set. Requiring a
+    # method the engine does not use is a tax on everyone who implements this
+    # protocol, so it is gone; implementations are free to keep one.
 
 
 # A convenience alias for factory functions that reconstruct an Evolvable from

--- a/agentdescent/ledger.py
+++ b/agentdescent/ledger.py
@@ -32,7 +32,7 @@ import os
 import subprocess
 import threading
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
 from .evolvable import Diff, Evolvable, VersionVector
 
@@ -42,7 +42,12 @@ class CASConflict(Exception):
 
 
 class ContractRejected(Exception):
-    """Raised when the ledger refuses a diff bound to a superseded major."""
+    """Raised when a commit would change an artifact's contract major.
+
+    An artifact's :class:`~agentdescent.evolvable.Contract` is what *other*
+    artifacts depend on. Bumping its major is a breaking change, and letting one
+    through the ordinary commit path would silently invalidate every dependant --
+    so it is refused here and has to go through a deliberate re-registration."""
 
 
 # A serializer turns an Evolvable into a JSON-friendly dict; the deserializer
@@ -151,6 +156,9 @@ class Ledger:
         self._author = author
         self._lock = threading.RLock()
         self._current_branch: Optional[str] = None   # see _checkout()
+        #: artifact id -> the Contract it was registered with. Commits are checked
+        #: against it, which is the only place the contract mechanism is enforced.
+        self._contracts: Dict[str, Any] = {}
         self._closed = False
         self._init_repo()
 
@@ -232,7 +240,12 @@ class Ledger:
     # -- public API -----------------------------------------------------------
 
     def register(self, artifact: Evolvable, branch: str = DEV) -> None:
-        """Add a brand-new artifact at version 1 on both branches."""
+        """Add a brand-new artifact at version 1 on both branches.
+
+        Also records the artifact's contract, which :meth:`commit` then enforces.
+        Re-registering an existing artifact is a no-op for its state, and is the
+        one supported way to move a contract to a new major."""
+        self._contracts[artifact.id] = getattr(artifact, "contract", None)
         with self._lock:
             self._ensure_open()
             for br in (self.STABLE, self.DEV):
@@ -310,12 +323,31 @@ class Ledger:
                 raise CASConflict(
                     f"{aid}: head={head} but diff based on {expected}"
                 )
+            self._assert_contract(new_state)
             new_version = head + 1
             self._dump_artifact(new_state, new_version)
             vv[aid] = new_version
             self._write_versions(vv)
             commit_hash = self._commit(message or f"update {aid} -> v{new_version}")
             return commit_hash, new_version
+
+    def _assert_contract(self, new_state: Evolvable) -> None:
+        """Refuse a commit that would change the registered contract major.
+
+        The check the design calls for and the codebase never made: `Contract`,
+        `Contract.is_compatible_with` and `ContractRejected` all existed, nothing
+        called any of them, and the docstrings described an enforcement that was
+        not there. Comparing against the contract recorded at
+        :meth:`register` needs no change to any serializer."""
+        known = self._contracts.get(new_state.id)
+        incoming = getattr(new_state, "contract", None)
+        if known is None or incoming is None:
+            return
+        if not known.is_compatible_with(incoming):
+            raise ContractRejected(
+                f"{new_state.id}: contract major {incoming.major} is incompatible "
+                f"with the registered major {known.major}. A breaking contract "
+                "change must be re-registered deliberately, not merged.")
 
     def commit_atomic(
         self,
@@ -325,6 +357,10 @@ class Ledger:
         message: str = "",
     ) -> Tuple[str, VersionVector]:
         """Two-phase, all-or-nothing commit of several artifacts.
+
+        **Not in any engine path.** `evolve()` and both async runtimes register a
+        single artifact, so there is never a second one to commit with. Provided
+        and tested for the multi-artifact library the design targets.
 
         Used for contract-breaking diffs that must land together with their
         adapter diffs (design doc, section 6, "atomic adaptation transaction").

--- a/agentdescent/parallel.py
+++ b/agentdescent/parallel.py
@@ -27,10 +27,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
-from .domains.router import RouterSkill
-from .evolvable import Diff, stable_hash
+from .evolvable import Diff, Evolvable, stable_hash
 
 
+#: Names for the three paradigms. Descriptive -- nothing dispatches on it; the
+#: strategy objects below are what `evolve(parallel=...)` takes.
 class ParallelMode(Enum):
     DP = "data_parallel"
     TP = "tensor_parallel"
@@ -87,21 +88,40 @@ class TensorParallelMerge:
 
     Because sections are disjoint, there is no conflict to resolve -- the merge
     is a union.  The consistency reviewer only asserts the no-overlap invariant
-    that makes that union sound (the cheap all-reduce analogue)."""
+    that makes that union sound (the cheap all-reduce analogue).
+
+    ``keys`` is the artifact's declared key space, and passing it matters: with it
+    the ownership map is :func:`assign_key_sections`, **the same partition
+    `TensorParallel` and `evolve()` enforce**. Without it this falls back to
+    :func:`section_of`, a hash bucket -- which is a different answer to the same
+    question, so a diff legal on the `evolve()` path could be rejected here and
+    vice versa. That divergence is why the argument exists."""
 
     n_sections: int
+    keys: Optional[Sequence[str]] = None
+
+    def owner_of(self, key: str) -> int:
+        """Which section owns ``key`` -- via the declared partition when there is one."""
+        if self.keys:
+            return assign_key_sections(self.keys, self.n_sections).get(
+                key, section_of(key, self.n_sections))
+        return section_of(key, self.n_sections)
 
     def validate(self, diff: Diff, section: int) -> None:
         for key in diff.ops:
-            if section_of(key, self.n_sections) != section:
+            if self.owner_of(key) != section:
                 raise SectionViolation(
                     f"diff {diff.diff_id} touches {key!r} outside section {section}"
                 )
 
     def merge(
-        self, base: RouterSkill, section_diffs: List[Tuple[int, Diff]]
-    ) -> Tuple[RouterSkill, bool]:
-        """Return (merged_skill, consistency_ok)."""
+        self, base: Evolvable, section_diffs: List[Tuple[int, Diff]]
+    ) -> Tuple[Evolvable, bool]:
+        """Return (merged_artifact, consistency_ok).
+
+        Any :class:`~agentdescent.evolvable.Evolvable` works -- this used to be
+        typed to the reference domain's ``RouterSkill``, which made a general
+        parallelism primitive depend on the demo domain."""
         seen_keys: Dict[str, int] = {}
         merged = base
         for section, diff in section_diffs:

--- a/agentdescent/pipeline.py
+++ b/agentdescent/pipeline.py
@@ -1,0 +1,96 @@
+"""Policies shared by the two barrier-free runtimes.
+
+There are two of them -- :func:`~agentdescent.async_evolve.async_evolve` (general,
+and the only one a real workload reaches) and
+:class:`~agentdescent.async_runtime.AsyncAgentDescent` (the reference runtime the
+parallelism results were measured with). They implement the same shape against
+different substrates, and for a while they implemented it *independently*: two
+measured fixes lived in whichever pipeline they had been written for, and the
+repair was to hand-port them rather than to share them. Hand-porting works once.
+
+So the parts that are **policy** rather than plumbing live here, and both
+runtimes call them. Nothing in this module touches a ledger, a thread or a task:
+it is arithmetic over counters, which is exactly why it can be shared by two
+pipelines that agree on nothing else.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+__all__ = ["WorkerHealth", "StallGuard"]
+
+
+@dataclass
+class WorkerHealth:
+    """When a worker should give up, and when it should keep going.
+
+    The rule is not "retire after N failures", and the difference was measured:
+    every worker shares one backend, so shedding workers cannot relieve
+    throttling -- it only guarantees the run dies. Against an intermittent
+    backend at a 1-in-3 failure rate, a blanket rule retired all three workers in
+    22 seconds with nothing learned.
+
+    So a worker retires only while **no** worker has ever completed a rollout.
+    That case reads as a misconfiguration -- a wrong key, a dead endpoint -- and
+    should fail fast and loudly. Once any worker has succeeded, the backend
+    demonstrably works, failures are transient, and the run continues on whatever
+    evidence it does gather.
+    """
+
+    max_errors: int = 3
+    #: Has *any* worker ever completed a rollout? Shared across workers on
+    #: purpose: it is the whole distinction between "misconfigured" and "flaky".
+    any_success: bool = False
+    retired: int = 0
+
+    def record_success(self) -> None:
+        self.any_success = True
+
+    def should_retire(self, consecutive_failures: int) -> bool:
+        return not self.any_success and consecutive_failures >= self.max_errors
+
+    def should_warn(self, consecutive_failures: int) -> bool:
+        """A worker that keeps failing *after* the backend has proved itself.
+
+        It will not retire, so without a line here a run finishes clean at a
+        fraction of its concurrency and nothing says so."""
+        return self.any_success and consecutive_failures == self.max_errors
+
+    def retire(self) -> None:
+        self.retired += 1
+
+    def backoff(self, consecutive_failures: int, cap: float = 5.0) -> float:
+        """Seconds to wait before this worker's next attempt."""
+        return min(2.0 ** max(0, consecutive_failures), cap)
+
+
+@dataclass
+class StallGuard:
+    """Backpressure: force a resync when evidence arrives and nothing commits.
+
+    A lag budget alone livelocks when it is wider than the staleness tolerance:
+    workers propose against a snapshot too old for the policy to accept, every
+    card is discarded, the head never moves -- and because the head never moves,
+    the version-based budget never triggers a refresh either. Counting sweeps
+    that produced no commit breaks the cycle.
+
+    It also covers **cold start**, where the head has not advanced yet and a
+    version-only budget cannot engage at all.
+    """
+
+    patience: int = 50
+    _idle: int = field(default=0, repr=False)
+    forced: int = 0
+
+    def note_sweep(self, committed: bool) -> None:
+        self._idle = 0 if committed else self._idle + 1
+
+    def should_force_refresh(self) -> bool:
+        return self._idle >= self.patience
+
+    def force(self) -> None:
+        """A worker resynced because of the stall; count it and reset."""
+        self.forced += 1
+        self._idle = 0

--- a/agentdescent/sampling.py
+++ b/agentdescent/sampling.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import math
 import threading
 from collections import defaultdict
+
+from .stats import difficulty_weight
 from typing import Dict, Optional, Protocol, Sequence, Tuple, runtime_checkable
 
 
@@ -116,8 +118,11 @@ class DifficultyWeighted:
 
     @staticmethod
     def _signal(pass_rate: float) -> float:
-        """Learning signal: peaks at pass_rate 0.5, ~0 when always/never solved."""
-        return 4.0 * pass_rate * (1.0 - pass_rate) + 1e-3
+        """Learning signal: peaks at pass_rate 0.5, ~0 when always/never solved.
+
+        Shared with :class:`~agentdescent.scheduler.TaskScheduler`, which applies
+        the same weight one granularity up (clusters rather than tasks)."""
+        return difficulty_weight(pass_rate, floor=1e-3)
 
     def pick(self, keys: Sequence[str], round_index: int) -> str:
         if not keys:

--- a/agentdescent/scheduler.py
+++ b/agentdescent/scheduler.py
@@ -15,8 +15,12 @@ mechanism:
   budget to high-blast-radius, high-uncertainty, low-trust diffs, and audits the
   aggregator's own merges to prevent self-pollution (design doc, section 5.3).
 * :class:`ResumeQueue` -- L-traj (system layer): turn-level checkpoints of
-  timed-out rollouts, resumed against the *latest* ledger, yielding a free A/B
-  signal across versions (design doc, section 5.1).
+  timed-out rollouts (design doc, section 5.1). **Detection only.** The design
+  calls for resuming them against the *latest* ledger, which would yield a free
+  A/B signal across versions; nothing in the library pops this queue, so a
+  checkpoint is a record that a straggler happened, not work that continues.
+  :class:`~agentdescent.async_runtime.AsyncAgentDescent` pushes;
+  ``AsyncStats.stragglers_checkpointed`` counts.
 """
 
 from __future__ import annotations
@@ -27,7 +31,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-from .stats import ucb_score
+from .stats import difficulty_weight, ucb_score
 
 
 @dataclass
@@ -42,7 +46,19 @@ class TaskCluster:
 
 
 class TaskScheduler:
-    """UCB over task clusters, with a difficulty (zero-advantage) filter."""
+    """UCB over task clusters, with a difficulty (zero-advantage) filter.
+
+    The same shape as :class:`~agentdescent.sampling.DifficultyWeighted`, one
+    granularity up: that one picks a **task** inside a worker's shard for
+    ``evolve()``, this one leases a **cluster** to a worker in the reference
+    runtimes. They share :func:`~agentdescent.stats.difficulty_weight`.
+
+    The exploration constants differ on purpose. ``DifficultyWeighted`` defaults
+    to ``c=0.2`` because a sweep at *task* granularity measured 1.4 as worse than
+    round-robin (15.5% vs 14.5% of rollouts landing on an informative task, versus
+    23.4% at 0.2). That sweep has not been repeated at *cluster* granularity,
+    where there are far fewer arms and each carries many tasks, so the textbook
+    ``1.4`` is kept here rather than transplanting a number measured elsewhere."""
 
     def __init__(self, clusters: List[TaskCluster], c: float = 1.4) -> None:
         self.clusters: Dict[str, TaskCluster] = {cl.id: cl for cl in clusters}
@@ -54,8 +70,7 @@ class TaskScheduler:
 
     def _difficulty_weight(self, cl: TaskCluster) -> float:
         """Down-weight clusters with no learning signal (GRPO zero-advantage)."""
-        # peaks at pass_rate ~0.5, ~0 at the all-pass / all-fail extremes.
-        return 4.0 * cl.pass_rate * (1.0 - cl.pass_rate) + 1e-3
+        return difficulty_weight(cl.pass_rate, floor=1e-3)
 
     def _ranked(self) -> List[TaskCluster]:
         self._t += 1
@@ -137,14 +152,24 @@ class AuditScheduler:
     audit loop over the optimizer itself.
     """
 
-    #: Cap on queued audits. Nothing in the engines drains this queue, so an
-    #: unbounded list would grow for the whole run; keep the highest-priority
-    #: items and drop the tail, which is the lowest-value work anyway.
+    #: Cap on queued audits, when queuing is on at all.
     MAX_QUEUED = 4096
 
-    def __init__(self, max_queued: int = MAX_QUEUED) -> None:
+    def __init__(self, max_queued: int = MAX_QUEUED, collect: bool = False) -> None:
+        """``collect=False`` (the default) computes priorities without queuing.
+
+        Nothing in the shipped runtimes calls :meth:`pop`, so every ``submit``
+        was a heap push plus a periodic rebuild for a queue no one would ever
+        read -- work done on the merge path, once per merge decision, for nothing.
+        The priority itself is *not* wasted: it is returned, and `force_oracle`
+        and the trust update are the parts the engine actually uses.
+
+        Pass ``collect=True`` to keep the queue for an out-of-band audit process;
+        then :meth:`pop` returns the highest-priority items and :attr:`dropped`
+        reports what the cap shed."""
         self._items: List[_AuditItem] = []          # a heap (see submit)
         self._trust: Dict[str, float] = defaultdict(lambda: 1.0)
+        self._collect = collect
         self._max_queued = max_queued
         self._dropped = 0
         self._lock = threading.Lock()               # submitted from worker threads
@@ -170,6 +195,8 @@ class AuditScheduler:
     ) -> float:
         with self._lock:
             priority = blast_radius * uncertainty / max(0.25, self._trust[artifact_id])
+            if not self._collect:
+                return priority          # see __init__: nothing drains the queue
             # heapq is a min-heap; negate so the highest priority pops first.
             # heappush is O(log n) -- a full sort per submit was O(n log n), which
             # made a long run quadratic overall.
@@ -220,7 +247,11 @@ class ResumeItem:
 
 
 class ResumeQueue:
-    """Turn-level checkpoints of timed-out rollouts (partial rollout)."""
+    """Turn-level checkpoints of timed-out rollouts (partial rollout).
+
+    Write-only in every shipped path: the runtimes push, nothing pops. Kept as
+    the primitive the resume path would need, and counted so a run reports how
+    much work it abandoned -- see the module docstring."""
 
     def __init__(self, p90_multiplier: float = 2.0) -> None:
         self.p90_multiplier = p90_multiplier

--- a/agentdescent/stats.py
+++ b/agentdescent/stats.py
@@ -89,6 +89,22 @@ def annealed_delta(base_delta: float, version: int, half_life: int = 64) -> floa
     return max(0.01, base_delta * factor)
 
 
+def difficulty_weight(pass_rate: float, floor: float = 0.0) -> float:
+    """`4*p*(1-p)` -- how much learning signal an item still carries.
+
+    Peaks at `p = 0.5` and vanishes at both extremes: something that always
+    passes yields no gradient, and neither does something that never passes
+    whatever the artifact says (the GRPO zero-advantage argument).
+
+    Lives here because two schedulers need it at two granularities --
+    :class:`~agentdescent.sampling.DifficultyWeighted` over *tasks* and
+    :class:`~agentdescent.scheduler.TaskScheduler` over task *clusters* -- and
+    they had written it out separately, which is one formula and two places for
+    it to drift."""
+    p = min(1.0, max(0.0, pass_rate))
+    return 4.0 * p * (1.0 - p) + floor
+
+
 def ucb_score(value: float, n_s: float, total: float, c: float = 1.4) -> float:
     """UCB1 acquisition used by the TaskScheduler (design doc, section 5.2).
 

--- a/agentdescent/strategies.py
+++ b/agentdescent/strategies.py
@@ -1,0 +1,171 @@
+"""The text strategies: what evolves, and how a proposal becomes a diff.
+
+A strategy answers two questions and nothing else -- what the artifact *is* (a
+flat ``{key: value}`` state) and what a proposal *means* (a :class:`Diff`).
+Everything downstream -- merging, conflict resolution, acceptance, versioning --
+is the aggregator's job and needs no cooperation.
+
+**One module per strategy family, none of them in the engine.** These three lived
+inside :mod:`agentdescent.evolution` while the file-tree strategy had a module of
+its own, so the same concept was filed two different ways depending on when it was
+written. The engine imports from here; ``from agentdescent.evolution import
+AppendRules`` still works.
+
+* here -- text artifacts: one slot, a playbook, keyed categories;
+* :mod:`agentdescent.treestrategy` -- a **directory**, one key per file path.
+
+The key space is the design decision, because it is what can be merged
+concurrently: content hashes fuse almost everything, a single slot makes every
+round a tournament, categories and file paths sit in between.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from typing import Dict, Optional, Protocol, Sequence, runtime_checkable
+
+from .evolvable import Diff
+
+__all__ = ["Strategy", "AppendRules", "SingleSlot", "KeyedRules", "rule_id"]
+
+
+def rule_id(text: str) -> str:
+    """Content-address a proposal so identical proposals dedupe automatically."""
+    return "r" + hashlib.sha1(text.strip().lower().encode()).hexdigest()[:10]
+
+
+@runtime_checkable
+class Strategy(Protocol):
+    """Defines *what evolves and how* -- the representation and the merge rule.
+
+    An artifact's state is a flat ``{key: value}`` dict (the diff op-space the
+    aggregator resolves conflicts and fusion over). A strategy decides the
+    initial state, how it renders, and how a proposal becomes a :class:`Diff`."""
+
+    def initial(self) -> Dict[str, str]: ...
+
+    def render(self, state: Dict[str, str]) -> str: ...
+
+    def to_diff(self, state: Dict[str, str], proposal: str, author: str,
+                base_version: int, target: str) -> Optional[Diff]: ...
+
+    # Optional. A strategy that knows, ahead of time, every key it can write should
+    # say so: that declared space is what tensor parallelism partitions into
+    # sections. A strategy that content-addresses its keys (AppendRules) has no
+    # such space, so it simply does not implement this -- and `evolve()` refuses to
+    # pair it with TP rather than silently dropping most of its proposals.
+    # def keys(self) -> Sequence[str]: ...
+
+
+@dataclass
+class AppendRules:
+    """Accumulate a deduped list of rules/lessons (append-only, content-addressed).
+
+    Identical proposals from different workers collapse to one; complementary
+    rules are *fused* by the aggregator."""
+
+    title: str = "# Playbook"
+
+    def initial(self) -> Dict[str, str]:
+        return {}
+
+    def render(self, state: Dict[str, str]) -> str:
+        if not state:
+            return f"{self.title}\n(empty)"
+        return "\n".join([self.title] + [f"- {state[k]}" for k in sorted(state)])
+
+    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
+        rid = rule_id(proposal)
+        if rid in state:
+            return None
+        return Diff(diff_id=f"{author}:{rid}:{base_version}", target=target,
+                    ops={rid: proposal}, author=author)
+
+
+@dataclass
+class SingleSlot:
+    """The artifact **is one value**, and each accepted proposal replaces it.
+
+    The most common thing anyone evolves -- a system prompt, an instruction, one
+    document -- and until now every caller wrote this themselves (three of the
+    shipped algorithm ports each rolled their own variant). Competing proposals
+    contradict on the same key, so the aggregator resolves them on held-out score
+    and the best replacement wins:
+
+        evolve(tasks, reward, agent=agent,
+               strategy=SingleSlot(initial_value="Answer concisely."))
+
+    ``key`` names the slot in the artifact state and ``initial_value`` seeds it.
+    ``min_chars`` is the shortest proposal worth taking, which guards against a
+    reflector that replies with a terse non-answer; ``empty_render`` is what the
+    artifact renders as before anything has been accepted."""
+
+    initial_value: str = ""
+    key: str = "value"
+    empty_render: str = "(no instruction yet)"
+    min_chars: int = 1
+
+    def keys(self) -> Sequence[str]:
+        """The artifact is one slot, so the key space has exactly one member.
+
+        Declared so ``evolve()`` can reject ``TensorParallel`` up front: a single
+        key cannot be split into disjoint sections, so every worker but one would
+        be authorised for nothing."""
+        return [self.key]
+
+    def initial(self) -> Dict[str, str]:
+        return {self.key: self.initial_value} if self.initial_value else {}
+
+    def render(self, state: Dict[str, str]) -> str:
+        return state.get(self.key) or self.empty_render
+
+    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
+        text = (proposal or "").strip()
+        if len(text) < self.min_chars or state.get(self.key) == text:
+            return None
+        return Diff(diff_id=f"{author}:{self.key}:{base_version}", target=target,
+                    ops={self.key: text}, author=author)
+
+
+@dataclass
+class KeyedRules:
+    """One entry per *category*: competing proposals contradict and are resolved.
+
+    Proposals look like ``"category: text"``. A new proposal for an existing
+    category **overwrites** it, so two workers proposing different text for the
+    same category produce a contradiction the aggregator resolves (keeping the
+    one that scores better). Unknown categories fall back to append behaviour."""
+
+    categories: Sequence[str]
+    title: str = "# Config (by category)"
+
+    def keys(self) -> Sequence[str]:
+        """The declared categories -- the key space tensor parallelism partitions.
+
+        Note that an *unrecognised* proposal still falls back to a content-addressed
+        key, which is outside this space; under TP those are reported as
+        ``section-violation`` rather than silently dropped."""
+        return list(self.categories)
+
+    def initial(self) -> Dict[str, str]:
+        return {}
+
+    def render(self, state: Dict[str, str]) -> str:
+        if not state:
+            return f"{self.title}\n(empty)"
+        return "\n".join([self.title] + [f"## {k}\n{state[k]}" for k in sorted(state)])
+
+    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
+        m = re.match(r"\s*([\w\- ]+?)\s*:\s*(.+)", proposal, re.DOTALL)
+        if m and m.group(1).strip().lower() in {c.lower() for c in self.categories}:
+            key, value = m.group(1).strip().lower(), m.group(2).strip()
+        else:
+            key, value = rule_id(proposal), proposal.strip()
+        if state.get(key) == value:
+            return None
+        return Diff(diff_id=f"{author}:{key}:{base_version}", target=target,
+                    ops={key: value}, author=author)
+
+

--- a/agentdescent/verifier.py
+++ b/agentdescent/verifier.py
@@ -52,8 +52,9 @@ class ThreeLayerVerifier:
     eval_fn: EvalFn
     held_out: Sequence
     #: How many held-out items the *cheap* layers score. Smaller is cheaper and
-    #: noisier; the acceptance test (:meth:`eval_counts`) always uses the full set,
-    #: so this trades tournament precision, not commit safety.
+    #: noisier. Everything that decides a *commit* -- the Beta-posterior acceptance
+    #: test and the regression guard beside it -- goes through :meth:`eval_counts`
+    #: on the full set, so this trades ranking precision and nothing else.
     rule_subset: int = 8
     learned_noise: float = 0.04
     seed: int = 0

--- a/agentdescent/worker.py
+++ b/agentdescent/worker.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Sequence
 
 from .evolvable import Diff, EvidenceCard, VersionVector, stable_hash
-from .domains.router import RouterSkill, Task
+from .domains.router import RouterSkill, RouterTask
 
 
 @dataclass
@@ -42,7 +42,7 @@ class Worker:
         self,
         skill: RouterSkill,
         base_version: VersionVector,
-        tasks: Sequence[Task],
+        tasks: Sequence[RouterTask],
     ) -> Optional[EvidenceCard]:
         """One rollout: classify tasks, propose a corrective diff for failures."""
         if self.rollout_latency is not None:
@@ -52,7 +52,7 @@ class Worker:
             return None
 
         # choose up to max_ops distinct failing keywords to fix this round.
-        seen: Dict[str, Task] = {}
+        seen: Dict[str, RouterTask] = {}
         for t in failures:
             if t.keyword not in seen:
                 seen[t.keyword] = t

--- a/docs/aggregator.md
+++ b/docs/aggregator.md
@@ -97,7 +97,8 @@ evolve(tasks, reward, agent=agent, agg_config=AggregatorConfig(
     avoid buying.
 
     `cheap_eval_tasks=N` scores N held-out tasks for ranking. The acceptance test
-    still uses the full set, so this trades ranking precision, never commit safety.
+    still uses the full set — as does the regression guard beside it — so this
+    trades ranking precision, never commit safety.
     The sample is **fixed for the run** — it used to be redrawn on every call,
     which is harmless only while the "sample" is the whole set, and silently scores
     candidate A on `{1,3,5}` against candidate B on `{2,4,6}` the moment it is not.

--- a/docs/algo-ace.md
+++ b/docs/algo-ace.md
@@ -105,7 +105,7 @@ for 8 rounds over 57 tasks — well under a cent at `deepseek-v4-flash` prices.
     actually fails: widen `--top-k` (rarer, more confusable concepts) until the
     baseline leaves headroom. The same effect is visible in
     [EvoSkill](algo-evoskill.md#empirical-results-real-openhands-agent-deepseek-on-officeqa),
-    and it is why [`DifficultyWeighted` task sampling](evolution.md#task-selection-which-rollout-to-spend)
+    and it is why [`DifficultyWeighted` task sampling](sampling.md)
     exists — it steers rollouts toward the tasks that still fail.
 
 ### `--top-k` sets the difficulty

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ page and the code disagree, so a signature here is the signature you get.
 Each section links to the page that explains *why* the module is shaped the
 way it is; this page is the *what*.
 
-135 public names across 23 modules.
+135 public names across 24 modules.
 
 ---
 
@@ -19,10 +19,6 @@ way it is; this page is the *what*.
 ### `Agent`
 
 Convenience actor: bundles running a task and proposing an improvement.
-
-### `AppendRules(title: str = '# Playbook') -> None`
-
-Accumulate a deduped list of rules/lessons (append-only, content-addressed).
 
 ### `EvolutionResult(...)`
 
@@ -38,15 +34,8 @@ An `Evolvable`: flat state + a strategy.
 
 | method | what it does |
 |---|---|
+| `full_eval(task_set: Sequence[Task]) -> Dict[str, float]` | Score on a task set. No longer part of the `Evolvable` protocol -- the engine reaches ground truth through the verifier's `eval_fn` -- and kept because it is a convenient thing for a caller to have. |
 | `score(tasks: Sequence[Task]) -> float` | Mean reward over `tasks`, evaluated concurrently. |
-
-### `KeyedRules(categories: Sequence[str], title: str = '# Config (by category)') -> None`
-
-One entry per *category*: competing proposals contradict and are resolved.
-
-| method | what it does |
-|---|---|
-| `keys() -> Sequence[str]` | The declared categories -- the key space tensor parallelism partitions. |
 
 ### `LLMAgent(...)`
 
@@ -61,18 +50,6 @@ Adapt a `Completion` (from `agents`) into an `Agent`.
 The caller's `reward` returned something outside the documented contract.
 
 ### `RoundInfo(...)`
-
-### `SingleSlot(...)`
-
-The artifact **is one value**, and each accepted proposal replaces it.
-
-| method | what it does |
-|---|---|
-| `keys() -> Sequence[str]` | The artifact is one slot, so the key space has exactly one member. |
-
-### `Strategy`
-
-Defines *what evolves and how* -- the representation and the merge rule.
 
 ### `Task(id: str, prompt: str, meta: Dict[str, Any] = <factory>) -> None`
 
@@ -89,10 +66,6 @@ Evolve an artifact. Provide either `agent` (with `solve`/`propose`) or the `run`
 ### `reflector(...)`
 
 Use any model as the *reflector* for an agent you already have.
-
-### `rule_id(text: str) -> str`
-
-Content-address a proposal so identical proposals dedupe automatically.
 
 ### `tasks_from(...)`
 
@@ -379,7 +352,7 @@ Raised when a commit's declared base version is stale.
 
 ### `ContractRejected`
 
-Raised when the ledger refuses a diff bound to a superseded major.
+Raised when a commit would change an artifact's contract major.
 
 ### `GitError`
 
@@ -533,13 +506,14 @@ TP -- one hot artifact is split into `n_sections` disjoint sections; each worker
 |---|---|
 | `section_map() -> Dict[str, int]` | `artifact key -> section`. Empty when no key space was declared. |
 
-### `TensorParallelMerge(n_sections: int) -> None`
+### `TensorParallelMerge(n_sections: int, keys: Optional[Sequence[str]] = None) -> None`
 
 Merge section-scoped diffs into one artifact (concatenation + review).
 
 | method | what it does |
 |---|---|
-| `merge(base: RouterSkill, section_diffs: List[Tuple[int, Diff]]) -> Tuple[RouterSkill, bool]` | Return (merged_skill, consistency_ok). |
+| `merge(base: Evolvable, section_diffs: List[Tuple[int, Diff]]) -> Tuple[Evolvable, bool]` | Return (merged_artifact, consistency_ok). |
+| `owner_of(key: str) -> int` | Which section owns `key` -- via the declared partition when there is one. |
 
 ### `WorkUnit(worker: int, keys: List[str], stage: int = 0, section: Optional[int] = None) -> None`
 
@@ -594,7 +568,7 @@ Chooses the next task id for a worker, and learns from the outcome.
 
 Duration-aware dispatch, straggler handling, and the oracle audit queue. &nbsp;·&nbsp; `agentdescent.scheduler` &nbsp;·&nbsp; [guide](duration-scheduling.md)
 
-### `AuditScheduler(max_queued: int = 4096) -> None`
+### `AuditScheduler(max_queued: int = 4096, collect: bool = False) -> None`
 
 Allocates oracle budget by estimated value G-hat (design doc, 5.3).
 
@@ -757,6 +731,10 @@ Values rather than classes or functions.
 
 `(ledger, verifier, audit, config, policy) -> AggregatorProtocol` — how a custom optimizer is installed.
 
+### `AppendRules`
+
+Accumulate a deduped list of rules/lessons (append-only, content-addressed).
+
 ### `Completion`
 
 `Callable[[str], str]` — the one contract every model and agent satisfies.
@@ -773,6 +751,10 @@ The L2/L1 blast-radius boundary (`0.30`).
 
 Artifact ids the loop may read but never mutate (L0).
 
+### `KeyedRules`
+
+One entry per *category*: competing proposals contradict and are resolved.
+
 ### `LAYOUTS`
 
 Where a runner writes the evolving tree inside a workspace (`claude_skill`, `skill_library`, `claude_agent`, `root`).
@@ -784,6 +766,14 @@ The exception tuple a caller catches to treat any ledger problem as recoverable.
 ### `SOLVED`
 
 Reward at or above which a task counts as solved (`0.999`). Lower it for a graded scorer, or every rollout asks the reflector to fix an answer that was already good.
+
+### `SingleSlot`
+
+The artifact **is one value**, and each accepted proposal replaces it.
+
+### `Strategy`
+
+Defines *what evolves and how* -- the representation and the merge rule.
 
 ### `TEST_FAILURE_MARKER`
 
@@ -800,3 +790,7 @@ Agentic backends -- a base agent that *navigates documents with tools*, not just
 ### `dataloader`
 
 Dependency-free dataset loading -- the *data layer* for examples/experiments.
+
+### `rule_id`
+
+Content-address a proposal so identical proposals dedupe automatically.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ This document explains how AgentDescent's components fit together and how a diff
 travels from a worker to a committed change in the shared artifact library.
 
 For the *why* behind each mechanism see [concepts.md](concepts.md); for how to
-run and extend the system see [usage.md](usage.md).
+run the system see [install and first run](install.md); for extending it, [run everything, and extend it](usage.md).
 
 ---
 
@@ -137,7 +137,7 @@ the Aggregator calls at steps 1–3 and 5 (cheap) and at step 4 (oracle, budgete
     `Aggregator`, staleness policies, governance and `AuditScheduler`, but **not**
     the `TaskScheduler`, `EvidenceBuffer`, `ResumeQueue` or `DurationEstimator`.
     It does its own sharding, keeps its own intake buffer, and selects tasks via a
-    [`task_sampler`](evolution.md#task-selection-which-rollout-to-spend).
+    [`task_sampler`](sampling.md).
 
     They are still **two implementations**, which is a known wart rather than a
     design intent. What no longer differs is *behaviour*: the worker-retirement
@@ -152,7 +152,7 @@ the Aggregator calls at steps 1–3 and 5 (cheap) and at step 4 (oracle, budgete
     One capability remains reference-only: **UCB task-cluster leasing** (§5.2 /
     L-task), because it partitions a `TaskUniverse` into clusters and `evolve()`
     takes a flat task list. `evolve()`'s
-    [`task_sampler`](evolution.md#task-selection-which-rollout-to-spend) covers the
+    [`task_sampler`](sampling.md) covers the
     same idea at task granularity. Partial-rollout **resume** is unimplemented on
     both paths — `run(rendered, task) -> output` is opaque, so there is no
     continuation state to check point; both now *detect* and count stragglers.

--- a/docs/async.md
+++ b/docs/async.md
@@ -36,7 +36,7 @@ staleness trade:
 | `async_ratio` | behaviour |
 |---|---|
 | small (1–2) | near-synchronous: few stale diffs, workers resync often |
-| **3** (default) | the measured sweet spot on the reference domain |
+| **3** (default) | the shipped default; the reference domain is measured at 4, [here](concepts.md#34-async_ratio-roll-flash-the-global-lag-budget) |
 | large (8+) | highly asynchronous: many stale diffs for the [staleness policy](staleness.md) to rebase or discard |
 
 The two knobs are one decision. A tight staleness tolerance with a large lag
@@ -74,6 +74,36 @@ result = async_evolve(tasks, reward, agent=agent,
                       max_seconds=120, max_iters=200)
 ```
 
+## How the pipeline holds together
+
+Three properties are worth knowing before you tune anything:
+
+* **The lag budget bounds un-merged work, not just version drift.** A worker will
+  not pile up more than `async_ratio` candidates ahead of the merger. That matters
+  at **cold start**: before the first commit the head has not advanced, so a
+  version-only budget cannot engage, and workers would flood the buffer while the
+  merger is busy with the first slow held-out evaluation. Gating on pending intake
+  prevents it.
+* **There is exactly one merger,** so it is the only writer — there are no CAS
+  conflicts on this path, and a custom
+  [`aggregator_factory`](aggregator.md) sees only already-rebased cards. Every
+  optimizer that works synchronously works here unchanged.
+* **A backpressure guard forces a global sync if the pipeline stalls** (evidence
+  arriving, nothing committing). Without it a mismatched `async_ratio > alpha`
+  livelocks under Guarded: workers propose against a snapshot too old to accept,
+  every card is discarded, the head never moves, so the lag budget never triggers
+  a refresh either. `stall_patience=` tunes it; `result.forced_refreshes` counts
+  how often it fired.
+
+`self_verify` controls whether a worker, after producing a diff, re-runs its own
+trajectory with the diff applied to record a local before/after signal
+(`before_after_delta`, which the staleness gate's cheap re-verify uses). Ports
+that score only the *candidate* on held-out — [EvoSkill](algo-evoskill.md),
+whose repo evaluates the child on the validation set and never re-runs the sampled
+task — pass `self_verify=False` to skip that extra rollout. So do the
+[directory entry points](directory-evolution.md), where it would double the agent
+calls per proposal.
+
 ## What the async path adds
 
 Beyond the barrier removal, three signals only it can report:
@@ -100,7 +130,7 @@ orchestrator it grew out of: it runs the same barrier-free pipeline over the
 which is what makes the parallelism claims testable offline.
 
 ```python
-from agentdescent import AsyncAgentDescent, AsyncConfig
+from agentdescent import AsyncAgentDescent, AsyncConfig, get_policy
 from agentdescent.domains.router import make_task_universe
 
 cfg = AsyncConfig(n_workers=6, async_ratio=4, noise=0.12,

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -13,7 +13,7 @@ computed**. A single completion cannot do that; an agent with tools can.
 AgentBackend.answer(question, document, *, skills="", skill_files=None) -> str
 ```
 
-That signature has three *domain* concepts baked in, which is why it is kept
+Every argument there is a *domain* concept, which is why the shape is kept
 deliberately **separate** from the general contract: it is a domain adapter built
 on `Completion`, not a competitor to it.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,7 +2,7 @@
 
 The ideas behind AgentDescent, in the order you need them. This is the *why*; for
 the *what fits where* see [architecture.md](architecture.md), and for the *how
-to run* see [usage.md](usage.md).
+to run* see [install and first run](install.md).
 
 ---
 
@@ -93,9 +93,14 @@ individual. η = 0 means "proposed against the current head".
 
 α is how much staleness the aggregator will try to salvage before giving up:
 
-- α is larger for **hot** artifacts (they iterate fast, so lag is expected).
+- α is larger for **hot** artifacts (they iterate fast, so lag is expected):
+  `alpha_head=5` versus `alpha_tail=1`. The selector is `classify(artifact)`, so
+  in practice *hot* means [L1](governance.md) — the boundary lives in exactly one
+  place, and re-deriving it elsewhere is a bug the aggregator has already had.
 - α is `0` for **contract-breaking** diffs (a cross-contract rebase costs more
   than re-proposing).
+
+Full detail: [staleness policies](staleness.md).
 
 ### 3.3 Staleness policies (FlashEvolve: Full / Guarded / Reflective)
 
@@ -220,7 +225,7 @@ mechanism:
   flow to all parameters but diffs only to triggered artifacts). Handled by
   **UCB over task clusters** and a difficulty filter (GRPO zero-advantage
   groups) — both implemented, the latter also reachable from
-  `evolve()` as [`DifficultyWeighted`](evolution.md#task-selection-which-rollout-to-spend)
+  `evolve()` as [`DifficultyWeighted`](sampling.md)
   task sampling. The design's cross-product **(task-cluster × artifact)** is
   **not implemented**: `TaskCluster` has no artifact dimension, and both reference
   runtimes register exactly one artifact, as does `evolve()` — so the second axis

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -33,9 +33,20 @@ class Evolvable(Protocol):
 
     def diff(self, other) -> Diff: ...
     def apply(self, diff: Diff) -> "Evolvable": ...
-    def cheap_eval(self, evidence: EvidenceCard) -> float: ...
-    def full_eval(self, task_set) -> Mapping[str, float]: ...
+    def evidence_eval(self, evidence: EvidenceCard) -> float: ...
 ```
+
+`evidence_eval` scores the artifact against the trajectories an evidence card
+carries. It was `cheap_eval` until that collided with
+[`ThreeLayerVerifier.cheap_eval`](verifier.md), which takes an *artifact* and
+means something else — and both are called from the same forty lines of the
+aggregator. The old name survives as an alias.
+
+A fourth method, `full_eval(task_set)`, used to be required here and was called
+by nothing: ground truth reaches the aggregator through the verifier's `eval_fn`,
+which the *domain* supplies, so an artifact never had to know how to score itself.
+Requiring a method the engine does not use is a tax on everyone implementing the
+protocol, so it is gone.
 
 `apply` returns a **new** artifact rather than mutating — the aggregator scores
 candidates side by side, and in-place mutation would make that impossible.
@@ -85,9 +96,11 @@ content-addressing.
     which is why two workers editing different files merge for free. Same
     machinery, three very different concurrency profiles.
 
-A `None` value **deletes** the key. `dict.update` could express add and replace
-but not remove — invisible for a rules playbook, disqualifying for a file tree
-where a key is a path.
+A `None` value **deletes** the key, on both sides: `apply` pops it, and `diff`
+emits one for every key the target no longer has. `dict.update` could express add
+and replace but not remove — invisible for a rules playbook, disqualifying for a
+file tree where a key is a path, and it left `a.apply(a.diff(b))` quietly
+different from `b`.
 
 `Diff.size()` is `len(ops)`, which is what the aggregator's trust region caps
 (`trust_region_ops`, default 6), alongside `trust_region_chars` (32 000) per
@@ -140,9 +153,16 @@ Contract(input_schema="task", output_schema="text", side_effects=(), major=1)
 ```
 
 Artifacts depend on each other's *interfaces*, not their contents. A change that
-breaks one is a semver-major event, and the ledger refuses a diff declaring a
-dependency on a superseded major. In a single-artifact `evolve()` run this rarely
-fires; it exists for the multi-artifact library the design targets.
+breaks one is a semver-major event, so the [ledger](ledger.md) records the
+contract an artifact was **registered** with and refuses any later commit whose
+major disagrees — a breaking change has to be re-registered deliberately rather
+than merged like an ordinary diff.
+
+In a single-artifact `evolve()` run this never fires; it exists for the
+multi-artifact library the design targets. Until recently it never fired at all:
+`Contract`, `is_compatible_with` and `ContractRejected` all existed and nothing
+called any of them, while the docstrings described the enforcement as if it were
+there.
 
 ## `stable_hash`
 

--- a/docs/duration-scheduling.md
+++ b/docs/duration-scheduling.md
@@ -162,17 +162,17 @@ that verdict with the cheap layer's is free and happens on every merge.
 re-deriving it. A third hand-written threshold here (`>= 0.5`) meant an artifact
 at 0.4 was L1 by governance and audited like an L2 skill: never.
 
-### The queue is bounded, and says when it sheds
+### The queue is opt-in, because nothing drains it
 
-`submit` keeps a heap capped at `MAX_QUEUED` (4096), dropping the
-lowest-priority tail — which is the lowest-value work by construction — and
-counting what it dropped in `audit.dropped`.
+```python
+AuditScheduler()                  # computes priorities, queues nothing (default)
+AuditScheduler(collect=True)      # keeps the heap for an out-of-band auditor
+```
 
-!!! note "Nothing drains the queue today"
-    `force_oracle` is the part in the engine's path; the priority queue itself
-    has no consumer in the shipped runtimes. It is the mechanism for an
-    out-of-band audit process, and it is bounded and counted so that using it
-    later does not require re-reading a run's worth of accumulated state. The
-    [architecture page](architecture.md#3-component-responsibilities) lists it
-    that way too — a queue that looks wired in and is not would be worse than no
-    queue.
+`force_oracle` and the trust update are the parts in the engine's path, and both
+work either way. The priority *queue* has no consumer in the shipped runtimes —
+so maintaining a heap plus a periodic rebuild, once per merge decision, bought
+nothing and cost work on the merge path. It is now off unless asked for.
+
+With `collect=True` the heap is capped at `MAX_QUEUED` (4096), sheds the
+lowest-priority tail, and reports what it shed in `audit.dropped`.

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -270,16 +270,16 @@ Details + the DP/TP/PP semantics: [Customizable parallelism](parallelism.md).
 
 ---
 
-## Task selection — which rollout to spend
+## Task selection — `task_sampler=`
 
-*What:* which task a worker rolls out next. *Module:*
-[`agentdescent.sampling`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/sampling.py).
+*What:* which task a worker rolls out next, from the shard
+[`parallel=`](parallelism.md) gave it. *Module:*
+[`agentdescent.sampling`](sampling.md).
 
-A rollout is the expensive unit of work — one LLM call, or an entire tool-using
-agent trajectory that can run for minutes. Spending it on a task the agent
-**already solves** teaches the system nothing: there is no failure, so no
-proposal, so no diff. The same is true of a task it can *never* solve. Only tasks
-somewhere in between carry a usable gradient (the GRPO zero-advantage argument).
+A rollout is the expensive unit of work. Spending it on a task the agent already
+solves teaches the system nothing — no failure, no proposal, no diff — and the
+same is true of one it can never solve. Only tasks in between carry a usable
+gradient (the GRPO zero-advantage argument).
 
 ```python
 from agentdescent import DifficultyWeighted, RoundRobin
@@ -291,40 +291,11 @@ evolve(tasks, reward, agent=agent, task_sampler=DifficultyWeighted())  # focus t
 | Sampler | Rule |
 |---|---|
 | **`RoundRobin`** (default) | cycle through the shard — deterministic, but spends rollouts uniformly |
-| **`DifficultyWeighted`** | track each task's pass rate; prefer those away from the all-pass / all-fail extremes, with a UCB bonus so untried tasks are still explored |
+| **`DifficultyWeighted`** | weight by `4·p·(1−p)`, plus a UCB bonus so untried tasks are still explored |
 
-Measured on a 40-task workload where only 6 tasks carry signal — the share of
-rollouts that landed on an informative task:
-
-| | round-robin | difficulty-weighted |
-|---|---|---|
-| clean reward | 14.5% | **23.4%** |
-| 15% reward noise | 7.3% | **16.3%** |
-
-!!! warning "That is a targeting measurement, not an accuracy claim"
-    Landing more rollouts on failing tasks does **not** automatically produce a
-    better artifact. On real [ACE / FiNER-139 runs](algo-ace.md#empirical-results-finer-139-with-deepseek)
-    the difficulty-weighted sampler reached a lesson sooner (round 0 versus round
-    2) but did not score better — and two runs of the *same* round-robin
-    configuration differed by 4.8 points, so at that sample size neither sampler
-    is distinguishable from the other. Concentrating on the hardest tasks can also
-    yield lessons that fit those tasks and generalise worse. Treat this sampler as
-    **worth trying and worth measuring on your own data**, not as a free win;
-    `RoundRobin` stays the default.
-
-Where it should help most is a *strong* base agent on a large task pool: failures
-are sparse, so round-robin spends most of its budget re-solving solved tasks.
-Write your own by implementing `pick` + `record`:
-
-```python
-class PreferRecentFailures:
-    def pick(self, keys, round_index): ...      # -> one task id
-    def record(self, task_id, score): ...       # learn from the outcome
-```
-
-!!! note "Default stays deterministic"
-    `RoundRobin` remains the default so existing runs and the RQ experiments stay
-    bit-reproducible. `DifficultyWeighted` is opt-in.
+The `c` sweep, the `pass_threshold` trap for graded scorers, how to write your
+own, and the **caveat that the measured gain is a targeting number rather than an
+accuracy claim** are all on [the sampling page](sampling.md).
 
 ---
 
@@ -396,8 +367,8 @@ evolve(tasks, reward, agent=agent, staleness_policy=get_policy("reflective"))
 
 Staleness bites when workers lag head — which is most visible in the **async
 runtime** (`async_ratio`), below. In synchronous `evolve()` each round proposes
-against the current head, so η is usually 0. Deep dive:
-[staleness in concepts](concepts.md#3-staleness).
+against the current head, so η is usually 0. Deep dive: [staleness policies](staleness.md) for the module,
+[concepts §3](concepts.md#3-staleness) for why it is the heart of the async story.
 
 ---
 
@@ -717,41 +688,32 @@ evolve(tasks, reward, agent=agent, asynchronous=True, async_ratio=3, max_seconds
 
 ## The barrier-free runtime: `async_evolve()`
 
-`evolve()`'s round barrier means the aggregator waits for all workers each round.
-[`async_evolve()`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/async_evolve.py)
-removes it while accepting the identical `run`/`reward`/`propose`/`strategy`/
-`aggregator_factory` plug-ins — so **any** task that runs under `evolve()` (ACE,
-GEPA, EvoSkill, SkillOpt, ADAS, DGM) also runs async:
-
-* **Workers** (`n_workers` threads) hold a snapshot and keep producing evidence
-  against it, refreshing only once head drifts past **`async_ratio`** (the lag
-  budget) — so staleness (η > 0) genuinely arises. The lag budget bounds
-  **un-merged** work too: a worker won't pile up more than `async_ratio`
-  candidates ahead of the merger. This matters at **cold start** — before the
-  first commit, head hasn't advanced, so a version-only budget can't engage and
-  workers would flood the buffer while the merger is busy on the first slow
-  held-out eval; gating on pending intake prevents that.
-* **One merger** drains a thread-safe buffer, runs each card through the
-  **staleness policy** (`accept η=0` / `rebase`+re-verify / `discard`), then
-  `ingest` + `step`. It is the only writer, so there are no CAS conflicts and
-  every custom optimizer sees only rebased cards — async-safe unchanged.
-* **`self_verify`** controls whether a worker, after producing a diff, re-runs
-  its own trajectory with the diff applied to record a local before/after signal
-  (`before_after_delta`, used by the staleness gate's cheap re-verify). Ports
-  that only score the *candidate* on held-out — e.g. [EvoSkill](algo-evoskill.md),
-  whose repo evaluates the child on the validation set and never re-runs the
-  sampled task — pass `self_verify=False` to skip that extra rollout.
+`evolve()`'s round barrier makes the aggregator wait for every worker each round.
+[`async_evolve()`](async.md) removes it while accepting the identical
+`run` / `reward` / `propose` / `strategy` / `aggregator_factory` plug-ins — so
+**any** task that runs under `evolve()` (ACE, GEPA, EvoSkill, SkillOpt, ADAS, DGM)
+also runs async:
 
 ```python
-from agentdescent import async_evolve
+from agentdescent import async_evolve, get_policy
+
 result = async_evolve(tasks, reward, agent=agent,
-                      n_workers=4, async_ratio=3, max_seconds=30,   # or max_iters / target_reward
+                      n_workers=4, async_ratio=3, max_seconds=30,
                       staleness_policy=get_policy("reflective"))
 ```
 
 Reach it via `evolve(asynchronous=True)` or directly. Small `async_ratio` →
 near-synchronous, few stale diffs; large → highly asynchronous, many stale diffs
-the policy must rebase or discard.
+for the policy to rebase or discard.
+
+!!! warning "Five arguments change meaning under `asynchronous=True`"
+    Three are ignored (`parallel`, `max_concurrency`, `round_timeout`) and two are
+    **redefined**: `rounds` becomes a budget of `rounds × n_workers` rollouts, and
+    `max_seconds=None` becomes 20 seconds where it meant "no limit". Each warns,
+    but check `result.stop_reason` — a budget expiry otherwise looks exactly like
+    convergence. The full table, the pipeline's cold-start and backpressure
+    behaviour, and what only the async path can report are on
+    [the async page](async.md).
 
 ### More async / parallel recipes
 
@@ -784,12 +746,11 @@ An aggregator can amortise the expensive held-out eval on the async path — app
 each diff as a cheap step and only validate every *N* steps, rolling back on no
 gain (SGD-style). See [the async optimizer variant](aggregator.md#the-async-optimizer-variant-sgd-style-descent).
 
-### The reference async orchestrator: `AsyncAgentDescent`
+### The reference async orchestrator
 
 For the router reference domain there is also `AsyncAgentDescent` — the original
-stage-orchestration runtime with duration-aware straggler checkpointing, where
-the staleness policies,
-[`async_ratio`](concepts.md#34-async_ratio-roll-flash-the-global-lag-budget), and
-[duration-aware straggler checkpointing](duration-scheduling.md) come into their
-own — use `AsyncAgentDescent` (same aggregator, staleness, and governance
-underneath). Measured trade-offs: [efficiency experiments](efficiency.md).
+stage-orchestration runtime, with duration-aware straggler checkpointing, and the
+thing the parallelism claims were measured with. Same aggregator, staleness and
+governance underneath. See [async](async.md#asyncagentdescent-the-reference-runtime),
+[the reference orchestrator and domain](orchestrator.md), and the measured
+trade-offs in [efficiency experiments](efficiency.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ pip install agentdescent
 
 -   :material-api: **[API reference](api.md)**
 
-    All 125 exported names with real signatures — generated from the code, and
+    Every public name with its real signature — generated from the code, and
     tested against it.
 
 -   :material-chart-box: **[Measured results](results.md)**
@@ -190,6 +190,9 @@ python -m examples.skill_dir_evolution # evolve a skill directory a real agent r
 python -m examples.rq2_staleness       # RQ2: staleness tolerance sweep
 pytest                                 # the suite, no external services
 ```
+
+Step by step: [install and first run](install.md). Everything runnable, with the
+output each one produces: [run everything](usage.md).
 
 No LLM or external service is required: the
 [reference domain](orchestrator.md#why-a-synthetic-domain-exists-at-all) is a

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,6 +60,9 @@ python -m examples.skill_dir_evolution    # evolve a skill DIRECTORY a real agen
 python -m examples.efficiency             # parallel scaling + async tail-hiding
 ```
 
+The complete list — every demo, every algorithm port, and what each one prints —
+is in [run everything](usage.md#1-run-the-demos).
+
 ## First real run — with a model
 
 Point the provider layer at whatever you have. Credentials are read from the

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -58,7 +58,7 @@ from agentdescent import AgentDescent
 from agentdescent.domains.router import make_task_universe
 
 system = AgentDescent(repo_path, make_task_universe(seed=7),
-                      n_workers=6, noise=0.15, refresh_interval=3, seed=0)
+                      n_workers=6, noise=0.15, refresh_interval=2, seed=0)
 stats = system.run(rounds=40)          # -> List[RoundStat]
 ```
 
@@ -67,7 +67,7 @@ Each `RoundStat` carries `round`, `dev_accuracy`, `stable_accuracy`,
 curve plus the reason it has that shape.
 
 Staleness arises **naturally** rather than being injected: workers refresh their
-ledger snapshot only every `refresh_interval` rounds, so between refreshes their
+ledger snapshot only every `refresh_interval` rounds (default 2), so between refreshes their
 `base_version` lags the head and the [staleness policy](staleness.md) has real
 work to do.
 

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -61,6 +61,19 @@ keeping twice the exploration of the empirical optimum, which matters when your
 reward is noisier than the workloads measured here. Lower it to focus harder,
 raise it to explore more.
 
+!!! warning "That is a targeting measurement, not an accuracy claim"
+    Landing more rollouts on failing tasks does **not** automatically produce a
+    better artifact. On real
+    [ACE / FiNER-139 runs](algo-ace.md#empirical-results-finer-139-with-deepseek)
+    the difficulty-weighted sampler reached a lesson sooner (round 0 versus round
+    2) but did not score better — and two runs of the *same* round-robin
+    configuration differed by 4.8 points, so at that sample size neither sampler
+    is distinguishable from the other.
+
+    Concentrating on the hardest tasks can also yield lessons that fit those tasks
+    and generalise worse. Treat this sampler as **worth trying and worth measuring
+    on your own data**, not as a free win.
+
 ### `pass_threshold` mirrors the engine
 
 A rollout counts as a pass when its reward reaches this, defaulting to the

--- a/docs/staleness.md
+++ b/docs/staleness.md
@@ -36,15 +36,36 @@ A **contract-breaking** diff is the exception in all three: once stale it is
 discarded rather than rebased, because a cross-contract rebase costs more than
 re-proposing.
 
-`alpha` is the tolerance, and it widens for a **cold** artifact — one that few
-diffs touch — because the odds that an unrelated merge invalidated this proposal
-are lower. The [aggregator](aggregator.md) supplies it.
+`alpha` is the tolerance, and the [aggregator](aggregator.md) picks it **by
+governance layer**, not by measured traffic:
+
+```python
+alpha_head = 5     # L1 -- a harness, a verifier: iterating fast, lag expected
+alpha_tail = 1     # L2 -- a local skill: a moved head more likely invalidates it
+```
+
+The config calls them *hot* and *cold*, which is the intent; the selector is
+`classify(artifact)`, which is the [one definition of the
+boundary](governance.md#the-l1l2-boundary-is-measured-not-declared). That
+substitution has bitten before: while the aggregator re-derived the layer with a
+different threshold, an artifact at 0.4 was L1 by governance and got the *cold*
+tolerance meant for an L2 skill.
 
 ## The trade-off, measured
 
-From [`examples/rq2_staleness.py`](https://github.com/Birfy/agentdescent/blob/main/examples/rq2_staleness.py)
-and [`examples/run_async.py`](async.md) on the reference domain, at the same
-`async_ratio`:
+Measured on the reference domain at `async_ratio=4`, where all three converge to
+1.000 ([the numbers](concepts.md#34-async_ratio-roll-flash-the-global-lag-budget)):
+
+| policy | rollouts | stale discarded | wall-clock |
+|---|---|---|---|
+| Full | ~8k | 0 | ~3.2s |
+| Reflective | ~7.8k | ~0.7k | ~3.3s |
+| Guarded | ~20k | ~17k | ~5.1s |
+
+Reproduce with
+[`examples/rq2_staleness.py`](https://github.com/Birfy/agentdescent/blob/main/examples/rq2_staleness.py)
+and [`examples/run_async.py`](https://github.com/Birfy/agentdescent/blob/main/examples/run_async.py).
+What the table says:
 
 * **Guarded discards more work than Reflective** — that is the claim under test,
   and it holds regardless of machine speed.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,7 +1,8 @@
 # Strategies — what evolves, and how a proposal becomes a diff
 
-*Module:* [`agentdescent.evolution`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/evolution.py)
-· [`agentdescent.treestrategy`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/treestrategy.py)
+*Modules:* [`agentdescent.strategies`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/strategies.py)
+(text) · [`agentdescent.treestrategy`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/treestrategy.py)
+(a directory) — one module per strategy family, none of them inside the engine
 · *API:* [`Strategy`, `SingleSlot`, `AppendRules`, `KeyedRules`](api.md#the-loop), [`FileTree`](api.md#the-file-tree-strategy)
 
 A strategy answers two questions and nothing else:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -150,6 +150,8 @@ with tempfile.TemporaryDirectory() as repo:
 | `alpha_head` | 5 | staleness tolerance α for hot artifacts |
 | `alpha_tail` | 1 | staleness tolerance α for cold artifacts |
 | `trust_region_ops` | 6 | max edits per diff (trust region) |
+| `trust_region_chars` | 32 000 | max characters in **one** op's value — for a [`FileTree`](directory-evolution.md) that is a per-file cap, and `TreeSpec.max_file_bytes` must stay under it |
+| `anneal_half_life` | 64 | versions over which the acceptance risk decays |
 | `promote_after_k` | 3 | dev→stable survival rounds (EMA) |
 
 ### `AsyncConfig` ([async](async.md))

--- a/docs/verifier.md
+++ b/docs/verifier.md
@@ -20,9 +20,10 @@ default mistake, and it is expensive in exactly the case that matters:
     On an LLM workload every held-out evaluation is a full sweep of real model
     calls. `cheap_eval_tasks=None` (the default) pins the cheap layer to the
     *whole* held-out set, so ranking N candidates costs N full sweeps. Set
-    `evolve(cheap_eval_tasks=4)` and ranking becomes cheap; the acceptance test
-    still uses the full set, so this trades tournament precision, never commit
-    safety. The [directory entry points](directory-evolution.md) default it to 4
+    `evolve(cheap_eval_tasks=4)` and ranking becomes cheap. Both gates that decide
+    a *commit* — the Beta-posterior acceptance test and the regression guard
+    beside it — read the full held-out set, so this trades ranking precision and
+    nothing else. The [directory entry points](directory-evolution.md) default it to 4
     for this reason.
 
 ## The three methods that matter
@@ -36,6 +37,14 @@ verifier.oracle_eval(artifact)    # ground truth, spends budget
 `eval_counts` is what feeds the Beta-posterior acceptance test, and it never
 sub-samples: the acceptance decision has to rest on an honest sample size, or the
 posterior is confident about noise.
+
+!!! note "It also feeds the regression guard, and that used to be a real hole"
+    The aggregator refuses a candidate that scores *worse* than the incumbent even
+    when the posterior likes it. That guard read the **cheap** layer until
+    recently, so with `cheap_eval_tasks=4` a four-task sample could veto a commit
+    the full-set test had just approved — while three source comments and two doc
+    pages promised sub-sampling could not touch commit safety. It now reads the
+    full-set rates `eval_counts` has already produced.
 
 ## The sample is fixed, and that is a correctness property
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
     - Async — no round barrier: async.md
     - Reference orchestrator & domain: orchestrator.md
   - API reference: api.md
+  - Run everything, and extend it: usage.md
   - Examples and results:
     - Complete example — skill evolution: skill-evolution.md
     - Efficiency experiments: efficiency.md
@@ -74,7 +75,6 @@ nav:
     - DGM — Darwin Gödel Machine (harness): algo-dgm.md
   - Design records:
     - Evolving a directory: design-directory-evolution.md
-  - Run everything, and extend it: usage.md
 
 markdown_extensions:
   - admonition

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -45,7 +45,7 @@ def test_oracle_eval_degrades_instead_of_raising_when_exhausted():
 
 
 def test_audit_queue_is_bounded():
-    a = AuditScheduler(max_queued=100)
+    a = AuditScheduler(max_queued=100, collect=True)
     for i in range(5000):
         a.submit(f"d{i}", "art", 0.5, (i % 97) / 97)
     assert len(a._items) <= 200          # cap, with the 2x amortisation headroom
@@ -67,7 +67,7 @@ def test_audit_submit_is_not_quadratic():
 
 
 def test_audit_pops_highest_priority_first():
-    a = AuditScheduler()
+    a = AuditScheduler(collect=True)
     a.submit("low", "art", 0.1, 0.1)
     a.submit("high", "art", 0.9, 0.9)
     a.submit("mid", "art", 0.5, 0.5)
@@ -75,7 +75,7 @@ def test_audit_pops_highest_priority_first():
 
 
 def test_audit_scheduler_is_thread_safe():
-    a = AuditScheduler()
+    a = AuditScheduler(collect=True)
 
     def submit_many(n):
         for i in range(n):
@@ -141,3 +141,16 @@ def test_resume_queue_is_thread_safe():
     while q.pop() is not None:
         drained += 1
     assert drained == 800
+
+
+def test_the_default_scheduler_queues_nothing():
+    """Nothing in the engines drains the queue, so nothing should fill it.
+
+    `submit` runs once per merge decision; maintaining a heap plus a periodic
+    rebuild for a queue no caller reads is work on the merge path that buys
+    nothing. The priority itself is still computed and returned -- `force_oracle`
+    and the trust update are what the engine actually uses."""
+    a = AuditScheduler()
+    priority = a.submit("d", "art", blast_radius=0.6, uncertainty=0.5)
+    assert priority > 0                  # still computed and returned
+    assert len(a) == 0 and a.pop() is None and a.dropped == 0


### PR DESCRIPTION
Two review passes: all 38 doc pages, then all 21 modules. Both looked for the same
thing — a claim that had stopped matching the code, or two places answering one
question differently. 14 problems in the docs, 15 in the code; all fixed here.

`pytest`: **628 passed, 1 skipped** · `mkdocs build --strict`: clean.

---

## 🔴 The one that matters: a four-task sample could veto a commit

The aggregator refuses a candidate that scores worse than the incumbent. Right
guard — but it read the **cheap** layer, which `cheap_eval_tasks` sub-samples:

```python
if p_improve <= 1.0 - delta or cand_score < base_score:   # cand_score = cheap layer
```

So a 4-task sample could overturn what the full held-out Beta test had just
approved — and `evolve_skill_dir` / `evolve_agent_dir` / `evolve_agent_code`
**default that knob to 4**. Meanwhile four places promised it could not happen:

| where | claim |
|---|---|
| `evolution.py:1083` | "sub-sampling trades tournament precision, never commit safety" |
| `evolution.py:1316` | "the acceptance test always scores the full set" |
| `verifier.py:56` | "trades tournament precision, not commit safety" |
| `docs/verifier.md`, `docs/aggregator.md` | repeated it |

The guard now reads the full-set rates `eval_counts` had **already computed** —
no extra evaluation, and the promise becomes true. All five claims corrected.

**Its rejection message was misleading too.** Both gates reported
`P(delta>0)=… <= …`, so a regression rejection printed things like
`P(delta>0)=0.97 <= 0.50` — self-contradictory to anyone reading `outcomes()` to
find out why nothing committed, which is that method's only job. It now says
`held-out regression 0.812 -> 0.780`.

## 🟡 Declared, not true

- **The contract mechanism was never wired.** `Contract.is_compatible_with` and
  `ContractRejected` both existed; nothing called either, while the docstrings
  described the enforcement. `Ledger.register` now records the contract and
  `commit` refuses a state whose major disagrees.
- **`diff()` could not express a deletion**, so `a.apply(a.diff(b)) != b` whenever
  `b` had dropped a key — silently, and for exactly the case a file tree cares
  about, where a key is a path.
- **`scheduler.py` claimed timed-out rollouts are "resumed against the latest
  ledger."** Nothing pops that queue. `architecture.md` was honest about it; the
  source was not.

## 🟠 One question, two answers

- **Two barrier-free runtimes** had already diverged once — a previous release
  hand-ported two measured fixes between them. The policies that diverged now
  live in `agentdescent/pipeline.py` (`WorkerHealth`, `StallGuard`) and both call
  them, so the next fix lands in both.
- **Two UCB task selectors** wrote out `4·p·(1−p)` separately → `stats.difficulty_weight`.
  The constants still differ (0.2 vs 1.4) and the docstring says why: the sweep
  behind 0.2 was measured at *task* granularity and has not been repeated at
  *cluster* granularity, so transplanting it would be borrowing a number from a
  different experiment.
- **Two definitions of which section owns a key** — `TensorParallelMerge` used the
  `section_of` hash bucket, `TensorParallel`/`evolve()` the `assign_key_sections`
  partition. A diff legal on one path could be rejected on the other.

## 🔵 Surface and layering

- `Evolvable` requires one method fewer: **`full_eval` was in the protocol and
  called by nothing** — ground truth reaches the aggregator through the verifier's
  `eval_fn`, which the domain supplies.
- **`Evolvable.cheap_eval` → `evidence_eval`.** It collided with
  `ThreeLayerVerifier.cheap_eval` — different argument, different meaning, both
  called from the same forty lines of the aggregator.
- **`AuditScheduler` queues only when asked** (`collect=True`). Nothing calls
  `pop()`, so every `submit` was a heap push plus a periodic rebuild, once per
  merge decision, for a queue no one reads.
- **The text strategies moved out of the 1700-line engine module** into
  `agentdescent/strategies.py`. `FileTree` already had its own, so the rule is now
  one module per strategy family rather than "wherever it was written".
- `parallel.py` no longer imports `RouterSkill` — a general primitive typed to the
  demo domain.
- `domains.router.Task` (the alias colliding with `evolution.Task`) is gone from
  the package's own code.

!!! note
    `AuditScheduler` and the `Evolvable` protocol are **API-visible** changes.
    Both keep back-compatible paths (`cheap_eval` alias, `collect=True`), but code
    outside this repo implementing `Evolvable` or relying on the audit queue's
    default should know.

## 📘 Docs pass (14 fixes)

The ones worth naming:

- **`staleness.md` had `alpha` backwards** — it widens for L1/*hot* artifacts
  (`alpha_head=5` vs `alpha_tail=1`, selected by `classify()`), and the page said
  *cold*, contradicting both `concepts.md` and the code.
- **`sampling.md` had dropped a caveat the page it replaced carried**: the
  difficulty-weighted numbers are a *targeting* measurement, not an accuracy
  claim — two runs of the same round-robin config differed by 4.8 points. The
  rewrite had made the docs less honest than what they replaced; restored.
- **`evolution.md` kept full copies of sections that now have their own pages**
  while its knob table linked away to them — two sources of truth, guaranteed to
  drift. Trimmed by 115 lines, with the three details it had and `async.md`
  lacked moved rather than deleted.
- The `AggregatorConfig` reference **omitted `trust_region_chars`**, which is the
  per-file cap a `FileTree` caller has to keep `TreeSpec.max_file_bytes` under.

## Not in this PR

Unifying `orchestrator` / `async_runtime` with `evolve` / `async_evolve`. That
would move the reproduction path of every measured result in the repo — a
decision, not a cleanup. The stated problem (they will diverge again) is fixed by
sharing the policies that actually diverged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
