### PR TITLE
fix: do not force a uid under a rootless container engine

### DIFF
--- a/agentdescent/sandbox_container.py
+++ b/agentdescent/sandbox_container.py
@@ -161,6 +161,7 @@ class ContainerProvider:
 
     def __init__(self, image: str, *, engine: Optional[str] = None,
                  ttl: float = 300.0, pids_limit: int = 512,
+                 rootless: Optional[bool] = None,
                  runner: Optional[Callable[..., str]] = None) -> None:
         if not image:
             raise ValueError("a container sandbox needs an image to run")
@@ -180,8 +181,36 @@ class ContainerProvider:
         self.engine = engine or "docker"
         self.ttl = ttl
         self.pids_limit = pids_limit
+        self._rootless = rootless
         self._run = runner or _run
         self._n = 0
+
+    def is_rootless(self) -> bool:
+        """Does this engine map the host user to root inside the container?
+
+        Asked once and remembered. Both engines answer `info --format json`;
+        their keys differ, so both are checked rather than guessing from the
+        engine's name -- docker has a rootless mode too.
+        """
+        if self._rootless is None:
+            self._rootless = self._detect_rootless()
+        return self._rootless
+
+    def _detect_rootless(self) -> bool:
+        try:
+            raw = self._run([self.engine, "info", "--format", "json"], timeout=30.0)
+            info = json.loads(raw)
+        except Exception:
+            # Unknown means "do not add --user": omitting it is correct under a
+            # rootless engine and merely means root-owned files under a rootful
+            # one, which is recoverable. The other way round the mount is
+            # unreadable and the run cannot proceed at all.
+            return True
+        security = (info.get("host") or {}).get("security") or {}
+        if "rootless" in security:                      # podman
+            return bool(security["rootless"])
+        options = info.get("SecurityOptions") or []     # docker
+        return any("rootless" in str(o) for o in options)
 
     # -- command construction -------------------------------------------------
 
@@ -218,8 +247,15 @@ class ContainerProvider:
             cmd += ["--network", "none"]
 
         # Run as the host user, so files written into the bind mount belong to
-        # whoever started the run. As root, the host cannot even delete them.
-        if os.name != "nt":
+        # whoever started the run -- as root, the host cannot even delete them.
+        #
+        # Only when the engine is rootful. A rootless engine already maps the
+        # host user to root *inside* the container, so naming a uid there maps it
+        # to a subuid instead, and a subuid has no access to files owned by the
+        # host user: the bind mount reads as empty. It looks exactly like a mount
+        # that did not happen, which is how this survived local testing on macOS,
+        # where the VM's mount layer rewrites ownership anyway.
+        if os.name != "nt" and not self.is_rootless():
             cmd += ["--user", f"{os.getuid()}:{os.getgid()}"]
 
         if spec.memory_mb:
@@ -275,13 +311,33 @@ class ContainerProvider:
         the first symptom is the candidate's own `FileNotFoundError`, blamed on
         the candidate.
         """
+        detail = ""
         try:
             self._run([self.engine, "exec", container_id,
-                       "test", "-f", f"{CONTAINER_WORKDIR}/.agentdescent-mount"],
+                       "cat", f"{CONTAINER_WORKDIR}/.agentdescent-mount"],
                       timeout=30.0)
             return
+        except Exception as e:
+            detail = str(e)[:300]
+        # Distinguish "nothing is mounted" from "mounted but unreadable": the
+        # second is a uid mapping problem and points somewhere completely
+        # different from the first.
+        try:
+            listing = self._run([self.engine, "exec", container_id,
+                                 "ls", "-a", CONTAINER_WORKDIR], timeout=30.0)
         except Exception:
-            pass
+            listing = ""
+        if ".agentdescent-mount" in listing:
+            try:
+                self._run([self.engine, "rm", "--force", container_id], timeout=60.0)
+            except Exception:
+                pass
+            raise EngineError(
+                f"the workspace {ws} is mounted but unreadable from inside the "
+                f"container ({detail}). This is a uid mapping problem: a rootless "
+                "engine maps your user to root inside, so forcing a uid maps it "
+                "to a subuid with no access to your files. Leave `--user` off "
+                "under a rootless engine.")
         try:
             self._run([self.engine, "rm", "--force", container_id], timeout=60.0)
         except Exception:

--- a/tests/test_sandbox_container.py
+++ b/tests/test_sandbox_container.py
@@ -114,6 +114,7 @@ def provider(**kw):
 
 
 def command_for(spec=None, **kw):
+    kw.setdefault("rootless", False)      # command construction, not this machine
     p = provider(**kw)
     return p.run_command(spec or SandboxSpec(), "/host/ws", "lease-1")
 
@@ -153,10 +154,21 @@ def test_the_workspace_is_bind_mounted_and_is_the_working_directory():
 
 
 @pytest.mark.skipif(os.name == "nt", reason="uid/gid are POSIX")
-def test_it_runs_as_the_host_user():
+def test_a_rootful_engine_runs_as_the_host_user():
     """Root inside the container writes root-owned files into the bind mount,
     and then the host cannot even delete its own workspace."""
     assert flag_value(command_for(), "--user") == f"{os.getuid()}:{os.getgid()}"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="uid/gid are POSIX")
+def test_a_rootless_engine_gets_no_user_flag():
+    """It already maps the host user to root inside. Naming a uid there maps it
+    to a *subuid*, which cannot read files owned by the host user -- so the bind
+    mount reads as empty, indistinguishable from a mount that never happened.
+
+    Found on CI: every podman case failed and every docker case passed, because
+    the runner's podman is rootless and its docker is not."""
+    assert "--user" not in command_for(rootless=True)
 
 
 def test_the_lease_is_a_label_so_orphans_can_be_found_later():


### PR DESCRIPTION
Fixes the CI failure introduced by #67.

## The diagnosis was in the failure list

Every `[podman]` case failed; every `[docker]` case passed. The GitHub runner's podman is **rootless** and its docker is not.

A rootless engine already maps the host user to root *inside* the container. Naming a uid there (`--user 1001:1001`) maps it to a **subuid**, which has no access to files owned by the host user — so the bind-mounted workspace reads as empty.

That is indistinguishable from a mount that never happened, so the code reported the macOS mount-sharing message and pointed nowhere near the cause.

## The fix

`--user` is added only when the engine is rootful, detected once from `info --format json`. Both engines are inspected rather than inferred from the engine's name — docker has a rootless mode too.

When detection itself fails, the flag is **omitted**. The two mistakes are not symmetric: omitting it under a rootful engine means root-owned files, which is annoying and recoverable; adding it under a rootless one makes the workspace unreadable and the run cannot proceed at all.

The mount check now separates the two conditions it had conflated — "nothing is mounted" and "mounted but unreadable" have entirely different fixes, so it lists the directory before deciding which to report.

## Why local testing missed it

Podman is rootless on my machine too. But on macOS the containers run inside a VM whose mount layer rewrites ownership, so the uid mismatch never bit. Catching it needed a **native Linux rootless engine** — which is exactly what CI is, and is a better reason to keep those tests unskipped than any amount of local confidence.

## Verification

36 container tests pass locally against docker 29.5.2 and podman 6.0.2, including the two new construction assertions (`--user` present when rootful, absent when rootless). CI is the real check for the rootless path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)