### PR TITLE
fix: read the code against the docs written for it, and fix both sides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,73 @@ All notable changes to AgentDescent are documented here. The format follows
   longer used inside the package (`worker.py` takes `RouterTask`). The alias
   stays, marked deprecated.
 
+- **`stable` never received the artifact a run produced.** Both reference
+  runtimes call `Aggregator.finalize()` on a clean exit, and `docs/ledger.md`
+  documents it — but `evolve()` and `async_evolve()`, the two engines a real
+  workload actually reaches, did not. Promotion needs `promote_after_k`
+  regression-free rounds and `target_reward` stops the run on the very commit
+  that reaches it, so a clean run that hit its target left `stable` holding the
+  *seed* artifact while `dev` held the one the run was for. Both engines now
+  publish their head on a clean exit (and only on a clean one: a run that died
+  leaves the confirmed branch where it was).
+
+- **`result.forced_refreshes` was non-zero on every healthy async run.** The
+  field, `docs/async.md`, `docs/staleness.md` and `concepts.md` all say a
+  non-zero count means the lag budget and the staleness tolerance disagree — but
+  it counted *every* snapshot refresh, including the ordinary lag-budget one that
+  happens all run long. A converged three-second run reported 3. Only
+  backpressure-forced resyncs are counted now, in both barrier-free runtimes, so
+  the diagnostic is quiet when there is nothing to diagnose.
+
+- **A stratified split could put the same item in `val` and `test`.** For a class
+  too small for the ratios the cut points collapse, and `g[a:b] or g[a:a+1]`
+  *copied* an item into `val` while `test` still took it — so the split
+  `Dataset` documents as "fully held out, never seen by the optimizer" contained
+  an item the acceptance gate had already scored. Rare classes are exactly what
+  stratifying is for (a thin FiNER tag, a low-resource MGSM language), and three
+  shipped ports stratify. The item is now *moved*, not copied.
+
+- **`KeyedRules.keys()` returned a key space the strategy never writes.**
+  Matching is case-insensitive and `to_diff` stores the folded key, so
+  `categories=["Routing"]` under tensor parallelism built a section map on
+  `"Routing"` while every diff wrote `"routing"`: no key had an owner and every
+  proposal in the run was rejected as `section-violation`.
+
+- **`document_agent` and `openhands()` leaked a workspace per call.** Each staged
+  a fresh temp directory — with a copy of the document, routinely a megabyte of
+  financial tables — and never removed it, while every other staging path in the
+  package cleans up after itself. Both now do, and `openhands()` still leaves a
+  caller-supplied `in_workspace()` directory alone, since that one holds the
+  caller's files.
+
+- **`EvidenceCard.trajectory_refs` was annotated `List[str]`, which quietly
+  disables the staleness gate.** Every producer in the package puts task
+  *objects* there and both consumers `isinstance`-filter for them, so a custom
+  domain that follows the annotation and stores ids gets an `evidence_eval` over
+  an empty list — the REBASE branch then compares `0.0 <= 0.0`, keeps every
+  rebased diff, and a diff that makes the artifact *worse* survives the
+  re-verification meant to catch it. Annotated `List[Any]`, documented, and
+  pinned by a test that a harmful rebased diff is discarded.
+
+- **`result.outcomes()` did not print the way any of its documentation shows.**
+  It is a dict, and printing a dict calls `repr` on its keys, so the `MergeOutcome`
+  enum rendered `{<MergeOutcome.COMMITTED: 'committed'>: 1}` where the README,
+  both quickstarts, `evolution.md` and the enum's own docstring all show
+  `{'committed': 1}`. `__repr__` is now the value's, as `enum.StrEnum` does on
+  3.11+; equality, `str()`, f-strings and lookups by bare string are unchanged.
+
+- **Three algorithm ports could crash in their final report, and three discarded
+  `error`.** GEPA indexed `agg.scores[0]` (an `IndexError` when no round
+  completed) behind a guard that would itself have raised `TypeError`
+  (`f"{[]:.3f}"`), and ACE and `skill_evolution` indexed `history[0]` — all on
+  the exact partial result the engine goes to lengths to return. GEPA also
+  dropped `evolve()`'s return value entirely, and `EvoResult` / `SkillOptResult`
+  carried no `error` or `stop_reason`, so a run killed by a rate limit printed
+  the same confident "seed → best" line as one that converged. Every port now
+  reports both. ACE and `skill_evolution` also label that first number "round 0"
+  rather than implying it is the seed's score — it is measured *after* round 0's
+  merge.
+
 ### Changed
 - **The two barrier-free runtimes share their policies.** `async_evolve` and
   `AsyncAgentDescent` implemented the same shape independently; a previous
@@ -45,6 +112,13 @@ All notable changes to AgentDescent are documented here. The format follows
   (`WorkerHealth`, `StallGuard`) and both call them, so the next fix lands in
   both. The runtimes themselves are still separate — unifying them would move
   every measured result's reproduction path, which is a decision, not a cleanup.
+
+  `StallGuard` was the half of that sentence which was not yet true: both
+  runtimes still counted their no-commit sweeps inline, so the module documented
+  a convergence it had not reached. Both now count through it, on identical
+  conditions to before — each still decides *which* sweeps count, because a sweep
+  with no evidence in it is neither progress nor a stall and the two runtimes
+  express "no evidence" differently.
 - **One difficulty-weight formula.** `4·p·(1−p)` was written out in both
   `sampling.DifficultyWeighted` (over tasks) and `scheduler.TaskScheduler` (over
   clusters); it now lives in `stats.difficulty_weight`. The exploration constants
@@ -76,6 +150,45 @@ All notable changes to AgentDescent are documented here. The format follows
   the reference domain.
 
 ### Documentation
+- A second pass, this time reading the docs *against* the code they describe:
+  - `docs/aggregator.md`'s stage list was mangled — steps 4 and 5 appeared twice
+    and the commit came *before* the audit gate, which is the one thing
+    `aggregator.py`'s own docstring insists on ("it holds a veto"). The README's
+    copy had the same inversion, and additionally said promotion counts
+    *commits* — it counts regression-free **rounds**, and a commit restarts the
+    clock.
+  - `concepts.md` said `duration_estimator=` is reachable from `evolve()`; it is
+    an `async_evolve` parameter and `evolve()` raises `TypeError` on it. It also
+    described the audit priority queue as always built, when `collect=False` (the
+    default) computes the priority without queuing anything.
+  - `docs/async.md` described `stall_patience` as counting *empty* merger sweeps
+    — it counts sweeps that had cards and committed nothing, the opposite
+    condition. `docs/usage.md` described `AsyncConfig.noise` as a fraction of
+    workers; it is the per-op probability that one of the (every third) noisy
+    workers proposes a wrong label.
+  - `docs/evolution.md`'s "why did nothing commit?" table was missing `oversized`
+    and `section-violation`, two of the eight categories `outcomes()` can return
+    — and `oversized` points at the opposite fix from the `all-stale` it used to
+    be folded into.
+  - `docs/modules.md` claims to list every module and omitted `strategies`,
+    `stats` and `pipeline`, still filing the text strategies under `evolution`
+    after they moved out.
+  - The `run_async` policy table in the README and `concepts.md` now carries the
+    same caveat `efficiency.md` already gave its own numbers: the ratios are the
+    result, the absolute counts scale with the machine.
+  - `agentdescent/__init__.py` pointed readers at `agentdescent_design.md`, which
+    is not in the repository.
+  - `docs/verifier.md` advertised a three-method interface for a custom verifier
+    (`cheap_eval` / `eval_counts` / `oracle_eval`); the aggregator also calls
+    `learned_eval`, so building to the page raised `AttributeError` from inside a
+    merge, after the run had spent its rollouts.
+  - `docs/duration-scheduling.md` said an overrunning rollout is "set aside and
+    resumed" and does not "block a worker" — contradicting its own warning three
+    paragraphs later, which is the accurate one: the record is written *after*
+    the rollout returns, and nothing resumes it. Its header also pointed only at
+    `AsyncAgentDescent`, though `async_evolve` takes `duration_estimator=` too.
+  - `docs/governance.md` says every algorithm port prints its governance layer at
+    startup; ACE and GEPA did not, so they now do.
 - A consistency pass over the new site found 14 problems and fixed them. The ones
   worth naming: `staleness.md` had the `alpha` tolerance **backwards** (it widens
   for L1/hot artifacts, not cold) and contradicted `concepts.md`; `sampling.md`

--- a/README.md
+++ b/README.md
@@ -374,16 +374,20 @@ optimizer step:
    keeping the better of the pair on a shared subset.
 3. **Fusion tournament (§4.3)** — complementary diffs are fused (model-soup
    analogy) and run against the individual candidates on held-out data.
-4. **Statistical acceptance (§4.4)** — commit only if
+4. **Audit gate (§5.3)** — the merge decision is itself submitted to the
+   `AuditScheduler`; high-blast-radius / low-trust merges are forced through the
+   oracle, which can **veto outright** (`oracle-rejected`) *before* the
+   acceptance test runs. The optimizer audits itself.
+5. **Statistical acceptance (§4.4)** — commit only if
    `P(Δ > 0) > 1 − δ` under a per-artifact Beta posterior, not a point threshold.
    `δ` anneals with version (LR decay); a trust-region caps diff size.
-5. **Commit (§4.1)** — compare-and-swap on `dev`, one artifact per merge
+6. **Commit (§4.1)** — compare-and-swap on `dev`, one artifact per merge
    (`commit_atomic`/2PC exists in the Ledger but no engine path calls it).
-6. **Dual-branch promotion (§4.5)** — `dev → stable` every *K* accepted commits
-   (EMA-style confirmation; it counts commits, not rounds).
-7. **Audit (§5.3)** — the merge decision is itself submitted to the
-   `AuditScheduler`; high-blast-radius / low-trust merges are forced through the
-   oracle. The optimizer audits itself.
+7. **Dual-branch promotion (§4.5)** — `dev → stable` after *K* **regression-free
+   rounds** on dev (EMA-style confirmation; one round is one `step()`, and a
+   commit *restarts* the clock rather than advancing it — so the artifact most
+   likely to be promoted is the one that stopped changing because nothing beat
+   it). A clean run publishes its head on the way out.
 
 ## Parallelism & asynchrony
 
@@ -429,6 +433,11 @@ to 1.000, but at `async_ratio=4`:
 | Full | ~8k | 0 | ~3.2s |
 | Reflective | ~7.8k | ~0.7k | ~3.3s |
 | Guarded | ~20k | ~17k | ~5.1s |
+
+The **ratios** are the result; the absolute counts scale with the machine (a
+slower host fits fewer rollouts into the same wall-clock window), so rerun it
+rather than quoting these — same caveat as
+[the efficiency numbers](https://github.com/Birfy/agentdescent/blob/main/docs/efficiency.md).
 
 ### DP / TP / PP ([`parallel.py`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/parallel.py), §8)
 

--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -6,8 +6,10 @@ recursive self-improvement, where the "parameters" are a library of evolvable
 artifacts (skills, prompts, harness modules, verifiers) and the "gradients" are
 diffs carrying evidence cards.
 
-See ``agentdescent_design.md`` for the full design; each module cites the section
-it implements.
+Every module cites the design-spec section it implements ("design doc, section
+4.2"). The spec itself is **not shipped in this repository**; ``docs/`` is written
+against the code that came out of it, so read ``docs/concepts.md`` for the *why*
+and ``docs/architecture.md`` for how the sections map onto the modules.
 """
 
 from .evolvable import (

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -135,6 +135,19 @@ class MergeOutcome(str, Enum):
     def __str__(self) -> str:            # so f-strings render the value, not the name
         return self.value
 
+    def __repr__(self) -> str:
+        """Render as the plain string, which is what every reader is shown.
+
+        ``outcomes()`` is a *dict*, and printing a dict uses ``repr`` on its keys
+        -- so the diagnostic the README, both quickstarts, ``evolution.md`` and
+        this class's own docstring all print as ``{'committed': 1}`` actually came
+        out as ``{<MergeOutcome.COMMITTED: 'committed'>: 1}``. The value is the
+        identity here (the enum subclasses ``str`` precisely so callers can use
+        the bare string), so the enum repr showed the reader nothing they needed
+        and contradicted every example of it. ``enum.StrEnum`` does this for free
+        on 3.11+; this package supports 3.9."""
+        return repr(self.value)
+
 
 class AggregatorContractError(ContractError, TypeError):
     """A custom aggregator returned something ``step()`` may not return."""

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -37,7 +37,7 @@ import warnings
 from typing import Callable, Dict, List, Optional
 
 from .evolution import (
-    _safe_log,
+    _publish_stable, _safe_log,
     Agent, EvolutionResult, Propose, Reward, RoundInfo, Run, Strategy, Task, _tally,
     SOLVED, _build_engine, _checked_proposal, _checked_reward,
 )
@@ -46,7 +46,7 @@ from .evolvable import ContractError, EvidenceCard, vv_staleness
 from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import DurationEstimator
-from .pipeline import WorkerHealth
+from .pipeline import StallGuard, WorkerHealth
 from .staleness import StaleAction, StalenessPolicy, get_policy
 
 
@@ -244,15 +244,16 @@ def async_evolve(
     # nothing commits), which forces every worker to resync regardless of the ratio.
     epoch = [0]
     forced_refreshes = [0]
-    no_commit_sweeps = [0]
     stragglers = [0]
     estimator = duration_estimator
     n_live = sum(1 for s in shards if s)      # workers that will actually start
     live = [n_live]                           # workers still running
     retired = [0]                             # workers that gave up (diagnostic)
-    # Retirement policy is shared with AsyncAgentDescent (`pipeline.WorkerHealth`),
-    # which is what keeps the two barrier-free runtimes from drifting apart again.
+    # Retirement and backpressure policy are shared with AsyncAgentDescent
+    # (`pipeline.WorkerHealth` / `pipeline.StallGuard`), which is what keeps the
+    # two barrier-free runtimes from drifting apart again.
     health = WorkerHealth(max_errors=max_worker_errors)
+    stall = StallGuard(patience=stall_patience)
     max_merger_errors = max(3, max_worker_errors)   # sweeps it may fail in a row
 
     def _worker(wid: int, shard: List[Task]) -> None:
@@ -286,13 +287,22 @@ def async_evolve(
             # accept, every card is discarded, head never moves, so the lag budget
             # never triggers a refresh either. It existed only in the reference
             # runtime, which is not the one a real workload reaches.
-            if head_v - base_v > async_ratio or epoch[0] != local_epoch:
+            forced = epoch[0] != local_epoch
+            if head_v - base_v > async_ratio or forced:
                 snap = eng.ledger.snapshot(Ledger.DEV)
                 base_v = snap.version.get(eng.artifact_id, 0)
                 artifact = snap.get(eng.artifact_id)
                 local_epoch = epoch[0]
-                with counter_lock:
-                    forced_refreshes[0] += 1
+                # Only the *forced* half is counted. Refreshing on one's own lag
+                # budget is what an async worker does all run long -- counting it
+                # made `forced_refreshes` non-zero on every healthy run, while the
+                # field, `docs/async.md`, `docs/staleness.md` and `concepts.md` all
+                # say a non-zero count means the lag budget and the staleness
+                # tolerance disagree. It is a diagnostic, so it has to be quiet
+                # when there is nothing to diagnose.
+                if forced:
+                    with counter_lock:
+                        forced_refreshes[0] += 1
             task = by_shard_id[sampler.pick(shard_ids, i)]
             i += 1
             # Duration-aware straggler detection (design spec 5.1, L-traj). It
@@ -380,12 +390,14 @@ def async_evolve(
                         f"(it succeeded earlier, so this reads as transient). "
                         f"Last error: {type(e).__name__}: {str(e)[:120]}",
                         RuntimeWarning, stacklevel=2)
-                # Cap the backoff well above the retirement threshold so a throttled
-                # run waits the limit out instead of hammering it.
-                # A short backoff on purpose: unlike a worker, the merger blocks
-                # the whole run while it waits, and its work is memoised, so a
-                # retry is cheap. A worker-sized backoff spent an entire short run
-                # asleep and produced no sweeps at all.
+                # Exponential, capped: a throttled run waits the limit out instead
+                # of hammering it, while staying short enough that a worker which
+                # recovers has time left to produce something. (The paragraph that
+                # used to sit here described the *merger's* backoff -- "unlike a
+                # worker, the merger blocks the whole run" -- and had been copied
+                # onto the worker path, where it contradicts both its own first
+                # sentence and the code: the merger below waits up to 30s, this
+                # waits up to 5.)
                 stop.wait(min(0.25 * 2.0 ** consecutive, 5.0))     # backoff, then retry
                 continue
             elapsed = time.time() - t_start
@@ -442,13 +454,12 @@ def async_evolve(
                                  len(reports) - committed, _tally(reports)))
         # A stalled pipeline: cards keep arriving and none of them commits. Under
         # Guarded with async_ratio > alpha that is a livelock, not slow progress.
-        if committed:
-            no_commit_sweeps[0] = 0
-        elif batch:
-            no_commit_sweeps[0] += 1
-            if no_commit_sweeps[0] >= stall_patience:
-                epoch[0] += 1                  # every worker resyncs on its next loop
-                no_commit_sweeps[0] = 0
+        # A sweep with no cards in it is neither, so it is not counted -- and this
+        # function has already returned in that case.
+        stall.note_sweep(committed)
+        if stall.should_force_refresh():
+            epoch[0] += 1                      # every worker resyncs on its next loop
+            stall.force()
         if verbose:
             print(f"sweep {len(history):>3}  reward={r:.3f}  merged={len(batch)}  "
                   f"+{committed}  pending={len(intake)}")
@@ -541,6 +552,12 @@ def async_evolve(
 
     if contract_error[0] is not None:
         raise contract_error[0]
+    if not died[0]:
+        # Same reason as the synchronous path: confirmation takes
+        # `promote_after_k` sweeps and `target_reward` stops the run on the very
+        # commit that reaches it, so publish the head this run produced rather
+        # than leaving `stable` on the seed artifact.
+        _publish_stable(eng.aggregator)
     try:
         final = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
     except LedgerFailure as e:

--- a/agentdescent/async_runtime.py
+++ b/agentdescent/async_runtime.py
@@ -49,7 +49,7 @@ from .scheduler import (
     TaskCluster,
     TaskScheduler,
 )
-from .pipeline import WorkerHealth
+from .pipeline import StallGuard, WorkerHealth
 from .staleness import StalenessPolicy, get_policy
 from .verifier import ThreeLayerVerifier, VerifierBudget
 from .worker import Worker
@@ -200,13 +200,19 @@ class AsyncAgentDescent:
             epoch = self._epoch()
             # refresh when the ratio budget is exceeded, or when a pipeline stall
             # forced a global sync (backpressure).
-            if drift > self.cfg.async_ratio or epoch != local_epoch:
+            forced = epoch != local_epoch
+            if drift > self.cfg.async_ratio or forced:
                 snap = self.ledger.snapshot(Ledger.DEV)
                 local = snap.get(self.skill_id)
                 local_v = snap.version.get(self.skill_id, 0)
                 local_epoch = epoch
-                with self._stats_lock:
-                    self.stats.forced_refreshes += 1
+                # Only the backpressure-forced half is counted -- see the same
+                # comment in `async_evolve._worker`: a lag-budget refresh is
+                # ordinary progress, and counting it made the stall diagnostic
+                # non-zero on every healthy run.
+                if forced:
+                    with self._stats_lock:
+                        self.stats.forced_refreshes += 1
 
             cluster = self.scheduler.lease_round_robin()
             # estimate this rollout's cost from task size, time it, and calibrate.
@@ -271,7 +277,8 @@ class AsyncAgentDescent:
     # -- aggregator thread ---------------------------------------------------
 
     def _aggregator_loop(self) -> None:
-        no_commit_streak = 0
+        # Backpressure policy is shared with `async_evolve` (`pipeline.StallGuard`).
+        stall = StallGuard(patience=self.cfg.stall_patience)
         consecutive = 0
         while not self._stop.is_set():
             try:
@@ -310,7 +317,7 @@ class AsyncAgentDescent:
                         if rep.fused:
                             self.stats.fused += 1
             if committed:
-                no_commit_streak = 0
+                stall.note_sweep(True)
                 self._publish_head()
                 acc = self._dev_accuracy()
                 with self._stats_lock:
@@ -318,14 +325,15 @@ class AsyncAgentDescent:
                 if acc >= self.cfg.target_accuracy:
                     self._stop.set()
                     return
-            else:
+            elif self.buffer_pending() > 0:
                 # pipeline is producing evidence but nothing commits (all stale /
-                # rejected) -> apply backpressure and force a global sync.
-                if self.buffer_pending() > 0:
-                    no_commit_streak += 1
-                    if no_commit_streak >= self.cfg.stall_patience:
-                        self._bump_epoch()
-                        no_commit_streak = 0
+                # rejected) -> apply backpressure and force a global sync. A sweep
+                # with an empty buffer is neither progress nor a stall, so it is
+                # not counted either way.
+                stall.note_sweep(False)
+                if stall.should_force_refresh():
+                    self._bump_epoch()
+                    stall.force()
             time.sleep(self.cfg.aggregator_interval)
 
     def buffer_pending(self) -> int:

--- a/agentdescent/backends.py
+++ b/agentdescent/backends.py
@@ -31,11 +31,15 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import tempfile
 import warnings
 from typing import Callable, Mapping, Optional, Protocol, runtime_checkable
 
 from .agents import Completion, WorkspaceAgent
+
+#: Prefix of the per-question scratch directory a workspace agent is given.
+_DOC_WS_PREFIX = "agentdescent-doc-"
 
 
 @runtime_checkable
@@ -63,11 +67,6 @@ class _FnBackend:
     def answer(self, question: str, document: str, *, skills: str = "",
                skill_files: Optional[Mapping[str, str]] = None) -> str:
         return self._fn(question, document, skills=skills, skill_files=skill_files)
-
-
-# ---------------------------------------------------------------------------
-# OpenHands backend -- a real tool-using agent (Read/Grep/Bash over the doc)
-# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------
@@ -121,20 +120,30 @@ def document_agent(completion: Completion, *, doc_filename: str = "document.txt"
                skill_files: Optional[Mapping[str, str]] = None) -> str:
         skill_block = f"Learned skills you should apply:\n{skills}\n\n" if skills.strip() else ""
         if isinstance(completion, WorkspaceAgent):
-            workdir = tempfile.mkdtemp(prefix="agentdescent-doc-")
-            with open(os.path.join(workdir, doc_filename), "w", encoding="utf-8") as f:
-                f.write(document)
-            if skill_files:
-                # Progressive disclosure: the library goes to disk and the prompt
-                # carries a pointer, so the agent opens the one skill it needs
-                # rather than reading all of them on every question.
-                from .filetree import materialize
+            workdir = tempfile.mkdtemp(prefix=_DOC_WS_PREFIX)
+            try:
+                with open(os.path.join(workdir, doc_filename), "w", encoding="utf-8") as f:
+                    f.write(document)
+                if skill_files:
+                    # Progressive disclosure: the library goes to disk and the prompt
+                    # carries a pointer, so the agent opens the one skill it needs
+                    # rather than reading all of them on every question.
+                    from .filetree import materialize
 
-                materialize(skill_files, workdir, prefix=skills_dir)
-                names = ", ".join(sorted({p.split("/", 1)[0] for p in skill_files})) or "(none)"
-                skill_block = _SKILL_DIR_INSTR.format(dir=skills_dir, names=names)
-            prompt = _DOC_INSTR.format(skills=skill_block, fname=doc_filename, q=question)
-            return completion.in_workspace(workdir)(prompt).strip()
+                    materialize(skill_files, workdir, prefix=skills_dir)
+                    names = ", ".join(sorted({p.split("/", 1)[0] for p in skill_files})) or "(none)"
+                    skill_block = _SKILL_DIR_INSTR.format(dir=skills_dir, names=names)
+                prompt = _DOC_INSTR.format(skills=skill_block, fname=doc_filename, q=question)
+                return completion.in_workspace(workdir)(prompt).strip()
+            finally:
+                # One workspace per *question*, and a document here is routinely a
+                # megabyte of financial tables -- so without this a benchmark run
+                # leaves one copy of it in $TMPDIR per rollout, forever. Every other
+                # place in the package that stages a directory for an agent cleans
+                # up after itself (`runners._stage`, `evolution._Engine.cleanup`);
+                # this one did not. The agent has already answered by here, so
+                # nothing still needs the files.
+                shutil.rmtree(workdir, ignore_errors=True)
         if len(document) > inline_chars:
             # Never drop half a document in silence: the answer may be in the part
             # the agent never saw, and an empty or wrong reply then looks like a
@@ -192,21 +201,32 @@ class _OpenHandsAgent:
 
     def __call__(self, prompt: str) -> str:
         llm, Agent, Conversation, Tool, max_iterations = self._load()
-        workdir = self.workspace or tempfile.mkdtemp(prefix="agentdescent-oh-")
-        agent = Agent(llm=llm, tools=[Tool(name="terminal"), Tool(name="file_editor")])
-        conv = Conversation(agent=agent, workspace=workdir,
-                           max_iteration_per_run=max_iterations)
-        conv.send_message(prompt)
-        conv.run()
-        texts = []
-        for ev in conv.state.events:
-            m = getattr(ev, "llm_message", None) or getattr(ev, "message", None)
-            if m is not None and getattr(m, "role", "") == "assistant":
-                for c in getattr(m, "content", []) or []:
-                    t = getattr(c, "text", None)
-                    if t:
-                        texts.append(t)
-        return texts[-1].strip() if texts else ""
+        # Clean up only the scratch directory *we* made: a workspace handed in
+        # through `in_workspace()` belongs to the caller (it is how a runner
+        # stages the candidate tree) and deleting it would delete their files.
+        # Without this the anonymous one leaked a directory per call, which on
+        # an agent that writes files is not a small directory.
+        workdir, ours = self.workspace, False
+        if workdir is None:
+            workdir, ours = tempfile.mkdtemp(prefix="agentdescent-oh-"), True
+        try:
+            agent = Agent(llm=llm, tools=[Tool(name="terminal"), Tool(name="file_editor")])
+            conv = Conversation(agent=agent, workspace=workdir,
+                               max_iteration_per_run=max_iterations)
+            conv.send_message(prompt)
+            conv.run()
+            texts = []
+            for ev in conv.state.events:
+                m = getattr(ev, "llm_message", None) or getattr(ev, "message", None)
+                if m is not None and getattr(m, "role", "") == "assistant":
+                    for c in getattr(m, "content", []) or []:
+                        t = getattr(c, "text", None)
+                        if t:
+                            texts.append(t)
+            return texts[-1].strip() if texts else ""
+        finally:
+            if ours:
+                shutil.rmtree(workdir, ignore_errors=True)
 
 
 def openhands(model: str = "openai/deepseek-v4-pro", *,

--- a/agentdescent/dataloader.py
+++ b/agentdescent/dataloader.py
@@ -113,8 +113,22 @@ def split_dataset(items: Sequence[Any], *, ratios: Tuple[float, float, float] = 
             if shuffle:
                 rng.shuffle(g)
             a, b = _cut_points(len(g), ratios)
+            # A group too small for the ratios has to give val an item from
+            # somewhere -- but by *moving* one, not copying it. `g[a:b] or
+            # g[a:a+1]` did the latter: for a two-item class the cut points
+            # collapse to a == b == 1, so val borrowed g[1] while test still took
+            # g[b:] == [g[1]]. The same item then sat in the split the optimizer
+            # gates on *and* in the one this class documents as "fully held out,
+            # never seen by the optimizer", which is the one promise a test split
+            # makes. Rare classes are exactly where this bites, and stratifying is
+            # what you do when you have them (FiNER tags, MGSM languages).
+            if a == b:
+                if b < len(g):
+                    b += 1              # take val's item from test
+                elif a > 0:
+                    a -= 1              # nothing left there: take it from train
             train += g[:a]
-            val += g[a:b] or g[a:a + 1]        # guarantee a non-empty val per class
+            val += g[a:b]
             test += g[b:]
         for split in (train, val, test):
             if shuffle:

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -554,6 +554,33 @@ def _safe_log(ledger: Ledger, limit: int = 40) -> List[str]:
         return []
 
 
+def _publish_stable(aggregator) -> None:
+    """Publish the run's dev head to ``stable``, if the aggregator knows how.
+
+    Promotion is confirmation-based -- ``promote_after_k`` regression-free rounds
+    -- and a run can legitimately end before that many elapse: ``target_reward``
+    fires on the very commit that reaches it, and ``patience`` / ``rounds`` /
+    ``max_seconds`` can all stop a converged run one round short. Both reference
+    runtimes therefore call ``Aggregator.finalize()`` on the way out, and the two
+    engines a real workload actually reaches -- :func:`evolve` and
+    :func:`~agentdescent.async_evolve.async_evolve` -- did not, so a clean run that
+    hit its target left ``stable`` holding the *seed* artifact while ``dev`` held
+    the one the run was for. ``docs/ledger.md`` documented the call that was not
+    being made.
+
+    Optional on purpose: ``finalize`` is not part of
+    :class:`~agentdescent.aggregator.AggregatorProtocol`, so a custom optimizer
+    need not have one. And it is a courtesy like ``_safe_log`` -- a git failure
+    while publishing must not discard a run that has already finished."""
+    fn = getattr(aggregator, "finalize", None)
+    if not callable(fn):
+        return
+    try:
+        fn()
+    except LedgerFailure:
+        pass
+
+
 def _tally(reports) -> Dict[str, int]:
     """Count merge outcomes by stable category (see ``MergeReport.category``)."""
     out: Dict[str, int] = {}
@@ -1095,7 +1122,7 @@ def evolve(
         ``target_reward``, ``final_reward``) would then be measured against it.
     reward:
         ``(task, output) -> [0, 1]``. Scores in ``[0, 1]``; the engine treats
-``>= solved_threshold`` as a pass (no proposal is requested).
+        ``>= solved_threshold`` as a pass (no proposal is requested).
     agent:
         An object with ``solve`` + ``propose``. Provide this **or** ``run`` and
         ``propose``; both signatures are checked before the first rollout.
@@ -1600,6 +1627,11 @@ def evolve(
                 warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
                               RuntimeWarning, stacklevel=2)
 
+    if run_error is None:
+        # A clean run publishes the head it produced (see `_publish_stable`);
+        # a run that died leaves `stable` where it was, which is the point of
+        # having a confirmed branch at all.
+        _publish_stable(aggregator)
     try:
         final = ledger.snapshot(Ledger.DEV).get(artifact_id)
     except LedgerFailure as e:

--- a/agentdescent/evolvable.py
+++ b/agentdescent/evolvable.py
@@ -126,8 +126,18 @@ class EvidenceCard:
     touched: List[str]
     # local before/after measurement made by the proposing worker.
     before_after_delta: float = 0.0
-    # trajectory references / failure traces that justify the diff.
-    trajectory_refs: List[str] = field(default_factory=list)
+    #: The failing work units that justify the diff -- **whatever the owning
+    #: artifact's** :meth:`Evolvable.evidence_eval` **can score**. Every producer
+    #: in the package puts task *objects* here (``evolution.Task`` /
+    #: ``RouterTask``) and both consumers filter for them with ``isinstance``.
+    #:
+    #: It was annotated ``List[str]``, which is a trap rather than a cosmetic
+    #: slip: a custom domain that follows the annotation and stores ids gets an
+    #: ``evidence_eval`` over an empty task list, so the staleness policy's
+    #: REBASE branch compares ``0.0 <= 0.0`` and keeps *every* rebased diff --
+    #: the cheap re-verification silently becomes a no-op, and a diff that makes
+    #: the artifact worse survives it.
+    trajectory_refs: List[Any] = field(default_factory=list)
     # per-turn version annotations, used when the ledger hot-updates mid-rollout.
     version_annotations: List[VersionVector] = field(default_factory=list)
     cost_tokens: int = 0

--- a/agentdescent/pipeline.py
+++ b/agentdescent/pipeline.py
@@ -8,10 +8,22 @@ different substrates, and for a while they implemented it *independently*: two
 measured fixes lived in whichever pipeline they had been written for, and the
 repair was to hand-port them rather than to share them. Hand-porting works once.
 
-So the parts that are **policy** rather than plumbing live here, and both
-runtimes call them. Nothing in this module touches a ledger, a thread or a task:
-it is arithmetic over counters, which is exactly why it can be shared by two
-pipelines that agree on nothing else.
+So the parts that are **policy** rather than plumbing live here. Nothing in this
+module touches a ledger, a thread or a task: it is arithmetic over counters,
+which is exactly why it can be shared by two pipelines that agree on nothing
+else.
+
+What is actually shared, so this page cannot claim more than the code does:
+
+* :class:`WorkerHealth` -- both runtimes call ``should_retire`` /
+  ``should_warn`` / ``record_success``, which is the rule that was hand-ported
+  and the one that matters. ``backoff`` is used by
+  :class:`~agentdescent.async_runtime.AsyncAgentDescent`; ``async_evolve``
+  deliberately waits a quarter of it and says so at the call site.
+* :class:`StallGuard` -- both runtimes count their no-commit sweeps through it.
+  Each decides for itself *which* sweeps count (a sweep with no evidence in it
+  is neither progress nor a stall, and the two express "no evidence"
+  differently), and hands the counting itself here.
 """
 
 from __future__ import annotations

--- a/agentdescent/strategies.py
+++ b/agentdescent/strategies.py
@@ -144,10 +144,17 @@ class KeyedRules:
     def keys(self) -> Sequence[str]:
         """The declared categories -- the key space tensor parallelism partitions.
 
+        Lower-cased, because that is what :meth:`to_diff` writes: matching is
+        case-insensitive and the key it stores is the *folded* one. Returning the
+        declared spelling meant that ``categories=["Routing"]`` under tensor
+        parallelism built a section map keyed on ``"Routing"`` while every diff
+        wrote ``"routing"`` -- so no key had an owner, and every proposal in the
+        run was rejected as a ``section-violation``.
+
         Note that an *unrecognised* proposal still falls back to a content-addressed
         key, which is outside this space; under TP those are reported as
         ``section-violation`` rather than silently dropped."""
-        return list(self.categories)
+        return [c.strip().lower() for c in self.categories]
 
     def initial(self) -> Dict[str, str]:
         return {}

--- a/docs/aggregator.md
+++ b/docs/aggregator.md
@@ -25,12 +25,10 @@ Evidence cards are bucketed by artifact; a bucket fires on batch size `B` or a
 1. **Staleness filter** — per-diff `η` vs `α`; the [staleness policy](evolution.md#6-staleness-staleness_policy) decides `ACCEPT / REBASE / DISCARD`.
 2. **Conflict resolution** — contradictory diffs (same key, different value) are projected out PCGrad-style; keep the better of the pair, iterating until no surviving pair contradicts. Key *overlap* alone is not a conflict — identical proposals are duplicates and dedupe.
 3. **Fusion tournament** — complementary diffs are fused (model-soup style) and run against the singles on held-out; the best wins.
-4. **Statistical acceptance** — commit only if `P(Δ > 0) > 1 − δ` under a Beta posterior (not a point threshold); `δ` anneals with version.
-5. **Commit** — compare-and-swap on `dev`, one artifact per merge. The `Ledger` *also* offers `commit_atomic` (2PC across several artifacts, for a contract-breaking diff that must land with its adapters), but the reference aggregator buckets by artifact and never needs it — no engine path calls it today.
 4. **Audit gate** — the candidate is submitted to the `AuditScheduler`; a high-blast-radius / low-trust merge is forced through the oracle, which can **veto it outright** (`oracle-rejected`) before the acceptance test runs. *The optimizer audits itself.* This is a blocking gate on the accept path, not a post-commit spot-check.
-5. **Statistical acceptance** — `P(Δ > 0) > 1 − δ` under a Beta posterior comparison, not a point threshold.
-6. **Commit** — compare-and-swap on `dev`, one artifact per merge.
-7. **Dual-branch promotion** — `dev → stable` after *K* **regression-free rounds** on dev. One round is one `step()`. A commit restarts the clock (the new version has survived nothing yet) and so does an oracle rejection. So a *converged* artifact — one that stopped committing because nothing beats it — is the one most likely to be promoted, which is the point.
+5. **Statistical acceptance** — commit only if `P(Δ > 0) > 1 − δ` under a Beta posterior comparison (not a point threshold); `δ` anneals with version.
+6. **Commit** — compare-and-swap on `dev`, one artifact per merge. The `Ledger` *also* offers `commit_atomic` (2PC across several artifacts, for a contract-breaking diff that must land with its adapters), but the reference aggregator buckets by artifact and never needs it — no engine path calls it today.
+7. **Dual-branch promotion** — `dev → stable` after *K* **regression-free rounds** on dev. One round is one `step()`. A commit restarts the clock (the new version has survived nothing yet) and so does an oracle rejection. So a *converged* artifact — one that stopped committing because nothing beats it — is the one most likely to be promoted, which is the point. A run that ends cleanly also publishes its head via `finalize()`, so stopping on `target_reward` does not leave `stable` a confirmation short.
 
 Deep dive on the *why*: [concepts §4](concepts.md#4-the-aggregator-a-discrete-space-optimizer).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,9 @@ The same flow, with the design-doc section numbers annotated:
                      dev branch (fast)   stable branch (EMA-confirmed)
                                      │
                     broadcast changed artifact → Workers refresh
-                                     │
-                    AuditScheduler (Ĝ) → Oracle spot-checks         §5.3
+
+           (step 4 above submits the candidate to the AuditScheduler,
+            which spends the oracle budget by Ĝ and may VETO it)      §5.3
 ```
 
 The three-layer **verifier** (rule / learned / oracle) is the evaluation backend

--- a/docs/async.md
+++ b/docs/async.md
@@ -118,9 +118,11 @@ Beyond the barrier removal, three signals only it can report:
 of its requested concurrency, so `error` stays `None` while throughput quietly
 drops. Check it to tell a fast run from a lucky one.
 
-`stall_patience` (default 50) is how many empty merger sweeps pass before a
-worker is forced to refresh; `shutdown_grace` is how long the runtime waits for
-in-flight rollouts when it stops.
+`stall_patience` (default 50) is how many merger sweeps may pass **with cards in
+them and nothing committing** before every worker is forced to refresh — a sweep
+that had no evidence to merge is neither progress nor a stall, and is not
+counted. `shutdown_grace` is how long the runtime waits for in-flight rollouts
+when it stops.
 
 ## `AsyncAgentDescent` — the reference runtime
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -159,6 +159,11 @@ Observed trade-off at `async_ratio=4` (all three converge to 1.000):
 | Reflective | ~7.8k | ~0.7k | ~3.3s |
 | Guarded | ~20k | ~17k | ~5.1s |
 
+The ratios between the rows are the result; the absolute counts scale with the
+machine, since each run is bounded by wall-clock. Rerun
+`python -m examples.run_async` rather than quoting these — the same caveat
+[the efficiency page](efficiency.md) attaches to its own numbers.
+
 ---
 
 ## 4. The aggregator: a discrete-space optimizer
@@ -209,10 +214,15 @@ mechanism:
 
 - **L-traj (system layer)** — heavy-tailed rollout durations. Handled today by
   the duration estimator + LPT dispatch and by **detecting** stragglers: a
-  rollout that overruns its prediction is counted. Reachable from `evolve()` /
-  `async_evolve` as `duration_estimator=` → `result.stragglers`; it used to exist
-  only in the reference runtime, which accepts nothing but the synthetic domain,
-  so the mechanism was unreachable from the API a real workload uses.
+  rollout that overruns its prediction is counted. Reachable from
+  [`async_evolve`](async.md) as `duration_estimator=` → `result.stragglers`; it
+  used to exist only in the reference runtime, which accepts nothing but the
+  synthetic domain, so the mechanism was unreachable from the API a real workload
+  uses. It is **not** a parameter of `evolve()` — not even with
+  `asynchronous=True`, which forwards only the knobs it declares — so reach for
+  `async_evolve` directly when you want it. The synchronous path bounds a slow
+  rollout with `round_timeout=` instead, which abandons the straggler rather than
+  measuring it.
   **The resume half is not implemented** — nothing pops that queue, and the
   recorded item carries no continuation state, because a resumable rollout would
   have to expose its turns and `run(rendered, task) -> output` is opaque. The
@@ -243,12 +253,16 @@ mechanism:
   never earn an audit — measured at the default 0.2, `oracle_calls_used` was 0 for
   a whole run.
 
-    !!! warning "The priority queue has no consumer"
-        `AuditScheduler.submit` ranks merges by `Ĝ` into a bounded heap, and
-        nothing in the engines pops it. The audit that actually runs is the inline
-        `force_oracle` gate in the merge pipeline, which reads trust but not the
-        queue. Treat the queue as a priority *model* — the ordering a fuller
-        system would spend a background budget against — not as work in flight.
+    !!! warning "The priority queue has no consumer — and is off by default"
+        `AuditScheduler.submit` computes `Ĝ` for every merge, but with the default
+        `collect=False` it does not queue anything: nothing in the engines would
+        pop that heap, so building it would be work done on the merge path for a
+        reader who never arrives. Pass `collect=True` to keep it for an
+        out-of-band audit process. The audit that actually runs either way is the
+        inline `force_oracle` gate in the merge pipeline, which reads trust but
+        not the queue. Treat the ranking as a priority *model* — the ordering a
+        fuller system would spend a background budget against — not as work in
+        flight.
 
 ---
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -117,15 +117,25 @@ class EvidenceCard:
     base_version: VersionVector     # what it was proposed against
     touched: List[str]
     before_after_delta: float = 0.0 # the proposer's own local measurement
-    trajectory_refs: List[str] = () # the failures that justify it
+    trajectory_refs: List[Any] = () # the failing work units that justify it
     cost_tokens: int = 0
     cost_wallclock: float = 0.0
 ```
 
-The card outlives the diff it justifies. When a diff is discarded for staleness
-the card settles back into the evidence pool and can be reused — the rollout that
-produced it was expensive, and the *observation* is still true even when the
-patch no longer applies.
+!!! warning "`trajectory_refs` holds task *objects*, not ids"
+    Whatever you put here is what your artifact's `evidence_eval` will be asked to
+    score, and that is how the staleness policy re-verifies a rebased diff. Store
+    ids instead and `evidence_eval` scores an empty list, so the REBASE branch
+    compares `0.0 <= 0.0` and keeps everything — the cheap re-verification
+    silently becomes a no-op and a diff that makes the artifact *worse* survives
+    it. The field was annotated `List[str]`, which invited exactly that.
+
+The card outlives the diff it justifies: when a diff is discarded for staleness
+the card is `settle()`d rather than dropped, because the rollout that produced it
+was expensive and the *observation* stays true even when the patch no longer
+applies. **Nothing in the library reads that pool back yet** — it is a bounded
+diagnostic ring of recent rejections, not a queue that feeds later rounds (see
+[concepts](concepts.md#33-staleness-policies-flashevolve-full-guarded-reflective)).
 
 `before_after_delta` is folded into the acceptance test as extra evidence for the
 candidate: it is the closest thing here to a gradient magnitude. It is populated

--- a/docs/duration-scheduling.md
+++ b/docs/duration-scheduling.md
@@ -1,8 +1,11 @@
 # Duration-aware scheduling
 
-> **Belongs to the async runtime**, not synchronous [`evolve`](evolution.md):
-> pass a `DurationEstimator` to `AsyncAgentDescent` for straggler checkpointing. The
-> `DurationEstimator` / `lpt_schedule` primitives are usable on their own too.
+> **Belongs to the async paths**, not synchronous [`evolve`](evolution.md), which
+> has no `duration_estimator=` parameter at all and bounds a slow rollout with
+> `round_timeout=` instead. Pass a `DurationEstimator` to `AsyncAgentDescent`
+> (reference runtime) or to [`async_evolve`](async.md) (the general one, where it
+> reports `result.stragglers`). The `DurationEstimator` / `lpt_schedule`
+> primitives are usable on their own too.
 
 Agentic rollouts are heavy-tailed and their cost correlates with task size. This
 module **estimates a rollout's duration from the task's length**, then uses that
@@ -78,9 +81,10 @@ guarantee is 4/3); round-robin is 28% over.
 ## 3. Straggler checkpointing in the async runtime
 
 Pass a `DurationEstimator` to `AsyncAgentDescent` and it becomes duration-aware: it
-times every rollout, calibrates the estimator, and **checkpoints any rollout
-that overruns `duration_timeout_factor × its estimate`** to the `ResumeQueue`
-(partial rollout) instead of letting it block a worker.
+times every rollout, calibrates the estimator, and **records any rollout that
+overran `duration_timeout_factor × its estimate`** into the `ResumeQueue`. The
+record is written once the rollout returns, so this measures the tail rather than
+cutting it short — see the warning below.
 
 ```python
 from agentdescent import AsyncAgentDescent, AsyncConfig
@@ -97,9 +101,11 @@ stats.stragglers_checkpointed        # overrunning rollouts DETECTED (see the no
 rollouts=727, learned base≈0.006s, stragglers detected=108
 ```
 
-This is the design's partial-rollout mechanism (§5.1) driven by a live estimate:
-a rollout predicted to be short but running long is set aside and resumed against
-the latest ledger, rather than defining the wall-clock of its worker.
+This is the *detection* half of the design's partial-rollout mechanism (§5.1),
+driven by a live estimate: a rollout predicted to be short but running long is
+identified and counted, so it shows up in the stats instead of silently setting
+the pace. The design's other half — setting it aside and resuming it against the
+latest ledger — is where the mechanism stops:
 
 !!! warning "Straggler *resume* is not implemented"
     A rollout that overruns its predicted cost is flagged into `ResumeQueue` and
@@ -127,8 +133,10 @@ priority(d) = blast_radius(d) * uncertainty(d) / trust(artifact)
 
 High blast radius means a mistake is expensive; high uncertainty means the cheap
 layers do not know; low trust means the cheap layers have been *wrong here
-before*. The aggregator enqueues its own merge decisions, which closes the audit
-loop over the optimizer itself.
+before*. The aggregator submits its own merge decisions here, which closes the
+audit loop over the optimizer itself — "submits", not "enqueues": with the
+default `collect=False` the priority is computed and returned without a queue
+being built (see below).
 
 ```python
 from agentdescent import AuditScheduler

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -397,9 +397,11 @@ every round by a stable category:
 | `committed` | accepted and written to the dev branch | — |
 | `below-threshold` | reached the acceptance gate and failed to beat the baseline | the **reflector** — its proposals do not help. Check it can see enough (`Task.meta`), and that it is not returning empty (`max_tokens`) |
 | `all-stale` | never reached the gate; the world moved on first | the **lag budget** — lower `async_ratio`, or use the sync path |
+| `oversized` | outside the trust region: too many ops, or one value too long | the **reflector** again, but the opposite fix — it is emitting whole documents where a rule was wanted. Raise `trust_region_ops` / `trust_region_chars` only if the size is genuinely intended |
 | `cas-conflict` | lost a commit race; the evidence is re-filed for retry | usually self-correcting; persistent means too many workers on one artifact |
 | `oracle-rejected` | the audit's oracle disagreed with the cheap evaluator | the **cheap evaluator** is miscalibrated |
 | `unknown-artifact` | diffs targeted an id the ledger does not hold | a caller bug in `artifact_id`/strategy |
+| `section-violation` | tensor parallelism only: a worker edited a key outside its own section | the strategy/`route=` pairing — see [§3](#3-the-parallelism-method-parallel) |
 
 `RoundInfo.reasons` is the same tally per round. A custom aggregator sees the
 underlying `MergeReport`, which carries both `category` and a human-readable

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -34,7 +34,7 @@ and *how*, that is *what*.
 
 | module | what it is | page |
 |---|---|---|
-| `evolution` (strategies) | `SingleSlot`, `AppendRules`, `KeyedRules` | [Strategies](strategies.md) |
+| `strategies` | `SingleSlot`, `AppendRules`, `KeyedRules` — the text strategies (re-exported from `evolution`, which is the published import path) | [Strategies](strategies.md) |
 | `filetree` | a directory ↔ artifact state, path safety, `TreeSpec` | [Directory evolution](directory-evolution.md) |
 | `treestrategy` | `FileTree`, the `<EDITS>` proposal protocol, `tree_reflector` | [Directory evolution](directory-evolution.md) |
 
@@ -61,8 +61,10 @@ and *how*, that is *what*.
 | module | what it is | page |
 |---|---|---|
 | `aggregator` | the optimizer: staleness → conflict → fusion → acceptance → commit | [Aggregator](aggregator.md) |
+| `stats` | the acceptance maths: Beta posterior, `P(Δ>0)`, annealed δ, UCB, difficulty weight | [Aggregator](aggregator.md) |
 | `verifier` | rule / learned / oracle, and the budget on the expensive one | [Verifier](verifier.md) |
 | `staleness` | what to do with a diff whose base version moved | [Staleness](staleness.md) |
+| `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -15,6 +15,15 @@ so you can reproduce it.
 | **[DGM](algo-dgm.md)** | surrogate | `--generations 4` | resolve-rate **0.000 → 0.300**; test 0.200 | offline |
 | **[ADAS](algo-adas.md)** | MGSM | `--hard`, all 11 languages | direct **0.919** → 222-item hard subset; lift **not yet measured** | ~2 h, 6k–17k calls |
 
+!!! note "What the *before* number is, per row"
+    GEPA, EvoSkill and SkillOpt score the **seed** artifact explicitly before
+    evolving it, so their "before" is a true baseline. ACE's is the **first round's**
+    held-out measurement, which is taken *after* that round's merge — the seed is
+    never scored on its own, because doing so would buy an extra val sweep of real
+    model calls and change the cost column. Read it as "where the run started
+    reporting", not "what the seed scored"; if round 0 committed, the real lift is
+    slightly larger than the row shows.
+
 !!! warning "ADAS is the exception: the lift row is still empty"
     Everything else in this table is a completed before → after. ADAS is not, and
     the honest reason is that no run against the current code has finished.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,7 +81,7 @@ python -m examples.dgm_self_improve                    # DGM   / SWE-bench Verif
 ### Tests
 
 ```bash
-pytest            #  tests
+pytest                          # the whole suite, no external services
 pytest -q tests/test_async.py   # just the async runtime
 ```
 
@@ -160,7 +160,7 @@ with tempfile.TemporaryDirectory() as repo:
 |---|---|---|
 | `n_workers` | 6 | worker threads |
 | `async_ratio` | 3 | ROLL Flash lag budget: max head-drift before a worker refreshes |
-| `noise` | 0.15 | fraction of workers that inject contradictory proposals |
+| `noise` | 0.15 | per-op probability that a *noisy* worker proposes a wrong label (every third worker is noisy; the rest are clean) |
 | `target_accuracy` | 0.98 | stop early when the dev branch reaches this |
 | `max_seconds` | 20.0 | wall-clock safety bound |
 | `aggregator_interval` | 0.002 | sleep between aggregator sweeps |

--- a/docs/verifier.md
+++ b/docs/verifier.md
@@ -111,9 +111,20 @@ ThreeLayerVerifier(eval_fn=lambda artifact, tasks: artifact.score(tasks),
                    budget=VerifierBudget(oracle_calls_remaining=200))
 ```
 
-Anything with `cheap_eval` / `eval_counts` / `oracle_eval` works, and an
-[`aggregator_factory`](aggregator.md#replacing-aggregator_factory-aggregatorprotocol) receives the
-verifier so a custom optimizer can use its own.
+The reference aggregator calls **four** methods, so a substitute needs all four —
+building to the three above raises `AttributeError` from inside the merge, after
+the run has already spent its rollouts:
+
+```python
+cheap_eval(artifact) -> float                 # ranking
+learned_eval(artifact) -> (score, uncertainty) # the audit priority's uncertainty term
+eval_counts(artifact) -> (successes, failures) # the acceptance test, full set
+oracle_eval(artifact) -> float                 # ground truth, spends budget
+```
+
+An [`aggregator_factory`](aggregator.md#replacing-aggregator_factory-aggregatorprotocol)
+receives the verifier, so a custom optimizer that does not want an audit gate can
+ignore whichever of these it never calls.
 
 A learned verifier is itself an evolvable artifact — and one that must never
 evolve itself. That is what the [L0 frozen layer](governance.md#l0-is-a-list-not-a-threshold)

--- a/examples/ace_context_evolution.py
+++ b/examples/ace_context_evolution.py
@@ -55,7 +55,8 @@ from typing import Dict, List, Optional, Tuple
 from agentdescent.agents import Usage, claude, openai_compatible
 from agentdescent.dataloader import Dataset, hf_feature_names, hf_rows, split_dataset
 from agentdescent.evolvable import Diff
-from agentdescent.evolution import LLMAgent, Task, evolve, rule_id
+from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rule_id
+from agentdescent.governance import classify
 from agentdescent.parallel import DataParallel
 from agentdescent.sampling import DifficultyWeighted, RoundRobin
 
@@ -317,7 +318,12 @@ def main() -> None:
     reward = make_reward()
 
     ntr, nva, nte = ds.sizes()
+    art = EvolvingArtifact("ace_context", blast_radius=0.2)
     print(f"Loaded   : {len(ds)} single-entity tasks, top-{args.top_k} concepts")
+    # Which governance layer this run actually landed in -- the line that tells a
+    # configuration mistake from a result, and which `docs/governance.md` says
+    # every port prints.
+    print(f"Governance: context blast_radius={art.blast_radius} -> {classify(art).name}")
     print(f"Splits   : {ntr} train / {nva} val / {nte} test")
     print(f"Concepts : {', '.join(ds.train[0].meta['candidates'])}")
     print("\nExample problem:")
@@ -372,10 +378,20 @@ def main() -> None:
     test_acc = evaluate(agent, result.rendered, ds.test, reward)
     print("\n=== evolved ACE playbook ===")
     print(result.rendered)
-    print(f"\nval accuracy : {result.history[0].held_out_reward:.3f} "
-          f"-> {result.final_reward:.3f}")
+    # Round 0's score, not the seed playbook's: by the time `history[0]` is
+    # recorded that round's merge has already happened. And guarded, because a
+    # run that died before finishing a round still returns a usable result --
+    # indexing an empty history turned that into an IndexError.
+    if result.history:
+        print(f"\nval accuracy : {result.history[0].held_out_reward:.3f} (round 0) "
+              f"-> {result.final_reward:.3f} (final)")
+    else:
+        print(f"\nval accuracy : {result.final_reward:.3f} (no round completed)")
     print(f"test accuracy: {test_acc:.3f}  (held out, never seen by the Curator)")
     print(f"bullets curated: {len(result.state)}")
+    print(f"stop reason  : {result.stop_reason}")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print(f"model usage  : {usage.summary()}")
 
 

--- a/examples/evoskill_skill_discovery.py
+++ b/examples/evoskill_skill_discovery.py
@@ -642,6 +642,12 @@ class EvoResult:
     #: :func:`agentdescent.filetree.materialize` or
     #: :meth:`~agentdescent.evolution.EvolutionResult.write_to` install.
     tree: Dict[str, str] = field(default_factory=dict)
+    #: Carried straight through from the underlying
+    #: :class:`~agentdescent.evolution.EvolutionResult`. Dropping them made a run
+    #: that died on a rate limit print the same confident "seed -> best" line as
+    #: one that converged, on the longest and most expensive path in the repo.
+    error: Optional[str] = None
+    stop_reason: str = "rounds"
 
 
 def run_evoskill(complete: Completion, docs: Dict[str, str],
@@ -721,7 +727,8 @@ def run_evoskill(complete: Completion, docs: Dict[str, str],
             print(f"\n[eval-at-end] final held-out score over {len(val_tasks)} items: {best:.3f}")
     # the artifact is path-keyed; the algorithm's own vocabulary is names.
     return EvoResult(skills_of(dict(result.state)), ctx.seed_score, best,
-                     iterations, tree=dict(result.state))
+                     iterations, tree=dict(result.state),
+                     error=result.error, stop_reason=result.stop_reason)
 
 
 # ===========================================================================
@@ -880,6 +887,9 @@ def main() -> None:
     print(f"\nval score : {result.seed_score:.3f} -> {result.best_score:.3f}")
     print(f"test score: {test_score:.3f}  (held out, never seen by the frontier)")
     print(f"skills discovered: {len(result.skills)}")
+    print(f"stopped   : {result.stop_reason}")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
 
 
 if __name__ == "__main__":

--- a/examples/gepa_prompt_evolution.py
+++ b/examples/gepa_prompt_evolution.py
@@ -53,7 +53,8 @@ from agentdescent.agents import Usage, claude, openai_compatible
 from agentdescent.aggregator import AggregatorProtocol, MergeReport
 from agentdescent.dataloader import Dataset, hf_rows, split_dataset
 from agentdescent.evolvable import Diff, EvidenceCard
-from agentdescent.evolution import LLMAgent, Task, evolve, rule_id
+from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rule_id
+from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 
 HOTPOTQA = ("hotpotqa/hotpot_qa", "validation", "distractor")   # (dataset, split, config)
@@ -409,7 +410,10 @@ def main() -> None:
     reward = make_reward()
 
     ntr, nva, nte = ds.sizes()
+    art = EvolvingArtifact("gepa_prompt", blast_radius=0.2)
     print(f"Loaded   : {len(ds)} tasks -> {ntr} train / {nva} val (D_pareto) / {nte} test")
+    # The layer this run landed in, as every other port reports it.
+    print(f"Governance: instruction blast_radius={art.blast_radius} -> {classify(art).name}")
     print("\nExample problem:")
     print("  Q:", ds.train[0].prompt.split('Question: ')[-1][:160])
     print("  A:", ds.train[0].meta["target"])
@@ -448,15 +452,19 @@ def main() -> None:
     factory = pareto_aggregator_factory(artifact_id="gepa_prompt", seed=args.seed)
     print("\nEvolving instruction (reflective mutation + Pareto selection, L2)...\n")
     # fit on train, Pareto-select on val (D_pareto); test stays fully held out.
-    evolve(ds.trainval, reward, agent=agent,
-           strategy=InstructionSlot(), initial_state={"instruction": _SEED_INSTRUCTION},
-           blast_radius=0.2, artifact_id="gepa_prompt",
-           rounds=args.rounds, n_workers=args.workers,
-           max_concurrency=1 if args.asynchronous else args.workers,
-           asynchronous=args.asynchronous, async_ratio=args.async_ratio,
-           max_seconds=args.max_seconds if args.asynchronous else None,
-           held_out_frac=ds.val_frac,
-           aggregator_factory=factory, verbose=True)
+    # Keep the result: `error` is the engine's one signal that a long, paid run
+    # ended on a rate limit rather than converging, and dropping it on the floor
+    # is exactly what its docstring tells callers not to do.
+    result = evolve(ds.trainval, reward, agent=agent,
+                    strategy=InstructionSlot(),
+                    initial_state={"instruction": _SEED_INSTRUCTION},
+                    blast_radius=0.2, artifact_id="gepa_prompt",
+                    rounds=args.rounds, n_workers=args.workers,
+                    max_concurrency=1 if args.asynchronous else args.workers,
+                    asynchronous=args.asynchronous, async_ratio=args.async_ratio,
+                    max_seconds=args.max_seconds if args.asynchronous else None,
+                    held_out_frac=ds.val_frac,
+                    aggregator_factory=factory, verbose=True)
 
     agg: ParetoAggregator = factory.holder["agg"]  # type: ignore[attr-defined]
     best = agg.best_state.get("instruction", _SEED_INSTRUCTION)
@@ -464,9 +472,19 @@ def main() -> None:
     print("\n=== GEPA-optimised instruction (best average on D_pareto) ===")
     print(best)
     print(f"\ncandidates explored: {len(agg.states)}")
-    print(f"seed D_pareto EM   : {agg.scores[0] and sum(agg.scores[0]) / len(agg.scores[0]):.3f}")
+    # The seed row exists only once the aggregator has stepped at least once, and
+    # `scores[0] and .../len(...)` did not guard it: on an empty row that formats
+    # a *list* with `:.3f` (TypeError), and with no row at all it is an IndexError
+    # -- both raised in the final print of a run the engine had deliberately kept
+    # alive to report.
+    seed_row = agg.scores[0] if agg.scores else []
+    seed_em = f"{sum(seed_row) / len(seed_row):.3f}" if seed_row else "n/a (no round completed)"
+    print(f"seed D_pareto EM   : {seed_em}")
     print(f"best D_pareto EM   : {agg.best_avg:.3f}")
     print(f"test EM            : {test_em:.3f}  (held out, never seen by the optimizer)")
+    print(f"stopped            : {result.stop_reason}")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print(f"model usage: {usage.summary()}")
 
 

--- a/examples/skill_evolution.py
+++ b/examples/skill_evolution.py
@@ -191,9 +191,20 @@ def main() -> None:
     print("\n=== evolved skill playbook ===")
     print(result.rendered)
     label = "held-out accuracy" if mc else "held-out score"
-    print(f"\n{label}: {result.history[0].held_out_reward:.3f} "
-          f"-> {result.final_reward:.3f}")
+    # `history[0]` is the score after round 0 has already merged, not the score
+    # of the seed playbook -- so say "round 0", not "before". And index it only
+    # if it exists: the whole point of the engine returning a partial result is
+    # that a run killed by a rate limit still has something to show, and
+    # `history[0]` on an empty history turned that into an IndexError.
+    if result.history:
+        print(f"\n{label}: {result.history[0].held_out_reward:.3f} (round 0) "
+              f"-> {result.final_reward:.3f} (final)")
+    else:
+        print(f"\n{label}: {result.final_reward:.3f} (no round completed)")
     print(f"lessons learned: {len(result.state)}")
+    print(f"stop reason: {result.stop_reason}")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print(f"model usage: {usage.summary()}")
 
 

--- a/examples/skillopt_skill_training.py
+++ b/examples/skillopt_skill_training.py
@@ -49,7 +49,7 @@ import string
 import sys
 import threading
 from dataclasses import dataclass, field
-from typing import Callable, List, Tuple
+from typing import Callable, List, Optional, Tuple
 
 from agentdescent.agents import Usage, claude, openai_compatible
 from agentdescent.aggregator import AggregatorProtocol, MergeReport
@@ -396,6 +396,12 @@ class SkillOptResult:
     accepted: int
     rejected: int
     history: List[float]
+    #: Carried through from the underlying
+    #: :class:`~agentdescent.evolution.EvolutionResult`: without them a run that
+    #: ended on a backend failure reported its "seed -> best" line exactly like a
+    #: converged one, which is what `error` exists to distinguish.
+    error: Optional[str] = None
+    stop_reason: str = "rounds"
 
 
 def run_skillopt(complete: Completion, train: List[dict], val: List[dict],
@@ -435,7 +441,8 @@ def run_skillopt(complete: Completion, train: List[dict], val: List[dict],
                     aggregator_factory=factory, verbose=verbose)
     return SkillOptResult(result.rendered, ctx.seed_em, ctx.best_em,
                           ctx.accepted, ctx.rejected,
-                          [h.held_out_reward for h in result.history])
+                          [h.held_out_reward for h in result.history],
+                          error=result.error, stop_reason=result.stop_reason)
 
 
 # ===========================================================================
@@ -570,6 +577,9 @@ def main() -> None:
     print(f"\nval hard-EM : {result.seed_em:.3f} -> {result.best_em:.3f}")
     print(f"test hard-EM: {test_em:.3f}  (held out, never seen by the gate)")
     print(f"edits accepted / rejected: {result.accepted} / {result.rejected}")
+    print(f"stopped     : {result.stop_reason}")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print(f"model usage: {usage.summary()}")
 
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -182,3 +182,45 @@ def test_oversized_diffs_are_counted_and_settled(tmp_path):
         f"the oversized diff should still be counted, got {reports[0].considered}")
     assert any(c.diff.diff_id == "huge" for c in agg.buffer.settled), \
         "the oversized diff's evidence should be settled back into the pool"
+
+
+def test_a_rebased_diff_that_no_longer_holds_is_discarded(tmp_path):
+    """The REBASE branch is only a gate if `evidence_eval` can see the failures.
+
+    `EvidenceCard.trajectory_refs` was annotated `List[str]`, and a card built to
+    that annotation scores an *empty* task list -- so the re-verification compares
+    `0.0 <= 0.0`, keeps everything, and a diff that makes the artifact worse
+    survives the rebase it was supposed to be caught by. This pins the behaviour
+    the annotation described away.
+    """
+    from agentdescent.staleness import get_policy
+
+    held = [Task(f"t-kw00-{i}", "acidbase", "kw00") for i in range(8)]
+    led, agg = _build(tmp_path, held)
+    agg.staleness_policy = get_policy("reflective")     # every stale card rebases
+    artifact = led.snapshot(Ledger.DEV).get("s").apply(
+        Diff("seed", "s", {"kw00": "acidbase"}))        # a head that already works
+    tasks = [Task("t-kw00-0", "acidbase", "kw00")]
+
+    # eta > 0, and the diff replaces the correct label with a wrong one.
+    harmful = _card("s", {"kw00": "thermo"}, 0, tasks, -1.0, "bad")
+    helpful = _card("s", {"kw01": "kinetics"}, 0, tasks, 1.0, "good")
+    survivors, discarded = agg._staleness_filter(artifact, {"s": 3}, [harmful, helpful])
+
+    assert [c.diff.author for c in discarded] == ["bad"], (
+        "a rebased diff whose improvement no longer holds must be discarded; "
+        f"discarded={[c.diff.author for c in discarded]}")
+    assert [c.diff.author for c in survivors] == ["good"]
+
+
+def test_evidence_eval_reads_the_task_objects_on_the_card():
+    """What a card carries has to be what the artifact can score."""
+    skill = RouterSkill("s", table={"kw00": "acidbase"})
+    tasks = [Task("t-kw00-0", "acidbase", "kw00")]
+    scored = EvidenceCard(diff=Diff("d", "s", {}), base_version={"s": 1},
+                          touched=["s"], trajectory_refs=tasks)
+    unscorable = EvidenceCard(diff=Diff("d", "s", {}), base_version={"s": 1},
+                              touched=["s"], trajectory_refs=["t-kw00-0"])   # ids
+    assert skill.evidence_eval(scored) == 1.0
+    assert skill.evidence_eval(unscorable) == 0.0, (
+        "ids are not scorable, which is why the field takes task objects")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -53,8 +53,16 @@ def test_guarded_discards_more_than_reflective():
 
     assert g.discarded_stale > r.discarded_stale   # the claim under test
     assert r.rollouts < g.rollouts                 # Reflective wastes far less work
-    # Recovering that work cannot leave Reflective behind, and both must progress.
-    assert r.final_dev_accuracy >= g.final_dev_accuracy
+    # Recovering that work cannot leave Reflective *materially* behind, and both
+    # must progress. Not `r >= g`: both runs stop at the first sweep that crosses
+    # `target_accuracy` (0.95 here), so the value each one *lands* on is a
+    # stopping artifact rather than a measure of the policy. Guarded takes
+    # hundreds of small sweeps and can land exactly on 1.000; Reflective takes
+    # ~8 large ones and lands wherever its batch put it (0.966 is common). That
+    # made the strict comparison fail roughly one run in six, on an assertion the
+    # test is not about. Both stopped past the same bar, so the widest legitimate
+    # gap is the width of the band above it.
+    assert r.final_dev_accuracy >= g.final_dev_accuracy - 0.05
     assert g.final_dev_accuracy > 0.0
 
 

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -137,6 +137,26 @@ def test_split_dataset_stratified_keeps_classes_in_each_split():
         assert classes == {"a", "b"}           # both classes present in each split
 
 
+def test_a_stratified_split_never_puts_an_item_in_both_val_and_test():
+    """`test` is documented as never seen by the optimizer; `val` is what it gates on.
+
+    A class too small for the ratios used to have its item *copied* into val
+    while test kept it too -- and a rare class is exactly what stratifying is
+    for (a thin FiNER tag, a low-resource MGSM language).
+    """
+    for rare_n in (1, 2, 3):
+        items = ([{"c": "rare", "i": i} for i in range(rare_n)]
+                 + [{"c": "common", "i": i} for i in range(10)])
+        ds = dl.split_dataset(items, ratios=(0.6, 0.2, 0.2), seed=0,
+                              stratify_key=lambda x: x["c"])
+        ids = [{(x["c"], x["i"]) for x in s} for s in (ds.train, ds.val, ds.test)]
+        train, val, test = ids
+        assert not (val & test), f"rare_n={rare_n}: {sorted(val & test)} is in val AND test"
+        assert not (train & val) and not (train & test)
+        assert len(train | val | test) == len(items), "an item was dropped"
+        assert "rare" in {c for c, _ in val}, "stratification must still reach val"
+
+
 def test_dataset_from_splits():
     ds = dl.dataset_from_splits([1, 2], [3], [4, 5], name="x")
     assert ds.sizes() == (2, 1, 2) and ds.name == "x"

--- a/tests/test_dual_branch_promotion.py
+++ b/tests/test_dual_branch_promotion.py
@@ -169,3 +169,89 @@ def test_the_reference_run_actually_reaches_the_stable_branch():
             "the stable branch never caught up with dev; dual-branch promotion "
             f"(design §4.5) is not firing. stable={history[-1].stable_accuracy}")
         assert system.final_accuracy(branch=Ledger.STABLE) > 0.9
+
+
+# -- and the two engines a real workload actually reaches ----------------------
+
+
+def _tasks():
+    from agentdescent.evolution import Task
+    return [Task(id=f"t{i}", prompt=f"item {i}") for i in range(12)]
+
+
+def _reward(task, output):
+    return 1.0 if "2026" in output else 0.0
+
+
+def _run(rendered, task):
+    return "answer" + (" 2026" if "year" in rendered else "")
+
+
+def _propose(rendered, task, output, reward):
+    return "always state the year"
+
+
+def _stable_state(repo):
+    """The artifact `stable` holds, straight out of git."""
+    import json
+    import subprocess
+
+    raw = subprocess.run(["git", "-C", repo, "show", "stable:artifacts/artifact.json"],
+                         capture_output=True, text=True).stdout
+    return json.loads(raw)["state"]["state"] if raw else None
+
+
+def test_evolve_publishes_its_head_to_stable(tmp_path):
+    """The reference runtimes called `finalize()`; `evolve()` did not.
+
+    So a clean run that stopped on `target_reward` -- the commit that reaches it
+    is the run's whole point -- left `stable` holding the *seed* artifact, while
+    `docs/ledger.md` documented the call that was not being made.
+    """
+    from agentdescent.evolution import evolve
+
+    repo = str(tmp_path / "ledger")
+    res = evolve(_tasks(), _reward, run=_run, propose=_propose, rounds=6,
+                 n_workers=3, repo_path=repo, target_reward=1.0)
+    assert res.error is None and res.final_reward == 1.0
+    assert _stable_state(repo), \
+        "a clean synchronous run left `stable` on the seed artifact"
+
+
+def test_async_evolve_publishes_its_head_to_stable(tmp_path):
+    """Same gap, same fix, on the barrier-free path."""
+    import warnings
+
+    from agentdescent.async_evolve import async_evolve
+
+    repo = str(tmp_path / "ledger")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = async_evolve(_tasks(), _reward, run=_run, propose=_propose,
+                           n_workers=2, max_seconds=6.0, repo_path=repo,
+                           target_reward=1.0)
+    assert res.error is None and res.final_reward == 1.0
+    assert _stable_state(repo), \
+        "a clean asynchronous run left `stable` on the seed artifact"
+
+
+def test_a_run_that_died_does_not_publish(tmp_path):
+    """`stable` is the confirmed branch: a run that ended on a failure keeps it.
+
+    Otherwise the branch production reads would be published by exactly the runs
+    whose evidence is least trustworthy.
+    """
+    import warnings
+
+    from agentdescent.evolution import evolve
+
+    def dead(rendered, task):
+        raise RuntimeError("backend is down")
+
+    repo = str(tmp_path / "ledger")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = evolve(_tasks(), _reward, run=dead, propose=_propose, rounds=6,
+                     n_workers=2, repo_path=repo, max_worker_errors=2)
+    assert res.error is not None, "premise: this run must die"
+    assert not _stable_state(repo), "a failed run must not publish to stable"

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -96,6 +96,19 @@ def test_merge_outcomes_are_str_so_existing_lookups_keep_working():
     assert {agentdescent.MergeOutcome.COMMITTED: 1}["committed"] == 1
 
 
+def test_outcomes_print_the_way_every_doc_shows_them():
+    """`outcomes()` is a dict, and printing a dict uses `repr` on its keys.
+
+    The README, both quickstarts, `evolution.md` and `MergeOutcome`'s own
+    docstring all show `{'committed': 1}`; the enum repr printed
+    `{<MergeOutcome.COMMITTED: 'committed'>: 1}` instead — noise in the one
+    diagnostic a user is told to read first.
+    """
+    printed = str({agentdescent.MergeOutcome.COMMITTED: 2,
+                   agentdescent.MergeOutcome.BELOW_THRESHOLD: 7})
+    assert printed == "{'committed': 2, 'below-threshold': 7}", printed
+
+
 def test_every_category_the_aggregator_emits_is_in_the_vocabulary():
     """The keys of `result.outcomes()` were bare literals written at six
     different return sites; to learn them you had to read the file."""

--- a/tests/test_unified_backends.py
+++ b/tests/test_unified_backends.py
@@ -213,6 +213,11 @@ def test_the_prompt_points_at_the_skills_instead_of_carrying_them():
     class _Recorder:
         def __call__(self, prompt):
             seen["prompt"] = prompt
+            # Checked *during* the call, because that is the only moment the
+            # promise has to hold -- the workspace is one question's scratch
+            # directory and is removed once the agent has answered.
+            seen["staged"] = os.path.exists(
+                os.path.join(seen["ws"], ".claude/skills/lookup/SKILL.md"))
             return "ok"
 
         def in_workspace(self, path):
@@ -223,7 +228,8 @@ def test_the_prompt_points_at_the_skills_instead_of_carrying_them():
     backend.answer("q", "doc", skill_files={"lookup/SKILL.md": "SECRET BODY"})
     assert ".claude/skills" in seen["prompt"] and "lookup" in seen["prompt"]
     assert "SECRET BODY" not in seen["prompt"]          # on disk, not in the prompt
-    assert os.path.exists(os.path.join(seen["ws"], ".claude/skills/lookup/SKILL.md"))
+    assert seen["staged"], "the agent must find the skill files while it runs"
+    assert not os.path.exists(seen["ws"]), "the scratch workspace must not be left behind"
 
 
 def test_a_backend_without_a_workspace_falls_back_to_inlining_them():


### PR DESCRIPTION
An audit of the repo against the README's definition of the project: read the code, read the docs written for it, and fix whichever side was wrong. Eight behaviour bugs and a set of documentation claims the code did not support.

## Behaviour

| | what was wrong |
|---|---|
| **`stable` never received the run's artifact** | Both reference runtimes call `Aggregator.finalize()` on a clean exit and `docs/ledger.md` documents it — but `evolve()` and `async_evolve()`, the two engines a real workload reaches, did not. A clean run that hit `target_reward` left `stable` holding the **seed** artifact while `dev` held the one the run was for. |
| **`forced_refreshes` was noise** | It counted every snapshot refresh, including the ordinary lag-budget one, while the field and three doc pages say a non-zero count means the lag budget and the staleness tolerance disagree. A converged 3s run reported 3; now 0 healthy / 12 stalled. |
| **`split_dataset` leaked `val` into `test`** | For a class too small for the ratios, `g[a:b] or g[a:a+1]` *copied* the borrowed item, so the split documented as "fully held out, never seen by the optimizer" contained an item the acceptance gate had already scored. Rare classes are exactly what stratifying is for, and three shipped ports stratify. |
| **`trajectory_refs: List[str]` disables the staleness gate** | Every producer puts task *objects* there and both consumers `isinstance`-filter for them. A domain that follows the annotation gets `evidence_eval` over an empty list, so REBASE compares `0.0 <= 0.0` and a diff that makes the artifact **worse** survives the re-verification meant to catch it. |
| **`KeyedRules.keys()` case mismatch** | `to_diff` stores the folded key, so `categories=["Routing"]` under TP built a section map no diff could match — every proposal rejected as `section-violation`. |
| **Two workspace leaks** | `document_agent` and `openhands()` staged a temp directory per call — with a copy of the document — and never removed it. `openhands()` still leaves a caller-supplied `in_workspace()` directory alone. |
| **`outcomes()` printed wrong** | `{<MergeOutcome.COMMITTED: 'committed'>: 1}` where the README, both quickstarts, `evolution.md` and the enum's own docstring all show `{'committed': 1}`. |
| **Ports crashed on partial results** | GEPA (`agg.scores[0]`, behind a guard that would itself have raised `TypeError`), ACE and `skill_evolution` (`history[0]`) — all in the final report, on exactly the partial result the engine works to return. GEPA dropped `evolve()`'s return value entirely; `EvoResult`/`SkillOptResult` carried no `error`, so a run killed by a rate limit printed the same confident "seed → best" line as a converged one. |

Also: `StallGuard` is now called by both barrier-free runtimes — which `CHANGELOG.md` already claimed, and which was the half of that sentence that was not yet true.

## Documentation

Fixed where the docs described behaviour the code did not have: `docs/aggregator.md`'s stage list was mangled (steps 4 and 5 twice, commit *before* the audit gate that `aggregator.py` insists holds a veto); the README said promotion counts commits rather than regression-free rounds; `concepts.md` offered `duration_estimator=` on `evolve()`, which raises `TypeError`; `verifier.md` advertised a three-method verifier for an aggregator that calls four (`AttributeError` mid-merge if you build to it); `duration-scheduling.md` contradicted its own warning about straggler resume; `modules.md` claims to list every module and omitted three.

## One test changed deliberately

`test_guarded_discards_more_than_reflective` asserted `reflective >= guarded` on final accuracy. Both runs stop at the **first** sweep crossing `target_accuracy=0.95`, so each lands on an arbitrary value in `[0.95, 1.0]` — Guarded on 1.000 via hundreds of small sweeps, Reflective on 0.966 via ~8 large ones. It failed ~1 run in 6. Instrumenting a pristine worktree and this branch showed identical rollout/sweep/accuracy distributions, so this is a stopping artifact, not a regression; the assertion now allows the width of the band above the bar. 8/8 clean after.

## Verification

- **634 passed, 1 skipped** (baseline 625 + 9 new tests), on a run with no edits in flight.
- `mkdocs build --strict` clean; `python -m tools.gen_api_docs --check` unchanged.
- The whole suite passes with **every socket connect forced to fail**, which is what `tests.yml` claims of it.
- Every documented default matches its signature; every keyword in every docs snippet names a real parameter; all 38 documented `python -m examples.…` invocations are accepted; `run_demo`, `parallelism` and DGM `--generations 4` reproduce their documented output exactly; every "not implemented / nothing calls this" claim still holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
