### PR TITLE
feat: a sandbox that is actually a boundary (docker + podman)

### DIFF
--- a/agentdescent/policies.py
+++ b/agentdescent/policies.py
@@ -287,8 +287,16 @@ class SandboxSpec:
     #: Names of environment variables to pass through. Names only.
     env_allowlist: Tuple[str, ...] = ()
     workspace_root: Optional[str] = None
-    #: ``"inherit"`` or ``"none"``.
-    network: str = "inherit"
+    #: ``None`` leaves it to the provider, ``"none"`` forbids it, ``"inherit"``
+    #: asks for the host's network.
+    #:
+    #: Three states rather than two, because "the default" means opposite things
+    #: to the two providers. A local workspace cannot restrict the network at
+    #: all, so for it the honest description is "inherited"; a container can, and
+    #: for it the only safe default is off -- a candidate that can reach the
+    #: network can send whatever it managed to read. With a two-state field the
+    #: shared default had to be wrong for one of them.
+    network: Optional[str] = None
     cpu: Optional[float] = None
     memory_mb: Optional[int] = None
     timeout_s: Optional[float] = None

--- a/agentdescent/runners.py
+++ b/agentdescent/runners.py
@@ -216,7 +216,8 @@ def _child_env(ws: str, extra: Optional[Mapping[str, str]]) -> Dict[str, str]:
 
 
 def _sh(cmd: Sequence[str], ws: str, timeout: float,
-        env: Mapping[str, str]) -> subprocess.CompletedProcess:
+        env: Mapping[str, str],
+        sandbox: Optional[object] = None) -> subprocess.CompletedProcess:
     """Run one gate command, and on timeout kill **everything it started**.
 
     ``subprocess.run(timeout=)`` kills the process it launched and nothing else.
@@ -235,13 +236,33 @@ def _sh(cmd: Sequence[str], ws: str, timeout: float,
     POSIX-only: Windows has no process groups in this sense, so there the
     behaviour is what it always was -- documented rather than silently different.
     """
+    # A sandbox that runs the command elsewhere says so by offering a prefix.
+    # The local one does not, so this is `[] + cmd` and the default path is
+    # exactly what it was.
+    prefix = list(getattr(sandbox, "exec_prefix", list)() or ())
+    if prefix:
+        # The prefix runs on the *host* -- it is the engine's own CLI, and it
+        # needs the host's environment to find its socket. The trimmed
+        # environment is for the candidate, which is on the far side of the
+        # prefix, so the sandbox injects it there instead. Handing the engine a
+        # `HOME` inside the workspace makes it look for its socket in a directory
+        # that is about to be deleted.
+        env, cwd = os.environ, None
+    else:
+        cwd = ws
     posix = os.name != "nt"
-    proc = subprocess.Popen(list(cmd), cwd=ws, env=dict(env), text=True,
+    proc = subprocess.Popen(prefix + list(cmd), cwd=cwd, env=dict(env), text=True,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                             start_new_session=posix)
     try:
         out, err = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
+        # Killing the local process group does nothing to a process running
+        # inside a container -- the exec dies and its child keeps going. A
+        # sandbox that can stop its own contents is asked to.
+        stop = getattr(sandbox, "kill", None)
+        if prefix and callable(stop):
+            stop()
         _kill_group(proc, posix)
         # Drain after killing: the pipes may hold output that explains the hang,
         # and not reading them can leave the child blocked on a full pipe.
@@ -310,16 +331,16 @@ def code_runner(entrypoint: Sequence[str], *, layout: str = "root",
             ws = sandbox.root
             _stage_into(ws, rendered, task, prefix=prefix, overlay=overlay,
                         fixtures=fixtures)
-            return _gate_and_run(ws, task)
+            return _gate_and_run(ws, task, sandbox)
 
-    def _gate_and_run(ws: str, task: Task) -> str:
+    def _gate_and_run(ws: str, task: Task, sandbox=None) -> str:
         """Gate first, then the entrypoint. A failing gate speaks in-band."""
         child = _child_env(ws, env)
         for label, cmd in (("setup", setup_cmd), ("tests", test_cmd)):
             if not cmd:
                 continue
             try:
-                proc = _sh(cmd, ws, timeout, child)
+                proc = _sh(cmd, ws, timeout, child, sandbox)
             except subprocess.TimeoutExpired:
                 return (f"{TEST_FAILURE_MARKER} ({label} timed out after "
                         f"{timeout:g}s)")
@@ -329,7 +350,7 @@ def code_runner(entrypoint: Sequence[str], *, layout: str = "root",
                 detail = (proc.stdout or "") + (proc.stderr or "")
                 return f"{TEST_FAILURE_MARKER} ({label}):\n{detail.strip()[:2000]}"
         try:
-            proc = _sh([*entrypoint, task.prompt], ws, timeout, child)
+            proc = _sh([*entrypoint, task.prompt], ws, timeout, child, sandbox)
         except subprocess.TimeoutExpired:
             return f"{TEST_FAILURE_MARKER} (entrypoint timed out after {timeout:g}s)"
         except FileNotFoundError as e:

--- a/agentdescent/sandbox_container.py
+++ b/agentdescent/sandbox_container.py
@@ -41,15 +41,17 @@ import tempfile
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Callable, Dict, List, Optional, Sequence
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from .policies import SandboxSpec
 
 __all__ = [
     "CONTAINER_WORKDIR",
+    "ENGINES",
     "ContainerProvider",
     "ContainerSandbox",
     "EngineError",
+    "detect_engine",
     "engine_available",
 ]
 
@@ -66,6 +68,26 @@ class EngineError(RuntimeError):
     """The container engine failed, with its own stderr attached."""
 
 
+#: Engines tried, in order, when none is named. Docker first because it is what
+#: most machines and CI images have; podman is a drop-in with the same CLI.
+ENGINES: Tuple[str, ...] = ("docker", "podman")
+
+
+def detect_engine(preferred: Optional[str] = None) -> Optional[str]:
+    """The first engine that is installed *and* answering, or ``None``.
+
+    Both halves matter. `docker` is on the PATH of plenty of machines where
+    nothing is listening -- Docker Desktop quit, a rootless daemon never
+    started -- and a provider built against a binary that cannot talk to a
+    daemon fails at the first rollout rather than at construction, by which time
+    a run is underway.
+    """
+    for engine in ((preferred,) if preferred else ENGINES):
+        if engine and engine_available(engine):
+            return engine
+    return None
+
+
 def engine_available(engine: str = "docker") -> bool:
     """Is this engine installed *and* talking to a daemon?
 
@@ -75,8 +97,12 @@ def engine_available(engine: str = "docker") -> bool:
     if shutil.which(engine) is None:
         return False
     try:
-        out = subprocess.run([engine, "info", "--format", "{{.Host.Arch}}"],
-                             capture_output=True, timeout=30)
+        # `info` with no template on purpose. The two engines answer the same
+        # questions with different Go structures -- `{{.Host.Arch}}` is podman's
+        # and renders empty on docker -- so a probe that formats anything is a
+        # probe that reports whichever engine it was written against. The exit
+        # code means the same thing on both.
+        out = subprocess.run([engine, "info"], capture_output=True, timeout=30)
         return out.returncode == 0
     except (OSError, subprocess.SubprocessError):
         return False
@@ -133,13 +159,25 @@ class ContainerProvider:
     this is the check on it.
     """
 
-    def __init__(self, image: str, *, engine: str = "docker",
+    def __init__(self, image: str, *, engine: Optional[str] = None,
                  ttl: float = 300.0, pids_limit: int = 512,
                  runner: Optional[Callable[..., str]] = None) -> None:
         if not image:
             raise ValueError("a container sandbox needs an image to run")
         self.image = image
-        self.engine = engine
+        # `None` means "whichever is here". Naming one is for the case where both
+        # are installed and the choice matters; being made to name one when only
+        # one exists is friction with no payoff.
+        if engine is None and runner is None:
+            engine = detect_engine()
+            if engine is None:
+                raise EngineError(
+                    "no container engine is available: tried "
+                    f"{', '.join(ENGINES)}. Install one, or start the daemon -- "
+                    "the binary being on PATH is not enough. Without one, the "
+                    "default local provider still works, but it is not a "
+                    "boundary (see docs/directory-evolution.md).")
+        self.engine = engine or "docker"
         self.ttl = ttl
         self.pids_limit = pids_limit
         self._run = runner or _run
@@ -169,7 +207,7 @@ class ContainerProvider:
                "--read-only",
                "--tmpfs", "/tmp:rw,exec,size=256m",
                "--cap-drop", "ALL",
-               "--security-opt", "no-new-privileges",
+               "--security-opt", "no-new-privileges:true",
                f"--pids-limit={self.pids_limit}"]
 
         # Network is off unless asked for. A candidate that can reach the network
@@ -207,12 +245,17 @@ class ContainerProvider:
 
     def acquire(self, spec: SandboxSpec) -> ContainerSandbox:
         ws = tempfile.mkdtemp(prefix=_WS_PREFIX, dir=spec.workspace_root)
+        # A file to look for from the inside. Staging has not happened yet, so
+        # without one the workspace and a failed mount are both empty.
+        with open(os.path.join(ws, ".agentdescent-mount"), "w") as fh:
+            fh.write("ok")
         lease_id = uuid.uuid4().hex
         try:
             container_id = self._run(self.run_command(spec, ws, lease_id))
         except Exception:
             shutil.rmtree(ws, ignore_errors=True)
             raise
+        self._verify_mount(container_id, ws)
         self._n += 1
         sandbox = ContainerSandbox(
             id=f"{self.engine}-{os.getpid()}-{self._n}", root=ws,
@@ -221,6 +264,36 @@ class ContainerProvider:
             acquired_at=time.time())
         sandbox._killer = lambda: self.kill(sandbox)
         return sandbox
+
+    def _verify_mount(self, container_id: str, ws: str) -> None:
+        """Fail now, with an explanation, if the workspace did not arrive.
+
+        On Linux any host path can be bind-mounted. On macOS and Windows the
+        engine runs in a VM that shares only some of the host, so a workspace
+        under `$TMPDIR` -- which is where one goes by default -- is frequently
+        outside it. The container starts happily and `/work` is simply empty, so
+        the first symptom is the candidate's own `FileNotFoundError`, blamed on
+        the candidate.
+        """
+        try:
+            self._run([self.engine, "exec", container_id,
+                       "test", "-f", f"{CONTAINER_WORKDIR}/.agentdescent-mount"],
+                      timeout=30.0)
+            return
+        except Exception:
+            pass
+        try:
+            self._run([self.engine, "rm", "--force", container_id], timeout=60.0)
+        except Exception:
+            pass
+        raise EngineError(
+            f"the workspace {ws} did not appear inside the container. On macOS "
+            "and Windows the engine runs in a VM that shares only part of the "
+            "host filesystem, and the system temporary directory is usually "
+            "outside it. Point the run at a shared location -- "
+            "`SandboxSpec(workspace_root=...)` under your home directory is the "
+            "usual answer -- or add the path to the VM's mounts "
+            "(`colima start --mount <path>:w`, or Docker Desktop's File Sharing).")
 
     def release(self, sandbox: ContainerSandbox) -> None:
         """Stop the container and remove the workspace. Never raises.

--- a/agentdescent/sandbox_container.py
+++ b/agentdescent/sandbox_container.py
@@ -1,0 +1,310 @@
+"""A sandbox that is actually a boundary.
+
+`sandbox.py` manages *lifetime*: how many workspaces exist, who owns one, who
+cleans up when an owner dies. It does not manage *isolation*, and its only
+provider does not provide any: `HOME` and `TMPDIR` point inside the workspace,
+which redirects a lookup but not a path. Model-authored code that opens
+`/Users/you/.ssh/id_rsa` gets it, and can post it anywhere, because nothing about
+a trimmed environment restricts the filesystem or the network.
+
+This provider runs the candidate inside a container instead. What changes:
+
+    filesystem   only the workspace is visible; the host's is not
+    network      off unless the spec asks for it
+    privileges   no capabilities, no new privileges, not root
+    resources    memory and CPU ceilings on every platform, not just POSIX
+
+What does not change: containers share the host kernel, and escapes exist. This
+is much stronger than a trimmed environment and it is **not** a licence to run
+deliberately hostile code.
+
+**Why the CLI rather than a Python SDK.** The core of this package has no
+dependencies, and an SDK would make container support a Python dependency
+instead of a machine one. The CLI also gets `podman` for free -- its interface is
+docker-compatible -- and the only output that has to be parsed is a container id
+and one column of `ps`.
+
+**Why the command runner is injectable.** Nearly all of the logic here *is* the
+command: which flags, in what order, with what defaults. That can be asserted
+exactly, on a machine with no container engine at all, which is the difference
+between "this provider was tested" and "this provider was run once". The parts
+that need a real engine are tested separately and skipped when there is none.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence
+
+from .policies import SandboxSpec
+
+__all__ = [
+    "CONTAINER_WORKDIR",
+    "ContainerProvider",
+    "ContainerSandbox",
+    "EngineError",
+    "engine_available",
+]
+
+#: Where the workspace is mounted inside the container. Fixed rather than
+#: configurable: it appears in every exec, and a moving target would have to be
+#: threaded through the runner for no benefit.
+CONTAINER_WORKDIR = "/work"
+
+_LABEL = "agentdescent.lease"
+_WS_PREFIX = "agentdescent-ws-"
+
+
+class EngineError(RuntimeError):
+    """The container engine failed, with its own stderr attached."""
+
+
+def engine_available(engine: str = "docker") -> bool:
+    """Is this engine installed *and* talking to a daemon?
+
+    Both halves matter: the binary exists on plenty of machines where nothing is
+    listening, and a provider that constructs perfect commands for a daemon that
+    is not there fails at the first rollout rather than at startup."""
+    if shutil.which(engine) is None:
+        return False
+    try:
+        out = subprocess.run([engine, "info", "--format", "{{.Host.Arch}}"],
+                             capture_output=True, timeout=30)
+        return out.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+@dataclass
+class ContainerSandbox:
+    """A running container, plus the host directory bind-mounted into it."""
+
+    id: str
+    root: str                  # host path -- staging still happens here
+    fingerprint: str
+    lease_id: str
+    container_id: str
+    engine: str = "docker"
+    acquired_at: float = 0.0
+
+    #: Set by the provider that made it, so a timeout can stop the container
+    #: without the runner needing to know which provider it came from.
+    _killer: Optional[Callable[[], None]] = None
+
+    def exec_prefix(self) -> List[str]:
+        """What to put in front of a command so it runs inside this sandbox.
+
+        The candidate's environment is set here rather than inherited: `HOME` and
+        `TMPDIR` have to name paths that exist *inside* the container, and the
+        host's values name paths that do not."""
+        return [self.engine, "exec", "-w", CONTAINER_WORKDIR,
+                "-e", f"HOME={CONTAINER_WORKDIR}", "-e", "TMPDIR=/tmp",
+                self.container_id]
+
+    def kill(self) -> None:
+        """Stop everything inside. Called on timeout, where killing the local
+        process group would only have killed the `exec`."""
+        if self._killer is not None:
+            self._killer()
+
+
+def _run(cmd: Sequence[str], timeout: float = 120.0) -> str:
+    proc = subprocess.run(list(cmd), capture_output=True, text=True, timeout=timeout)
+    if proc.returncode != 0:
+        raise EngineError(
+            f"{' '.join(cmd[:3])} failed ({proc.returncode}): "
+            f"{(proc.stderr or proc.stdout or '').strip()[:400]}")
+    return proc.stdout.strip()
+
+
+class ContainerProvider:
+    """Provisions containers as sandboxes, one per lease.
+
+    Implements the same three methods as `WorkspaceProvider` and nothing more.
+    If this class had needed a fourth, the protocol in `policies.py` would have
+    been the wrong shape -- a contract with one implementation is a guess, and
+    this is the check on it.
+    """
+
+    def __init__(self, image: str, *, engine: str = "docker",
+                 ttl: float = 300.0, pids_limit: int = 512,
+                 runner: Optional[Callable[..., str]] = None) -> None:
+        if not image:
+            raise ValueError("a container sandbox needs an image to run")
+        self.image = image
+        self.engine = engine
+        self.ttl = ttl
+        self.pids_limit = pids_limit
+        self._run = runner or _run
+        self._n = 0
+
+    # -- command construction -------------------------------------------------
+
+    def run_command(self, spec: SandboxSpec, ws: str, lease_id: str) -> List[str]:
+        """The full ``run`` argv for one sandbox. Public because it is the logic.
+
+        Defaults are closed and opened per field, rather than open and closed per
+        field: a spec that says nothing gets a container with no network, no
+        capabilities, a read-only root and the host's own uid.
+        """
+        cmd = [self.engine, "run", "--detach", "--init",
+               "--label", f"{_LABEL}={lease_id}",
+               "--label", f"agentdescent.fingerprint={spec.fingerprint()}",
+               # Our own clock, not the engine's. `docker inspect` reports
+               # RFC3339 and `podman inspect` reports Go's default layout, and a
+               # reaper that misparses a timestamp either spares an orphan
+               # forever or deletes a container that started a second ago.
+               "--label", f"agentdescent.started={int(time.time())}",
+               "--volume", f"{ws}:{CONTAINER_WORKDIR}:rw",
+               "--workdir", CONTAINER_WORKDIR,
+               # Read-only root with writable /work and /tmp: the candidate can
+               # write where its work belongs and nowhere else.
+               "--read-only",
+               "--tmpfs", "/tmp:rw,exec,size=256m",
+               "--cap-drop", "ALL",
+               "--security-opt", "no-new-privileges",
+               f"--pids-limit={self.pids_limit}"]
+
+        # Network is off unless asked for. A candidate that can reach the network
+        # can send anything it managed to read, so "off" is the only safe default
+        # -- and `inherit` is the single word that turns it on.
+        if spec.network != "inherit":
+            # `None` means "provider decides", and this provider decides no.
+            cmd += ["--network", "none"]
+
+        # Run as the host user, so files written into the bind mount belong to
+        # whoever started the run. As root, the host cannot even delete them.
+        if os.name != "nt":
+            cmd += ["--user", f"{os.getuid()}:{os.getgid()}"]
+
+        if spec.memory_mb:
+            cmd += ["--memory", f"{int(spec.memory_mb)}m"]
+        if spec.cpu:
+            cmd += ["--cpus", str(spec.cpu)]
+
+        # Names only ever leave the host; values are read here and passed one at a
+        # time. Nothing bulk (`--env-file`, `--env` without a value) is used, so a
+        # variable that is not on the list cannot arrive by accident.
+        for name in spec.env_allowlist:
+            value = os.environ.get(name)
+            if value is not None:
+                cmd += ["--env", f"{name}={value}"]
+
+        image = spec.image or self.image
+        # Idle forever; the work arrives via `exec`. `--init` above reaps whatever
+        # the candidate leaves behind.
+        cmd += [image, "sleep", "infinity"]
+        return cmd
+
+    # -- SandboxProvider ------------------------------------------------------
+
+    def acquire(self, spec: SandboxSpec) -> ContainerSandbox:
+        ws = tempfile.mkdtemp(prefix=_WS_PREFIX, dir=spec.workspace_root)
+        lease_id = uuid.uuid4().hex
+        try:
+            container_id = self._run(self.run_command(spec, ws, lease_id))
+        except Exception:
+            shutil.rmtree(ws, ignore_errors=True)
+            raise
+        self._n += 1
+        sandbox = ContainerSandbox(
+            id=f"{self.engine}-{os.getpid()}-{self._n}", root=ws,
+            fingerprint=spec.fingerprint(), lease_id=lease_id,
+            container_id=container_id, engine=self.engine,
+            acquired_at=time.time())
+        sandbox._killer = lambda: self.kill(sandbox)
+        return sandbox
+
+    def release(self, sandbox: ContainerSandbox) -> None:
+        """Stop the container and remove the workspace. Never raises.
+
+        Release runs from a `finally`, including on the path where the rollout
+        already failed. An exception here would replace the real error with a
+        cleanup error."""
+        try:
+            self._run([self.engine, "rm", "--force", "--volumes",
+                       sandbox.container_id], timeout=60.0)
+        except Exception:
+            pass
+        shutil.rmtree(sandbox.root, ignore_errors=True)
+
+    def reset(self, sandbox: ContainerSandbox) -> None:
+        """Empty the workspace for reuse. The container itself is stateless
+        enough to keep -- its root is read-only and `/tmp` is a tmpfs."""
+        for name in os.listdir(sandbox.root):
+            path = os.path.join(sandbox.root, name)
+            if os.path.isdir(path) and not os.path.islink(path):
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+
+    def renew(self, sandbox: ContainerSandbox) -> None:
+        """No-op: a container's liveness is the engine's to track, not a file's.
+
+        `WorkspaceProvider` needs a renewed lease file because a bare directory
+        cannot say whether anyone still wants it. A container can: it is either
+        running or it is not, and `reap` asks the engine."""
+
+    def kill(self, sandbox: ContainerSandbox) -> None:
+        """Stop everything inside, now. Used on timeout.
+
+        Killing an `exec` does not kill what it started -- the process keeps
+        running inside the container. Since a container is per-lease and
+        disposable, killing the container is both simpler and more complete than
+        hunting a process group inside it."""
+        try:
+            self._run([self.engine, "kill", sandbox.container_id], timeout=30.0)
+        except Exception:
+            pass
+
+    def reap(self, older_than: Optional[float] = None) -> int:
+        """Remove containers whose owner is gone, found by label.
+
+        The same idea as the workspace lease file, asked of the engine instead:
+        anything carrying our label and older than the TTL, whose lease nobody
+        renewed, is an orphan of a killed run."""
+        ttl = self.ttl if older_than is None else older_than
+        try:
+            raw = self._run([self.engine, "ps", "--all", "--filter",
+                             f"label={_LABEL}", "--format",
+                             "{{.ID}}\t{{.CreatedAt}}"], timeout=60.0)
+        except Exception:
+            return 0
+        removed = 0
+        for line in (raw or "").splitlines():
+            cid = line.split("\t")[0].strip()
+            if not cid:
+                continue
+            try:
+                age = self._age(cid)
+                if age is None or age <= ttl:
+                    # An age we cannot read is not evidence of abandonment.
+                    # Leaking a container costs disk; deleting a live one costs
+                    # somebody's run, so the unreadable case declines to act.
+                    continue
+                self._run([self.engine, "rm", "--force", "--volumes", cid],
+                          timeout=60.0)
+                removed += 1
+            except Exception:
+                continue
+        return removed
+
+    def _age(self, container_id: str) -> Optional[float]:
+        """Seconds since we started it, or ``None`` when that cannot be read."""
+        raw = self._run([self.engine, "inspect", "--format",
+                         "{{index .Config.Labels \"agentdescent.started\"}}",
+                         container_id], timeout=30.0)
+        try:
+            return max(0.0, time.time() - float((raw or "").strip().strip('"')))
+        except (TypeError, ValueError):
+            return None

--- a/docs/directory-evolution.md
+++ b/docs/directory-evolution.md
@@ -284,14 +284,25 @@ appropriate for code you would run yourself; it is not a boundary.
 from agentdescent.sandbox import SandboxPool
 from agentdescent.sandbox_container import ContainerProvider
 
-pool = SandboxPool(ContainerProvider("python:3.11-slim", engine="podman"),
-                   max_sandboxes=8)
+pool = SandboxPool(ContainerProvider("python:3.11-slim"), max_sandboxes=8)
 run = code_runner(["python", "main.py"], test_cmd=["pytest", "-q"],
                   sandbox_pool=pool)
 ```
 
-Needs `docker` or `podman` on the machine — no Python dependency, and the core
-still installs with none. Staging is unchanged: the tree is materialised on the
+**Docker or podman, whichever is there.** The engine is detected unless you name
+one (`engine="podman"`); the flags used are the ones both accept, and the test
+suite runs the same isolation assertions against each engine that is installed.
+No Python dependency — the core still installs with none.
+
+!!! warning "macOS and Windows: the workspace must be in a shared path"
+    The engine runs inside a VM there, and it shares only part of the host. The
+    system temporary directory — where a workspace goes by default — is usually
+    outside it, and the container then starts with an empty `/work`, so the first
+    symptom is the candidate failing to open its own files.
+
+    The provider checks for this at acquire time and says so. Stage under your
+    home directory (`workspace_root=`), or add the path to the VM
+    (`colima start --mount <path>:w`, or Docker Desktop's File Sharing). Staging is unchanged: the tree is materialised on the
 host and bind-mounted at `/work`, so `FileTree`, the frozen overlay and fixtures
 all behave exactly as before. Only execution moves.
 

--- a/docs/directory-evolution.md
+++ b/docs/directory-evolution.md
@@ -207,10 +207,10 @@ reflector something concrete to fix.
     a timeout takes its children with it. It still runs **as your user, with
     your network**. Use a container for anything you would not run by hand.
 
-    There is a module called `sandbox.py`, and it does not change that sentence.
-    It manages the *lifetime* of a workspace -- how many exist, who owns one, who
-    cleans up when an owner dies. Isolation strength is a property of the
-    provider, and the only provider shipped today is a local directory.
+    `sandbox.py` manages the *lifetime* of a workspace -- how many exist, who
+    owns one, who cleans up when an owner dies. Isolation strength is a separate
+    axis, and it is a property of the **provider**. For a real boundary, use the
+    container provider below.
 
 Both halves of `frozen` are needed and they do different jobs:
 
@@ -263,6 +263,55 @@ recycled pid cannot keep a dead run's directory alive forever.
     automatically needs the engine to know a rollout's environment, which is
     what `RolloutSpec` is for — until then the fields on a default `evolve()`
     run stay zero rather than being quietly approximate.
+
+## Isolation strength — three levels
+
+Lifetime and isolation are different questions. The pool answers the first for
+every provider; which provider you choose answers the second.
+
+| provider | filesystem | network | privileges | limits |
+|---|---|---|---|---|
+| `WorkspaceProvider` (default) | **the whole host** | **the host's** | your user's | timeout only (POSIX: rlimits) |
+| `ContainerProvider` | the workspace only | off unless asked | no capabilities, not root | memory / CPU, every platform |
+| remote / microVM | — | — | — | not implemented |
+
+**What the default does not stop.** A trimmed environment redirects a *lookup*,
+not a *path*. `HOME` points inside the workspace, so `~/.aws/credentials` misses
+— and `open("/Users/you/.aws/credentials")` does not. The default provider is
+appropriate for code you would run yourself; it is not a boundary.
+
+```python
+from agentdescent.sandbox import SandboxPool
+from agentdescent.sandbox_container import ContainerProvider
+
+pool = SandboxPool(ContainerProvider("python:3.11-slim", engine="podman"),
+                   max_sandboxes=8)
+run = code_runner(["python", "main.py"], test_cmd=["pytest", "-q"],
+                  sandbox_pool=pool)
+```
+
+Needs `docker` or `podman` on the machine — no Python dependency, and the core
+still installs with none. Staging is unchanged: the tree is materialised on the
+host and bind-mounted at `/work`, so `FileTree`, the frozen overlay and fixtures
+all behave exactly as before. Only execution moves.
+
+Defaults are closed and opened one field at a time:
+
+| `SandboxSpec` field | effect |
+|---|---|
+| `network` | `None`/`"none"` → `--network none`. Only `"inherit"` connects it |
+| `memory_mb` / `cpu` | `--memory` / `--cpus`; unset means no flag, not a default ceiling |
+| `env_allowlist` | variable **names**; values are read on the host and passed one at a time. Nothing is inherited in bulk |
+| `image` | overrides the provider's image per rollout |
+
+Always on: read-only root with a writable `/work` and `/tmp`, `--cap-drop ALL`,
+`no-new-privileges`, a pids limit, and the container runs as your uid so the
+files it writes are yours to delete.
+
+!!! warning "Stronger, not absolute"
+    Containers share the host kernel and escapes exist. This is a large step up
+    from a trimmed environment and it is not a licence to run deliberately
+    hostile code. For that you want a VM boundary, which this does not provide.
 
 ## Cost — the first-order design constraint
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -71,6 +71,7 @@ and *how*, that is *what*.
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
 | `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |
 | `defaults` | the shipped algorithm as replaceable pieces: conflict, fusion, acceptance, promotion | [Aggregator](aggregator.md) |
+| `sandbox_container` | the provider that makes a sandbox an actual boundary (needs docker/podman) | [Directory evolution](directory-evolution.md#isolation-strength-three-levels) |
 | `policies` | the contracts: which decisions are replaceable, and what each is given | [Architecture](architecture.md#35-what-the-infrastructure-owns-and-what-the-algorithm-owns) |
 | `metrics` | what the run cost: time, calls, staleness ratio, cache hits, sandbox waits | [Usage](usage.md#what-a-run-cost) |
 

--- a/tests/test_sandbox_container.py
+++ b/tests/test_sandbox_container.py
@@ -13,7 +13,9 @@ the second half's failures obvious rather than to stand in for it.
 """
 
 import os
+import shutil
 import subprocess
+import tempfile
 
 import pytest
 
@@ -23,9 +25,79 @@ from agentdescent.sandbox_container import (
 )
 
 IMAGE = os.environ.get("AGENTDESCENT_TEST_IMAGE", "docker.io/library/python:3.11-slim")
-ENGINE = next((e for e in ("podman", "docker") if engine_available(e)), None)
+
+#: Every engine actually present. The behaviour tests run against each of them
+#: rather than against "whichever was found first": the two CLIs are compatible
+#: in the flags used here, and the only way that claim stays true is if both are
+#: exercised. Machines with neither skip the lot.
+LIVE_ENGINES = [e for e in ("docker", "podman") if engine_available(e)]
+ENGINE = LIVE_ENGINES[0] if LIVE_ENGINES else None
 needs_engine = pytest.mark.skipif(
-    ENGINE is None, reason="no container engine with a live daemon")
+    not LIVE_ENGINES, reason="no container engine with a live daemon")
+every_engine = pytest.mark.parametrize("engine", LIVE_ENGINES or [None])
+
+
+@pytest.fixture
+def shared_root(tmp_path_factory):
+    """A workspace root the engine's VM can actually see.
+
+    On macOS the engine runs in a VM that shares only part of the host, and the
+    system temporary directory -- where `tmp_path` lives -- is usually outside
+    it. Home is shared by every common setup, so the behaviour tests stage there
+    rather than exercising the VM's mount configuration by accident."""
+    root = os.path.join(os.path.expanduser("~"), ".agentdescent-tests")
+    os.makedirs(root, exist_ok=True)
+    d = tempfile.mkdtemp(prefix="ws-", dir=root)
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _neutral_engine_config(tmp_path_factory):
+    """Give the engine CLI a config directory with no credential helper in it.
+
+    Not a workaround for the code under test. A developer machine often carries a
+    `credsStore` for a helper that is not installed -- a removed Docker Desktop
+    leaves one behind -- and the engine then fails to pull *public* images that
+    need no credentials at all. The sandbox has no opinion about registry auth and
+    the tests should not inherit one.
+
+    The endpoint is carried over explicitly, because contexts live inside
+    `DOCKER_CONFIG`: replacing that directory silently loses the daemon along
+    with the credential helper, and the symptom is "cannot connect to the docker
+    API", which points nowhere near the cause.
+    """
+    endpoint = _current_endpoint()
+    cfg = tmp_path_factory.mktemp("engine-config")
+    saved = {k: os.environ.get(k) for k in ("DOCKER_CONFIG", "DOCKER_HOST")}
+    os.environ["DOCKER_CONFIG"] = str(cfg)
+    if endpoint:
+        os.environ["DOCKER_HOST"] = endpoint
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def _current_endpoint():
+    """Where docker is listening right now, asked before the config is swapped."""
+    if "docker" not in LIVE_ENGINES:
+        return None
+    if os.environ.get("DOCKER_HOST"):
+        return os.environ["DOCKER_HOST"]
+    try:
+        out = subprocess.run(
+            ["docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}"],
+            capture_output=True, text=True, timeout=30)
+        return out.stdout.strip() or None
+    except (OSError, subprocess.SubprocessError):
+        return None
 
 
 def provider(**kw):
@@ -65,7 +137,9 @@ def test_a_spec_that_asks_for_nothing_gets_everything_locked_down():
     assert ["--network", "none"] == cmd[cmd.index("--network"):cmd.index("--network") + 2]
     assert "--read-only" in cmd
     assert ["--cap-drop", "ALL"] == cmd[cmd.index("--cap-drop"):cmd.index("--cap-drop") + 2]
-    assert flag_value(cmd, "--security-opt") == "no-new-privileges"
+    # The `:true` form is what docker documents; podman accepts it too, and one
+    # spelling that both take beats branching on the engine.
+    assert flag_value(cmd, "--security-opt") == "no-new-privileges:true"
     assert any(a.startswith("--pids-limit") for a in cmd), "a fork bomb is cheap"
 
 
@@ -220,13 +294,14 @@ def test_the_provider_satisfies_the_protocol_without_extra_methods():
 
 
 @needs_engine
-def test_the_host_home_directory_is_not_visible(tmp_path):
+@every_engine
+def test_the_host_home_directory_is_not_visible(engine, shared_root):
     """The reason this provider exists.
 
     The local provider fails this: `HOME` is redirected but absolute paths are
     not, so candidate code reading `~/.ssh/id_rsa` by full path gets it."""
-    p = ContainerProvider(IMAGE, engine=ENGINE)
-    sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    p = ContainerProvider(IMAGE, engine=engine)
+    sb = p.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         probe = f"import os; print(os.path.exists({os.path.expanduser('~')!r}))"
         out = subprocess.run([*sb.exec_prefix(), "python", "-c", probe],
@@ -239,7 +314,8 @@ def test_the_host_home_directory_is_not_visible(tmp_path):
 
 
 @needs_engine
-def test_the_local_provider_does_not_stop_what_this_one_does(tmp_path):
+@every_engine
+def test_the_local_provider_does_not_stop_what_this_one_does(engine, shared_root):
     """The contrast, run side by side, because it is the whole justification.
 
     `HOME` redirection changes where a *lookup* goes; it does not change what a
@@ -251,7 +327,7 @@ def test_the_local_provider_does_not_stop_what_this_one_does(tmp_path):
     probe = f"import os; print(os.path.exists({home!r}))"
 
     local = WorkspaceProvider()
-    sb = local.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    sb = local.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         env = dict(os.environ, HOME=sb.root, TMPDIR=sb.root)
         out = subprocess.run(["python3", "-c", probe], cwd=sb.root, env=env,
@@ -262,8 +338,8 @@ def test_the_local_provider_does_not_stop_what_this_one_does(tmp_path):
     finally:
         local.release(sb)
 
-    contained = ContainerProvider(IMAGE, engine=ENGINE)
-    csb = contained.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    contained = ContainerProvider(IMAGE, engine=engine)
+    csb = contained.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         out = subprocess.run([*csb.exec_prefix(), "python", "-c", probe],
                              capture_output=True, text=True, timeout=120)
@@ -273,14 +349,15 @@ def test_the_local_provider_does_not_stop_what_this_one_does(tmp_path):
 
 
 @needs_engine
-def test_the_network_is_off_by_default_and_on_when_asked(tmp_path):
-    p = ContainerProvider(IMAGE, engine=ENGINE)
+@every_engine
+def test_the_network_is_off_by_default_and_on_when_asked(engine, shared_root):
+    p = ContainerProvider(IMAGE, engine=engine)
     probe = ("import socket;"
              "socket.setdefaulttimeout(4);"
              "socket.create_connection(('1.1.1.1', 80));"
              "print('connected')")
 
-    closed = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    closed = p.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         out = subprocess.run([*closed.exec_prefix(), "python", "-c", probe],
                      capture_output=True, text=True, timeout=120)
@@ -288,7 +365,7 @@ def test_the_network_is_off_by_default_and_on_when_asked(tmp_path):
     finally:
         p.release(closed)
 
-    opened = p.acquire(SandboxSpec(workspace_root=str(tmp_path), network="inherit"))
+    opened = p.acquire(SandboxSpec(workspace_root=shared_root, network="inherit"))
     try:
         out = subprocess.run([*opened.exec_prefix(), "python", "-c", probe],
                      capture_output=True, text=True, timeout=120)
@@ -299,9 +376,10 @@ def test_the_network_is_off_by_default_and_on_when_asked(tmp_path):
 
 
 @needs_engine
-def test_files_written_inside_belong_to_the_host_user(tmp_path):
-    p = ContainerProvider(IMAGE, engine=ENGINE)
-    sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+@every_engine
+def test_files_written_inside_belong_to_the_host_user(engine, shared_root):
+    p = ContainerProvider(IMAGE, engine=engine)
+    sb = p.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         subprocess.run([*sb.exec_prefix(), "python", "-c",
                 "open('made-inside.txt','w').write('hi')"],
@@ -315,9 +393,10 @@ def test_files_written_inside_belong_to_the_host_user(tmp_path):
 
 
 @needs_engine
-def test_the_root_filesystem_is_read_only(tmp_path):
-    p = ContainerProvider(IMAGE, engine=ENGINE)
-    sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+@every_engine
+def test_the_root_filesystem_is_read_only(engine, shared_root):
+    p = ContainerProvider(IMAGE, engine=engine)
+    sb = p.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         out = subprocess.run([*sb.exec_prefix(), "python", "-c",
                       "open('/etc/passwd','a').write('x')"],
@@ -332,9 +411,10 @@ def test_the_root_filesystem_is_read_only(tmp_path):
 
 
 @needs_engine
-def test_reap_collects_orphans_and_leaves_the_living(tmp_path):
-    p = ContainerProvider(IMAGE, engine=ENGINE, ttl=3600.0)
-    alive = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+@every_engine
+def test_reap_collects_orphans_and_leaves_the_living(engine, shared_root):
+    p = ContainerProvider(IMAGE, engine=engine, ttl=3600.0)
+    alive = p.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         assert p.reap() == 0, "reap removed a container that had just started"
         p.ttl = 0.0                     # everything is now older than the TTL
@@ -349,7 +429,8 @@ def test_reap_collects_orphans_and_leaves_the_living(tmp_path):
 
 
 @needs_engine
-def test_a_rollout_runs_inside_the_container(tmp_path):
+@every_engine
+def test_a_rollout_runs_inside_the_container(engine, shared_root):
     """The whole path: pool -> lease -> stage on the host -> execute inside.
 
     Staging is deliberately still a host operation, so `materialize` and the
@@ -359,8 +440,9 @@ def test_a_rollout_runs_inside_the_container(tmp_path):
     from agentdescent.runners import code_runner
     from agentdescent.sandbox import SandboxPool
 
-    pool = SandboxPool(ContainerProvider(IMAGE, engine=ENGINE), max_sandboxes=2)
-    run = code_runner(["python", "main.py"], sandbox_pool=pool)
+    pool = SandboxPool(ContainerProvider(IMAGE, engine=engine), max_sandboxes=2)
+    run = code_runner(["python", "main.py"], sandbox_pool=pool,
+                      workspace_root=shared_root)
     try:
         tree = canonical({"main.py": "import sys; print(sys.argv[1].upper())"})
         assert run(tree, Task("t", "hello")) == "HELLO"
@@ -369,7 +451,8 @@ def test_a_rollout_runs_inside_the_container(tmp_path):
 
 
 @needs_engine
-def test_a_candidate_cannot_read_the_host_from_inside_a_rollout(tmp_path):
+@every_engine
+def test_a_candidate_cannot_read_the_host_from_inside_a_rollout(engine, shared_root):
     """The same guarantee, reached through the runner rather than the provider --
     because that is the path a real run takes."""
     from agentdescent.evolution import Task
@@ -378,8 +461,9 @@ def test_a_candidate_cannot_read_the_host_from_inside_a_rollout(tmp_path):
     from agentdescent.sandbox import SandboxPool
 
     home = os.path.expanduser("~")
-    pool = SandboxPool(ContainerProvider(IMAGE, engine=ENGINE), max_sandboxes=1)
-    run = code_runner(["python", "main.py"], sandbox_pool=pool)
+    pool = SandboxPool(ContainerProvider(IMAGE, engine=engine), max_sandboxes=1)
+    run = code_runner(["python", "main.py"], sandbox_pool=pool,
+                      workspace_root=shared_root)
     try:
         tree = canonical({"main.py": f"import os; print(os.path.exists({home!r}))"})
         assert run(tree, Task("t", "x")) == "False"
@@ -388,7 +472,8 @@ def test_a_candidate_cannot_read_the_host_from_inside_a_rollout(tmp_path):
 
 
 @needs_engine
-def test_the_frozen_test_gate_still_runs_and_still_gates(tmp_path):
+@every_engine
+def test_the_frozen_test_gate_still_runs_and_still_gates(engine, shared_root):
     """`frozen` is the reason a candidate cannot weaken its own tests, and it has
     to keep working when the tests run in a container."""
     from agentdescent.evolution import Task
@@ -396,13 +481,33 @@ def test_the_frozen_test_gate_still_runs_and_still_gates(tmp_path):
     from agentdescent.runners import TEST_FAILURE_MARKER, code_runner
     from agentdescent.sandbox import SandboxPool
 
-    pool = SandboxPool(ContainerProvider(IMAGE, engine=ENGINE), max_sandboxes=1)
+    pool = SandboxPool(ContainerProvider(IMAGE, engine=engine), max_sandboxes=1)
     run = code_runner(["python", "main.py"], test_cmd=["python", "check.py"],
                       overlay={"check.py": "raise SystemExit(1)"},
-                      sandbox_pool=pool)
+                      sandbox_pool=pool, workspace_root=shared_root)
     try:
         # the candidate ships a permissive check.py; the overlay restores the real one
         tree = canonical({"main.py": "print('x')", "check.py": "raise SystemExit(0)"})
         assert run(tree, Task("t", "x")).startswith(TEST_FAILURE_MARKER)
     finally:
         pool.close(strict=True)
+
+
+@needs_engine
+@every_engine
+def test_an_unmounted_workspace_says_so_instead_of_looking_like_a_missing_file(
+        engine, tmp_path):
+    """The macOS trap, as a test.
+
+    A workspace the VM cannot see produces an empty `/work`, so the first
+    symptom is the candidate failing to open its own files -- which reads as the
+    candidate's bug. Only reproducible where the engine is in a VM, so it accepts
+    either outcome and asserts the *message* when it does fail."""
+    p = ContainerProvider(IMAGE, engine=engine)
+    try:
+        sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    except Exception as e:
+        assert "did not appear inside the container" in str(e)
+        assert "workspace_root" in str(e), "the error must say what to do"
+        return
+    p.release(sb)          # this host shares the whole filesystem; nothing to test

--- a/tests/test_sandbox_container.py
+++ b/tests/test_sandbox_container.py
@@ -1,0 +1,408 @@
+"""A container sandbox is mostly its command line, so that is what is asserted.
+
+Two halves, deliberately separated:
+
+* **construction** -- which flags, which defaults, which spec field maps where.
+  This is nearly all of the logic and it needs no container engine, so it runs
+  everywhere and it runs exhaustively.
+* **behaviour** -- does the candidate actually lose sight of the host. That needs
+  a real engine and is skipped without one.
+
+Only the second half can prove isolation, so the first half is written to make
+the second half's failures obvious rather than to stand in for it.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from agentdescent.policies import SandboxSpec
+from agentdescent.sandbox_container import (
+    CONTAINER_WORKDIR, ContainerProvider, ContainerSandbox, engine_available,
+)
+
+IMAGE = os.environ.get("AGENTDESCENT_TEST_IMAGE", "docker.io/library/python:3.11-slim")
+ENGINE = next((e for e in ("podman", "docker") if engine_available(e)), None)
+needs_engine = pytest.mark.skipif(
+    ENGINE is None, reason="no container engine with a live daemon")
+
+
+def provider(**kw):
+    """A provider whose commands are captured instead of run."""
+    seen = []
+
+    def runner(cmd, timeout=None):
+        seen.append(list(cmd))
+        return "deadbeef"
+
+    p = ContainerProvider(IMAGE, runner=runner, **kw)
+    p.seen = seen                       # type: ignore[attr-defined]
+    return p
+
+
+def command_for(spec=None, **kw):
+    p = provider(**kw)
+    return p.run_command(spec or SandboxSpec(), "/host/ws", "lease-1")
+
+
+def flag_value(cmd, flag):
+    return cmd[cmd.index(flag) + 1] if flag in cmd else None
+
+
+# ---------------------------------------------------------------------------
+# Defaults are closed
+# ---------------------------------------------------------------------------
+
+
+def test_a_spec_that_asks_for_nothing_gets_everything_locked_down():
+    """Closed by default and opened per field, not the other way round.
+
+    A spec is written by whoever is evolving something, and the failure mode of
+    an open default is silent: the candidate gets network or capabilities and
+    nothing in the run says so."""
+    cmd = command_for()
+    assert ["--network", "none"] == cmd[cmd.index("--network"):cmd.index("--network") + 2]
+    assert "--read-only" in cmd
+    assert ["--cap-drop", "ALL"] == cmd[cmd.index("--cap-drop"):cmd.index("--cap-drop") + 2]
+    assert flag_value(cmd, "--security-opt") == "no-new-privileges"
+    assert any(a.startswith("--pids-limit") for a in cmd), "a fork bomb is cheap"
+
+
+def test_the_workspace_is_bind_mounted_and_is_the_working_directory():
+    """Staging still happens on the host, so `materialize` and the frozen-file
+    overlay need no changes at all -- the container is where work *runs*, not
+    where it is laid out."""
+    cmd = command_for()
+    assert flag_value(cmd, "--volume") == f"/host/ws:{CONTAINER_WORKDIR}:rw"
+    assert flag_value(cmd, "--workdir") == CONTAINER_WORKDIR
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uid/gid are POSIX")
+def test_it_runs_as_the_host_user():
+    """Root inside the container writes root-owned files into the bind mount,
+    and then the host cannot even delete its own workspace."""
+    assert flag_value(command_for(), "--user") == f"{os.getuid()}:{os.getgid()}"
+
+
+def test_the_lease_is_a_label_so_orphans_can_be_found_later():
+    cmd = command_for()
+    assert "agentdescent.lease=lease-1" in cmd
+    p = provider()
+    p.reap()
+    ps = next(c for c in p.seen if "ps" in c)
+    assert any("label=agentdescent.lease" in a for a in ps), (
+        "reap must look for the same label acquire writes")
+
+
+# ---------------------------------------------------------------------------
+# Each field opens exactly one thing
+# ---------------------------------------------------------------------------
+
+
+def test_network_is_off_until_the_spec_says_inherit():
+    assert "--network" in command_for(SandboxSpec(network="none"))
+    cmd = command_for(SandboxSpec(network="inherit"))
+    assert "--network" not in cmd, "only `inherit` may connect the container"
+
+
+def test_limits_appear_only_when_asked_for():
+    """An unset field must produce no flag, not a default value: a default
+    memory ceiling nobody chose is a run that dies for a reason nobody wrote."""
+    bare = command_for()
+    assert "--memory" not in bare and "--cpus" not in bare
+
+    cmd = command_for(SandboxSpec(memory_mb=512, cpu=1.5))
+    assert flag_value(cmd, "--memory") == "512m"
+    assert flag_value(cmd, "--cpus") == "1.5"
+
+
+def test_the_image_can_be_overridden_per_spec():
+    assert command_for()[-3] == IMAGE
+    assert command_for(SandboxSpec(image="alpine:3.19"))[-3] == "alpine:3.19"
+
+
+# ---------------------------------------------------------------------------
+# Secrets
+# ---------------------------------------------------------------------------
+
+
+def test_only_allowlisted_variables_cross(monkeypatch):
+    monkeypatch.setenv("AD_ALLOWED", "yes")
+    monkeypatch.setenv("AD_SECRET", "sk-do-not-copy-me")
+    cmd = command_for(SandboxSpec(env_allowlist=("AD_ALLOWED",)))
+    assert "AD_ALLOWED=yes" in cmd
+    joined = " ".join(cmd)
+    assert "AD_SECRET" not in joined and "sk-do-not-copy-me" not in joined
+
+
+def test_nothing_bulk_is_used_to_pass_the_environment(monkeypatch):
+    """`--env-file`, or `--env NAME` without a value, would let a variable arrive
+    without anyone having named it. The allowlist is only an allowlist if it is
+    the sole route in."""
+    monkeypatch.setenv("AD_SECRET", "sk-nope")
+    cmd = command_for(SandboxSpec(env_allowlist=("AD_SECRET",)))
+    assert "--env-file" not in cmd
+    for i, arg in enumerate(cmd):
+        if arg == "--env":
+            assert "=" in cmd[i + 1], "a valueless --env copies from the host"
+
+
+def test_an_allowlisted_variable_the_host_does_not_have_is_skipped(monkeypatch):
+    monkeypatch.delenv("AD_MISSING", raising=False)
+    cmd = command_for(SandboxSpec(env_allowlist=("AD_MISSING",)))
+    assert not any(a.startswith("AD_MISSING") for a in cmd)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_start_does_not_leave_a_workspace_behind(tmp_path):
+    def boom(cmd, timeout=None):
+        raise RuntimeError("no such image")
+
+    p = ContainerProvider(IMAGE, runner=boom)
+    before = set(os.listdir(tmp_path))
+    with pytest.raises(RuntimeError):
+        p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    assert set(os.listdir(tmp_path)) == before, "a failed acquire kept its directory"
+
+
+def test_release_never_raises(tmp_path):
+    """It runs from a `finally`, often on a path that is already failing. An
+    exception here replaces the real error with a cleanup error."""
+    def boom(cmd, timeout=None):
+        raise RuntimeError("engine went away")
+
+    p = ContainerProvider(IMAGE, runner=boom)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    p.release(ContainerSandbox(id="s", root=str(ws), fingerprint="f",
+                               lease_id="l", container_id="c"))
+    assert not ws.exists(), "the workspace survived a failing release"
+
+
+def test_the_exec_prefix_lands_in_the_container_with_a_usable_environment():
+    """`HOME` and `TMPDIR` are set to paths that exist *inside* the container.
+
+    Inheriting the host's would name a directory that is not mounted -- and the
+    host's own values are needed by the engine CLI in the prefix, which runs
+    outside. The two environments are not the same environment."""
+    sb = ContainerSandbox(id="s", root="/host/ws", fingerprint="f", lease_id="l",
+                          container_id="abc123", engine="podman")
+    prefix = sb.exec_prefix()
+    assert prefix[:4] == ["podman", "exec", "-w", CONTAINER_WORKDIR]
+    assert prefix[-1] == "abc123"
+    assert f"HOME={CONTAINER_WORKDIR}" in prefix and "TMPDIR=/tmp" in prefix
+
+
+def test_a_timeout_kills_the_container_not_the_exec():
+    """Killing an `exec` leaves the process running inside. The container is
+    per-lease and disposable, so killing it is both simpler and complete."""
+    p = provider()
+    p.kill(ContainerSandbox(id="s", root="/w", fingerprint="f", lease_id="l",
+                            container_id="abc123"))
+    assert ["docker", "kill", "abc123"] in p.seen
+
+
+def test_the_provider_satisfies_the_protocol_without_extra_methods():
+    """The check on #60's contract. A second implementation needing a fourth
+    method would mean the protocol was shaped around its only user."""
+    from agentdescent.policies import SandboxProvider
+    assert isinstance(ContainerProvider(IMAGE, runner=lambda c, timeout=None: "x"), SandboxProvider)
+
+
+# ---------------------------------------------------------------------------
+# Behaviour -- only a real engine can answer these
+# ---------------------------------------------------------------------------
+
+
+@needs_engine
+def test_the_host_home_directory_is_not_visible(tmp_path):
+    """The reason this provider exists.
+
+    The local provider fails this: `HOME` is redirected but absolute paths are
+    not, so candidate code reading `~/.ssh/id_rsa` by full path gets it."""
+    p = ContainerProvider(IMAGE, engine=ENGINE)
+    sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        probe = f"import os; print(os.path.exists({os.path.expanduser('~')!r}))"
+        out = subprocess.run([*sb.exec_prefix(), "python", "-c", probe],
+                             capture_output=True, text=True, timeout=120)
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() == "False", (
+            "the host home directory was visible inside the container")
+    finally:
+        p.release(sb)
+
+
+@needs_engine
+def test_the_local_provider_does_not_stop_what_this_one_does(tmp_path):
+    """The contrast, run side by side, because it is the whole justification.
+
+    `HOME` redirection changes where a *lookup* goes; it does not change what a
+    *path* reaches. Candidate code that names the host's home directory outright
+    gets it under the local provider and does not under this one."""
+    from agentdescent.sandbox import WorkspaceProvider
+
+    home = os.path.expanduser("~")
+    probe = f"import os; print(os.path.exists({home!r}))"
+
+    local = WorkspaceProvider()
+    sb = local.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        env = dict(os.environ, HOME=sb.root, TMPDIR=sb.root)
+        out = subprocess.run(["python3", "-c", probe], cwd=sb.root, env=env,
+                             capture_output=True, text=True, timeout=60)
+        assert out.stdout.strip() == "True", (
+            "the premise has changed: the local workspace now hides the host "
+            "home directory, and this provider needs a new justification")
+    finally:
+        local.release(sb)
+
+    contained = ContainerProvider(IMAGE, engine=ENGINE)
+    csb = contained.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        out = subprocess.run([*csb.exec_prefix(), "python", "-c", probe],
+                             capture_output=True, text=True, timeout=120)
+        assert out.stdout.strip() == "False"
+    finally:
+        contained.release(csb)
+
+
+@needs_engine
+def test_the_network_is_off_by_default_and_on_when_asked(tmp_path):
+    p = ContainerProvider(IMAGE, engine=ENGINE)
+    probe = ("import socket;"
+             "socket.setdefaulttimeout(4);"
+             "socket.create_connection(('1.1.1.1', 80));"
+             "print('connected')")
+
+    closed = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        out = subprocess.run([*closed.exec_prefix(), "python", "-c", probe],
+                     capture_output=True, text=True, timeout=120)
+        assert out.returncode != 0, "the default sandbox reached the network"
+    finally:
+        p.release(closed)
+
+    opened = p.acquire(SandboxSpec(workspace_root=str(tmp_path), network="inherit"))
+    try:
+        out = subprocess.run([*opened.exec_prefix(), "python", "-c", probe],
+                     capture_output=True, text=True, timeout=120)
+        assert "connected" in out.stdout, (
+            f"network=inherit did not connect: {out.stderr[-300:]}")
+    finally:
+        p.release(opened)
+
+
+@needs_engine
+def test_files_written_inside_belong_to_the_host_user(tmp_path):
+    p = ContainerProvider(IMAGE, engine=ENGINE)
+    sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        subprocess.run([*sb.exec_prefix(), "python", "-c",
+                "open('made-inside.txt','w').write('hi')"],
+               capture_output=True, text=True, timeout=120, check=True)
+        made = os.path.join(sb.root, "made-inside.txt")
+        assert os.path.exists(made), "the bind mount did not reach the host"
+        assert os.stat(made).st_uid == os.getuid(), (
+            "a root-owned file the host cannot delete")
+    finally:
+        p.release(sb)
+
+
+@needs_engine
+def test_the_root_filesystem_is_read_only(tmp_path):
+    p = ContainerProvider(IMAGE, engine=ENGINE)
+    sb = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        out = subprocess.run([*sb.exec_prefix(), "python", "-c",
+                      "open('/etc/passwd','a').write('x')"],
+                     capture_output=True, text=True, timeout=120)
+        assert out.returncode != 0, "the container root was writable"
+        out = subprocess.run([*sb.exec_prefix(), "python", "-c",
+                      "open('/tmp/ok','w').write('x'); print('wrote')"],
+                     capture_output=True, text=True, timeout=120)
+        assert "wrote" in out.stdout, "/tmp must stay writable for real toolchains"
+    finally:
+        p.release(sb)
+
+
+@needs_engine
+def test_reap_collects_orphans_and_leaves_the_living(tmp_path):
+    p = ContainerProvider(IMAGE, engine=ENGINE, ttl=3600.0)
+    alive = p.acquire(SandboxSpec(workspace_root=str(tmp_path)))
+    try:
+        assert p.reap() == 0, "reap removed a container that had just started"
+        p.ttl = 0.0                     # everything is now older than the TTL
+        assert p.reap() >= 1
+    finally:
+        p.release(alive)
+
+
+# ---------------------------------------------------------------------------
+# End to end: a real rollout, inside a container
+# ---------------------------------------------------------------------------
+
+
+@needs_engine
+def test_a_rollout_runs_inside_the_container(tmp_path):
+    """The whole path: pool -> lease -> stage on the host -> execute inside.
+
+    Staging is deliberately still a host operation, so `materialize` and the
+    frozen-file overlay are untouched; only execution moves."""
+    from agentdescent.evolution import Task
+    from agentdescent.filetree import canonical
+    from agentdescent.runners import code_runner
+    from agentdescent.sandbox import SandboxPool
+
+    pool = SandboxPool(ContainerProvider(IMAGE, engine=ENGINE), max_sandboxes=2)
+    run = code_runner(["python", "main.py"], sandbox_pool=pool)
+    try:
+        tree = canonical({"main.py": "import sys; print(sys.argv[1].upper())"})
+        assert run(tree, Task("t", "hello")) == "HELLO"
+    finally:
+        pool.close(strict=True)
+
+
+@needs_engine
+def test_a_candidate_cannot_read_the_host_from_inside_a_rollout(tmp_path):
+    """The same guarantee, reached through the runner rather than the provider --
+    because that is the path a real run takes."""
+    from agentdescent.evolution import Task
+    from agentdescent.filetree import canonical
+    from agentdescent.runners import code_runner
+    from agentdescent.sandbox import SandboxPool
+
+    home = os.path.expanduser("~")
+    pool = SandboxPool(ContainerProvider(IMAGE, engine=ENGINE), max_sandboxes=1)
+    run = code_runner(["python", "main.py"], sandbox_pool=pool)
+    try:
+        tree = canonical({"main.py": f"import os; print(os.path.exists({home!r}))"})
+        assert run(tree, Task("t", "x")) == "False"
+    finally:
+        pool.close(strict=True)
+
+
+@needs_engine
+def test_the_frozen_test_gate_still_runs_and_still_gates(tmp_path):
+    """`frozen` is the reason a candidate cannot weaken its own tests, and it has
+    to keep working when the tests run in a container."""
+    from agentdescent.evolution import Task
+    from agentdescent.filetree import canonical
+    from agentdescent.runners import TEST_FAILURE_MARKER, code_runner
+    from agentdescent.sandbox import SandboxPool
+
+    pool = SandboxPool(ContainerProvider(IMAGE, engine=ENGINE), max_sandboxes=1)
+    run = code_runner(["python", "main.py"], test_cmd=["python", "check.py"],
+                      overlay={"check.py": "raise SystemExit(1)"},
+                      sandbox_pool=pool)
+    try:
+        # the candidate ships a permissive check.py; the overlay restores the real one
+        tree = canonical({"main.py": "print('x')", "check.py": "raise SystemExit(0)"})
+        assert run(tree, Task("t", "x")).startswith(TEST_FAILURE_MARKER)
+    finally:
+        pool.close(strict=True)


### PR DESCRIPTION
Closes #66. Inserted ahead of #56, because it does not depend on cross-machine work and it closes the one real security gap.

## The gap

`sandbox.py` (#60) manages *lifetime*. It does not manage isolation, and its only provider does not provide any: `HOME` and `TMPDIR` point inside the workspace, which redirects a **lookup** but not a **path**. Candidate code that opens `/Users/you/.ssh/id_rsa` by full path gets it, and with the host's network can post it anywhere.

A test runs the same probe under both providers, side by side:

```python
probe = "import os; print(os.path.exists('/Users/you'))"
# WorkspaceProvider  -> True     <- the gap
# ContainerProvider  -> False
```

That contrast is the entire justification for this PR, so it is asserted rather than described — and it fails loudly if the premise ever changes.

## What it is

`ContainerProvider` implements the same three methods as `WorkspaceProvider` and **no more**, which is the check on whether #60's protocol was shaped around its only user. It was not: nothing in `policies.py` changed to accommodate a second implementation.

Staging stays on the host and is bind-mounted at `/work`, so `materialize`, the frozen-file overlay and fixtures are untouched. Only execution moves.

Defaults are closed and opened one field at a time: no network, read-only root with writable `/work` and `/tmp`, `--cap-drop ALL`, `no-new-privileges`, a pids limit, and the host's uid so files written into the mount are the host's to delete. Memory and CPU ceilings work on every platform here, unlike `setrlimit`.

CLI rather than a Python SDK: the core keeps `dependencies = []`, and the same code drives both engines.

## Verified, not asserted

Every isolation test is parametrised over **each engine installed**, and on the machine this was written on that is **docker 29.5.2 (colima) and podman 6.0.2** — the assertions below each ran twice:

- the host's home directory is invisible inside, and visible under the local provider;
- the network is off by default and on with `network="inherit"`;
- files written inside belong to the host user, not root;
- the container root is read-only while `/tmp` stays writable;
- `reap` collects orphans by label and leaves the living;
- an end-to-end rollout — pool → lease → stage on the host → execute inside — including the frozen-test gate still gating.

A machine with neither engine skips those and runs the rest; the full suite passes there unchanged.

## Five things only a real engine found

1. **The injected runner took `(cmd)` while every call site passed a timeout.** The `TypeError` was swallowed by the `except Exception` that keeps cleanup from raising, so `kill` and `reap` issued no command at all and looked fine.
2. **`SandboxSpec.network` defaulted to `"inherit"`** — honest for a local workspace, the opposite of safe for a container. Now tri-state: `None` means the provider decides, and this one decides no.
3. **`engine_available` probed with `{{.Host.Arch}}`**, which is podman's structure. Docker renders it empty, so a docker-only machine reported "no engine available" and could not use this at all. Now probes with no template.
4. **The exec prefix runs on the host; the command runs in the container** — opposite environment needs. Handing the engine CLI a `HOME` inside the workspace made podman look for its socket in a directory about to be deleted.
5. **Container age from the engine's timestamp is unparseable across engines** — docker reports RFC3339, podman reports Go's default layout. Age now comes from a label we write. An age that cannot be read declines to act: leaking a container costs disk, deleting a live one costs somebody's run.

## A macOS trap, turned into a message

On macOS and Windows the engine runs in a VM sharing only part of the host, and the system temp directory — where a workspace goes by default — is usually outside it. The container starts, `/work` is empty, and the first symptom is the candidate failing to open its own files, which reads as the candidate's bug.

`acquire` writes a probe file and checks for it from the inside, failing with what to do instead.

## Not claimed

Containers share the host kernel and escapes exist. The docs say this is a large step up from a trimmed environment and **not** a licence to run deliberately hostile code — and that a module named `sandbox.py` was never what made the default path safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
