### PR TITLE
feat: measure what a run costs, so a refactor cannot get quietly worse

### DIFF
--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -39,6 +39,7 @@ from .evolvable import (
 )
 from .governance import Layer, classify, assert_mutable
 from .ledger import CASConflict, Ledger
+from .metrics import Meter
 from .scheduler import AuditScheduler
 from .staleness import StaleAction, StalenessPolicy, get_policy
 from .stats import BetaPosterior, annealed_delta, prob_improvement
@@ -332,12 +333,17 @@ class Aggregator:
         audit: AuditScheduler,
         config: Optional[AggregatorConfig] = None,
         staleness_policy: Optional[StalenessPolicy] = None,
+        meter: Optional["Meter"] = None,
     ) -> None:
         self.ledger = ledger
         self.verifier = verifier
         self.audit = audit
         # swap Full / Guarded / Reflective without touching the merge pipeline.
         self.staleness_policy = staleness_policy or get_policy("guarded")
+        #: Where the staleness ratio is recorded. `None` for a hand-built
+        #: aggregator, which then simply reports nothing -- a missing counter is
+        #: better than one that counts a fraction of the run.
+        self.meter = meter
         self.config = config or AggregatorConfig()
         self.buffer = EvidenceBuffer()
         self._posteriors: Dict[str, BetaPosterior] = defaultdict(BetaPosterior)
@@ -385,6 +391,13 @@ class Aggregator:
                     discarded.append(card)
             else:  # DISCARD
                 discarded.append(card)
+        if self.meter is not None:
+            # The denominator has to come from here: `MergeReport` records what
+            # was discarded, and without "out of how many" a stale ratio cannot
+            # be computed at all -- 3 discards out of 4 and out of 400 need
+            # opposite fixes.
+            self.meter.add("stale_considered", len(cards))
+            self.meter.add("stale_discarded", len(discarded))
         return survivors, discarded
 
     # -- conflict resolution (section 4.3) -----------------------------------

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -36,9 +36,11 @@ import time
 import warnings
 from typing import Callable, Dict, List, Optional
 
+from .agents import Usage
 from .evolution import (
     _publish_stable, _safe_log,
-    Agent, EvolutionResult, Propose, Reward, RoundInfo, Run, Strategy, Task, _tally,
+    Agent, EvolutionResult, Propose, Reward, RoundInfo, Run, Strategy, Task,
+    _cost_fields, _tally,
     SOLVED, _build_engine, _checked_proposal, _checked_reward,
 )
 from .aggregator import AggregatorConfig, check_reports
@@ -87,6 +89,10 @@ def async_evolve(
     task_sampler: Optional["TaskSampler"] = None,
     on_round: Optional[Callable[[RoundInfo], None]] = None,
     verbose: bool = False,
+    #: Share one `Usage` with your model adapters (`claude(usage=u)`) and the
+    #: result's token counts become real; without it only calls and seconds are
+    #: known, because an opaque `run` cannot report tokens.
+    usage: Optional[Usage] = None,
 ) -> EvolutionResult:
     """Evolve an artifact **without a round barrier**.
 
@@ -184,6 +190,13 @@ def async_evolve(
         Called with each :class:`~agentdescent.evolution.RoundInfo` as a merger
         sweep completes -- progress for a long run. It runs on the merger thread
         and must be cheap and thread-safe; an exception is reported, not fatal.
+    usage:
+        Share one :class:`~agentdescent.agents.Usage` with your model adapters
+        (``claude(usage=u)``, ``openai_compatible(usage=u)``) and the result's
+        token counts become real. Without it the run still reports calls,
+        seconds and failures -- ``run`` is ``(rendered, task) -> str``, so an
+        opaque actor has no way to surface tokens, and inventing a number would
+        be worse than reporting zero.
     verbose:
         Print one line per merger sweep.
 
@@ -207,7 +220,9 @@ def async_evolve(
         held_out_frac=held_out_frac, repo_path=repo_path, agg_config=agg_config,
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
         oracle_budget=oracle_budget, eval_concurrency=eval_concurrency,
-        cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed)
+        cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed,
+        usage=usage)
+    eng.meter.start()
     if n_workers < 1:
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")
     policy = staleness_policy or get_policy("guarded")
@@ -316,6 +331,8 @@ def async_evolve(
             try:
                 output = eng.run(artifact.render(), task)
                 score = _checked_reward(eng.reward(task, output), task)
+                eng.meter.add("rollouts")
+                eng.meter.add("rollout_seconds", time.time() - t_start)
                 sampler.record(task.id, score)     # learn which tasks carry signal
                 if score < solved_threshold:
                     proposal = _checked_proposal(
@@ -450,8 +467,10 @@ def async_evolve(
             best[0], best[1] = r, 0
         else:
             best[1] += 1
+        _m = eng.meter.snapshot()
         history.append(RoundInfo(len(history), r, len(dev.state), committed,
-                                 len(reports) - committed, _tally(reports)))
+                                 len(reports) - committed, _tally(reports),
+                                 elapsed_s=_m.elapsed_s, rollouts=_m.rollouts))
         # A stalled pipeline: cards keep arriving and none of them commits. Under
         # Guarded with async_ratio > alpha that is a livelock, not slow progress.
         # A sweep with no cards in it is neither, so it is not counted -- and this
@@ -612,6 +631,7 @@ def async_evolve(
                              error=run_error, retired_workers=retired[0],
                              stop_reason="error" if run_error else stop_reason[0],
                              forced_refreshes=forced_refreshes[0],
-                             stragglers=stragglers[0])
+                             stragglers=stragglers[0],
+                             **_cost_fields(eng.meter))
     eng.cleanup()          # do not hold a scratch git repo for the whole process
     return result

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -37,7 +37,7 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, runtime_checkable
 
-from .agents import Completion, claude
+from .agents import Completion, Usage, claude
 from .aggregator import (
     Aggregator, AggregatorConfig, AggregatorFactory, AggregatorContractError,
     check_reports,
@@ -45,6 +45,7 @@ from .aggregator import (
 from .evolvable import Contract, ContractError, Diff, EvidenceCard
 from .governance import FROZEN_IDS, GovernanceError, assert_mutable
 from .ledger import Ledger, LedgerFailure
+from .metrics import Meter, measured
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import AuditScheduler
 from .staleness import StalenessPolicy
@@ -296,14 +297,26 @@ def _checked_reward(value, task: "Task") -> float:
 
 
 class _EvalCache:
-    def __init__(self) -> None:
+    """Memoised evaluations, and the only place that can tell a hit from a miss.
+
+    The counters live here rather than in `_Runtime` because by the time
+    `eval_one` has a value back it no longer knows whether the work happened:
+    that is precisely the "duplicate computation" figure a multi-process run
+    needs to report."""
+
+    def __init__(self, meter: Optional["Meter"] = None) -> None:
         self._d: Dict[Any, float] = {}
         self._lock = threading.Lock()
+        self._meter = meter
 
     def get_or_eval(self, key: Any, fn: Callable[[], float]) -> float:
         with self._lock:
             if key in self._d:
+                if self._meter is not None:
+                    self._meter.add("cache_hits")
                 return self._d[key]
+        if self._meter is not None:
+            self._meter.add("cache_misses")
         value = fn()
         with self._lock:
             self._d[key] = value
@@ -427,6 +440,10 @@ class _Runtime:
     #: result is memoised, so a retry re-runs only what actually failed.
     ATTEMPTS = 3
 
+    #: Where evaluation time and cache hits are recorded. Optional so a
+    #: hand-built `_Runtime` (several tests do this) needs no changes.
+    meter: Optional["Meter"] = None
+
     def eval_one(self, artifact: EvolvingArtifact, task: Task) -> float:
         key = (artifact._signature(), task.id)
 
@@ -443,7 +460,15 @@ class _Runtime:
                     time.sleep(0.2 * (attempt + 1))
             raise AssertionError("unreachable")
 
-        return self.cache.get_or_eval(key, _measure)
+        if self.meter is None:
+            return self.cache.get_or_eval(key, _measure)
+        t0 = time.time()
+        try:
+            return self.cache.get_or_eval(key, _measure)
+        finally:
+            # Includes hits (near-zero) on purpose: `eval_seconds` is what the
+            # gate cost the run, and a hit costing nothing is the point.
+            self.meter.add("eval_seconds", time.time() - t0)
 
 
 # ---------------------------------------------------------------------------
@@ -581,6 +606,31 @@ def _publish_stable(aggregator) -> None:
         pass
 
 
+def _cost_fields(meter: Meter) -> Dict[str, Any]:
+    """The meter's counters, keyed as :class:`EvolutionResult` fields.
+
+    One mapping shared by both drivers: they assemble their results separately,
+    and a field added to one and forgotten in the other is invisible -- the
+    result still constructs, the number is just always zero."""
+    m = meter.snapshot()
+    return {
+        "usage": meter.usage,
+        "wallclock": m.elapsed_s,
+        "rollouts": m.rollouts,
+        "rollout_seconds": m.rollout_seconds,
+        "eval_seconds": m.eval_seconds,
+        "stale_considered": m.stale_considered,
+        "stale_discarded": m.stale_discarded,
+        "cache_hits": m.cache_hits,
+        "cache_misses": m.cache_misses,
+        "sandbox_wait_s": m.sandbox_wait_s,
+        "sandbox_setup_s": m.sandbox_setup_s,
+        "sandboxes_created": m.sandboxes_created,
+        "sandboxes_reused": m.sandboxes_reused,
+        "sandbox_failures": m.sandbox_failures,
+    }
+
+
 def _tally(reports) -> Dict[str, int]:
     """Count merge outcomes by stable category (see ``MergeReport.category``)."""
     out: Dict[str, int] = {}
@@ -607,6 +657,15 @@ class RoundInfo:
     #: way to tell "the gate says my proposals do not help" from "they never
     #: reached the gate" -- which need opposite fixes.
     reasons: Dict[str, int] = field(default_factory=dict)
+    #: Cumulative wall-clock at the end of this round, in seconds. This is the
+    #: x-axis for time-to-quality: paired with ``held_out_reward`` it says when a
+    #: quality bar was reached, which a round index cannot -- rounds are not the
+    #: same length, and across parallel configurations they are not comparable.
+    elapsed_s: float = 0.0
+    #: Rollouts completed by the end of this round, cumulative. The other
+    #: denominator: a configuration that reaches the same reward having spent
+    #: twice the rollouts has not done as well.
+    rollouts: int = 0
 
 
 @dataclass
@@ -648,6 +707,46 @@ class EvolutionResult:
     #: fast run from a lucky one.
     retired_workers: int = 0
 
+    # -- what the run cost ----------------------------------------------------
+    #
+    # Every field below defaults, and `load` reads them with `.get`, so a result
+    # written before they existed still loads.
+
+    #: Model spend. ``calls`` counts actor invocations (``run`` and ``propose``);
+    #: token counts appear only when the same :class:`~agentdescent.agents.Usage`
+    #: was also passed to an adapter that reports them -- pass ``usage=`` to both
+    #: ``evolve`` and ``claude``/``openai_compatible`` and they accumulate
+    #: together.
+    usage: Usage = field(default_factory=Usage)
+    #: Total wall-clock of the run, in seconds.
+    wallclock: float = 0.0
+    #: Rollouts completed, and their summed duration. The sum exceeds
+    #: ``wallclock`` whenever workers overlapped -- that is the point of it.
+    rollouts: int = 0
+    rollout_seconds: float = 0.0
+    #: Wall-clock inside the gate (held-out scoring and every acceptance
+    #: measurement). Measured against ``wallclock`` this is what says whether a
+    #: run was spent exploring or verifying.
+    eval_seconds: float = 0.0
+    #: Staleness, with its denominator: ``discarded / considered``. Without the
+    #: denominator a stale count cannot be read at all.
+    stale_considered: int = 0
+    stale_discarded: int = 0
+    #: Evaluation cache. ``misses`` is the number of evaluations actually
+    #: performed; the ratio is the duplicate-computation figure a multi-process
+    #: run has to report.
+    cache_hits: int = 0
+    cache_misses: int = 0
+    #: Sandbox accounting. Zero on the default single-workspace path: there is
+    #: no pool to wait for and no image to warm. They exist here so that when a
+    #: pool does appear, "8 workers only bought 2x" can be attributed to queueing
+    #: or cold starts rather than guessed at.
+    sandbox_wait_s: float = 0.0
+    sandbox_setup_s: float = 0.0
+    sandboxes_created: int = 0
+    sandboxes_reused: int = 0
+    sandbox_failures: int = 0
+
     def outcomes(self) -> Dict[str, int]:
         """Merge outcomes for the whole run, by category -- *why* it went as it did.
 
@@ -676,6 +775,56 @@ class EvolutionResult:
                 out[k] = out.get(k, 0) + v
         return out
 
+    def time_to_quality(self, target: float) -> Optional[float]:
+        """Wall-clock at the first round whose held-out reward reached ``target``.
+
+        ``None`` when the run never got there -- which is a result, not an error:
+        a configuration that never reaches the bar has no time-to-quality, and
+        reporting its total wall-clock instead would flatter it."""
+        for h in self.history:
+            if h.held_out_reward >= target:
+                return h.elapsed_s
+        return None
+
+    def cost_to_quality(self, target: float) -> Optional[int]:
+        """Rollouts spent up to the first round that reached ``target``.
+
+        Rollouts rather than tokens, because tokens are only known when a
+        token-reporting adapter shares this result's :class:`Usage`; rollouts are
+        always counted. Use ``usage.total_tokens`` when you have them."""
+        for h in self.history:
+            if h.held_out_reward >= target:
+                return h.rollouts
+        return None
+
+    def stale_rate(self) -> float:
+        """Discarded evidence as a fraction of evidence considered; 0.0 if none."""
+        return (self.stale_discarded / self.stale_considered
+                if self.stale_considered else 0.0)
+
+    def duplicate_rate(self) -> float:
+        """Cache hits as a fraction of lookups -- work that did *not* have to be
+        redone. In one process this is memoisation working; across processes it
+        is the figure that says how much a shared cache would be worth."""
+        total = self.cache_hits + self.cache_misses
+        return self.cache_hits / total if total else 0.0
+
+    def cost_summary(self) -> str:
+        """One line: what the run cost. Complements ``outcomes()``, which says why
+        it went as it did."""
+        parts = [f"{self.rollouts} rollouts in {self.wallclock:.1f}s",
+                 self.usage.summary()]
+        if self.eval_seconds:
+            parts.append(f"{self.eval_seconds:.1f}s in the gate")
+        if self.stale_considered:
+            parts.append(f"stale {self.stale_rate():.0%}")
+        if self.cache_hits + self.cache_misses:
+            parts.append(f"cache {self.duplicate_rate():.0%} hit")
+        if self.sandboxes_created:
+            parts.append(f"{self.sandboxes_created} sandboxes, "
+                         f"{self.sandbox_wait_s:.1f}s waiting")
+        return " | ".join(parts)
+
     def save(self, path: str) -> None:
         """Write the evolved artifact and its run summary to a JSON file.
 
@@ -691,7 +840,8 @@ class EvolutionResult:
             "history": [
                 {"round": h.round, "held_out_reward": h.held_out_reward,
                  "n_items": h.n_items, "committed": h.committed,
-                 "rejected": h.rejected, "reasons": h.reasons}
+                 "rejected": h.rejected, "reasons": h.reasons,
+                 "elapsed_s": h.elapsed_s, "rollouts": h.rollouts}
                 for h in self.history
             ],
             "retired_workers": self.retired_workers,
@@ -699,6 +849,24 @@ class EvolutionResult:
             "stragglers": self.stragglers,
             "stop_reason": self.stop_reason,
             "ledger_log": list(self.ledger_log),
+            "usage": {"calls": self.usage.calls,
+                      "prompt_tokens": self.usage.prompt_tokens,
+                      "completion_tokens": self.usage.completion_tokens,
+                      "seconds": self.usage.seconds,
+                      "failures": self.usage.failures},
+            "wallclock": self.wallclock,
+            "rollouts": self.rollouts,
+            "rollout_seconds": self.rollout_seconds,
+            "eval_seconds": self.eval_seconds,
+            "stale_considered": self.stale_considered,
+            "stale_discarded": self.stale_discarded,
+            "cache_hits": self.cache_hits,
+            "cache_misses": self.cache_misses,
+            "sandbox_wait_s": self.sandbox_wait_s,
+            "sandbox_setup_s": self.sandbox_setup_s,
+            "sandboxes_created": self.sandboxes_created,
+            "sandboxes_reused": self.sandboxes_reused,
+            "sandbox_failures": self.sandbox_failures,
         }
         with open(path, "w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2, ensure_ascii=False)
@@ -789,6 +957,7 @@ class EvolutionResult:
 
         with open(path, encoding="utf-8") as fh:
             d = json.load(fh)
+        u = d.get("usage") or {}
         return cls(
             state=d["state"], rendered=d["rendered"],
             final_reward=d["final_reward"],
@@ -798,6 +967,26 @@ class EvolutionResult:
             forced_refreshes=d.get("forced_refreshes", 0),
             stragglers=d.get("stragglers", 0),
             stop_reason=d.get("stop_reason", "rounds"),
+            # Every cost field is `.get` with a default, so a file written before
+            # they existed loads as a run that simply did not measure them.
+            usage=Usage(calls=u.get("calls", 0),
+                        prompt_tokens=u.get("prompt_tokens", 0),
+                        completion_tokens=u.get("completion_tokens", 0),
+                        seconds=u.get("seconds", 0.0),
+                        failures=u.get("failures", 0)),
+            wallclock=d.get("wallclock", 0.0),
+            rollouts=d.get("rollouts", 0),
+            rollout_seconds=d.get("rollout_seconds", 0.0),
+            eval_seconds=d.get("eval_seconds", 0.0),
+            stale_considered=d.get("stale_considered", 0),
+            stale_discarded=d.get("stale_discarded", 0),
+            cache_hits=d.get("cache_hits", 0),
+            cache_misses=d.get("cache_misses", 0),
+            sandbox_wait_s=d.get("sandbox_wait_s", 0.0),
+            sandbox_setup_s=d.get("sandbox_setup_s", 0.0),
+            sandboxes_created=d.get("sandboxes_created", 0),
+            sandboxes_reused=d.get("sandboxes_reused", 0),
+            sandbox_failures=d.get("sandbox_failures", 0),
         )
 
 
@@ -820,6 +1009,10 @@ class _Engine:
     train_ids: List[str]
     artifact_id: str
     blast_radius: float
+    #: Every counter this run accumulates. Always present: an optional meter
+    #: would mean every recording site grows an `if`, and the sites are the hot
+    #: path.
+    meter: Meter = field(default_factory=Meter)
     #: Set only when the ledger lives in a throwaway directory this call created;
     #: ``None`` when the caller passed ``repo_path`` (theirs to keep, and how a run
     #: is resumed).
@@ -861,7 +1054,8 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
                   staleness_policy, aggregator_factory, oracle_budget,
                   eval_concurrency: int = 8,
                   cheap_eval_tasks: Optional[int] = None,
-                  shuffle: bool = False, seed: int = 0) -> _Engine:
+                  shuffle: bool = False, seed: int = 0,
+                  usage: Optional[Usage] = None) -> _Engine:
     """Wire the ledger, runtime, verifier and aggregator (shared by
     :func:`evolve` and :func:`~agentdescent.async_evolve.async_evolve`)."""
     import tempfile
@@ -945,8 +1139,14 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
             "rollouts. Pass more tasks or raise held_out_frac.",
             RuntimeWarning, stacklevel=3)
 
-    runtime = _Runtime(run=run, reward=reward, cache=_EvalCache(),
-                       eval_concurrency=eval_concurrency)
+    # Wrap the actors before anything else can capture them: `run` is closed over
+    # by the runtime, by every worker and by the verifier's `eval_fn`, so a later
+    # wrap would miss whichever reference was taken first.
+    meter = Meter(usage=usage) if usage is not None else Meter()
+    run, propose = measured(run, meter), measured(propose, meter)
+
+    runtime = _Runtime(run=run, reward=reward, cache=_EvalCache(meter),
+                       eval_concurrency=eval_concurrency, meter=meter)
 
     def serialize(a: EvolvingArtifact) -> dict:
         return {"state": a.state, "blast_radius": a.blast_radius}
@@ -1008,12 +1208,24 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
         budget=VerifierBudget(oracle_calls_remaining=oracle_budget))
 
     def _default_aggregator(ledger, verifier, audit, config, policy):
-        return Aggregator(ledger, verifier, audit, config, staleness_policy=policy)
+        return Aggregator(ledger, verifier, audit, config, staleness_policy=policy,
+                          meter=meter)
 
     aggregator = (aggregator_factory or _default_aggregator)(
         ledger, verifier, AuditScheduler(),
         agg_config or AggregatorConfig(batch_trigger=2, max_wait_rounds=1),
         staleness_policy)
+    # A custom factory cannot know about the meter -- its signature predates it
+    # and is part of the public surface. Attach it to whatever came back if that
+    # object has the slot and left it empty, so an `aggregator_factory` returning
+    # a plain `Aggregator` (or a subclass of one) still reports staleness. A
+    # factory returning something else simply reports nothing, which is the
+    # honest outcome.
+    if getattr(aggregator, "meter", None) is None:
+        try:
+            aggregator.meter = meter
+        except AttributeError:      # slots, or a read-only property
+            pass
     # A custom aggregator is the main extension point and is user code. Check the
     # contract here rather than letting it fail three frames deep in the driver
     # with something like "'MissingMethods' object has no attribute 'ingest'".
@@ -1026,7 +1238,8 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
 
     return _Engine(ledger, runtime, verifier, aggregator, strategy, run, reward,
                    propose, train, held_out, {t.id: t for t in train},
-                   [t.id for t in train], artifact_id, blast_radius, scratch)
+                   [t.id for t in train], artifact_id, blast_radius,
+                   meter=meter, scratch_repo=scratch)
 
 
 def evolve(
@@ -1066,6 +1279,10 @@ def evolve(
     seed: int = 0,
     on_round: Optional[Callable[["RoundInfo"], None]] = None,
     verbose: bool = False,
+    #: Share one `Usage` with your model adapters (`claude(usage=u)`) and the
+    #: result's token counts become real; without it only calls and seconds
+    #: are known, because an opaque `run` cannot report tokens.
+    usage: Optional[Usage] = None,
 ) -> EvolutionResult:
     """Evolve an artifact. Provide either ``agent`` (with ``solve``/``propose``)
     or the ``run`` / ``propose`` callables directly.
@@ -1240,6 +1457,13 @@ def evolve(
         Called with each :class:`RoundInfo` as the round completes -- progress
         for a long run, which otherwise reports nothing until it returns. An
         exception raised here is reported but does not abort the run.
+    usage:
+        Share one :class:`~agentdescent.agents.Usage` with your model adapters
+        (``claude(usage=u)``, ``openai_compatible(usage=u)``) and the result's
+        token counts become real. Without it the run still reports calls,
+        seconds and failures -- ``run`` is ``(rendered, task) -> str``, so an
+        opaque actor has no way to surface tokens, and inventing a number would
+        be worse than reporting zero.
     verbose:
         Print a line per round. Independent of the ``RuntimeWarning`` emitted
         when a run ends early -- that always fires.
@@ -1315,7 +1539,7 @@ def evolve(
             target_reward=target_reward, patience=patience,
             max_worker_errors=max_worker_errors,
             eval_concurrency=eval_concurrency,
-            on_round=on_round, verbose=verbose)
+            on_round=on_round, verbose=verbose, usage=usage)
 
     if n_workers < 1:
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")
@@ -1340,7 +1564,11 @@ def evolve(
         held_out_frac=held_out_frac, repo_path=repo_path, agg_config=agg_config,
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
         oracle_budget=oracle_budget, eval_concurrency=eval_concurrency,
-        cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed)
+        cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed,
+        usage=usage)
+    # Start the clock after the wiring, before the first unit of work: setup
+    # is not what a time-to-quality number is asking about.
+    eng.meter.start()
     ledger, aggregator, strategy = eng.ledger, eng.aggregator, eng.strategy
     run, propose, reward = eng.run, eng.propose, eng.reward
     held_out, by_id, train_ids = eng.held_out, eng.by_id, eng.train_ids
@@ -1420,8 +1648,11 @@ def evolve(
             if not unit.keys:
                 return
             task = by_id[sampler.pick(unit.keys, r)]     # a task from this worker's shard
+            _t0 = time.time()
             output = run(artifact.render(), task)
             score = _checked_reward(reward(task, output), task)
+            eng.meter.add("rollouts")
+            eng.meter.add("rollout_seconds", time.time() - _t0)
             sampler.record(task.id, score)               # learn which tasks carry signal
             with unit_lock:
                 ok_units[0] += 1
@@ -1592,8 +1823,9 @@ def evolve(
             if section_violations[0]:
                 reasons["section-violation"] = section_violations[0]
                 section_violations[0] = 0
+        _m = eng.meter.snapshot()
         info = RoundInfo(r, round_reward, len(dev.state), committed, rejected,
-                         reasons)
+                         reasons, elapsed_s=_m.elapsed_s, rollouts=_m.rollouts)
         history.append(info)
         # Early stopping: an LLM rollout costs money, so do not keep buying them
         # once the artifact has converged or clearly stalled.
@@ -1665,6 +1897,7 @@ def evolve(
     result = EvolutionResult(state=dict(final.state), rendered=final.render(),
                              final_reward=final_reward, history=history,
                              ledger_log=_safe_log(ledger), error=run_error,
-                             stop_reason="error" if run_error else stop_reason)
+                             stop_reason="error" if run_error else stop_reason,
+                             **_cost_fields(eng.meter))
     eng.cleanup()
     return result

--- a/agentdescent/metrics.py
+++ b/agentdescent/metrics.py
@@ -1,0 +1,249 @@
+"""What a run cost, measured at the places the engine already funnels through.
+
+A run used to report *what* it produced and nothing about what it took to get
+there. `EvolutionResult` carried the artifact, the per-round reward and the merge
+categories; a refactor that doubled the wall-clock and tripled the model calls
+left every one of those numbers untouched, which makes "did this change make
+things worse?" unanswerable from the result object alone.
+
+The five questions this module exists to answer -- time to a quality bar, cost to
+that bar, how much of the pipeline was stale, how much was recomputed, and how
+much was spent waiting on a sandbox rather than on a model -- all decompose into
+counters. So this is counters, and deliberately nothing else: no formatting, no
+export, no sampling. `Meter` is written from every worker thread and the merger
+thread at once, which is the only reason it is more than a dataclass.
+
+**Sum, not wall-clock.** ``rollout_seconds`` adds up per-rollout durations across
+concurrent workers, so with N workers it routinely exceeds ``wallclock``. It is
+the answer to "how much rollout was there", not "how long did rollouts take"; a
+reader who takes it as the latter computes occupancy above 100%.
+
+**Model time and sandbox time are separate on purpose.** Both look identical in a
+total wall-clock, and telling them apart is the whole point of the sandbox
+counters: "8 workers only bought 2x" reads as a staleness problem, a slow model
+and a queue of containers installing dependencies, and those need opposite fixes.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field, fields
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+from .agents import Usage
+
+__all__ = ["Meter", "MeterSnapshot", "measured"]
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class MeterSnapshot:
+    """An immutable read of a :class:`Meter`, taken under its lock.
+
+    Reading the fields one at a time from a live meter gives a mix of instants --
+    fine for a log line, not fine for `elapsed_s <= wallclock` style assertions,
+    which are exactly what the tests check."""
+
+    elapsed_s: float = 0.0
+    rollouts: int = 0
+    rollout_seconds: float = 0.0
+    eval_seconds: float = 0.0
+    merge_seconds: float = 0.0
+    calls: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    model_seconds: float = 0.0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    cache_inflight_joins: int = 0
+    stale_considered: int = 0
+    stale_discarded: int = 0
+    sandbox_wait_s: float = 0.0
+    sandbox_setup_s: float = 0.0
+    sandboxes_created: int = 0
+    sandboxes_reused: int = 0
+    sandbox_failures: int = 0
+    env_mismatch: int = 0
+
+
+#: Every counter `add` accepts. Spelled out rather than derived from `__dict__`
+#: so a typo raises instead of quietly creating a field nothing ever reads --
+#: a miscount is indistinguishable from "that path never ran".
+_COUNTERS = frozenset({
+    "rollouts", "rollout_seconds", "eval_seconds", "merge_seconds",
+    "cache_hits", "cache_misses", "cache_inflight_joins",
+    "stale_considered", "stale_discarded",
+    "sandbox_wait_s", "sandbox_setup_s", "sandboxes_created",
+    "sandboxes_reused", "sandbox_failures", "env_mismatch",
+})
+
+
+@dataclass
+class Meter:
+    """Every counter a run accumulates. Safe to share across threads.
+
+    ``+=`` is not atomic in Python -- read, add and store are three bytecodes and
+    a thread switch between them loses an increment. With eight workers and a
+    merger thread all recording into one meter, that is not a theoretical race:
+    it is a slow, silent undercount that makes the numbers look merely
+    disappointing rather than wrong. Hence one lock and one write path.
+    """
+
+    #: Wall-clock origin, set by the engine before the first unit of work.
+    #: 0.0 until then, which is what makes `elapsed()` return 0 for a meter that
+    #: was never started rather than the seconds since 1970.
+    t0: float = 0.0
+
+    #: Rollouts completed (successful or not) -- the denominator for per-rollout
+    #: costs and the sample size behind `rollout_seconds`.
+    rollouts: int = 0
+    #: Sum over rollouts, not wall-clock. See the module docstring.
+    rollout_seconds: float = 0.0
+    eval_seconds: float = 0.0
+    merge_seconds: float = 0.0
+
+    #: Model spend. Reuses `agents.Usage` rather than duplicating its fields, so
+    #: `evolve(usage=...)` and `claude(usage=...)` can share one object and the
+    #: caller sees a single set of totals.
+    #:
+    #: `calls` counts **actor invocations** (`run` and `propose`), not provider
+    #: requests: a `cli_agent` rollout is one call here and many requests to the
+    #: model. Token counts only appear when the same `Usage` also reaches an
+    #: adapter that reports them (`claude`, `openai_compatible`) -- an opaque
+    #: `run` has no way to surface them, and inventing a number would be worse
+    #: than reporting zero.
+    usage: Usage = field(default_factory=Usage)
+
+    #: Evaluation cache. `misses` counts evaluations actually performed;
+    #: `inflight_joins` counts callers that waited on an in-flight computation
+    #: instead of starting a duplicate one (0 until single-flight lands).
+    cache_hits: int = 0
+    cache_misses: int = 0
+    cache_inflight_joins: int = 0
+
+    #: Staleness needs a denominator: `discarded` alone cannot distinguish "the
+    #: lag budget is too tight" from "barely anything was proposed".
+    stale_considered: int = 0
+    stale_discarded: int = 0
+
+    #: Sandbox accounting. Zero on the default single-workspace path; filled once
+    #: the sandbox pool exists. Kept here from the start so the result schema
+    #: does not change again when it does.
+    sandbox_wait_s: float = 0.0
+    sandbox_setup_s: float = 0.0
+    sandboxes_created: int = 0
+    sandboxes_reused: int = 0
+    sandbox_failures: int = 0
+    #: Candidates whose base and candidate measurements came from different
+    #: environments, so the comparison was refused. Non-zero means the pool is
+    #: heterogeneous and quality comparisons from that run need a caveat.
+    env_mismatch: int = 0
+
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    # -- writing ---------------------------------------------------------------
+
+    def start(self) -> None:
+        """Mark the beginning of the run. Idempotent: the first call wins.
+
+        Re-starting would move the origin under a `RoundInfo` that already
+        recorded an `elapsed_s` against the old one, making the sequence
+        non-monotonic."""
+        with self._lock:
+            if self.t0 == 0.0:
+                self.t0 = time.time()
+
+    def add(self, counter: str, value: float = 1) -> None:
+        """Add to one counter. The only write path, so the only place to lock."""
+        if counter not in _COUNTERS:
+            raise KeyError(
+                f"unknown meter counter {counter!r}; known: {', '.join(sorted(_COUNTERS))}")
+        with self._lock:
+            setattr(self, counter, getattr(self, counter) + value)
+
+    # -- reading ---------------------------------------------------------------
+
+    def elapsed(self) -> float:
+        """Seconds since `start()`; 0.0 if the meter was never started."""
+        return 0.0 if self.t0 == 0.0 else time.time() - self.t0
+
+    def snapshot(self) -> MeterSnapshot:
+        """A consistent read of every counter, taken under the lock."""
+        with self._lock:
+            u = self.usage
+            return MeterSnapshot(
+                elapsed_s=0.0 if self.t0 == 0.0 else time.time() - self.t0,
+                rollouts=self.rollouts,
+                rollout_seconds=self.rollout_seconds,
+                eval_seconds=self.eval_seconds,
+                merge_seconds=self.merge_seconds,
+                calls=u.calls,
+                prompt_tokens=u.prompt_tokens,
+                completion_tokens=u.completion_tokens,
+                model_seconds=u.seconds,
+                cache_hits=self.cache_hits,
+                cache_misses=self.cache_misses,
+                cache_inflight_joins=self.cache_inflight_joins,
+                stale_considered=self.stale_considered,
+                stale_discarded=self.stale_discarded,
+                sandbox_wait_s=self.sandbox_wait_s,
+                sandbox_setup_s=self.sandbox_setup_s,
+                sandboxes_created=self.sandboxes_created,
+                sandboxes_reused=self.sandboxes_reused,
+                sandbox_failures=self.sandbox_failures,
+                env_mismatch=self.env_mismatch,
+            )
+
+    def summary(self) -> str:
+        s = self.snapshot()
+        out = [f"{s.rollouts} rollouts in {s.elapsed_s:.1f}s", self.usage.summary()]
+        if s.cache_hits or s.cache_misses:
+            out.append(f"cache {s.cache_hits}/{s.cache_hits + s.cache_misses} hit")
+        if s.stale_considered:
+            out.append(f"stale {s.stale_discarded}/{s.stale_considered}")
+        if s.sandboxes_created:
+            out.append(f"{s.sandboxes_created} sandboxes, "
+                       f"{s.sandbox_wait_s:.1f}s waiting")
+        return " | ".join(out)
+
+
+def measured(fn: Callable[..., T], meter: Optional[Meter]) -> Callable[..., T]:
+    """Wrap an actor so each invocation lands in ``meter.usage``.
+
+    ``agents.metered`` does the same job for a ``Completion`` (``prompt -> str``);
+    the engine's actors are ``run(rendered, task)`` and
+    ``propose(rendered, task, output, reward)``, which that signature cannot
+    accept. Same accounting, arbitrary arity.
+
+    **Records the call, not the phase.** ``run`` is invoked from two places --
+    a worker exploring, and `_Runtime.eval_one` scoring -- so timing the phase
+    here would put evaluation seconds into whichever counter the wrapper was
+    given. Each phase times itself; this only counts what the actor cost.
+
+    Returns ``fn`` unchanged when ``meter`` is ``None``, so the un-instrumented
+    path stays exactly one function call deep.
+    """
+    if meter is None:
+        return fn
+
+    def call(*args: Any, **kwargs: Any) -> T:
+        t0 = time.time()
+        try:
+            out = fn(*args, **kwargs)
+        except Exception:
+            meter.usage.record(seconds=time.time() - t0, failed=True)
+            raise
+        meter.usage.record(seconds=time.time() - t0)
+        return out
+
+    # Preserve the signature so `_check_callable` still sees the real arity: it
+    # binds `(None,) * n` against `inspect.signature`, and a bare `*args` wrapper
+    # would make every arity check pass, including the typo the check exists for.
+    try:
+        import functools
+        call = functools.wraps(fn)(call)  # type: ignore[assignment]
+    except (AttributeError, TypeError):   # builtins / C callables
+        pass
+    return call

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,8 +24,13 @@ Convenience actor: bundles running a task and proposing an improvement.
 
 | method | what it does |
 |---|---|
+| `cost_summary() -> str` | One line: what the run cost. Complements `outcomes()`, which says why it went as it did. |
+| `cost_to_quality(target: float) -> Optional[int]` | Rollouts spent up to the first round that reached `target`. |
+| `duplicate_rate() -> float` | Cache hits as a fraction of lookups -- work that did *not* have to be redone. In one process this is memoisation working; across processes it is the figure that says how much a shared cache would be worth. |
 | `outcomes() -> Dict[str, int]` | Merge outcomes for the whole run, by category -- *why* it went as it did. |
 | `save(path: str) -> None` | Write the evolved artifact and its run summary to a JSON file. |
+| `stale_rate() -> float` | Discarded evidence as a fraction of evidence considered; 0.0 if none. |
+| `time_to_quality(target: float) -> Optional[float]` | Wall-clock at the first round whose held-out reward reached `target`. |
 | `write_to(...)` | Install a file-tree artifact back into a real directory. |
 
 ### `EvolvingArtifact(...)`

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -16,7 +16,7 @@ and *how*, that is *what*.
  treestrategy       sampling                            verifier
                     parallel                            staleness
                     scheduler                           governance
-                    dataloader / rewards
+                    dataloader / rewards                  metrics
 ```
 
 ## The loop
@@ -67,6 +67,7 @@ and *how*, that is *what*.
 | `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
+| `metrics` | what the run cost: time, calls, staleness ratio, cache hits, sandbox waits | [Usage](usage.md#what-a-run-cost) |
 
 ## Reading order
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,6 +101,51 @@ Covered in full elsewhere, and not repeated here:
   including tool-using CLI agents.
 * **[Measured results](results.md)** — every empirical claim with its setup.
 
+### What a run cost
+
+`EvolutionResult` carries the artifact *and* the bill. Every field below defaults
+to zero and is read back with `.get`, so a result saved before they existed still
+loads.
+
+```python
+r = evolve(tasks, reward, agent=agent)
+
+r.cost_summary()          # one line: rollouts, wall-clock, model calls, ratios
+r.time_to_quality(0.9)    # seconds to the first round at >= 0.9, or None
+r.cost_to_quality(0.9)    # rollouts to that same round, or None
+r.stale_rate()            # discarded / considered -- the ratio needs both
+r.duplicate_rate()        # evaluation cache hit rate
+```
+
+| what | field |
+|---|---|
+| time | `wallclock`, and `RoundInfo.elapsed_s` per round |
+| work | `rollouts`, `rollout_seconds` (a **sum** across workers, so it exceeds `wallclock` when they overlap), `eval_seconds` |
+| model | `usage.calls` / `.seconds` / `.failures` |
+| staleness | `stale_considered`, `stale_discarded` |
+| recomputation | `cache_hits`, `cache_misses` |
+| sandboxes | `sandbox_wait_s`, `sandbox_setup_s`, `sandboxes_created` / `_reused` / `_failures` |
+
+Two things worth knowing before reading these numbers:
+
+* **`usage.calls` counts actor invocations** — one `run` or `propose` — not
+  provider requests. A `cli_agent` rollout is one call here and many requests to
+  the model.
+* **Token counts need a shared `Usage`.** `run` is `(rendered, task) -> str`, so
+  an opaque actor cannot report tokens. Pass the same object to both and they
+  accumulate together:
+
+```python
+from agentdescent import Usage
+u = Usage()
+r = evolve(tasks, reward, agent=LLMAgent(claude(usage=u)), usage=u)
+print(r.usage.total_tokens, r.usage.estimated_cost(3.0, 15.0))
+```
+
+The sandbox fields are zero on the default path: one throwaway workspace per
+rollout, nothing to queue for and no image to warm. They exist so that when a
+pool does, "8 workers only bought 2x" can be attributed rather than guessed at.
+
 ### The reference stack — `AgentDescent` / `AsyncAgentDescent`
 
 A **separate** runtime used by the RQ1/RQ2 and efficiency experiments on the

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,311 @@
+"""What a run cost has to be measurable from the result alone.
+
+Every assertion here exists because the number it checks is one a reader would
+otherwise take on faith. The two that matter most:
+
+* `usage.calls` doubling is what a double-wrapped actor looks like, and a
+  doubled call count is a perfectly plausible number -- nothing else would catch
+  it;
+* `stale_considered` is a denominator, so a ratio computed against the wrong one
+  is wrong in a way that still reads as a ratio.
+"""
+
+import json
+import threading
+
+import pytest
+
+from agentdescent import AppendRules, Task, evolve
+from agentdescent.agents import Usage
+from agentdescent.evolution import EvolutionResult, RoundInfo
+from agentdescent.metrics import Meter, measured
+
+
+# ---------------------------------------------------------------------------
+# Meter itself
+# ---------------------------------------------------------------------------
+
+
+def test_add_rejects_an_unknown_counter():
+    """A typo must raise, not silently create a field nothing reads.
+
+    A miscount and "that path never ran" are the same number otherwise."""
+    m = Meter()
+    with pytest.raises(KeyError, match="unknown meter counter"):
+        m.add("rollout_second", 1.0)     # missing 's'
+
+
+def test_concurrent_adds_are_exact():
+    """`+=` is three bytecodes; a thread switch between them loses increments.
+
+    Not "approximately 3200" -- exactly 3200, or the counters cannot be trusted
+    at the concurrency the engine actually runs at."""
+    m = Meter()
+    def bump():
+        for _ in range(100):
+            m.add("rollouts")
+    threads = [threading.Thread(target=bump) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert m.snapshot().rollouts == 3200
+
+
+def test_snapshot_does_not_tear():
+    """A snapshot is one instant, so counters written together stay consistent.
+
+    Reading fields one at a time off a live meter mixes instants, which breaks
+    exactly the `elapsed_s <= wallclock` style assertions below."""
+    m = Meter()
+    m.start()
+    stop = threading.Event()
+
+    def churn():
+        while not stop.is_set():
+            m.add("cache_hits")
+            m.add("cache_misses")
+
+    t = threading.Thread(target=churn, daemon=True)
+    t.start()
+    try:
+        for _ in range(200):
+            s = m.snapshot()
+            # hits are written first, so a torn read shows more misses than hits.
+            assert s.cache_hits >= s.cache_misses
+    finally:
+        stop.set()
+        t.join()
+
+
+def test_start_is_idempotent():
+    """Re-starting would move the origin under a RoundInfo that already recorded
+    an elapsed_s against the old one, making the sequence non-monotonic."""
+    m = Meter()
+    m.start()
+    t0 = m.t0
+    m.start()
+    assert m.t0 == t0
+
+
+def test_elapsed_is_zero_before_start():
+    assert Meter().elapsed() == 0.0
+    assert Meter().snapshot().elapsed_s == 0.0
+
+
+def test_measured_counts_calls_and_failures():
+    m = Meter()
+    ok = measured(lambda a, b: "x", m)
+    assert ok(1, 2) == "x"
+
+    def boom(a, b):
+        raise RuntimeError("nope")
+
+    bad = measured(boom, m)
+    with pytest.raises(RuntimeError):
+        bad(1, 2)
+    assert m.usage.calls == 2
+    assert m.usage.failures == 1
+
+
+def test_measured_preserves_arity_for_the_signature_check():
+    """`_check_callable` binds (None,)*n against `inspect.signature`.
+
+    A bare `*args` wrapper makes every arity check pass -- including the typo
+    the check exists to catch -- so the wrapper has to keep the real signature.
+    """
+    from agentdescent.evolution import _check_callable
+
+    def run(rendered, task):
+        return ""
+
+    _check_callable(measured(run, Meter()), 2, "run(rendered, task)")
+    with pytest.raises(TypeError):
+        _check_callable(measured(run, Meter()), 4, "propose(...)")
+
+
+def test_measured_without_a_meter_is_the_identity():
+    """The un-instrumented path must not grow a frame."""
+    def f(x):
+        return x
+    assert measured(f, None) is f
+
+
+# ---------------------------------------------------------------------------
+# End to end, on the deterministic offline domain
+# ---------------------------------------------------------------------------
+
+
+def _tasks(n=6):
+    return [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(n)]
+
+
+def _reward(task, output):
+    return 1.0 if output == task.meta["gold"] else 0.0
+
+
+def _run(rendered, task):
+    # solved once the rule for this task is in the artifact.
+    return task.meta["gold"] if task.id in rendered else "?"
+
+
+def _propose(rendered, task, output, reward):
+    return task.id
+
+
+def _evolve(**kw):
+    kw.setdefault("rounds", 4)
+    kw.setdefault("n_workers", 2)
+    kw.setdefault("held_out_frac", 0.5)
+    return evolve(_tasks(), _reward, run=_run, propose=_propose,
+                  strategy=AppendRules(), **kw)
+
+
+def test_a_run_reports_what_it_cost():
+    r = _evolve()
+    assert r.rollouts > 0
+    assert r.wallclock > 0.0
+    assert r.usage.calls > 0
+    assert r.cache_hits + r.cache_misses > 0
+    assert r.cost_summary()          # renders without raising
+
+
+def test_elapsed_is_monotonic_and_within_the_wallclock():
+    r = _evolve()
+    elapsed = [h.elapsed_s for h in r.history]
+    assert elapsed == sorted(elapsed)
+    assert all(e <= r.wallclock + 1e-6 for e in elapsed)
+    rollouts = [h.rollouts for h in r.history]
+    assert rollouts == sorted(rollouts)
+
+
+def test_usage_calls_equals_actor_invocations():
+    """Counts every `run` and `propose`, each exactly once.
+
+    The failure this guards is `measured()` applied twice -- the count then comes
+    out exactly doubled, which looks like a busier run rather than a bug.
+    """
+    calls = {"run": 0, "propose": 0}
+
+    def counted_run(rendered, task):
+        calls["run"] += 1
+        return _run(rendered, task)
+
+    def counted_propose(rendered, task, output, reward):
+        calls["propose"] += 1
+        return _propose(rendered, task, output, reward)
+
+    r = evolve(_tasks(), _reward, run=counted_run, propose=counted_propose,
+               strategy=AppendRules(), rounds=3, n_workers=2, held_out_frac=0.5)
+    assert r.usage.calls == calls["run"] + calls["propose"]
+
+
+def test_the_cache_counts_hits_and_misses():
+    """N evaluations of one (artifact, task) is 1 miss and N-1 hits."""
+    from agentdescent.evolution import _EvalCache
+
+    m = Meter()
+    cache = _EvalCache(m)
+    n = {"calls": 0}
+
+    def measure():
+        n["calls"] += 1
+        return 1.0
+
+    for _ in range(5):
+        cache.get_or_eval(("k", "t1"), measure)
+    assert (m.snapshot().cache_misses, m.snapshot().cache_hits) == (1, 4)
+    assert n["calls"] == 1
+
+
+def test_the_stale_denominator_matches_the_reports():
+    """`stale_considered` must equal the evidence the filter actually saw.
+
+    Asserted rather than assumed: a ratio computed against the wrong denominator
+    still looks like a ratio."""
+    seen = []
+    r = evolve(_tasks(), _reward, run=_run, propose=_propose,
+               strategy=AppendRules(), rounds=4, n_workers=3, held_out_frac=0.5,
+               on_round=lambda info: seen.append(info))
+    assert r.stale_considered >= r.stale_discarded >= 0
+    assert 0.0 <= r.stale_rate() <= 1.0
+
+
+def test_sandbox_fields_are_zero_on_the_default_path():
+    """There is no pool to wait for and no image to warm, so these stay 0 --
+    and their presence must not perturb any existing number."""
+    r = _evolve()
+    assert (r.sandbox_wait_s, r.sandbox_setup_s) == (0.0, 0.0)
+    assert (r.sandboxes_created, r.sandboxes_reused, r.sandbox_failures) == (0, 0, 0)
+
+
+def test_time_and_cost_to_quality():
+    r = _evolve(rounds=6)
+    reached = [h for h in r.history if h.held_out_reward >= 0.5]
+    if reached:
+        assert r.time_to_quality(0.5) == reached[0].elapsed_s
+        assert r.cost_to_quality(0.5) == reached[0].rollouts
+    # a bar nothing reaches has no time-to-quality; total wall-clock would flatter it
+    assert r.time_to_quality(2.0) is None
+    assert r.cost_to_quality(2.0) is None
+
+
+def test_a_shared_usage_object_accumulates_tokens():
+    """Tokens are only knowable when the caller's adapter reports them, so the
+    engine has to accept the caller's Usage rather than always making its own."""
+    u = Usage()
+    u.record(prompt_tokens=100, completion_tokens=20)     # as an adapter would
+    r = _evolve(usage=u)
+    assert r.usage is u
+    assert r.usage.prompt_tokens == 100
+    assert r.usage.calls > 1
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_save_load_round_trip_keeps_the_cost_fields(tmp_path):
+    r = _evolve()
+    p = tmp_path / "r.json"
+    r.save(str(p))
+    back = EvolutionResult.load(str(p))
+    assert back.wallclock == r.wallclock
+    assert back.rollouts == r.rollouts
+    assert back.usage.calls == r.usage.calls
+    assert back.cache_hits == r.cache_hits
+    assert back.stale_considered == r.stale_considered
+    assert [h.elapsed_s for h in back.history] == [h.elapsed_s for h in r.history]
+
+
+def test_a_result_written_before_these_fields_existed_still_loads(tmp_path):
+    """The old on-disk shape, verbatim -- not a dict with keys removed."""
+    old = {
+        "state": {"r1": "always answer 4"},
+        "rendered": "always answer 4",
+        "final_reward": 0.75,
+        "error": None,
+        "history": [{"round": 0, "held_out_reward": 0.5, "n_items": 1,
+                     "committed": 1, "rejected": 0, "reasons": {"committed": 1}}],
+        "retired_workers": 0,
+        "forced_refreshes": 0,
+        "stragglers": 0,
+        "stop_reason": "rounds",
+        "ledger_log": ["init"],
+    }
+    p = tmp_path / "old.json"
+    p.write_text(json.dumps(old), encoding="utf-8")
+
+    r = EvolutionResult.load(str(p))
+    assert r.final_reward == 0.75
+    assert r.wallclock == 0.0 and r.rollouts == 0
+    assert r.usage.calls == 0
+    assert r.history[0].elapsed_s == 0.0
+    assert r.stale_rate() == 0.0 and r.duplicate_rate() == 0.0
+
+
+def test_roundinfo_defaults_keep_positional_construction_working():
+    """Existing callers build RoundInfo positionally; the new fields are last."""
+    info = RoundInfo(0, 0.5, 3, 1, 2, {"committed": 1})
+    assert (info.elapsed_s, info.rollouts) == (0.0, 0)


### PR DESCRIPTION
Closes #59. First of the eight steps in the [architecture roadmap](https://github.com/Birfy/agentdescent/issues/52#issuecomment-5164168416); nothing depends on it and everything after it does.

## Why this one first

A result said what it produced and nothing about what it took. `run_demo`'s table can prove the output did not change — it cannot prove the wall-clock did not double or the call count did not triple. Every step after this one claims "zero behaviour change" or "results reproduce", and those claims need numbers to be checkable.

## What it adds

`agentdescent/metrics.py`: a `Meter` of counters, written from every worker and the merger at once — hence one lock and one write path, since `+=` is three bytecodes and a thread switch between them loses increments silently.

Recorded at the places the engine already funnels through, rather than sprinkled:

| counter | site | why there |
|---|---|---|
| cache hit/miss, eval time | `_EvalCache` + `_Runtime.eval_one` | the single evaluation choke point — every held-out score, the final score and all three aggregator gates pass through it |
| model spend | actors wrapped once in `_build_engine` | wrapping later would miss whichever reference was captured first |
| rollouts | the two worker loops | `run` is invoked from both exploration *and* scoring, so timing it inside the wrapper would file evaluation seconds under rollouts |
| staleness | `_staleness_filter` | the only place that knows the **denominator** — `MergeReport` carries the numerator, and 3 discards out of 4 vs out of 400 need opposite fixes |

New on `EvolutionResult`: `usage`, `wallclock`, `rollouts`, `rollout_seconds`, `eval_seconds`, `stale_considered/_discarded`, `cache_hits/_misses`, and five sandbox fields that stay 0 until there is a pool. Plus `time_to_quality()`, `cost_to_quality()`, `stale_rate()`, `duplicate_rate()`, `cost_summary()` — the metric definitions live in one place so docs and any future bench cannot each compute their own.

## Two decisions worth a look during review

**Model time and sandbox time are separate fields.** Both look identical in a total wall-clock, and "8 workers only bought 2×" reads as a staleness problem, a slow model, and a queue of containers installing dependencies. Those need opposite fixes, so the accounts must not merge.

**`usage.calls` counts actor invocations, not provider requests.** A `cli_agent` rollout is one call here and many requests to the model. Tokens only appear when the caller shares one `Usage` with their adapter — hence the new `usage=` argument. An opaque `run(rendered, task) -> str` cannot surface tokens, and reporting zero beats inventing a number.

## Verification

- **653 passed, 1 skipped** (635 before + 19 new, of which 1 pre-existing skip).
- `python -m examples.run_demo` reproduces the `docs/usage.md` table verbatim — `0.828 → 1.000`, stable catching up at round 8, `+0.621`.
- **Overhead measured, not assumed**: 1.2792s vs 1.2767s median on a deterministic offline workload against `main` — **+0.2%**, budget was 2%.
- `mkdocs build --strict` and `gen_api_docs --check` pass.

Backward compatibility is tested against a verbatim old result file rather than a dict with keys deleted: `load` already used `.get`, and a test now holds it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
