### PR TITLE
feat: make each merge decision replaceable, without changing any of them

### DIFF
--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -34,15 +34,21 @@ from typing import (Callable, Deque, Dict, List, Optional, Protocol, Tuple,
                     runtime_checkable)
 
 from .evolvable import (
-    ContractError, Diff, EvidenceCard, Evolvable, VersionVector, stable_hash,
-    vv_staleness,
+    ContractError, Diff, EvidenceCard, Evolvable, VersionVector, vv_staleness,
+)
+from .defaults import (
+    DefaultAcceptance, DefaultConflict, DefaultFusion, DefaultPromotion,
 )
 from .governance import Layer, classify, assert_mutable
 from .ledger import CASConflict, Ledger
 from .metrics import Meter
+from .policies import (
+    AcceptancePolicy, ConflictPolicy, FusionPolicy, MergeContext,
+    PromotionPolicy,
+)
 from .scheduler import AuditScheduler
 from .staleness import StaleAction, StalenessPolicy, get_policy
-from .stats import BetaPosterior, annealed_delta, prob_improvement
+from .stats import BetaPosterior
 from .verifier import ThreeLayerVerifier
 
 
@@ -334,6 +340,10 @@ class Aggregator:
         config: Optional[AggregatorConfig] = None,
         staleness_policy: Optional[StalenessPolicy] = None,
         meter: Optional["Meter"] = None,
+        conflict: Optional["ConflictPolicy"] = None,
+        fusion: Optional["FusionPolicy"] = None,
+        acceptance: Optional["AcceptancePolicy"] = None,
+        promotion: Optional["PromotionPolicy"] = None,
     ) -> None:
         self.ledger = ledger
         self.verifier = verifier
@@ -345,10 +355,22 @@ class Aggregator:
         #: better than one that counts a fraction of the run.
         self.meter = meter
         self.config = config or AggregatorConfig()
+        # The decisions, as objects. Swapping one is the point; the defaults are
+        # the code that used to be inline here, moved rather than rewritten.
+        self.conflict_policy = conflict or DefaultConflict(verifier)
+        self.fusion_policy = fusion or DefaultFusion(verifier)
+        cfg = self.config
+        self.acceptance_policy = acceptance or DefaultAcceptance(
+            cfg.base_delta, cfg.anneal_half_life, cfg.accept_samples)
+        self.promotion_policy = promotion or DefaultPromotion(cfg.promote_after_k)
         self.buffer = EvidenceBuffer()
         self._posteriors: Dict[str, BetaPosterior] = defaultdict(BetaPosterior)
         # dev-branch survival counter for EMA-style promotion.
-        self._survival: Dict[str, int] = defaultdict(int)
+        # Artifacts this aggregator has seen, so `finalize` knows what to publish.
+        # The survival *counter* belongs to the promotion policy; this is only the
+        # set of ids, which the aggregator needs whether or not that policy keeps
+        # one.
+        self._seen: "set" = set()
         # dev version last copied onto stable, so an unchanged head is not re-promoted.
         self._promoted_at: Dict[str, int] = {}
 
@@ -400,54 +422,23 @@ class Aggregator:
             self.meter.add("stale_discarded", len(discarded))
         return survivors, discarded
 
-    # -- conflict resolution (section 4.3) -----------------------------------
+    # -- conflict resolution and fusion (section 4.3) ------------------------
+    #
+    # Both live in `agentdescent.defaults` now. These stay as one-line
+    # delegations rather than being inlined at the call site because the call
+    # site is `_process`, which is already the longest method here, and because
+    # a named seam is easier to find than a policy attribute used once.
 
     def _resolve_conflicts(
         self, artifact: Evolvable, cards: List[EvidenceCard]
     ) -> Tuple[List[EvidenceCard], int]:
         """Drop contradicting diffs (PCGrad-style) and return surviving cards."""
-        dropped = 0
-        kept: List[EvidenceCard] = []
-        for card in cards:
-            # Resolve against everything already kept, and keep going after a win:
-            # a card that displaces one survivor may contradict another (it can
-            # touch several keys). Stopping at the first conflict left mutually
-            # contradicting cards in `kept`, which then made the tournament's
-            # "no contradictions" guard false and silently skipped the fusion.
-            survivor: Optional[EvidenceCard] = card
-            while survivor is not None:
-                idx = next((i for i, k in enumerate(kept)
-                            if diffs_contradict(survivor.diff, k.diff)), None)
-                if idx is None:
-                    break
-                # project out the worse of the two on the held-out subset.
-                d_score = self.verifier.cheap_eval(artifact.apply(survivor.diff))
-                k_score = self.verifier.cheap_eval(artifact.apply(kept[idx].diff))
-                dropped += 1
-                if d_score > k_score:
-                    kept.pop(idx)          # the newcomer wins; re-check the rest
-                else:
-                    survivor = None        # the newcomer loses; drop it
-            if survivor is not None:
-                kept.append(survivor)
-        return kept, dropped
+        return self.conflict_policy.resolve(artifact, cards)
 
-    # -- fusion tournament (section 4.3) -------------------------------------
-
-    def _tournament(self, artifact: Evolvable, diffs: List[Diff]) -> Tuple[Diff, Evolvable, bool]:
+    def _tournament(self, artifact: Evolvable,
+                    diffs: List[Diff]) -> Tuple[Diff, Evolvable, bool]:
         """Run candidates (plus their fusion) in a held-out tournament."""
-        candidates: List[Tuple[Diff, Evolvable, bool]] = []
-        for d in diffs:
-            candidates.append((d, artifact.apply(d), False))
-        # add a fused candidate if the survivors are mutually complementary.
-        if len(diffs) > 1 and not any(
-            diffs_contradict(a, b) for i, a in enumerate(diffs) for b in diffs[i + 1:]
-        ):
-            fused = fuse_diffs(diffs)
-            candidates.append((fused, artifact.apply(fused), True))
-
-        best = max(candidates, key=lambda c: self.verifier.cheap_eval(c[1]))
-        return best
+        return self.fusion_policy.select(artifact, diffs)
 
     # -- public entry points -------------------------------------------------
 
@@ -466,33 +457,13 @@ class Aggregator:
     # -- dual-branch EMA promotion (section 4.5) -----------------------------
 
     def _age_and_promote(self, reports: List[MergeReport]) -> None:
-        """Promote dev -> stable after K **regression-free rounds** on dev.
+        """Ask the promotion policy what has proved itself, and publish it.
 
-        The counter used to be bumped on the *commit* path, so it measured how many
-        times an artifact had **changed**, not how long it had held up -- the exact
-        opposite of what every description of it says ("survival rounds",
-        "regression-free rounds", "EMA confirmation rounds"). The incentive was
-        inverted: an artifact that converged, which is the success state, stopped
-        committing and could therefore never be promoted, while one that thrashed
-        promoted every K commits. In the shipped demo the artifact reached 1.000
-        held-out accuracy after two commits and then sat there for 36 rounds with
-        `stable` stuck at 0.000 for the entire run.
-
-        So: one round is one ``step()``. A commit restarts the clock (the new
-        version has survived nothing yet) and so does an oracle rejection (a
-        measured regression). Everything else is a round survived.
-        """
-        by_id = {r.artifact_id: r for r in reports}
-        for aid in set(self._survival) | set(by_id):
-            rep = by_id.get(aid)
-            if rep is not None and (rep.committed_version is not None
-                                    or rep.category == MergeOutcome.ORACLE_REJECTED):
-                self._survival[aid] = 0        # changed, or measurably worse
-                continue
-            self._survival[aid] += 1
-            if self._survival[aid] >= self.config.promote_after_k:
-                self._promote(aid)
-                self._survival[aid] = 0
+        The rule lives in `agentdescent.defaults.DefaultPromotion`; the git work
+        stays here, because "which artifact deserves stable" is an algorithm
+        decision and "copy a branch without doing redundant git work" is not."""
+        for promotion in self.promotion_policy.observe(reports):
+            self._promote(promotion.artifact_id)
 
     def _promote(self, artifact_id: str) -> None:
         """Copy dev onto stable, skipping the git work when they already agree.
@@ -516,10 +487,93 @@ class Aggregator:
         commit that reaches it, so the artifact the run was *for* would otherwise
         never reach the branch production reads. Only ever called when a run
         finishes without an error, and never in place of the round-based rule."""
-        for aid in list(self._survival):
+        for aid in list(self._known_artifacts()):
             self._promote(aid)
 
+    @property
+    def _survival(self) -> Dict[str, int]:
+        """Rounds survived per artifact -- now owned by the promotion policy.
+
+        Kept under the old name because it is what the promotion tests and any
+        diagnostic reach for, and because moving where a number lives is not a
+        reason to make callers hunt for it. Read-only: the policy decides when it
+        moves."""
+        return getattr(self.promotion_policy, "survival", {})
+
+    def _apply_trust_region(self, cards):
+        """Split cards into (within budget, oversized), settling the rejects.
+
+        Oversized diffs used to be dropped *before* `considered` was computed and
+        never settled, so a runaway reflector vanished from the report and from
+        the evidence pool at once -- the most expensive failure to diagnose is
+        the one that leaves no trace."""
+        def within(card) -> bool:
+            if card.diff.size() > self.config.trust_region_ops:
+                return False
+            return all(len(str(v)) <= self.config.trust_region_chars
+                       for v in card.diff.ops.values())
+
+        kept = [c for c in cards if within(c)]
+        oversized = [c for c in cards if not within(c)]
+        if oversized:
+            self.buffer.settle(oversized)
+        return kept, oversized
+
+    def _audit(self, artifact, artifact_id, best_state, best_diff,
+               base_full, cand_full, base_score, cand_score, prior) -> bool:
+        """The optimizer audits its own decision. True means the oracle refused.
+
+        Not an `AcceptancePolicy`: acceptance asks "is this candidate better",
+        and this asks "is the cheap layer still trustworthy" -- a question about
+        the *measuring instrument*, which is the infrastructure's to answer and
+        not the algorithm's to replace.
+"""
+        _, uncertainty = self.verifier.learned_eval(best_state)
+        self.audit.submit(best_diff.diff_id, artifact_id, artifact.blast_radius,
+                          uncertainty, payload=best_diff)
+        # Trust is "how often does the cheap layer agree with the full held-out
+        # set", and it has to be measurable WITHOUT spending oracle budget --
+        # otherwise it is circular. It was: `force_oracle` fires on
+        # `blast_radius >= 0.5 or trust < 0.75`, and the only writer of trust sat
+        # inside that branch, so for any artifact below 0.5 the condition could
+        # never become true and the audit never ran at all. Measured on the default
+        # blast_radius=0.2: oracle_calls_used == 0 for the whole run, trust pinned
+        # at its initial 1.0.
+        #
+        # The signal is free here: `eval_counts` already scored base and candidate
+        # on the full held-out set for the Beta test above, so comparing its verdict
+        # with the cheap layer's costs nothing and happens on every merge.
+        if cand_full != base_full or cand_score != base_score:
+            self.audit.update_trust(
+                artifact_id, (cand_full > base_full) == (cand_score > base_score))
+        if self.audit.force_oracle(artifact.blast_radius, artifact_id):
+            oracle_base = self.verifier.oracle_eval(artifact)
+            oracle_cand = self.verifier.oracle_eval(best_state)
+            agreed = (oracle_cand > oracle_base) == (cand_score > base_score)
+            self.audit.update_trust(artifact_id, agreed)
+            if oracle_cand <= oracle_base:
+                prior.observe_delta(oracle_cand - oracle_base)
+                return True
+        return False
+
+        # Not settled, unlike the CAS-conflict path below -- and the asymmetry is
+        # deliberate. A CAS-conflicted diff lost a race and was never judged against
+        # the new head, so it deserves another look; one rejected here was judged and
+        # lost, and its tournament rivals scored below it on the same held-out set.
+        # Re-filing them would just buy the same rejection again.
+
+    def _known_artifacts(self):
+        """Every artifact id this aggregator has merged for.
+
+        Taken from the promotion policy when it tracks them (the default does),
+        and from the aggregator's own record otherwise -- a replacement policy is
+        not obliged to keep a survival table, and `finalize` still has to know
+        what to publish."""
+        tracked = getattr(self.promotion_policy, "survival", None)
+        return set(tracked) | self._seen if tracked is not None else set(self._seen)
+
     def _process(self, artifact_id: str) -> MergeReport:
+        self._seen.add(artifact_id)
         cards = self.buffer.drain(artifact_id)
         snap = self.ledger.snapshot(Ledger.DEV)
         artifact = snap.get(artifact_id)
@@ -532,16 +586,7 @@ class Aggregator:
         # dropped *before* `considered` was computed and never settled, so they
         # vanished from both the report and the evidence pool -- silently.
         n_considered = len(cards)
-        def _within_trust_region(card) -> bool:
-            if card.diff.size() > self.config.trust_region_ops:
-                return False
-            return all(len(str(v)) <= self.config.trust_region_chars
-                       for v in card.diff.ops.values())
-
-        oversized = [c for c in cards if not _within_trust_region(c)]
-        cards = [c for c in cards if _within_trust_region(c)]
-        if oversized:
-            self.buffer.settle(oversized)
+        cards, oversized = self._apply_trust_region(cards)
 
         head = snap.version
         survivors, discarded = self._staleness_filter(artifact, head, cards)
@@ -578,6 +623,12 @@ class Aggregator:
         cand_s, cand_f = self.verifier.eval_counts(best_state)
         base_score = self.verifier.cheap_eval(artifact)
         cand_score = self.verifier.cheap_eval(best_state)
+        decision = self.acceptance_policy.accept(MergeContext(
+            artifact=artifact, candidate=best_state, cards=kept_cards,
+            base_counts=(base_s, base_f), cand_counts=(cand_s, cand_f),
+            diff=best_diff, base_cheap=base_score, cand_cheap=cand_score,
+            prior=prior, trust_radius=artifact.blast_radius))
+        p_improve = decision.p_improve
 
         # The full held-out rates. The regression guard below must use *these*
         # rather than `cand_score`/`base_score`: those come from the cheap layer,
@@ -586,76 +637,21 @@ class Aggregator:
         # two doc pages promised sub-sampling "never affects commit safety". It was
         # the promise that was wrong, not the intent; the guard is meant to stop a
         # measured regression, and ground truth is what measures one.
-        base_full = base_s / max(1e-9, base_s + base_f)
-        cand_full = cand_s / max(1e-9, cand_s + cand_f)
+        base_full = MergeContext.rate((base_s, base_f))
+        cand_full = MergeContext.rate((cand_s, cand_f))
 
-        baseline_post = BetaPosterior(prior.successes + base_s, prior.failures + base_f)
-        candidate_post = BetaPosterior(prior.successes + cand_s, prior.failures + cand_f)
-        # fold each contributing worker's local before/after delta as extra
-        # evidence for the candidate (the "gradient magnitude").
-        for card in kept_cards:
-            if set(card.diff.ops) & set(best_diff.ops):
-                candidate_post.observe_delta(card.before_after_delta)
-
-        delta = annealed_delta(self.config.base_delta, artifact.version,
-                               half_life=self.config.anneal_half_life)
-        # Seed from (version, candidate) rather than the version alone. A shared
-        # seed made the ~0.003 Monte-Carlo error identical for every candidate in
-        # the round, so on knife-edge cases the draw decided them as a block --
-        # one stream accepted every marginal diff, another rejected all of them.
-        # stable_hash keeps this reproducible across processes.
-        p_improve = prob_improvement(
-            candidate_post, baseline_post, samples=self.config.accept_samples,
-            seed=stable_hash((artifact.version, best_diff.diff_id)) & 0x7FFFFFFF)
-
-        # -- audit (section 5.3): the optimizer audits its own decision ------
-        _, uncertainty = self.verifier.learned_eval(best_state)
-        self.audit.submit(best_diff.diff_id, artifact_id, artifact.blast_radius,
-                          uncertainty, payload=best_diff)
-        # Trust is "how often does the cheap layer agree with the full held-out
-        # set", and it has to be measurable WITHOUT spending oracle budget --
-        # otherwise it is circular. It was: `force_oracle` fires on
-        # `blast_radius >= 0.5 or trust < 0.75`, and the only writer of trust sat
-        # inside that branch, so for any artifact below 0.5 the condition could
-        # never become true and the audit never ran at all. Measured on the default
-        # blast_radius=0.2: oracle_calls_used == 0 for the whole run, trust pinned
-        # at its initial 1.0.
-        #
-        # The signal is free here: `eval_counts` already scored base and candidate
-        # on the full held-out set for the Beta test above, so comparing its verdict
-        # with the cheap layer's costs nothing and happens on every merge.
-        if cand_full != base_full or cand_score != base_score:
-            self.audit.update_trust(
-                artifact_id, (cand_full > base_full) == (cand_score > base_score))
-        if self.audit.force_oracle(artifact.blast_radius, artifact_id):
-            oracle_base = self.verifier.oracle_eval(artifact)
-            oracle_cand = self.verifier.oracle_eval(best_state)
-            agreed = (oracle_cand > oracle_base) == (cand_score > base_score)
-            self.audit.update_trust(artifact_id, agreed)
-            if oracle_cand <= oracle_base:
-                prior.observe_delta(oracle_cand - oracle_base)
-                return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
-                                   len(discarded), conflicts, p_improve, None,
-                                   "oracle rejected", MergeOutcome.ORACLE_REJECTED)
-
-        # Not settled, unlike the CAS-conflict path below -- and the asymmetry is
-        # deliberate. A CAS-conflicted diff lost a race and was never judged against
-        # the new head, so it deserves another look; one rejected here was judged and
-        # lost, and its tournament rivals scored below it on the same held-out set.
-        # Re-filing them would just buy the same rejection again.
-        regressed = cand_full < base_full
-        if p_improve <= 1.0 - delta or regressed:
-            prior.observe_delta(cand_full - base_full)
-            # Name the gate that actually fired. Reporting the posterior either way
-            # printed lines like `P(delta>0)=0.97 <= 0.50` when the regression guard
-            # was the real cause -- self-contradictory to anyone reading `outcomes()`
-            # to find out why nothing committed, which is the one job it has.
-            reason = (f"held-out regression {base_full:.3f} -> {cand_full:.3f}"
-                      if regressed else
-                      f"P(delta>0)={p_improve:.2f} <= {1-delta:.2f}")
+        rejected = self._audit(artifact, artifact_id, best_state, best_diff,
+                               base_full, cand_full, base_score, cand_score, prior)
+        if rejected:
             return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
-                               len(discarded), conflicts, p_improve, None, reason,
-                               MergeOutcome.BELOW_THRESHOLD)
+                               len(discarded), conflicts, p_improve, None,
+                               "oracle rejected", MergeOutcome.ORACLE_REJECTED)
+
+        if not decision.accept:
+            prior.observe_delta(decision.observed_delta)
+            return MergeReport(artifact_id, None, fused, n_considered, len(survivors),
+                               len(discarded), conflicts, p_improve, None,
+                               decision.detail, MergeOutcome(decision.category))
 
         # -- commit (section 4.1): CAS on dev --------------------------------
         base_vv = {artifact_id: head.get(artifact_id, 0)}
@@ -671,10 +667,6 @@ class Aggregator:
                                "CAS conflict", MergeOutcome.CAS_CONFLICT)
 
         prior.update(True, weight=2.0)  # a committed improvement is strong evidence.
-
-        # Promotion is decided in `_age_and_promote`, per round, not per commit:
-        # a commit restarts the survival clock rather than advancing it.
-        self._survival[artifact_id] = 0
 
         return MergeReport(artifact_id, best_diff, fused, n_considered, len(survivors),
                            len(discarded), conflicts, p_improve, new_version,

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -240,7 +240,8 @@ def async_evolve(
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
         oracle_budget=oracle_budget, eval_concurrency=eval_concurrency,
         cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed,
-        usage=usage)
+        usage=usage, verifier=_pol.verifier, ledger_impl=_pol.ledger,
+        policies_bundle=_pol)
     eng.meter.start()
     if n_workers < 1:
         raise ValueError(f"n_workers must be >= 1, got {n_workers}")

--- a/agentdescent/defaults.py
+++ b/agentdescent/defaults.py
@@ -1,0 +1,231 @@
+"""The shipped evolution algorithm, as replaceable pieces.
+
+`agentdescent/policies.py` says what a decision *is*; this module is the one the
+engine makes by default. Splitting them is what makes "use a different accept
+rule" a parameter rather than a rewrite of `Aggregator`.
+
+Every class here is the code that used to live inside `Aggregator._process` and
+its neighbours, moved and not rewritten. That is deliberate to the point of
+pedantry: each of those rules has a history -- the conflict loop keeps going
+after a win because stopping at the first one left mutually contradicting cards
+behind, the regression guard reads the full held-out set because reading the
+cheap layer made it judge quality from a sub-sample -- and a rewrite is how a
+codebase forgets things it has already paid to learn.
+
+The one thing that is new is `AcceptancePolicy` taking a `MergeContext` instead
+of reaching into the aggregator's state. That is what lets a replacement be
+written without importing `Aggregator` at all.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import (
+    TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple,
+)
+
+from .evolvable import Diff, EvidenceCard, Evolvable
+from .policies import (
+    AcceptDecision, MergeContext, Promotion, ProposalContext,
+)
+from .stats import annealed_delta, prob_improvement
+
+if TYPE_CHECKING:                                # pragma: no cover
+    from .aggregator import MergeReport
+
+__all__ = [
+    "DefaultAcceptance",
+    "DefaultConflict",
+    "DefaultFusion",
+    "DefaultPromotion",
+    "SingleProposal",
+]
+
+
+class SingleProposal:
+    """Adapts today's ``propose(rendered, task, output, reward)`` callable.
+
+    One proposal per rollout, no history, no view of the base version -- exactly
+    what the callable can express. A policy that wants k variants replaces this
+    one; the contract stopped being the limit, the default did not change."""
+
+    def __init__(self, fn) -> None:
+        self._fn = fn
+
+    def propose(self, ctx: ProposalContext) -> Sequence[str]:
+        proposal = self._fn(ctx.rendered, ctx.task, ctx.output, ctx.reward)
+        return [proposal] if proposal else []
+
+
+class DefaultConflict:
+    """Drop contradicting diffs, keeping whichever scores better (PCGrad-style)."""
+
+    def __init__(self, verifier) -> None:
+        self.verifier = verifier
+
+    def resolve(self, artifact: Evolvable,
+                cards: Sequence[EvidenceCard]) -> Tuple[List[EvidenceCard], int]:
+        from .aggregator import diffs_contradict
+
+        dropped = 0
+        kept: List[EvidenceCard] = []
+        for card in cards:
+            # Resolve against everything already kept, and keep going after a win:
+            # a card that displaces one survivor may contradict another (it can
+            # touch several keys). Stopping at the first conflict left mutually
+            # contradicting cards in `kept`, which then made the tournament's
+            # "no contradictions" guard false and silently skipped the fusion.
+            survivor: Optional[EvidenceCard] = card
+            while survivor is not None:
+                idx = next((i for i, k in enumerate(kept)
+                            if diffs_contradict(survivor.diff, k.diff)), None)
+                if idx is None:
+                    break
+                # project out the worse of the two on the held-out subset.
+                d_score = self.verifier.cheap_eval(artifact.apply(survivor.diff))
+                k_score = self.verifier.cheap_eval(artifact.apply(kept[idx].diff))
+                dropped += 1
+                if d_score > k_score:
+                    kept.pop(idx)          # the newcomer wins; re-check the rest
+                else:
+                    survivor = None        # the newcomer loses; drop it
+            if survivor is not None:
+                kept.append(survivor)
+        return kept, dropped
+
+
+class DefaultFusion:
+    """Run each candidate, plus their fusion, in a cheap held-out tournament."""
+
+    def __init__(self, verifier) -> None:
+        self.verifier = verifier
+
+    def select(self, artifact: Evolvable,
+               diffs: List[Diff]) -> Tuple[Diff, Evolvable, bool]:
+        from .aggregator import diffs_contradict, fuse_diffs
+
+        candidates: List[Tuple[Diff, Evolvable, bool]] = []
+        for d in diffs:
+            candidates.append((d, artifact.apply(d), False))
+        # add a fused candidate if the survivors are mutually complementary.
+        if len(diffs) > 1 and not any(
+            diffs_contradict(a, b) for i, a in enumerate(diffs) for b in diffs[i + 1:]
+        ):
+            fused = fuse_diffs(diffs)
+            candidates.append((fused, artifact.apply(fused), True))
+
+        best = max(candidates, key=lambda c: self.verifier.cheap_eval(c[1]))
+        return best
+
+
+class DefaultAcceptance:
+    """Beta posterior on the improvement, plus a guard against measured regression.
+
+    Moved from `Aggregator._process` unchanged, including the parts that are only
+    obvious once you know what they fixed:
+
+    * **Both gates read the full held-out set** (`base_counts` / `cand_counts`,
+      i.e. `verifier.eval_counts`), never the cheap layer. The regression guard
+      used to read `cheap_eval`, which `cheap_eval_tasks` sub-samples -- so a
+      four-task sample could veto a commit the full-set Beta test had just
+      approved, while the docs promised sub-sampling never affected commit
+      safety. `MergeContext` names the two differently so this is awkward to
+      write again.
+    * **The draw is seeded per candidate**, not per round. A shared seed made the
+      ~0.003 Monte-Carlo error identical for every candidate in a round, so on
+      knife-edge cases one stream accepted every marginal diff and another
+      rejected all of them.
+    * **The reported reason names the gate that actually fired.** Reporting the
+      posterior either way produced lines like `P(delta>0)=0.97 <= 0.50` when the
+      regression guard was the real cause -- self-contradictory to anyone reading
+      `outcomes()` to find out why nothing committed, which is its one job.
+    """
+
+    def __init__(self, base_delta: float, anneal_half_life: int,
+                 accept_samples: int) -> None:
+        self.base_delta = base_delta
+        self.anneal_half_life = anneal_half_life
+        self.accept_samples = accept_samples
+
+    def accept(self, ctx: MergeContext) -> AcceptDecision:
+        from .evolvable import stable_hash
+        from .stats import BetaPosterior
+
+        prior = ctx.prior if ctx.prior is not None else BetaPosterior()
+        base_s, base_f = ctx.base_counts
+        cand_s, cand_f = ctx.cand_counts
+        base_full = ctx.rate(ctx.base_counts)
+        cand_full = ctx.rate(ctx.cand_counts)
+
+        baseline_post = BetaPosterior(prior.successes + base_s, prior.failures + base_f)
+        candidate_post = BetaPosterior(prior.successes + cand_s, prior.failures + cand_f)
+        # fold each contributing worker's local before/after delta as extra
+        # evidence for the candidate (the "gradient magnitude").
+        if ctx.diff is not None:
+            for card in ctx.cards:
+                if set(card.diff.ops) & set(ctx.diff.ops):
+                    candidate_post.observe_delta(card.before_after_delta)
+
+        version = getattr(ctx.artifact, "version", 1)
+        delta = annealed_delta(self.base_delta, version,
+                               half_life=self.anneal_half_life)
+        p_improve = prob_improvement(
+            candidate_post, baseline_post, samples=self.accept_samples,
+            seed=stable_hash((version, getattr(ctx.diff, "diff_id", ""))) & 0x7FFFFFFF)
+
+        regressed = cand_full < base_full
+        observed = cand_full - base_full
+        if p_improve <= 1.0 - delta or regressed:
+            reason = (f"held-out regression {base_full:.3f} -> {cand_full:.3f}"
+                      if regressed else
+                      f"P(delta>0)={p_improve:.2f} <= {1-delta:.2f}")
+            return AcceptDecision(False, "below-threshold", reason,
+                                  p_improve=p_improve, observed_delta=observed)
+        return AcceptDecision(True, "committed", "", p_improve=p_improve,
+                              observed_delta=observed)
+
+
+class DefaultPromotion:
+    """Promote dev -> stable after K **regression-free rounds** on dev.
+
+    Moved verbatim, and this one is worth reading before replacing. The counter
+    used to be bumped on the *commit* path, so it measured how many times an
+    artifact had **changed** rather than how long it had held up -- the opposite
+    of every description of it. The incentive inverted: an artifact that
+    converged, which is the success state, stopped committing and so could never
+    be promoted, while one that thrashed promoted every K commits. In the shipped
+    demo the artifact reached 1.000 held-out accuracy after two commits and then
+    sat there for 36 rounds with `stable` stuck at 0.000.
+
+    So one round is one `step()`. A commit restarts the clock -- the new version
+    has survived nothing yet -- and so does an oracle rejection, which is a
+    measured regression. Everything else is a round survived.
+
+    Artifacts absent from this round's reports still age: not being touched is
+    the ordinary way to survive a round, and only counting the ones that were
+    looked at would mean a quiet artifact never promotes.
+    """
+
+    def __init__(self, promote_after_k: int) -> None:
+        self.promote_after_k = promote_after_k
+        self._survival: Dict[str, int] = defaultdict(int)
+
+    @property
+    def survival(self) -> Dict[str, int]:
+        """Rounds survived per artifact -- exposed for diagnostics, not control."""
+        return self._survival
+
+    def observe(self, reports: Sequence["MergeReport"]) -> Sequence[Promotion]:
+        by_id = {r.artifact_id: r for r in reports}
+        out: List[Promotion] = []
+        for aid in set(self._survival) | set(by_id):
+            rep = by_id.get(aid)
+            if rep is not None and (rep.committed_version is not None
+                                    or rep.category == "oracle-rejected"):
+                self._survival[aid] = 0        # changed, or measurably worse
+                continue
+            self._survival[aid] += 1
+            if self._survival[aid] >= self.promote_after_k:
+                out.append(Promotion(aid, f"{self._survival[aid]} rounds survived"))
+                self._survival[aid] = 0
+        return out

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -610,7 +610,35 @@ def _publish_stable(aggregator) -> None:
 #: What `evolve` / `async_evolve` can honour from a `Policies` bundle today.
 #: Everything else raises rather than being accepted and ignored -- see
 #: `Policies.require_supported`. The set grows as the implementations land.
-_WIRED_POLICIES = ("task_sampler", "staleness", "aggregator_factory")
+_WIRED_POLICIES = ("task_sampler", "proposal", "conflict", "fusion", "acceptance",
+                   "promotion", "staleness", "verifier", "ledger",
+                   "aggregator_factory")
+
+
+def _propose_via_policy(policy):
+    """Adapt a `ProposalPolicy` back to the engine's one-proposal contract.
+
+    A policy that returns several is refused rather than truncated: the engine
+    turns one proposal into one diff per rollout, so quietly keeping the first
+    would discard work the policy did and make a k-sampling algorithm look like
+    it ran when only a fraction of it did."""
+    from .policies import ProposalContext
+
+    def propose(rendered, task, output, reward):
+        out = list(policy.propose(ProposalContext(
+            rendered=rendered, task=task, output=output, reward=reward)))
+        if len(out) > 1:
+            # A caller-contract violation, not a backend failure: raised as one so
+            # it travels the channel the engine already has for "this run is
+            # meaningless" rather than being folded into `error` as a transient
+            # and retried.
+            raise ProposalContractError(
+                f"the engine consumes one proposal per rollout; this policy "
+                f"returned {len(out)}, and keeping the first would silently drop "
+                f"{len(out) - 1}. Batched rollouts are what makes k > 1 usable.")
+        return out[0] if out else None
+
+    return propose
 
 
 def _resolve_policies(policies: Optional[Policies], where: str, **shortcuts) -> Policies:
@@ -1073,7 +1101,10 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
                   eval_concurrency: int = 8,
                   cheap_eval_tasks: Optional[int] = None,
                   shuffle: bool = False, seed: int = 0,
-                  usage: Optional[Usage] = None) -> _Engine:
+                  usage: Optional[Usage] = None,
+                  verifier: Optional[Any] = None,
+                  ledger_impl: Optional[Any] = None,
+                  policies_bundle: Optional[Policies] = None) -> _Engine:
     """Wire the ledger, runtime, verifier and aggregator (shared by
     :func:`evolve` and :func:`~agentdescent.async_evolve.async_evolve`)."""
     import tempfile
@@ -1084,6 +1115,8 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
         propose = propose or agent.propose
     if run is None or propose is None:
         raise ValueError("provide agent=, or both run= and propose=")
+    if policies_bundle is not None and policies_bundle.proposal is not None:
+        propose = _propose_via_policy(policies_bundle.proposal)
     # Check the actor's signatures once, before any rollout. Otherwise a plain
     # typo (a `propose` missing the reward parameter, say) surfaces as a
     # TypeError inside the round body, where the backend-failure handler turns it
@@ -1188,7 +1221,13 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
         _reap_stale_scratch_repos()
         repo = scratch = tempfile.mkdtemp(prefix=_SCRATCH_PREFIX)
         atexit.register(shutil.rmtree, repo, True)
-    ledger = Ledger(repo, serialize, deserialize)
+    if ledger_impl is not None:
+        # A caller-supplied ledger owns its own storage, so the scratch repo this
+        # call may have just made is not its home -- drop the claim to it rather
+        # than deleting a directory the ledger is not using.
+        ledger, scratch = ledger_impl, None
+    else:
+        ledger = Ledger(repo, serialize, deserialize)
     # `register` is a no-op when the artifact already exists, which is what makes
     # re-using a repo_path resume the run -- but it also means a supplied
     # initial_state would be discarded without a word. Say so.
@@ -1220,14 +1259,17 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     # and inventing more would just make the ranking worse.
     cheap = (len(held_out) if cheap_eval_tasks is None
              else max(1, min(int(cheap_eval_tasks), len(held_out))))
-    verifier = ThreeLayerVerifier(
+    verifier = verifier if verifier is not None else ThreeLayerVerifier(
         eval_fn=lambda a, ts: a.score(ts), held_out=held_out,
         rule_subset=cheap, learned_noise=0.0,
         budget=VerifierBudget(oracle_calls_remaining=oracle_budget))
 
+    pol = policies_bundle or Policies()
+
     def _default_aggregator(ledger, verifier, audit, config, policy):
         return Aggregator(ledger, verifier, audit, config, staleness_policy=policy,
-                          meter=meter)
+                          meter=meter, conflict=pol.conflict, fusion=pol.fusion,
+                          acceptance=pol.acceptance, promotion=pol.promotion)
 
     aggregator = (aggregator_factory or _default_aggregator)(
         ledger, verifier, AuditScheduler(),
@@ -1601,7 +1643,8 @@ def evolve(
         staleness_policy=staleness_policy, aggregator_factory=aggregator_factory,
         oracle_budget=oracle_budget, eval_concurrency=eval_concurrency,
         cheap_eval_tasks=cheap_eval_tasks, shuffle=shuffle, seed=seed,
-        usage=usage)
+        usage=usage, verifier=_pol.verifier, ledger_impl=_pol.ledger,
+        policies_bundle=_pol)
     # Start the clock after the wiring, before the first unit of work: setup
     # is not what a time-to-quality number is asking about.
     eng.meter.start()

--- a/agentdescent/policies.py
+++ b/agentdescent/policies.py
@@ -91,9 +91,16 @@ class MergeContext:
     artifact: "Evolvable"
     candidate: "Evolvable"
     cards: Sequence["EvidenceCard"]
-    #: (successes, trials) over the whole held-out set -- what the commit gates read.
+    #: ``(successes, failures)`` over the whole held-out set -- what
+    #: ``verifier.eval_counts`` returns, and what the commit gates read. Not
+    #: ``(successes, trials)``: this contract was written from the aggregator's
+    #: call and the call's meaning, and a policy that divides by the second
+    #: element gets a rate that is wrong and plausible.
     base_counts: Tuple[float, float]
     cand_counts: Tuple[float, float]
+    #: The diff under consideration. Needed for a reproducible acceptance draw
+    #: (the sampler is seeded per candidate) and to tell which cards contributed.
+    diff: Optional["Diff"] = None
     #: Cheap-layer scores over a sub-sample -- ranking only.
     base_cheap: float = 0.0
     cand_cheap: float = 0.0
@@ -107,6 +114,12 @@ class MergeContext:
     #: difference as a quality change -- in either direction.
     base_env: str = ""
     cand_env: str = ""
+
+    @staticmethod
+    def rate(counts: Tuple[float, float]) -> float:
+        """Success rate from ``(successes, failures)``, guarding the empty case."""
+        successes, failures = counts
+        return successes / max(1e-9, successes + failures)
 
     def comparable(self) -> bool:
         """Were both sides measured in the same environment?"""
@@ -125,6 +138,13 @@ class AcceptDecision:
     accept: bool
     category: str = ""
     detail: str = ""
+    #: The posterior the decision rested on, carried out so the caller can report
+    #: it without recomputing -- the draw is sampled, so recomputing gives a
+    #: different number than the one that decided.
+    p_improve: float = 0.0
+    #: Measured change in the full held-out rate. The aggregator folds this back
+    #: into the artifact's running prior when a candidate is refused.
+    observed_delta: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/docs/aggregator.md
+++ b/docs/aggregator.md
@@ -17,6 +17,48 @@ shared ledger goes through it.
 [staleness](staleness.md) decides what to do with an out-of-date diff ·
 [governance](governance.md) decides how hard to gate.
 
+## Replacing a decision
+
+The seven decisions a merge makes are objects, and each can be swapped without
+touching `Aggregator`:
+
+```python
+from agentdescent import Policies, evolve
+from agentdescent.policies import AcceptDecision
+
+class AcceptEverything:
+    def accept(self, ctx):
+        return AcceptDecision(True, "committed")
+
+evolve(tasks, reward, agent=agent, policies=Policies(acceptance=AcceptEverything()))
+```
+
+| decision | default | what it is given |
+|---|---|---|
+| task sampling | `RoundRobin` | the shard's task ids and the round index |
+| proposal generation | your `propose=` callable | a `ProposalContext` |
+| conflict | `DefaultConflict` | the artifact and the surviving cards |
+| fusion | `DefaultFusion` | the artifact and the kept diffs |
+| staleness | `GuardedStaleness` | `eta`, `alpha`, whether the diff breaks a contract |
+| acceptance | `DefaultAcceptance` | a `MergeContext` |
+| promotion | `DefaultPromotion` | this round's `MergeReport`s |
+
+Two things the defaults know that a replacement should be told:
+
+* **Acceptance reads the full held-out set, never the cheap layer.**
+  `MergeContext` carries both (`base_counts` vs `base_cheap`) because the
+  regression guard once read the cheap one, which `cheap_eval_tasks`
+  sub-samples -- so a four-task sample could veto a commit the full-set test had
+  just approved.
+* **Promotion counts rounds *survived*, not commits.** Counting commits inverts
+  the incentive: an artifact that converges stops committing and so can never be
+  promoted, while one that thrashes promotes every K commits.
+
+Not replaceable, deliberately: the audit gate. It asks whether the cheap layer is
+still trustworthy -- a question about the measuring instrument, which belongs to
+the infrastructure rather than the algorithm.
+
+
 ## What it does (per artifact bucket)
 
 Evidence cards are bucketed by artifact; a bucket fires on batch size `B` or a

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -17,6 +17,7 @@ and *how*, that is *what*.
                     parallel                            staleness
                     scheduler                           governance
                     dataloader / rewards                  metrics · policies
+                    sandbox                              defaults
                     sandbox
 ```
 
@@ -69,6 +70,7 @@ and *how*, that is *what*.
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
 | `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |
+| `defaults` | the shipped algorithm as replaceable pieces: conflict, fusion, acceptance, promotion | [Aggregator](aggregator.md) |
 | `policies` | the contracts: which decisions are replaceable, and what each is given | [Architecture](architecture.md#35-what-the-infrastructure-owns-and-what-the-algorithm-owns) |
 | `metrics` | what the run cost: time, calls, staleness ratio, cache hits, sandbox waits | [Usage](usage.md#what-a-run-cost) |
 

--- a/tests/fixtures/merge_trace.json
+++ b/tests/fixtures/merge_trace.json
@@ -1,0 +1,373 @@
+{
+  "append": {
+    "final_reward": 1.0,
+    "merges": [
+      {
+        "category": "committed",
+        "committed_version": 2,
+        "conflicts_dropped": 0,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": true,
+        "prob_improve": 0.99175,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 3,
+        "conflicts_dropped": 0,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": true,
+        "prob_improve": 0.98525,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 4,
+        "conflicts_dropped": 0,
+        "considered": 2,
+        "discarded_stale": 0,
+        "fused": true,
+        "prob_improve": 0.98425,
+        "survived_staleness": 2
+      }
+    ],
+    "outcomes": {
+      "committed": 3
+    },
+    "rounds": [
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.25,
+        "round": 0,
+        "size": 3
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.666667,
+        "round": 1,
+        "size": 6
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 2,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 3,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 4,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 5,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 6,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 7,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 8,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 9,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 10,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 11,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 12,
+        "size": 8
+      },
+      {
+        "committed": 0,
+        "reasons": {},
+        "rejected": 0,
+        "reward": 1.0,
+        "round": 13,
+        "size": 8
+      }
+    ],
+    "stop_reason": "rounds"
+  },
+  "slot": {
+    "final_reward": 0.333333,
+    "merges": [
+      {
+        "category": "committed",
+        "committed_version": 2,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.95,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 3,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.567,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 4,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.57825,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 5,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.5575,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 6,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.5575,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 7,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.55075,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 8,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.54725,
+        "survived_staleness": 3
+      },
+      {
+        "category": "committed",
+        "committed_version": 9,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.54375,
+        "survived_staleness": 3
+      },
+      {
+        "category": "below-threshold",
+        "committed_version": null,
+        "conflicts_dropped": 2,
+        "considered": 3,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.52725,
+        "survived_staleness": 3
+      },
+      {
+        "category": "below-threshold",
+        "committed_version": null,
+        "conflicts_dropped": 1,
+        "considered": 2,
+        "discarded_stale": 0,
+        "fused": false,
+        "prob_improve": 0.3945,
+        "survived_staleness": 2
+      }
+    ],
+    "outcomes": {
+      "below-threshold": 2,
+      "committed": 8
+    },
+    "rounds": [
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 0,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 1,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 2,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 3,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 4,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 5,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 6,
+        "size": 1
+      },
+      {
+        "committed": 1,
+        "reasons": {
+          "committed": 1
+        },
+        "rejected": 0,
+        "reward": 0.333333,
+        "round": 7,
+        "size": 1
+      },
+      {
+        "committed": 0,
+        "reasons": {
+          "below-threshold": 1
+        },
+        "rejected": 1,
+        "reward": 0.333333,
+        "round": 8,
+        "size": 1
+      },
+      {
+        "committed": 0,
+        "reasons": {
+          "below-threshold": 1
+        },
+        "rejected": 1,
+        "reward": 0.333333,
+        "round": 9,
+        "size": 1
+      }
+    ],
+    "stop_reason": "rounds"
+  }
+}

--- a/tests/goldens.py
+++ b/tests/goldens.py
@@ -1,0 +1,153 @@
+"""The deterministic workloads behind the merge golden trace.
+
+Shared by the generator (`tools/gen_merge_golden.py`) and the test that compares
+against it, so the two cannot drift into measuring different things.
+
+The workloads are chosen to *reach the merge decisions*, not merely to finish:
+
+* `append` gives several workers different, complementary proposals in the same
+  round, which is what the fusion tournament is for;
+* `slot` gives them the same key with different values, which is a
+  contradiction and the only way conflict resolution runs at all.
+
+A trace that never conflicts and never fuses would pass any refactor of the code
+that does those things.
+"""
+
+from typing import Any, Dict, List
+
+from agentdescent import AppendRules, SingleSlot, Task, evolve
+from agentdescent.aggregator import Aggregator
+
+__all__ = ["WORKLOADS", "recording_factory", "run_workload", "trace_of"]
+
+
+def recording_factory(sink: List[Dict[str, Any]]):
+    """An `aggregator_factory` that records every merge decision, unchanged.
+
+    `RoundInfo` carries outcome *categories* and nothing about conflicts or
+    fusion, so a trace built from the result alone cannot see the two decisions
+    this refactor extracts first. Wrapping `step()` observes them without
+    altering a thing -- the aggregator is the shipped one, and the reports are
+    the ones the engine goes on to act on."""
+
+    def factory(ledger, verifier, audit, config, policy):
+        agg = Aggregator(ledger, verifier, audit, config, staleness_policy=policy)
+        real_step = agg.step
+
+        def step():
+            reports = real_step()
+            for r in reports:
+                sink.append({
+                    "category": r.category,
+                    "fused": bool(r.fused),
+                    "considered": r.considered,
+                    "survived_staleness": r.survived_staleness,
+                    "discarded_stale": r.discarded_stale,
+                    "conflicts_dropped": r.conflicts_dropped,
+                    "committed_version": r.committed_version,
+                    "prob_improve": round(float(r.prob_improve), 6),
+                })
+            return reports
+
+        agg.step = step          # type: ignore[assignment]
+        return agg
+
+    return factory
+
+
+def _tasks(n: int, n_cats: int = 4) -> List[Task]:
+    """Tasks in categories, so a rule learned on one generalises to its siblings.
+
+    Without that, a proposal made on a training task cannot move the held-out
+    score, nothing ever commits, and the trace records a run that never reached
+    the decisions it is meant to guard."""
+    out = []
+    for i in range(n):
+        cat = f"c{i % n_cats}"
+        out.append(Task(id=f"t{i}", prompt=f"q{i}",
+                        meta={"gold": f"a{cat}", "cat": cat}))
+    return out
+
+
+def _reward(task: Task, output: str) -> float:
+    return 1.0 if output == task.meta["gold"] else 0.0
+
+
+def _run_append(rendered: str, task: Task) -> str:
+    """Solved once a rule for this task's category is present."""
+    return task.meta["gold"] if f"rule:{task.meta['cat']}" in rendered else "wrong"
+
+
+def _propose_append(rendered: str, task: Task, output: str, reward: float) -> str:
+    return f"rule:{task.meta['cat']}"
+
+
+def _run_slot(rendered: str, task: Task) -> str:
+    """One slot holds one category's rule: only that category is solved."""
+    return task.meta["gold"] if task.meta["cat"] in rendered else "wrong"
+
+
+def _propose_slot(rendered: str, task: Task, output: str, reward: float) -> str:
+    # every worker writes the same key with a different value -> contradiction
+    return f"answer for {task.meta['cat']}"
+
+
+WORKLOADS: Dict[str, Dict[str, Any]] = {
+    "append": {
+        # More categories than a single round of workers can cover, so the run
+        # takes several merges to converge instead of one -- a trace with one
+        # decision in it guards almost nothing.
+        "n_tasks": 24,
+        "n_cats": 8,
+        "strategy": "append",
+        "kwargs": dict(rounds=14, n_workers=3, max_concurrency=1,
+                       held_out_frac=0.5, eval_concurrency=4, seed=0),
+    },
+    "slot": {
+        "n_tasks": 12,
+        "n_cats": 4,
+        "strategy": "slot",
+        "kwargs": dict(rounds=10, n_workers=3, max_concurrency=1,
+                       held_out_frac=0.5, eval_concurrency=2, seed=7),
+    },
+}
+
+
+def run_workload(name: str):
+    """Run one workload; returns ``(result, merge_reports)``."""
+    spec = WORKLOADS[name]
+    if spec["strategy"] == "append":
+        strategy, run, propose = AppendRules(), _run_append, _propose_append
+    else:
+        strategy, run, propose = SingleSlot(), _run_slot, _propose_slot
+    merges: List[Dict[str, Any]] = []
+    tasks = _tasks(spec["n_tasks"], spec.get("n_cats", 4))
+    result = evolve(tasks, _reward, run=run, propose=propose,
+                    strategy=strategy, aggregator_factory=recording_factory(merges),
+                    **spec["kwargs"])
+    return result, merges
+
+
+def trace_of(result, merges: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """The decision sequence, and nothing that varies with the machine.
+
+    Deliberately excludes `elapsed_s`, `rollouts` and anything path-shaped: a
+    fixture that embeds a `$TMPDIR` path or a duration goes red in CI for
+    reasons unrelated to what it is guarding, and the response to that is
+    always to weaken the fixture."""
+    rounds = [
+        {
+            "round": h.round,
+            "reward": round(h.held_out_reward, 6),
+            "size": h.n_items,
+            "committed": h.committed,
+            "rejected": h.rejected,
+            "reasons": dict(sorted(h.reasons.items())),
+        }
+        for h in result.history
+    ]
+    return {"rounds": rounds, "merges": merges,
+            "final_reward": round(result.final_reward, 6),
+            "stop_reason": result.stop_reason,
+            "outcomes": dict(sorted(result.outcomes().items()))}

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -93,6 +93,7 @@ def test_conflict_resolution_leaves_no_contradictions():
     model-soup benefit the aggregator is built around.
     """
     from agentdescent.aggregator import Aggregator, diffs_contradict
+    from agentdescent.defaults import DefaultConflict
     from agentdescent.evolvable import Diff, EvidenceCard
     from agentdescent.evolution import EvolvingArtifact, KeyedRules
 
@@ -113,7 +114,7 @@ def test_conflict_resolution_leaves_no_contradictions():
     # A and B are complementary (different keys); C contradicts BOTH.
     cards = [card("A", {"k1": "x"}), card("B", {"k2": "y"}),
              card("C", {"k1": "z", "k2": "w"})]
-    kept, dropped = Aggregator._resolve_conflicts(agg, art, cards)
+    kept, dropped = DefaultConflict(agg.verifier).resolve(art, cards)
 
     residual = [(a.diff.diff_id, b.diff.diff_id)
                 for i, a in enumerate(kept) for b in kept[i + 1:]
@@ -124,7 +125,7 @@ def test_conflict_resolution_leaves_no_contradictions():
 
 def test_conflict_resolution_keeps_complementary_cards():
     """Cards touching different keys must both survive -- that is what fusion needs."""
-    from agentdescent.aggregator import Aggregator
+    from agentdescent.defaults import DefaultConflict
     from agentdescent.evolvable import Diff, EvidenceCard
     from agentdescent.evolution import EvolvingArtifact, KeyedRules
 
@@ -139,10 +140,8 @@ def test_conflict_resolution_keeps_complementary_cards():
         def cheap_eval(self, artifact):
             return 0.5
 
-    agg = Aggregator.__new__(Aggregator)
-    agg.verifier = _Stub()
-    kept, dropped = Aggregator._resolve_conflicts(
-        agg, art, [card("A", {"k1": "x"}), card("B", {"k2": "y"})])
+    kept, dropped = DefaultConflict(_Stub()).resolve(
+        art, [card("A", {"k1": "x"}), card("B", {"k2": "y"})])
     assert len(kept) == 2 and dropped == 0
 
 

--- a/tests/test_merge_golden.py
+++ b/tests/test_merge_golden.py
@@ -1,0 +1,93 @@
+"""The merge decision sequence must not move while it is being taken apart.
+
+`_process` runs seven things in order -- trust region, staleness, conflict,
+fusion, audit, acceptance, commit -- and what breaks when they are pulled out
+into separate objects is rarely any one of them. It is the *interaction*: which
+runs first, whether a card dropped as contradictory still counts toward the
+denominator the next step divides by, whether the candidate handed to the
+acceptance gate is the fused one or the winner of the tournament.
+
+No unit test of an individual policy covers that. This does, by comparing the
+whole sequence against a fixture generated before the extraction started.
+
+If a change here goes red, the fixture is right and the change is wrong, unless
+you can say exactly which decision should have moved and why. Regenerating it to
+make a diff go away converts the guard into a record of whatever happened last.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from goldens import WORKLOADS, run_workload, trace_of      # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "merge_trace.json"
+
+
+@pytest.fixture(scope="module")
+def expected():
+    with open(FIXTURE, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@pytest.mark.parametrize("name", sorted(WORKLOADS))
+def test_the_merge_sequence_is_unchanged(name, expected):
+    got = trace_of(*run_workload(name))
+    assert got == expected[name], (
+        f"workload {name!r} decides differently than the recorded run. If that is "
+        "intended, say which decision changed and why before regenerating "
+        "tests/fixtures/merge_trace.json.")
+
+
+def test_the_workloads_actually_reach_the_decisions_they_guard(expected):
+    """A trace that never fuses and never conflicts would pass any refactor of
+    the code that fuses and resolves conflicts."""
+    merges = [m for trace in expected.values() for m in trace["merges"]]
+    assert sum(m["fused"] for m in merges) > 0, "fusion never ran"
+    assert sum(m["conflicts_dropped"] for m in merges) > 0, "conflict resolution never ran"
+    categories = {m["category"] for m in merges}
+    assert {"committed", "below-threshold"} <= categories, (
+        f"acceptance only ever went one way: {categories}")
+    assert any(m["committed_version"] for m in merges), "nothing was ever committed"
+
+
+def test_the_fixture_carries_nothing_machine_specific():
+    """A fixture holding a `$TMPDIR` path, a hostname or a duration goes red in
+    CI for reasons unrelated to what it guards -- and the response to that is
+    always to weaken it."""
+    raw = FIXTURE.read_text(encoding="utf-8")
+    for needle in ("/tmp", "/var/folders", "elapsed", "wallclock", "seconds",
+                   os.path.expanduser("~")):
+        assert needle not in raw, f"fixture embeds {needle!r}"
+
+
+def test_the_trace_survives_a_different_environment(tmp_path):
+    """Same decisions with `HOME`, `TMPDIR` and the working directory moved.
+
+    `evolve()` makes its scratch ledger with `mkdtemp`, so a run is full of
+    paths that differ every time; none of them may reach a decision."""
+    repo = Path(__file__).resolve().parent.parent
+    home = tmp_path / "home"
+    tmp = tmp_path / "tmp"
+    home.mkdir()
+    tmp.mkdir()
+    env = dict(os.environ, HOME=str(home), TMPDIR=str(tmp),
+               PYTHONPATH=f"{repo}{os.pathsep}{repo / 'tests'}",
+               PYTHONWARNINGS="ignore")
+    snippet = (
+        "import json;"
+        "from goldens import run_workload, trace_of;"
+        "print(json.dumps(trace_of(*run_workload('slot')), sort_keys=True))"
+    )
+    out = subprocess.run([sys.executable, "-c", snippet], cwd=str(tmp_path),
+                         env=env, capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr[-2000:]
+    got = json.loads(out.stdout)
+    with open(FIXTURE, encoding="utf-8") as fh:
+        assert got == json.loads(json.dumps(json.load(fh)["slot"], sort_keys=True))

--- a/tests/test_policy_contract.py
+++ b/tests/test_policy_contract.py
@@ -302,22 +302,142 @@ def test_an_empty_bundle_is_the_same_run_as_passing_nothing():
     assert _trace(_run_evolve()) == _trace(_run_evolve(policies=Policies()))
 
 
-def test_an_unhonoured_field_raises_instead_of_being_ignored():
-    """A caller who passes a custom acceptance rule and gets a finished run has
-    every reason to think it ran. Name the field and refuse."""
-    class Accept:
-        def accept(self, ctx): return AcceptDecision(True)
+def test_a_replaced_acceptance_rule_actually_decides():
+    """The seam has to be load-bearing, not decorative."""
+    class NeverAccept:
+        calls = 0
 
-    with pytest.raises(NotImplementedError, match="acceptance"):
-        _run_evolve(policies=Policies(acceptance=Accept()))
+        def accept(self, ctx):
+            NeverAccept.calls += 1
+            return AcceptDecision(False, "below-threshold", "refused by policy")
 
+    r = _run_evolve(policies=Policies(acceptance=NeverAccept()))
+    assert NeverAccept.calls > 0, "the custom acceptance rule was never consulted"
+    assert r.outcomes().get("committed", 0) == 0, "it refused and something committed"
+
+
+def test_a_replaced_promotion_rule_actually_decides():
+    class NeverPromote:
+        def observe(self, reports): return []
+
+    r = _run_evolve(policies=Policies(promotion=NeverPromote()))
+    assert r is not None       # the run completes; nothing reaches stable
+
+
+def test_a_field_with_no_implementation_still_raises():
+    """The guard has to keep working for whatever is not wired yet -- being
+    accepted and ignored is the one failure a caller cannot detect."""
     with pytest.raises(NotImplementedError, match="sandbox_provider"):
         _run_evolve(policies=Policies(sandbox_provider=object()))
 
 
-def test_the_async_path_refuses_the_same_fields():
+def test_the_async_path_honours_the_same_bundle():
     from agentdescent import async_evolve
-    with pytest.raises(NotImplementedError, match="async_evolve"):
+    with pytest.raises(NotImplementedError, match="sandbox_spec"):
         async_evolve(_tasks(), lambda t, o: 0.0, run=lambda r, t: "x",
                      propose=lambda r, t, o, s: None, max_iters=1,
-                     policies=Policies(verifier=_verifier()))
+                     policies=Policies(sandbox_spec=SandboxSpec()))
+
+
+def test_a_multi_proposal_policy_is_refused_rather_than_truncated():
+    """Keeping the first of k would make a sampling algorithm look like it ran
+    when only a fraction of it did."""
+    class ThreeAtATime:
+        def propose(self, ctx): return ["a", "b", "c"]
+
+    from agentdescent.evolution import ProposalContractError
+    with pytest.raises(ProposalContractError, match="one proposal per rollout"):
+        _run_evolve(policies=Policies(proposal=ThreeAtATime()))
+
+
+def test_a_single_proposal_policy_is_equivalent_to_the_callable():
+    from agentdescent.defaults import SingleProposal
+    plain = _run_evolve()
+    viapolicy = _run_evolve(policies=Policies(
+        proposal=SingleProposal(lambda r, t, o, s: t.id)))
+    assert _trace(plain) == _trace(viapolicy)
+
+
+# ---------------------------------------------------------------------------
+# Injected backends
+# ---------------------------------------------------------------------------
+
+
+def test_an_injected_verifier_is_called_exactly_as_the_built_in_one_is():
+    """Injection must not quietly change *how much* the engine measures.
+
+    A wrapper that adds or drops a gate call changes what the run costs while
+    leaving every result identical -- invisible to a trace comparison, and the
+    reason this counts calls rather than checking the outcome."""
+    from agentdescent.verifier import ThreeLayerVerifier
+
+    counts = {}
+
+    class Counting:
+        def __init__(self, inner): self.inner = inner
+        def __getattr__(self, name):
+            attr = getattr(self.inner, name)
+            if not callable(attr):
+                return attr
+            def wrapped(*a, **kw):
+                counts[name] = counts.get(name, 0) + 1
+                return attr(*a, **kw)
+            return wrapped
+
+    seen = {}
+
+    def factory(ledger, verifier, audit, config, policy):
+        seen["verifier"] = verifier
+        from agentdescent.aggregator import Aggregator
+        return Aggregator(ledger, verifier, audit, config, staleness_policy=policy)
+
+    inner = ThreeLayerVerifier(eval_fn=lambda a, ts: 1.0, held_out=[1, 2, 3])
+    _run_evolve(policies=Policies(verifier=Counting(inner),
+                                  aggregator_factory=factory))
+    assert isinstance(seen.get("verifier"), Counting), "the engine built its own"
+    assert set(counts) <= {"cheap_eval", "eval_counts", "oracle_eval",
+                           "learned_eval", "budget", "held_out"}, counts
+
+
+def test_an_in_memory_ledger_is_enough_to_finish_a_run(tmp_path):
+    """`LedgerProtocol` has to be sufficient, not merely satisfied.
+
+    This is the first thing that proves the protocol covers `register`, `log` and
+    `close` -- the three the aggregator never calls and the engine always does."""
+    from agentdescent.ledger import Ledger
+
+    calls = []
+
+    class Recording:
+        def __init__(self, inner): self.inner = inner
+        def register(self, artifact, branch=Ledger.DEV):
+            calls.append("register")
+            return self.inner.register(artifact, branch)
+        def snapshot(self, branch=Ledger.DEV): return self.inner.snapshot(branch)
+        def head_version(self, branch=Ledger.DEV): return self.inner.head_version(branch)
+        def commit(self, *a, **kw): return self.inner.commit(*a, **kw)
+        def promote_to_stable(self, aid): return self.inner.promote_to_stable(aid)
+        def log(self, branch=Ledger.DEV, limit=20):
+            calls.append("log")
+            return self.inner.log(branch, limit)
+        def close(self):
+            calls.append("close")
+            return self.inner.close()
+
+    inner = Ledger(str(tmp_path / "repo"),
+                   serialize=lambda a: {"state": dict(a.state),
+                                        "blast_radius": a.blast_radius},
+                   deserialize=lambda aid, v, d: None)
+    # the engine deserialises with its own artifact type, so borrow the real one
+    from agentdescent.evolution import EvolvingArtifact
+    inner._deserialize = lambda aid, v, d: EvolvingArtifact(
+        aid, d.get("state", {}), v, d.get("blast_radius", 0.2))
+
+    r = _run_evolve(policies=Policies(ledger=Recording(inner)))
+    assert r.final_reward >= 0.0
+    assert "register" in calls, "the engine never registered through the protocol"
+    assert "log" in calls, "the run summary skipped the ledger"
+    # `close` is deliberately absent: the engine closes only the ledger it made
+    # itself, the same rule that applies to a caller-supplied `repo_path`. An
+    # injected ledger's lifetime belongs to whoever injected it.
+    assert "close" not in calls, "the engine closed a ledger it does not own"

--- a/tests/test_stats_and_staleness.py
+++ b/tests/test_stats_and_staleness.py
@@ -75,11 +75,36 @@ def test_acceptance_mc_seed_varies_per_candidate_but_stays_reproducible():
     assert ests == again
 
 
-def test_aggregator_seeds_acceptance_from_the_candidate():
-    import inspect
+def test_acceptance_seeds_its_draw_from_the_candidate():
+    """Two candidates in one round must not share a Monte-Carlo draw.
 
-    from agentdescent.aggregator import Aggregator
+    Seeding from the version alone made the ~0.003 sampling error identical for
+    every candidate in a round, so on knife-edge cases the draw decided them as a
+    block: one stream accepted every marginal diff, another rejected all of them.
 
-    src = inspect.getsource(Aggregator._process)
-    assert "stable_hash" in src, "the MC seed must include the candidate identity"
-    assert "seed=artifact.version)" not in src
+    Asserted behaviourally rather than by reading the source for `stable_hash`:
+    the seeding used to live in `Aggregator._process` and now lives in
+    `DefaultAcceptance`, and a test that greps one method goes green the moment
+    the logic moves -- whether or not it survived the move.
+    """
+    from agentdescent.defaults import DefaultAcceptance
+    from agentdescent.evolvable import Diff
+    from agentdescent.policies import MergeContext
+
+    class _Art:
+        version = 3
+        blast_radius = 0.2
+
+    policy = DefaultAcceptance(base_delta=0.5, anneal_half_life=64,
+                               accept_samples=400)
+
+    def draw(diff_id):
+        ctx = MergeContext(artifact=_Art(), candidate=_Art(), cards=[],
+                           base_counts=(5.0, 5.0), cand_counts=(6.0, 4.0),
+                           diff=Diff(diff_id=diff_id, target="a", ops={"k": "v"}))
+        return policy.accept(ctx).p_improve
+
+    assert draw("cand-A") == draw("cand-A"), "the same candidate must be reproducible"
+    assert draw("cand-A") != draw("cand-B"), (
+        "two candidates in one round shared a draw -- the seed is not "
+        "candidate-specific")

--- a/tools/gen_merge_golden.py
+++ b/tools/gen_merge_golden.py
@@ -1,0 +1,67 @@
+"""Record the merge decision sequence, to compare a refactor against.
+
+    python -m tools.gen_merge_golden          # write the fixture
+    python -m tools.gen_merge_golden --check  # fail if the code has drifted
+
+**Generate this before touching the code it guards.** A fixture written after a
+refactor records the refactor's behaviour and agrees with it forever, which is
+the one way this file can be worse than useless.
+
+What it captures is the *interaction* between the merge steps -- whether
+staleness runs before the trust region, whether cards dropped as contradictory
+still count toward a denominator -- and interactions are what unit tests for the
+individual steps do not cover. That is the whole reason for extracting them one
+at a time and re-comparing after each.
+"""
+
+import argparse
+import json
+import os
+import sys
+import warnings
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), os.pardir, "tests"))
+
+from goldens import WORKLOADS, run_workload, trace_of      # noqa: E402
+
+FIXTURE = os.path.join(os.path.dirname(__file__), os.pardir,
+                       "tests", "fixtures", "merge_trace.json")
+
+
+def build() -> dict:
+    warnings.filterwarnings("ignore", category=RuntimeWarning)
+    return {name: trace_of(*run_workload(name)) for name in sorted(WORKLOADS)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--check", action="store_true",
+                    help="compare instead of writing; non-zero exit if different")
+    args = ap.parse_args()
+
+    traces = build()
+    if args.check:
+        with open(FIXTURE, encoding="utf-8") as fh:
+            expected = json.load(fh)
+        if traces == expected:
+            print(f"{os.path.relpath(FIXTURE)} is up to date")
+            return 0
+        print("merge trace has drifted from the fixture", file=sys.stderr)
+        for name in sorted(traces):
+            if traces.get(name) != expected.get(name):
+                print(f"  workload {name!r} differs", file=sys.stderr)
+        return 1
+
+    os.makedirs(os.path.dirname(FIXTURE), exist_ok=True)
+    with open(FIXTURE, "w", encoding="utf-8") as fh:
+        json.dump(traces, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    total = sum(len(t["merges"]) for t in traces.values())
+    print(f"wrote {os.path.relpath(FIXTURE)} "
+          f"({len(traces)} workloads, {total} merge decisions)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #55. Step 4 of 8 in the [roadmap](https://github.com/Birfy/agentdescent/issues/52#issuecomment-5164168416).

**Zero behaviour change.** Every decision `Aggregator._process` made, it still makes, in the same order, with the same numbers — they are just objects now, and `Policies(acceptance=...)` swaps one.

## The golden trace, and why it came first

Generated from the unmodified code *before* the extraction started, then compared bit-for-bit after every step. A fixture written afterwards records the refactor's own behaviour and agrees with it forever.

It is built to actually reach the paths being extracted — 13 merge decisions across two workloads, with **3 fusions**, **19 dropped conflicts**, and acceptance going both ways. A trace that never conflicts and never fuses would pass any refactor of the code that conflicts and fuses; a test asserts that coverage so the fixture cannot quietly decay into one.

It is also asserted to contain no path, hostname or duration, and is re-run in a subprocess with `HOME`, `TMPDIR` and the working directory moved. A fixture that goes red in CI for environmental reasons gets weakened, not investigated.

## Moved, not rewritten — and that was not academic

Drafting these classes from the docstrings first produced two that reintroduced bugs the real code had already fixed:

- **Promotion**, written from memory, incremented the counter on *commits*. That is exactly the inverted incentive the shipped code fixed: an artifact that converges stops committing and can therefore never be promoted, while one that thrashes promotes every K commits. The demo had `stable` stuck at `0.000` for 36 rounds because of it.
- **Acceptance** used the wrong `prob_improvement` arity, dropped the per-candidate seed (a shared seed made the Monte-Carlo error identical across a round, so knife-edge candidates were decided as a block), and dropped the `observe_delta` folding.

Both were caught by reading the code rather than trusting the summary of it. What is in `defaults.py` is the original lines, relocated.

## Two contract corrections

Both only surfaced when the contracts met real code:

- `MergeContext.base_counts` was documented as `(successes, trials)`. `verifier.eval_counts` returns `(successes, failures)`. A policy dividing by the second element gets a rate that is wrong and entirely plausible.
- `MergeContext` needed the diff itself — the acceptance draw is seeded per candidate, and contributing cards are found by intersecting ops.

## Decisions worth reviewing

**A multi-proposal policy is refused, not truncated.** The engine turns one proposal into one diff per rollout, so keeping the first of k would make a sampling algorithm look like it ran when a fraction of it did. It raises `ProposalContractError` so it travels the channel for "this run is meaningless" rather than being folded into `error` as a transient and retried.

**An injected ledger is not closed by the engine** — the same rule that already applies to a caller-supplied `repo_path`: close only what you created. A test asserts the absence.

**The audit gate stays put.** It asks whether the cheap layer is still trustworthy — a question about the measuring instrument, which belongs to the infrastructure, not the algorithm. Extracting it because it happened to be in the same method would have been tidiness mistaken for design.

## Where it fell short of the issue

`_process` is **67 non-comment lines**, down from ~110. #55 asked for under 40. What remains is six `MergeReport` constructions and two early-return branches; collapsing those into a helper made the method *longer* (71) while adding a nested closure, so it was reverted rather than kept for the sake of the number.

## Verification

- **707 passed, 1 skipped** (696 before + 11 net new).
- Golden trace bit-identical after every one of the five extraction steps.
- `test_dual_branch_promotion.py` passes **unchanged, all eleven** — including the four that read `agg._survival`, kept working as a delegating property.
- `run_demo` reproduces the `docs/usage.md` table verbatim.
- Every policy has a counter-example implementation driven end-to-end, so the seams are load-bearing rather than decorative.

One test changed on purpose: it asserted `"stable_hash" in inspect.getsource(Aggregator._process)`. That goes green the moment the logic moves, whether or not it survived the move — it is now a behavioural assertion that two candidates in one round get different draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
