### PR TITLE
feat: give a sandbox an owner, a ceiling, and a way to be reclaimed

### DIFF
--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -81,6 +81,7 @@ from .policies import (
     SandboxSpec,
     VerifierProtocol,
 )
+from .sandbox import LocalWorkspaceSandbox, SandboxPool, WorkspaceProvider
 from . import rewards                      # agentdescent.rewards.last_number(...)
 from .skill import evolve_skill
 from .filetree import (
@@ -221,6 +222,9 @@ __all__ = [
     "VerifierProtocol",
     "LedgerProtocol",
     "SandboxSpec",
+    "SandboxPool",
+    "WorkspaceProvider",
+    "LocalWorkspaceSandbox",
     "SandboxProvider",
     "Sandbox",
     "Worker",

--- a/agentdescent/runners.py
+++ b/agentdescent/runners.py
@@ -28,14 +28,22 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 import tempfile
 import time
-from typing import Callable, Dict, Mapping, Optional, Sequence
+import warnings
+from typing import (
+    TYPE_CHECKING, Callable, Dict, Mapping, Optional, Sequence, Tuple,
+)
 
 from .agents import AgentError, Completion, WorkspaceAgent
 from .evolution import Task
 from .filetree import TreeError, materialize, parse_tree
+
+if TYPE_CHECKING:                                   # pragma: no cover
+    from .policies import SandboxSpec
+    from .sandbox import SandboxPool
 
 __all__ = [
     "LAYOUTS",
@@ -59,8 +67,11 @@ LAYOUTS: Dict[str, str] = {
 #: signal a reflector needs -- so it is reported in-band and scored 0.
 TEST_FAILURE_MARKER = "AGENTDESCENT_GATE_FAILED"
 
-_WS_PREFIX = "agentdescent-ws-"
-_WS_MAX_AGE = 6 * 3600.0
+#: How many workspaces a runner that was given no pool will allow at once.
+#: Matches `evolve`'s default `eval_concurrency`, which is the larger of the two
+#: concurrencies that reach a runner today -- so the default ceiling does not
+#: bind on any configuration that worked before.
+_DEFAULT_MAX_SANDBOXES = 8
 
 _DEFAULT_PROMPT = (
     "{prompt}\n\n"
@@ -75,52 +86,55 @@ def layout_prefix(layout: str, name: str) -> str:
     return template.format(name=name) if "{name}" in template else template
 
 
-def _reap_stale_workspaces(max_age: float = _WS_MAX_AGE) -> int:
-    """Collect workspaces left behind by a killed process.
+def _pool_for(pool: Optional["SandboxPool"],
+              workspace_root: Optional[str]) -> "Tuple[SandboxPool, SandboxSpec]":
+    """The pool this runner will lease from, and the spec it asks for.
 
-    ``evolve()`` reaps its own scratch *ledgers* the same way
-    (``_reap_stale_scratch_repos``) and for the same reason: ``atexit`` does not
-    run on SIGKILL or an OOM kill, and a long sweep otherwise leaves one
-    directory per rollout in ``$TMPDIR``. Best-effort and silent -- reclaiming
-    disk must never fail a run."""
-    root, now, n = tempfile.gettempdir(), time.time(), 0
+    A runner given no pool makes its own, so the common single-`evolve()` case
+    needs no wiring. Sharing one across runners is what puts rollouts and
+    evaluations under a single ceiling, which is the point of having one."""
+    from .policies import SandboxSpec
+    from .sandbox import SandboxPool, WorkspaceProvider
+
+    spec = SandboxSpec(workspace_root=workspace_root)
+    if pool is not None:
+        return pool, spec
+    provider = WorkspaceProvider()
+    provider.reap()                 # collect what earlier killed processes left
+    return SandboxPool(provider, max_sandboxes=_DEFAULT_MAX_SANDBOXES), spec
+
+
+def _preserve(ws: str) -> Optional[str]:
+    """Copy a workspace out before the pool reclaims it (`keep_failed`).
+
+    Holding the sandbox itself would be the easy implementation and the wrong
+    one: the ceiling exists to bound what is on the machine, and a debugging
+    flag must not be able to raise it one failed rollout at a time."""
     try:
-        names = os.listdir(root)
+        dest = tempfile.mkdtemp(prefix="agentdescent-failed-")
+        shutil.rmtree(dest, ignore_errors=True)
+        shutil.copytree(ws, dest, symlinks=True)
+        return dest
     except OSError:
-        return 0
-    for name in names:
-        if not name.startswith(_WS_PREFIX):
-            continue
-        path = os.path.join(root, name)
-        try:
-            if now - os.path.getmtime(path) < max_age:
-                continue
-            shutil.rmtree(path, ignore_errors=True)
-            n += 1
-        except OSError:
-            pass
-    return n
+        return None
 
 
-def _stage(rendered: str, task: Task, *, prefix: str,
-           overlay: Optional[Mapping[str, str]],
-           fixtures: Optional[Callable[[Task], Mapping[str, str]]],
-           workspace_root: Optional[str]) -> str:
-    """Build one workspace for one rollout and return its path."""
+def _stage_into(ws: str, rendered: str, task: Task, *, prefix: str,
+                overlay: Optional[Mapping[str, str]],
+                fixtures: Optional[Callable[[Task], Mapping[str, str]]]) -> None:
+    """Lay one rollout's files out inside an already-acquired workspace.
+
+    Splitting this from *making* the directory is what lets the pool own the
+    lifetime: staging can fail, and when it does the sandbox still has to go
+    back through the same release path as a successful rollout."""
     tree = parse_tree(rendered)
-    ws = tempfile.mkdtemp(prefix=_WS_PREFIX, dir=workspace_root)
-    try:
-        materialize(tree, ws, prefix=prefix)
-        if overlay:
-            # after the candidate, so the candidate cannot win the race.
-            materialize(overlay, ws, prefix=prefix)
-        staged = fixtures(task) if fixtures else (task.meta or {}).get("fixtures")
-        if staged:
-            materialize(staged, ws)
-    except Exception:
-        shutil.rmtree(ws, ignore_errors=True)
-        raise
-    return ws
+    materialize(tree, ws, prefix=prefix)
+    if overlay:
+        # after the candidate, so the candidate cannot win the race.
+        materialize(overlay, ws, prefix=prefix)
+    staged = fixtures(task) if fixtures else (task.meta or {}).get("fixtures")
+    if staged:
+        materialize(staged, ws)
 
 
 def tree_runner(agent: Completion, *, layout: str = "claude_skill",
@@ -130,7 +144,8 @@ def tree_runner(agent: Completion, *, layout: str = "claude_skill",
                 fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
                 answer_file: Optional[str] = None,
                 keep_failed: bool = False,
-                workspace_root: Optional[str] = None) -> Callable[[str, Task], str]:
+                workspace_root: Optional[str] = None,
+                sandbox_pool: Optional["SandboxPool"] = None) -> Callable[[str, Task], str]:
     """Build a ``run(rendered, task)`` that gives ``agent`` the evolving directory.
 
     ``agent`` should be a :class:`~agentdescent.agents.WorkspaceAgent`
@@ -151,26 +166,30 @@ def tree_runner(agent: Completion, *, layout: str = "claude_skill",
             "would only ever see the prompt. Use claude_code(), codex(), "
             "cli_agent([...]) or openhands().")
     prefix = layout_prefix(layout, name)
-    _reap_stale_workspaces()
+    pool, spec = _pool_for(sandbox_pool, workspace_root)
 
     def run(rendered: str, task: Task) -> str:
-        ws = _stage(rendered, task, prefix=prefix, overlay=overlay,
-                    fixtures=fixtures, workspace_root=workspace_root)
-        ok = False
-        try:
-            prompt = prompt_template.format(prompt=task.prompt, name=name,
-                                            tree_dir=prefix or ".")
-            out = agent.in_workspace(ws)(prompt)
-            if answer_file:
-                path = os.path.join(ws, answer_file)
-                if os.path.exists(path):
-                    with open(path, encoding="utf-8", errors="replace") as fh:
-                        out = fh.read()
-            ok = True
-            return (out or "").strip()
-        finally:
-            if ok or not keep_failed:
-                shutil.rmtree(ws, ignore_errors=True)
+        with pool.lease(spec) as sandbox:
+            ws, ok = sandbox.root, False
+            try:
+                _stage_into(ws, rendered, task, prefix=prefix, overlay=overlay,
+                            fixtures=fixtures)
+                prompt = prompt_template.format(prompt=task.prompt, name=name,
+                                                tree_dir=prefix or ".")
+                out = agent.in_workspace(ws)(prompt)
+                if answer_file:
+                    path = os.path.join(ws, answer_file)
+                    if os.path.exists(path):
+                        with open(path, encoding="utf-8", errors="replace") as fh:
+                            out = fh.read()
+                ok = True
+                return (out or "").strip()
+            finally:
+                if keep_failed and not ok:
+                    kept = _preserve(ws)
+                    if kept:
+                        warnings.warn(f"kept the failed workspace at {kept}",
+                                      RuntimeWarning, stacklevel=2)
 
     return run
 
@@ -198,8 +217,62 @@ def _child_env(ws: str, extra: Optional[Mapping[str, str]]) -> Dict[str, str]:
 
 def _sh(cmd: Sequence[str], ws: str, timeout: float,
         env: Mapping[str, str]) -> subprocess.CompletedProcess:
-    return subprocess.run(list(cmd), cwd=ws, capture_output=True, text=True,
-                          timeout=timeout, env=dict(env))
+    """Run one gate command, and on timeout kill **everything it started**.
+
+    ``subprocess.run(timeout=)`` kills the process it launched and nothing else.
+    That is fine for a leaf command and wrong for every command here: ``pytest``
+    forks, ``pip install`` forks, an agent CLI forks. On a timeout the direct
+    child dies, the run continues, and the grandchildren keep going -- still
+    burning CPU, still holding open a workspace the ``finally`` has already
+    deleted. Eight workers hitting a timeout leave eight of them behind, and
+    nothing in the run reports it.
+
+    So the child gets its own process group (``start_new_session``) and the
+    timeout path signals the **group**. ``SIGTERM`` first, because a test runner
+    given the chance will remove its own temporary files; ``SIGKILL`` for
+    whatever is left.
+
+    POSIX-only: Windows has no process groups in this sense, so there the
+    behaviour is what it always was -- documented rather than silently different.
+    """
+    posix = os.name != "nt"
+    proc = subprocess.Popen(list(cmd), cwd=ws, env=dict(env), text=True,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            start_new_session=posix)
+    try:
+        out, err = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_group(proc, posix)
+        # Drain after killing: the pipes may hold output that explains the hang,
+        # and not reading them can leave the child blocked on a full pipe.
+        try:
+            out, err = proc.communicate(timeout=5.0)
+        except subprocess.TimeoutExpired:                    # pragma: no cover
+            out, err = "", ""
+        raise subprocess.TimeoutExpired(cmd, timeout, output=out, stderr=err)
+    return subprocess.CompletedProcess(cmd, proc.returncode, out, err)
+
+
+def _kill_group(proc: "subprocess.Popen", posix: bool) -> None:
+    """Terminate the process group ``proc`` leads, then make sure it is gone."""
+    if not posix:
+        proc.kill()
+        return
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:                      # already reaped
+        return
+    for sig, grace in ((signal.SIGTERM, 0.5), (signal.SIGKILL, 0.0)):
+        try:
+            os.killpg(pgid, sig)
+        except OSError:                  # the group is gone; nothing left to do
+            return
+        if grace:
+            deadline = time.time() + grace
+            while time.time() < deadline:
+                if proc.poll() is not None:
+                    return
+                time.sleep(0.02)
 
 
 def code_runner(entrypoint: Sequence[str], *, layout: str = "root",
@@ -210,7 +283,8 @@ def code_runner(entrypoint: Sequence[str], *, layout: str = "root",
                 fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
                 timeout: float = 120.0,
                 env: Optional[Mapping[str, str]] = None,
-                workspace_root: Optional[str] = None) -> Callable[[str, Task], str]:
+                workspace_root: Optional[str] = None,
+                sandbox_pool: Optional["SandboxPool"] = None) -> Callable[[str, Task], str]:
     """Run **candidate code** on a task: materialise, gate, execute.
 
     ``entrypoint`` is argv; the task prompt is appended as the last argument and
@@ -229,38 +303,41 @@ def code_runner(entrypoint: Sequence[str], *, layout: str = "root",
     hand.
     """
     prefix = layout_prefix(layout, name)
-    _reap_stale_workspaces()
+    pool, spec = _pool_for(sandbox_pool, workspace_root)
 
     def run(rendered: str, task: Task) -> str:
-        ws = _stage(rendered, task, prefix=prefix, overlay=overlay,
-                    fixtures=fixtures, workspace_root=workspace_root)
+        with pool.lease(spec) as sandbox:
+            ws = sandbox.root
+            _stage_into(ws, rendered, task, prefix=prefix, overlay=overlay,
+                        fixtures=fixtures)
+            return _gate_and_run(ws, task)
+
+    def _gate_and_run(ws: str, task: Task) -> str:
+        """Gate first, then the entrypoint. A failing gate speaks in-band."""
         child = _child_env(ws, env)
-        try:
-            for label, cmd in (("setup", setup_cmd), ("tests", test_cmd)):
-                if not cmd:
-                    continue
-                try:
-                    proc = _sh(cmd, ws, timeout, child)
-                except subprocess.TimeoutExpired:
-                    return (f"{TEST_FAILURE_MARKER} ({label} timed out after "
-                            f"{timeout:g}s)")
-                except FileNotFoundError as e:
-                    raise AgentError(f"{cmd[0]!r} is not installed or not on PATH") from e
-                if proc.returncode != 0:
-                    detail = (proc.stdout or "") + (proc.stderr or "")
-                    return f"{TEST_FAILURE_MARKER} ({label}):\n{detail.strip()[:2000]}"
+        for label, cmd in (("setup", setup_cmd), ("tests", test_cmd)):
+            if not cmd:
+                continue
             try:
-                proc = _sh([*entrypoint, task.prompt], ws, timeout, child)
+                proc = _sh(cmd, ws, timeout, child)
             except subprocess.TimeoutExpired:
-                return f"{TEST_FAILURE_MARKER} (entrypoint timed out after {timeout:g}s)"
+                return (f"{TEST_FAILURE_MARKER} ({label} timed out after "
+                        f"{timeout:g}s)")
             except FileNotFoundError as e:
-                raise AgentError(
-                    f"{entrypoint[0]!r} is not installed or not on PATH") from e
+                raise AgentError(f"{cmd[0]!r} is not installed or not on PATH") from e
             if proc.returncode != 0:
-                detail = (proc.stderr or proc.stdout or "").strip()[:2000]
-                return f"{TEST_FAILURE_MARKER} (entrypoint exited {proc.returncode}):\n{detail}"
-            return (proc.stdout or "").strip()
-        finally:
-            shutil.rmtree(ws, ignore_errors=True)
+                detail = (proc.stdout or "") + (proc.stderr or "")
+                return f"{TEST_FAILURE_MARKER} ({label}):\n{detail.strip()[:2000]}"
+        try:
+            proc = _sh([*entrypoint, task.prompt], ws, timeout, child)
+        except subprocess.TimeoutExpired:
+            return f"{TEST_FAILURE_MARKER} (entrypoint timed out after {timeout:g}s)"
+        except FileNotFoundError as e:
+            raise AgentError(
+                f"{entrypoint[0]!r} is not installed or not on PATH") from e
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout or "").strip()[:2000]
+            return f"{TEST_FAILURE_MARKER} (entrypoint exited {proc.returncode}):\n{detail}"
+        return (proc.stdout or "").strip()
 
     return run

--- a/agentdescent/sandbox.py
+++ b/agentdescent/sandbox.py
@@ -1,0 +1,380 @@
+"""Sandboxes as a managed resource: bounded, owned, and reclaimable.
+
+A rollout that evolves a *directory* needs that directory to exist on disk, and
+`runners.py` has always made one per call. What it has not had is an owner. The
+workspace is created inside the `run` closure and deleted by that closure's
+`finally`, which means:
+
+* nothing bounds how many exist at once -- `max_concurrency` worker threads and
+  `eval_concurrency` scoring threads each make their own, and neither knows about
+  the other, so the real ceiling is their sum;
+* the `finally` does not run when the thread is abandoned (a round timeout leaves
+  the straggler running, and Python cannot cancel a thread) or when the process
+  is killed;
+* what *does* clean up after a killed process is a sweep that deletes anything in
+  `$TMPDIR` older than six hours -- and "old enough" is not "unused".
+
+This module makes the lifetime explicit. One pool, one ceiling, one release path,
+and a lease file so a directory can say who owns it.
+
+**Why leases rather than reference counts.** The interesting failures are the
+ones where the owner is already gone: an abandoned thread whose `finally` will
+never run, a process that took a SIGKILL. A counter kept in the dead process
+cannot help. A lease written *into the sandbox* can: the owner renews it while it
+is working, and any other process can later read it, see that nobody has renewed
+it, and clean up.
+
+**Why the default is still a fresh workspace per rollout.** `code_runner`'s
+frozen-file overlay assumes a clean directory: materialise the candidate, write
+the pristine files back over it, then run the tests. A workspace carrying the
+previous candidate's writes breaks that guarantee, and the symptom is not a
+crash -- it is a score that looks entirely ordinary and is wrong. Reuse has to be
+asked for.
+
+The only provider here is the local-directory one, which reproduces today's
+behaviour exactly. Process-per-worker and remote/container providers implement
+the same `SandboxProvider` protocol and land with the work that needs them; there
+are no stubs for them here, because a provider that exists but does not isolate
+is worse than one that does not exist.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import tempfile
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Dict, Iterator, Optional
+
+from .metrics import Meter
+from .policies import SandboxSpec
+
+__all__ = [
+    "LEASE_FILE",
+    "LocalWorkspaceSandbox",
+    "SandboxLeak",
+    "SandboxPool",
+    "WorkspaceProvider",
+]
+
+#: Written into every sandbox root. Named so a human who finds one in `$TMPDIR`
+#: can tell what made it and whether anything still owns it.
+LEASE_FILE = ".agentdescent-lease.json"
+
+_WS_PREFIX = "agentdescent-ws-"
+
+#: This process, for lease ownership. The token distinguishes two runs that
+#: happen to get the same pid after a restart -- without it, a stale lease from a
+#: recycled pid looks alive forever.
+_HOST = socket.gethostname()
+_TOKEN = uuid.uuid4().hex[:12]
+
+
+class SandboxLeak(RuntimeError):
+    """A sandbox was never returned. Only raised by tests asking for strictness."""
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+@dataclass
+class LocalWorkspaceSandbox:
+    """A throwaway directory on this machine -- what a rollout has always got.
+
+    Isolation here is a trimmed environment, `HOME` and `TMPDIR` pointing inside
+    the workspace, and a hard timeout. It is **not** a security boundary: the
+    code still runs as your user, with your network. That is unchanged by this
+    module, and saying otherwise because there is now a file called `sandbox.py`
+    would be the worst thing this refactor could do.
+    """
+
+    id: str
+    root: str
+    fingerprint: str
+    lease_id: str = ""
+    acquired_at: float = 0.0
+
+
+class WorkspaceProvider:
+    """Provisions :class:`LocalWorkspaceSandbox` -- `mkdtemp`, plus a lease file."""
+
+    def __init__(self, ttl: float = 300.0) -> None:
+        self.ttl = ttl
+        self._n = 0
+        self._lock = threading.Lock()
+
+    def acquire(self, spec: SandboxSpec) -> LocalWorkspaceSandbox:
+        root = tempfile.mkdtemp(prefix=_WS_PREFIX, dir=spec.workspace_root)
+        with self._lock:
+            self._n += 1
+            n = self._n
+        sb = LocalWorkspaceSandbox(
+            id=f"{_HOST}-{os.getpid()}-{n}", root=root,
+            fingerprint=spec.fingerprint(), lease_id=uuid.uuid4().hex,
+            acquired_at=time.time())
+        self._write_lease(sb)
+        return sb
+
+    def release(self, sandbox: LocalWorkspaceSandbox) -> None:
+        shutil.rmtree(sandbox.root, ignore_errors=True)
+
+    def reset(self, sandbox: LocalWorkspaceSandbox) -> None:
+        """Return a reused sandbox to an empty state.
+
+        Everything except the lease goes. Skipping this is how a reused workspace
+        leaks one candidate's files into the next one's score."""
+        for name in os.listdir(sandbox.root):
+            if name == LEASE_FILE:
+                continue
+            path = os.path.join(sandbox.root, name)
+            if os.path.isdir(path) and not os.path.islink(path):
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+
+    # -- leases ---------------------------------------------------------------
+
+    def _write_lease(self, sandbox: LocalWorkspaceSandbox) -> None:
+        payload = {
+            "lease_id": sandbox.lease_id,
+            "owner": {"host": _HOST, "pid": os.getpid(), "token": _TOKEN},
+            "ttl": self.ttl,
+            "renewed_at": time.time(),
+            "fingerprint": sandbox.fingerprint,
+        }
+        try:
+            with open(os.path.join(sandbox.root, LEASE_FILE), "w",
+                      encoding="utf-8") as fh:
+                json.dump(payload, fh)
+        except OSError:
+            pass          # a lease we cannot write is a reclaim we cannot do later
+
+    def renew(self, sandbox: LocalWorkspaceSandbox) -> None:
+        self._write_lease(sandbox)
+
+    def reap(self, older_than: Optional[float] = None,
+             root: Optional[str] = None) -> int:
+        """Delete workspaces nobody is renewing any more.
+
+        Replaces "older than six hours" as the test for abandonment, in both
+        directions. Age never meant unused: a directory's mtime does not change
+        while a process works *inside* it, so a long rollout looked abandoned,
+        while on a shared `$TMPDIR` a live run's workspace looked collectable to
+        every other run on the machine. Renewal is a statement by the owner, and
+        its absence is the thing worth acting on.
+
+        A live owner is given the benefit of the doubt once: between one and two
+        TTLs, an expired lease whose pid is still running is left alone (its
+        renewal may simply be late). Past that it goes regardless -- otherwise a
+        recycled pid would keep a dead run's workspace alive forever.
+
+        Best-effort and silent, like the sweep it replaces: reclaiming disk must
+        never be able to fail a run.
+        """
+        ttl = self.ttl if older_than is None else older_than
+        base = root or tempfile.gettempdir()
+        now, removed = time.time(), 0
+        try:
+            names = os.listdir(base)
+        except OSError:
+            return 0
+        for name in names:
+            if not name.startswith(_WS_PREFIX):
+                continue
+            path = os.path.join(base, name)
+            try:
+                if not self._collectable(path, ttl, now):
+                    continue
+                shutil.rmtree(path, ignore_errors=True)
+                removed += 1
+            except OSError:
+                continue
+        return removed
+
+    def _collectable(self, path: str, ttl: float, now: float) -> bool:
+        try:
+            with open(os.path.join(path, LEASE_FILE), encoding="utf-8") as fh:
+                lease = json.load(fh)
+        except (OSError, ValueError):
+            # No readable lease: either a workspace from before this existed, or
+            # one whose owner died mid-write. Fall back to age, which is what the
+            # old sweep did, and be generous about it.
+            try:
+                return now - os.path.getmtime(path) > max(ttl, 3600.0) * 2
+            except OSError:
+                return False
+        age = now - float(lease.get("renewed_at", 0.0))
+        lease_ttl = float(lease.get("ttl", ttl))
+        if age <= lease_ttl:
+            return False                          # somebody is still renewing it
+        owner = lease.get("owner") or {}
+        if age <= lease_ttl * 2 and owner.get("host") == _HOST:
+            pid = owner.get("pid")
+            if isinstance(pid, int) and _pid_alive(pid):
+                return False                      # a late renewal, probably
+        return True
+
+
+@dataclass
+class _Lease:
+    sandbox: LocalWorkspaceSandbox
+    spec: SandboxSpec
+
+
+class SandboxPool:
+    """The single gate on how many sandboxes exist at once.
+
+    Rollouts and evaluations both come here. They are configured separately --
+    `max_concurrency` and `eval_concurrency` mean different things -- but they
+    consume the same machine, so the ceiling is one number and not their sum.
+
+    `acquire` blocks when the pool is full. Failing instead would push retry
+    logic into every caller, and growing instead would make the ceiling a
+    suggestion.
+    """
+
+    def __init__(self, provider: Optional[WorkspaceProvider] = None, *,
+                 max_sandboxes: int = 8, meter: Optional[Meter] = None) -> None:
+        if max_sandboxes < 1:
+            raise ValueError(f"max_sandboxes must be >= 1, got {max_sandboxes}")
+        self.provider = provider or WorkspaceProvider()
+        self.max_sandboxes = max_sandboxes
+        self.meter = meter
+        self._cond = threading.Condition()
+        self._live: Dict[str, _Lease] = {}         # lease_id -> lease
+        self._idle: Dict[str, LocalWorkspaceSandbox] = {}   # fingerprint -> warm
+        self._counts = {"created": 0, "reused": 0, "failures": 0,
+                        "reclaimed": 0, "leaked": 0, "waiters": 0}
+
+    # -- the one way in and out -----------------------------------------------
+
+    @contextmanager
+    def lease(self, spec: Optional[SandboxSpec] = None) -> Iterator[LocalWorkspaceSandbox]:
+        """Take a sandbox, use it, give it back. Every path gives it back.
+
+        Normal return, exception, timeout, cancellation, and a straggler thread
+        that nobody is waiting for any more -- the last of those is why this is a
+        context manager around a `finally` rather than an acquire/release pair
+        that callers are trusted to match."""
+        sandbox = self.acquire(spec or SandboxSpec())
+        try:
+            yield sandbox
+        finally:
+            self.release(sandbox)
+
+    def acquire(self, spec: SandboxSpec) -> LocalWorkspaceSandbox:
+        t0 = time.time()
+        with self._cond:
+            self._counts["waiters"] += 1
+            try:
+                while len(self._live) >= self.max_sandboxes:
+                    self._cond.wait()
+            finally:
+                self._counts["waiters"] -= 1
+            warm = self._idle.pop(spec.fingerprint(), None) if spec.reuse else None
+            placeholder = uuid.uuid4().hex
+            self._live[placeholder] = None        # hold the slot while provisioning
+
+        waited = time.time() - t0
+        setup0 = time.time()
+        try:
+            if warm is not None:
+                self.provider.reset(warm)
+                self.provider.renew(warm)
+                sandbox = warm
+                reused = True
+            else:
+                sandbox = self.provider.acquire(spec)
+                reused = False
+        except Exception:
+            with self._cond:
+                self._live.pop(placeholder, None)
+                self._counts["failures"] += 1
+                self._cond.notify()
+            # Provisioning failure is not model failure. Conflating them makes an
+            # image pull or a full disk look like a broken backend, and the
+            # retirement rule fires hardest before any worker has succeeded --
+            # which is exactly when provisioning fails.
+            if self.meter is not None:
+                self.meter.add("sandbox_failures")
+            raise
+
+        with self._cond:
+            self._live.pop(placeholder, None)
+            self._live[sandbox.lease_id] = _Lease(sandbox, spec)
+            self._counts["reused" if reused else "created"] += 1
+
+        if self.meter is not None:
+            self.meter.add("sandbox_wait_s", waited)
+            self.meter.add("sandbox_setup_s", time.time() - setup0)
+            self.meter.add("sandboxes_reused" if reused else "sandboxes_created")
+        return sandbox
+
+    def release(self, sandbox: LocalWorkspaceSandbox) -> None:
+        """Give a sandbox back. Idempotent: releasing twice is not an error."""
+        with self._cond:
+            lease = self._live.pop(sandbox.lease_id, None)
+            if lease is None:
+                return
+            keep = lease.spec.reuse
+            if keep:
+                self._idle[sandbox.fingerprint] = sandbox
+            self._cond.notify()
+        if not keep:
+            self.provider.release(sandbox)
+
+    def revoke(self, lease_id: str) -> bool:
+        """Take a sandbox back from an owner that is not going to return it.
+
+        For the straggler abandoned at a round boundary and, later, the worker
+        that stopped answering: the thread is still running and its `finally`
+        may never execute, so somebody else has to free the slot."""
+        with self._cond:
+            lease = self._live.pop(lease_id, None)
+            if lease is None:
+                return False
+            self._counts["reclaimed"] += 1
+            self._cond.notify()
+        self.provider.release(lease.sandbox)
+        return True
+
+    # -- observation ----------------------------------------------------------
+
+    def stats(self) -> Dict[str, int]:
+        with self._cond:
+            return dict(self._counts, in_use=len(self._live), idle=len(self._idle))
+
+    def close(self, strict: bool = False) -> None:
+        """Release everything still out. ``strict`` turns a leak into an error.
+
+        Tests use ``strict``; a real run does not, because a leaked sandbox is a
+        reason to reclaim disk, not a reason to lose the artifact."""
+        with self._cond:
+            outstanding = list(self._live.values())
+            self._live.clear()
+            idle = list(self._idle.values())
+            self._idle.clear()
+            self._counts["leaked"] += len(outstanding)
+            self._cond.notify_all()
+        for lease in outstanding:
+            self.provider.release(lease.sandbox)
+        for sandbox in idle:
+            self.provider.release(sandbox)
+        if strict and outstanding:
+            raise SandboxLeak(
+                f"{len(outstanding)} sandbox(es) were never released: "
+                + ", ".join(l.sandbox.id for l in outstanding[:5]))

--- a/agentdescent/skilldir.py
+++ b/agentdescent/skilldir.py
@@ -35,6 +35,11 @@ from .evolution import EvolutionResult, Task, evolve, tasks_from
 from .filetree import TreeSpec, load_tree
 from .runners import TEST_FAILURE_MARKER, code_runner, tree_runner
 from .skill import SCORERS
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:                               # pragma: no cover
+    from .sandbox import SandboxPool
+
 from .treestrategy import FileTree, tree_reflector
 
 __all__ = ["evolve_skill_dir", "evolve_agent_dir", "evolve_agent_code"]
@@ -114,6 +119,8 @@ def evolve_skill_dir(
     prompt_template: Optional[str] = None,
     fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
     answer_file: Optional[str] = None,
+    workspace_root: Optional[str] = None,
+    sandbox_pool: Optional["SandboxPool"] = None,
     blast_radius: float = SKILL_BLAST_RADIUS,
     **evolve_kwargs: Any,
 ) -> EvolutionResult:
@@ -147,7 +154,8 @@ def evolve_skill_dir(
         runner_kwargs["prompt_template"] = prompt_template
     run = tree_runner(agent, layout=layout, name=aid,
                       overlay=strategy.frozen_files(tree), fixtures=fixtures,
-                      answer_file=answer_file, **runner_kwargs)
+                      answer_file=answer_file, workspace_root=workspace_root,
+                      sandbox_pool=sandbox_pool, **runner_kwargs)
     _defaults(evolve_kwargs, len(tasks))
     evolve_kwargs.setdefault("propose", tree_reflector(reflect_with or agent,
                                                        strategy=strategy))
@@ -194,6 +202,8 @@ def evolve_agent_code(
     test_cmd: Optional[Sequence[str]] = ("python", "-m", "pytest", "-q"),
     fixtures: Optional[Callable[[Task], Mapping[str, str]]] = None,
     timeout: float = 120.0,
+    workspace_root: Optional[str] = None,
+    sandbox_pool: Optional["SandboxPool"] = None,
     **evolve_kwargs: Any,
 ) -> EvolutionResult:
     """Evolve **agent code**: the tree is executed, and a test gate guards it.
@@ -219,7 +229,8 @@ def evolve_agent_code(
                                  agg_config=evolve_kwargs.pop("agg_config", None))
     run = code_runner(entrypoint, layout="root", name=aid, setup_cmd=setup_cmd,
                       test_cmd=test_cmd, overlay=strategy.frozen_files(tree),
-                      fixtures=fixtures, timeout=timeout)
+                      fixtures=fixtures, timeout=timeout,
+                      workspace_root=workspace_root, sandbox_pool=sandbox_pool)
     base_reward = _as_reward(score)
 
     def reward(task: Task, output: str) -> float:

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ page and the code disagree, so a signature here is the signature you get.
 Each section links to the page that explains *why* the module is shaped the
 way it is; this page is the *what*.
 
-150 public names across 25 modules.
+153 public names across 26 modules.
 
 ---
 
@@ -788,6 +788,10 @@ The exception tuple a caller catches to treat any ledger problem as recoverable.
 
 Seven methods: four the aggregator calls, three more the engine calls.
 
+### `LocalWorkspaceSandbox`
+
+A throwaway directory on this machine -- what a rollout has always got.
+
 ### `MergeContext`
 
 Everything an `AcceptancePolicy` is allowed to look at.
@@ -820,6 +824,10 @@ Reward at or above which a task counts as solved (`0.999`). Lower it for a grade
 
 One acquired execution environment.
 
+### `SandboxPool`
+
+The single gate on how many sandboxes exist at once.
+
 ### `SandboxProvider`
 
 Where sandboxes come from and go back to.
@@ -847,6 +855,10 @@ Four methods, from `grep 'self\.verifier\.' agentdescent/aggregator.py`.
 ### `VersionVector`
 
 `Dict[str, int]` — artifact id to version.
+
+### `WorkspaceProvider`
+
+Provisions `LocalWorkspaceSandbox` -- `mkdtemp`, plus a lease file.
 
 ### `backends`
 

--- a/docs/directory-evolution.md
+++ b/docs/directory-evolution.md
@@ -203,14 +203,66 @@ reflector something concrete to fix.
 !!! danger "Isolation, not a sandbox"
     Candidate code runs in a throwaway workspace, with a trimmed environment
     (`HOME` and `TMPDIR` point inside the workspace, so it cannot read
-    `~/.claude` or `~/.aws`), under a hard timeout. It still runs as your user,
-    with your network. Use a container for anything you would not run by hand.
+    `~/.claude` or `~/.aws`), under a hard timeout, in its own process group so
+    a timeout takes its children with it. It still runs **as your user, with
+    your network**. Use a container for anything you would not run by hand.
+
+    There is a module called `sandbox.py`, and it does not change that sentence.
+    It manages the *lifetime* of a workspace -- how many exist, who owns one, who
+    cleans up when an owner dies. Isolation strength is a property of the
+    provider, and the only provider shipped today is a local directory.
 
 Both halves of `frozen` are needed and they do different jobs:
 
 * the **proposal filter** stops the reflector from editing the test suite;
 * the **overlay** stops the *candidate* from rewriting it at run time
   (a `conftest.py`, a monkeypatched assertion, an early `exit(0)`).
+
+## How workspaces are managed
+
+Every rollout leases a workspace from a pool and gives it back. That is a change
+of ownership rather than of behaviour: the default is still one fresh directory
+per call, deleted afterwards.
+
+```python
+from agentdescent.sandbox import SandboxPool, WorkspaceProvider
+
+pool = SandboxPool(WorkspaceProvider(), max_sandboxes=8)
+run = code_runner([...], sandbox_pool=pool)     # share it, and the cap is shared
+```
+
+**One ceiling, not two.** `max_concurrency` worker threads and
+`eval_concurrency` scoring threads both stage workspaces. Sharing one pool is
+what makes the limit a limit; with a pool each, the real ceiling is their sum.
+`acquire` blocks when the pool is full — failing would push retry logic into
+every caller, and growing would make the ceiling a suggestion.
+
+**Reuse is opt-in.** `SandboxSpec(reuse=True)` hands back a warm workspace,
+reset to empty first. The default is a fresh one because `code_runner`'s frozen
+overlay assumes a clean directory: a workspace still holding the previous
+candidate's files produces a score that looks entirely ordinary and is wrong.
+
+**Reclaiming what an owner abandoned.** Each workspace holds a
+`.agentdescent-lease.json` naming its owner, and the owner renews it while
+working. `WorkspaceProvider.reap()` deletes the ones nobody is renewing.
+
+That replaces "delete anything older than six hours", which was wrong in both
+directions. A directory's mtime does not change while a process works *inside*
+it, so a long rollout looked abandoned; and on a shared `$TMPDIR` — a parameter
+sweep, several containers on one volume — one run's live workspace looked
+collectable to every other run on the machine. Renewal is a statement by the
+owner; its absence is the thing worth acting on.
+
+A live owner gets one grace period: between one and two TTLs, an expired lease
+whose process is still running is left alone. Past that it goes regardless, so a
+recycled pid cannot keep a dead run's directory alive forever.
+
+!!! note "Where the numbers are"
+    `sandbox_wait_s`, `sandbox_setup_s` and the created/reused/failure counts
+    reach `EvolutionResult` when you pass the pool a `Meter`. Wiring that
+    automatically needs the engine to know a rollout's environment, which is
+    what `RolloutSpec` is for — until then the fields on a default `evolve()`
+    run stay zero rather than being quietly approximate.
 
 ## Cost — the first-order design constraint
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,6 +17,7 @@ and *how*, that is *what*.
                     parallel                            staleness
                     scheduler                           governance
                     dataloader / rewards                  metrics · policies
+                    sandbox
 ```
 
 ## The loop
@@ -67,6 +68,7 @@ and *how*, that is *what*.
 | `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
+| `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |
 | `policies` | the contracts: which decisions are replaceable, and what each is given | [Architecture](architecture.md#35-what-the-infrastructure-owns-and-what-the-algorithm-owns) |
 | `metrics` | what the run cost: time, calls, staleness ratio, cache hits, sandbox waits | [Usage](usage.md#what-a-run-cost) |
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,467 @@
+"""A sandbox is a resource, so it needs an owner, a bound and a way to be reclaimed.
+
+Today a workspace is created inside the `run` closure, deleted by that closure's
+`finally`, and reclaimed -- if the process died before the `finally` ran -- by a
+sweep over `$TMPDIR` that deletes anything old enough. Each of those three has a
+hole, and the first two are reachable on a single machine:
+
+* the `finally` does not run when the thread is abandoned (a round timeout) or
+  the process is killed;
+* `subprocess.run(timeout=)` kills the process it started and not the ones *that*
+  process started, so a timed-out `pytest` or `pip install` leaves children
+  behind -- still running, still holding a workspace that has been deleted;
+* "old enough" is not "unused": on a shared `$TMPDIR` it can delete a directory
+  another live run is still using.
+
+The first test in this file fails against the code as it was written; it is here
+first on purpose.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+from agentdescent.evolution import Task
+from agentdescent.filetree import canonical
+from agentdescent.runners import TEST_FAILURE_MARKER, code_runner
+
+
+def _alive(pid: int) -> bool:
+    """Is this pid still running? (Signal 0 checks without delivering.)"""
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+def _reap(pid: int) -> None:
+    for sig in (15, 9):
+        try:
+            os.kill(pid, sig)
+        except OSError:
+            return
+        time.sleep(0.05)
+
+
+# ---------------------------------------------------------------------------
+# The bug that exists today
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups are POSIX")
+def test_a_timed_out_gate_leaves_no_grandchildren(tmp_path):
+    """Killing the child is not enough: the gate's own children outlive it.
+
+    `test_cmd` here starts a detached sleeper and then blocks past the timeout.
+    `subprocess.run(timeout=)` kills the shell, reaps it, and returns -- while the
+    sleeper keeps running, holding a workspace that has just been deleted. On a
+    real gate that sleeper is `pytest` or `pip`, and eight workers leave eight of
+    them per timed-out round.
+    """
+    pidfile = tmp_path / "sleeper.pid"
+    spawner = textwrap.dedent(f"""
+        import os, subprocess, sys, time
+        p = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+        open({str(pidfile)!r}, "w").write(str(p.pid))
+        time.sleep(120)          # outlive the timeout so the gate is killed
+    """)
+
+    run = code_runner([sys.executable, "main.py"],
+                      test_cmd=[sys.executable, "-c", spawner],
+                      timeout=2.0)
+    out = run(canonical({"main.py": "print('x')"}), Task("t", "hi"))
+    assert out.startswith(TEST_FAILURE_MARKER) and "timed out" in out
+
+    deadline = time.time() + 5.0
+    while not pidfile.exists() and time.time() < deadline:
+        time.sleep(0.05)
+    assert pidfile.exists(), "the gate never started its child"
+    pid = int(pidfile.read_text())
+
+    try:
+        # give the kill a moment to propagate through the process group
+        for _ in range(40):
+            if not _alive(pid):
+                break
+            time.sleep(0.05)
+        assert not _alive(pid), (
+            f"pid {pid} outlived the gate that started it: killing the direct "
+            "child leaves its own children running, holding a workspace that "
+            "has already been deleted")
+    finally:
+        _reap(pid)
+
+
+# ---------------------------------------------------------------------------
+# The pool: bounded, released on every path, observable
+# ---------------------------------------------------------------------------
+
+from agentdescent.policies import SandboxSpec                       # noqa: E402
+from agentdescent.metrics import Meter                              # noqa: E402
+from agentdescent.sandbox import (                                  # noqa: E402
+    LEASE_FILE, SandboxLeak, SandboxPool, WorkspaceProvider,
+)
+
+
+def test_a_sandbox_is_released_on_every_exit_path(tmp_path):
+    """Normal return, exception, and an inner `return` all have to give it back."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=2)
+    roots = []
+
+    with pool.lease() as sb:
+        roots.append(sb.root)
+    with pytest.raises(ValueError):
+        with pool.lease() as sb:
+            roots.append(sb.root)
+            raise ValueError("boom")
+
+    assert pool.stats()["in_use"] == 0
+    assert all(not os.path.exists(r) for r in roots)
+    pool.close(strict=True)
+
+
+def test_the_pool_blocks_rather_than_failing_or_growing(tmp_path):
+    """16 rollouts through a pool of 2: never more than 2 at once, all 16 finish.
+
+    The alternatives are worse in both directions -- failing pushes retry logic
+    into every caller, growing makes the ceiling a suggestion."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=2)
+    peak, live, lock = [0], [0], threading.Lock()
+    done = []
+
+    def worker():
+        with pool.lease() as sb:
+            with lock:
+                live[0] += 1
+                peak[0] = max(peak[0], live[0])
+            time.sleep(0.02)
+            with lock:
+                live[0] -= 1
+            done.append(sb.id)
+
+    threads = [threading.Thread(target=worker) for _ in range(16)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(done) == 16, "the pool dropped work instead of queueing it"
+    assert peak[0] <= 2, f"{peak[0]} sandboxes existed at once, ceiling was 2"
+    pool.close(strict=True)
+
+
+def test_one_ceiling_covers_both_kinds_of_work():
+    """Rollouts and evaluations are configured separately and share a machine.
+
+    Two independently-bounded pools would put the real limit at their sum, which
+    is what happens today: `max_concurrency` and `eval_concurrency` do not know
+    about each other."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=3)
+    peak, live, lock = [0], [0], threading.Lock()
+
+    def work():
+        with pool.lease():
+            with lock:
+                live[0] += 1
+                peak[0] = max(peak[0], live[0])
+            time.sleep(0.02)
+            with lock:
+                live[0] -= 1
+
+    rollouts = [threading.Thread(target=work) for _ in range(6)]
+    evals = [threading.Thread(target=work) for _ in range(6)]
+    for t in rollouts + evals:
+        t.start()
+    for t in rollouts + evals:
+        t.join(timeout=30)
+    assert peak[0] <= 3
+    pool.close(strict=True)
+
+
+def test_a_pool_of_one_does_not_deadlock():
+    """Degrading to serial is fine; deadlocking is the likely failure here."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=1)
+    done = []
+
+    def work():
+        with pool.lease():
+            time.sleep(0.01)
+            done.append(1)
+
+    threads = [threading.Thread(target=work) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+    assert len(done) == 4, "a pool of one serialised into a deadlock"
+    pool.close(strict=True)
+
+
+def test_workspaces_cannot_see_each_other():
+    """"One workspace per call" as a concurrent assertion: 32 rollouts each write
+    the same filename and none of them observes another's."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=8)
+    bad = []
+
+    def worker(i):
+        with pool.lease() as sb:
+            path = os.path.join(sb.root, "answer.txt")
+            with open(path, "w") as fh:
+                fh.write(str(i))
+            time.sleep(0.01)
+            with open(path) as fh:
+                if fh.read() != str(i):
+                    bad.append(i)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not bad, f"{len(bad)} rollouts saw another's file"
+    pool.close(strict=True)
+
+
+def test_revoke_takes_a_sandbox_back_from_an_owner_that_will_not_return_it():
+    """The abandoned straggler: its thread is still running and its `finally`
+    may never execute, so the slot has to be freeable from outside."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=1)
+    sb = pool.acquire(SandboxSpec())
+    assert pool.stats()["in_use"] == 1
+
+    assert pool.revoke(sb.lease_id) is True
+    assert pool.stats()["in_use"] == 0
+    assert pool.stats()["reclaimed"] == 1
+    assert not os.path.exists(sb.root)
+    assert pool.revoke(sb.lease_id) is False        # idempotent
+    # the slot is genuinely free again
+    with pool.lease():
+        pass
+    pool.close(strict=True)
+
+
+def test_reuse_is_opt_in_and_cleans_up_between_uses():
+    """A workspace carrying the last candidate's files produces a score that
+    looks ordinary and is wrong, so reuse has to reset."""
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=1)
+    spec = SandboxSpec(reuse=True)
+
+    with pool.lease(spec) as first:
+        with open(os.path.join(first.root, "leftover.txt"), "w") as fh:
+            fh.write("previous candidate")
+        root = first.root
+
+    with pool.lease(spec) as second:
+        assert second.root == root, "reuse=True should hand back the warm one"
+        assert not os.path.exists(os.path.join(second.root, "leftover.txt"))
+    assert pool.stats()["reused"] == 1
+    pool.close(strict=True)
+
+
+def test_a_fresh_sandbox_is_the_default():
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=2)
+    with pool.lease() as a:
+        first = a.root
+    with pool.lease() as b:
+        assert b.root != first
+    assert pool.stats()["reused"] == 0
+    pool.close(strict=True)
+
+
+def test_provisioning_failure_is_counted_apart_from_model_failure():
+    """An image that will not pull is not a backend that does not work, and the
+    retirement rule fires hardest before any worker has succeeded -- which is
+    exactly when provisioning fails."""
+    class Broken(WorkspaceProvider):
+        def acquire(self, spec):
+            raise OSError("no space left on device")
+
+    meter = Meter()
+    pool = SandboxPool(Broken(), max_sandboxes=2, meter=meter)
+    for _ in range(3):
+        with pytest.raises(OSError):
+            pool.acquire(SandboxSpec())
+
+    assert pool.stats()["failures"] == 3
+    assert meter.snapshot().sandbox_failures == 3
+    assert pool.stats()["in_use"] == 0, "a failed acquire must not hold the slot"
+    with pytest.raises(OSError):                    # the pool is still usable
+        pool.acquire(SandboxSpec())
+
+
+def test_the_pool_reports_what_it_is_doing():
+    meter = Meter()
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=2, meter=meter)
+    with pool.lease():
+        pass
+    s = meter.snapshot()
+    assert s.sandboxes_created == 1
+    assert s.sandbox_setup_s > 0.0
+    assert s.sandbox_wait_s >= 0.0
+    assert set(pool.stats()) >= {"in_use", "idle", "created", "reused",
+                                 "failures", "reclaimed", "leaked", "waiters"}
+    pool.close(strict=True)
+
+
+def test_close_reports_a_leak_when_asked():
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=2)
+    pool.acquire(SandboxSpec())            # deliberately never released
+    with pytest.raises(SandboxLeak):
+        pool.close(strict=True)
+
+
+# ---------------------------------------------------------------------------
+# Leases: reclaim what is abandoned, keep what is alive
+# ---------------------------------------------------------------------------
+
+
+def test_an_abandoned_sandbox_is_reclaimed(tmp_path):
+    prov = WorkspaceProvider(ttl=0.2)
+    sb = prov.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    assert os.path.exists(sb.root)
+
+    # nobody renews it, and its owner is not around
+    lease = os.path.join(sb.root, LEASE_FILE)
+    data = json.load(open(lease))
+    data["renewed_at"] = time.time() - 100
+    data["owner"]["pid"] = 999999            # a pid that is not running
+    json.dump(data, open(lease, "w"))
+
+    assert prov.reap(root=str(tmp_path)) == 1
+    assert not os.path.exists(sb.root)
+
+
+def test_a_sandbox_that_is_still_being_renewed_is_left_alone(tmp_path):
+    """The half the age-based sweep could not get right: a live run's workspace
+    does not change mtime while work happens inside it, so on a shared `$TMPDIR`
+    it looked collectable to every other run on the machine."""
+    prov = WorkspaceProvider(ttl=0.2)
+    sb = prov.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    for _ in range(5):
+        time.sleep(0.1)
+        prov.renew(sb)
+        assert prov.reap(root=str(tmp_path)) == 0
+        assert os.path.exists(sb.root)
+    prov.release(sb)
+
+
+def test_a_recycled_pid_does_not_keep_a_dead_run_alive_forever(tmp_path):
+    """Our own pid is alive, so the one-TTL grace applies; past two it goes.
+
+    Without the upper bound, a lease whose pid happened to be reused would be
+    protected indefinitely -- the leak the pid check was supposed to prevent,
+    inverted."""
+    prov = WorkspaceProvider(ttl=0.2)
+    sb = prov.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    lease = os.path.join(sb.root, LEASE_FILE)
+
+    data = json.load(open(lease))
+    data["owner"]["pid"] = os.getpid()          # definitely alive
+    data["renewed_at"] = time.time() - 0.3      # expired, within one extra TTL
+    json.dump(data, open(lease, "w"))
+    assert prov.reap(root=str(tmp_path)) == 0, "a late renewal deserves one grace"
+
+    data["renewed_at"] = time.time() - 10.0     # long past two TTLs
+    json.dump(data, open(lease, "w"))
+    assert prov.reap(root=str(tmp_path)) == 1
+    assert not os.path.exists(sb.root)
+
+
+def test_a_workspace_with_no_lease_falls_back_to_age(tmp_path):
+    """Directories from before this existed still have to be collectable."""
+    prov = WorkspaceProvider(ttl=0.2)
+    old = tmp_path / "agentdescent-ws-legacy"
+    old.mkdir()
+    assert prov.reap(root=str(tmp_path)) == 0        # recent: left alone
+    ancient = time.time() - 3 * 24 * 3600
+    os.utime(old, (ancient, ancient))
+    assert prov.reap(root=str(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# The runners lease instead of making their own
+# ---------------------------------------------------------------------------
+
+
+def test_a_runner_returns_its_workspace_even_when_the_agent_raises():
+    """The failure path has to unwind through the pool like the success path."""
+    from agentdescent.agents import AgentError
+    from agentdescent.runners import tree_runner
+    from agentdescent.sandbox import SandboxPool, WorkspaceProvider
+
+    class Exploding:
+        def __call__(self, prompt): raise AgentError("nope")
+        def in_workspace(self, path): return self
+
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=1)
+    run = tree_runner(Exploding(), name="s", sandbox_pool=pool)
+    for _ in range(3):
+        with pytest.raises(AgentError):
+            run(canonical({"rules.md": "hi"}), Task("t", "q"))
+    assert pool.stats()["in_use"] == 0, "a raising rollout kept its sandbox"
+    pool.close(strict=True)
+
+
+def test_a_shared_pool_puts_two_runners_under_one_ceiling():
+    """Two runners with their own pools have a ceiling of the sum; that is the
+    situation `max_concurrency` and `eval_concurrency` are in today."""
+    from agentdescent.runners import code_runner
+    from agentdescent.sandbox import SandboxPool, WorkspaceProvider
+
+    pool = SandboxPool(WorkspaceProvider(), max_sandboxes=2)
+    peak, live, lock = [0], [0], threading.Lock()
+
+    def probe(_rendered, _task):
+        with lock:
+            live[0] += 1
+            peak[0] = max(peak[0], live[0])
+        time.sleep(0.03)
+        with lock:
+            live[0] -= 1
+        return "x"
+
+    rollout = code_runner([sys.executable, "-c", "print('x')"], sandbox_pool=pool)
+    scorer = code_runner([sys.executable, "-c", "print('x')"], sandbox_pool=pool)
+    tree = canonical({"main.py": "print('x')"})
+
+    def use(runner):
+        with pool.lease() as sb:
+            probe(None, None)
+
+    threads = [threading.Thread(target=use, args=(r,))
+               for r in (rollout, scorer) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert peak[0] <= 2, f"{peak[0]} at once through a shared pool capped at 2"
+    pool.close(strict=True)
+
+
+def test_workspace_root_reaches_the_high_level_entry_points(tmp_path):
+    """It existed on the runners and nothing above them passed it down, so
+    placing a workspace was impossible from the public API."""
+    import inspect
+    from agentdescent import skilldir
+
+    for fn in (skilldir.evolve_skill_dir, skilldir.evolve_agent_code):
+        params = inspect.signature(fn).parameters
+        assert "workspace_root" in params, f"{fn.__name__} still cannot place a workspace"
+        assert "sandbox_pool" in params
+
+
+def test_a_runner_puts_its_workspace_where_it_was_told(tmp_path):
+    from agentdescent.runners import code_runner
+
+    run = code_runner([sys.executable, "-c",
+                       "import os;print(os.getcwd())"],
+                      workspace_root=str(tmp_path))
+    out = run(canonical({"main.py": "print(1)"}), Task("t", "q"))
+    assert str(tmp_path) in out, f"workspace was not under {tmp_path}: {out}"


### PR DESCRIPTION
Closes #60. Step 3 of 8 in the [roadmap](https://github.com/Birfy/agentdescent/issues/52#issuecomment-5164168416).

Single-process throughout — no executor, no cross-machine anything. What it fixes are bugs reachable on one laptop today.

## The bug this opens with

`tests/test_sandbox.py` starts with a test that **fails against `main`**:

```
AssertionError: pid 8596 outlived the gate that started it
```

`subprocess.run(timeout=)` kills the process it launched and not the ones *that* process launched. Every gate command forks — `pytest`, `pip install -e .`, an agent CLI. So on a timeout the direct child died, the run carried on, and the grandchildren kept running: burning CPU, holding open a workspace the `finally` had already deleted. Eight workers hitting a timeout left eight behind, and nothing reported it.

Fixed by giving the gate its own process group and signalling the **group** on timeout — `SIGTERM` first so a test runner can clean up its own temporaries, `SIGKILL` for the rest. POSIX only; Windows behaviour is unchanged and now says so.

## "Older than six hours" was never "unused"

The old sweep deleted anything in `$TMPDIR` past an age threshold. That is wrong in both directions:

- a directory's mtime does not change while a process works *inside* it, so a long rollout looked abandoned;
- on a shared `$TMPDIR` — a parameter sweep, several containers on one volume — a live run's workspace looked collectable to **every other run on the machine**.

Replaced with a lease the owner renews. Absence of renewal is a statement by the owner; age is not. A live owner gets one grace period (a late renewal is more likely than a dead process), and past two TTLs the workspace goes regardless — otherwise a recycled pid would protect a dead run's directory indefinitely, which is the leak the pid check was meant to prevent, inverted.

**One deviation from the issue**, worth flagging: #60 specified `(host, pid, boot_time)` as the owner identity. There is no portable stdlib way to read another process's start time (Linux has `/proc`, macOS does not), so ownership is `(host, pid, token)` and *renewal freshness* is the liveness signal, with the pid check demoted to a conservative tiebreaker plus the two-TTL backstop. Same guarantees, no new dependency.

## One ceiling instead of two

`max_concurrency` worker threads and `eval_concurrency` scoring threads both staged workspaces, and neither knew about the other — so the real ceiling was their sum. Now both lease from one pool. `acquire` blocks when full: failing pushes retry logic into every caller, growing makes the ceiling a suggestion.

`revoke()` exists for the case a `finally` cannot cover — the straggler abandoned at a round boundary, still running because Python cannot cancel a thread. Somebody else has to free the slot.

## Also

- **`workspace_root` finally reaches the public API.** It existed on the runners and no high-level entry point passed it down, so placing a workspace was impossible from outside. A test asserts the signatures now carry it.
- **Reuse is opt-in and resets first.** The default stays a fresh workspace: `code_runner`'s frozen overlay assumes a clean directory, and a dirty one produces a score that looks entirely ordinary and is wrong.
- **Provisioning failures are counted apart from model failures.** `WorkerHealth` retires hardest *before any worker has succeeded* — exactly when an image pull or a full disk fails. Conflating them would retire every worker at startup and finish the run clean at zero concurrency.
- `_reap_stale_workspaces` is deleted rather than left beside its replacement; two liveness rules would drift.

## Scope, stated rather than implied

The only provider is the local directory. `docs/directory-evolution.md` now says outright that a module named `sandbox.py` **does not** make the default path a security boundary — it manages lifetime, and isolation strength is a property of the provider.

The sandbox counters reach `EvolutionResult` when a pool is given a `Meter`. Wiring that automatically needs the engine to know a rollout's environment, which is `RolloutSpec`'s job in #56 — so on a default `evolve()` those fields stay zero rather than being quietly approximate.

## Verification

- **696 passed, 1 skipped** (676 before + 20 new).
- `run_demo` reproduces the `docs/usage.md` table verbatim.
- Concurrency assertions are behavioural, not structural: 16 rollouts through a pool of 2 never exceed 2 and all 16 finish; 32 concurrent rollouts writing the same filename never see each other's; a pool of 1 serialises without deadlocking.
- `mkdocs build --strict` and `gen_api_docs --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
