### PR TITLE
feat: describe a rollout as data, and give it somewhere else to run

### DIFF
--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -81,7 +81,10 @@ from .policies import (
     SandboxSpec,
     VerifierProtocol,
 )
+from .executor import Executor, Result, ThreadExecutor
 from .sandbox import LocalWorkspaceSandbox, SandboxPool, WorkspaceProvider
+from .supervisor import ProcessExecutor
+from .workspec import Ref, RefError, RolloutSpec
 from . import rewards                      # agentdescent.rewards.last_number(...)
 from .skill import evolve_skill
 from .filetree import (
@@ -223,6 +226,13 @@ __all__ = [
     "LedgerProtocol",
     "SandboxSpec",
     "SandboxPool",
+    "Executor",
+    "ThreadExecutor",
+    "ProcessExecutor",
+    "Result",
+    "Ref",
+    "RefError",
+    "RolloutSpec",
     "WorkspaceProvider",
     "LocalWorkspaceSandbox",
     "SandboxProvider",

--- a/agentdescent/executor.py
+++ b/agentdescent/executor.py
@@ -1,0 +1,167 @@
+"""Where rollouts run, as a replaceable thing.
+
+Today's answer is threads, and for the workload that is measured to be the right
+one: a rollout is almost entirely waiting on a model, and `docs/efficiency.md`
+records **7.1x** on I/O against **1.0x** on CPU for eight of them. Nothing here
+is an attempt to make rollouts faster by using processes.
+
+What processes buy is different and not available any other way:
+
+* **fault isolation** -- the code being evolved is model-authored, so a segfault,
+  an OOM or a runaway allocation is an ordinary Tuesday, and in a thread each of
+  those takes the run with it;
+* **capacity beyond one machine**, later;
+* **heterogeneous workers**, later still.
+
+**Not `ProcessPoolExecutor`.** Four reasons, and the first is disqualifying:
+
+1. one worker dying abruptly breaks the whole pool (`BrokenProcessPool`) and
+   every in-flight task with it. Fault isolation implemented on top of something
+   that fails as a unit is not fault isolation;
+2. `max_tasks_per_child` arrived in 3.11 and this package supports 3.9, so a
+   worker that leaks cannot be recycled;
+3. it has no notion of a sandbox, and no place to say "this task needs an
+   environment with fingerprint X, wait for one";
+4. its default start method is `fork` on Linux, and this engine is threaded. A
+   `fork` from a process holding locks in other threads produces a child holding
+   locks that will never be released.
+
+So: persistent workers, a bounded task queue, and a supervisor that decides on
+its own when a worker is gone. About three hundred lines, all standard library.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator, List, Optional, Protocol, Sequence, runtime_checkable
+
+from .metrics import Meter
+from .workspec import RolloutSpec
+
+__all__ = ["Executor", "Result", "ThreadExecutor"]
+
+
+@dataclass
+class Result:
+    """What one rollout produced, or why it did not.
+
+    ``error`` and ``output`` are both present because a rollout that failed still
+    identifies itself: the caller has to know *which* task to re-dispatch, and a
+    bare exception does not say."""
+
+    lease_id: str
+    task_id: str
+    output: Optional[str] = None
+    reward: Optional[float] = None
+    error: Optional[str] = None
+    #: How the failure should be counted. Infrastructure failures must not feed
+    #: the worker-retirement rule, which fires hardest before any worker has
+    #: succeeded -- exactly when sandboxes fail to start.
+    kind: str = "ok"          # "ok" | "model" | "infrastructure" | "caller"
+    seconds: float = 0.0
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Runs rollouts somewhere. Threads here, processes and hosts later."""
+
+    def map_rollouts(self, specs: Sequence[RolloutSpec]) -> Iterator[Result]: ...
+
+    def shutdown(self, grace: float = 5.0) -> None: ...
+
+
+class ThreadExecutor:
+    """The default: a bounded pool of threads in this process.
+
+    Deliberately the same shape as the process one, so that swapping them is a
+    change of executor rather than a change of engine. It accepts specs whose
+    `Ref`s resolve *or* closures already bound into them, because in-process
+    there is no boundary for a closure to fail to cross.
+    """
+
+    def __init__(self, max_workers: int = 4, *, meter: Optional[Meter] = None,
+                 sandbox_pool: Optional[Any] = None,
+                 run: Optional[Callable[[str, Any], str]] = None,
+                 reward: Optional[Callable[[Any, str], float]] = None) -> None:
+        if max_workers < 1:
+            raise ValueError(f"max_workers must be >= 1, got {max_workers}")
+        self.max_workers = max_workers
+        self.meter = meter
+        self.sandbox_pool = sandbox_pool
+        # In-process, the actors can be handed over directly. A spec still
+        # carries `Ref`s so the same spec works across a boundary, but resolving
+        # them here would rebuild a model client per rollout.
+        self._run = run
+        self._reward = reward
+        self._closed = False
+
+    # -- the work -------------------------------------------------------------
+
+    def _one(self, spec: RolloutSpec) -> Result:
+        t0 = time.time()
+        try:
+            run = self._run or spec.run.resolve()
+            reward = self._reward or spec.reward.resolve()
+        except Exception as e:                        # a Ref that will not resolve
+            return Result(spec.lease_id, spec.task.id, error=f"{type(e).__name__}: {e}",
+                          kind="caller", seconds=time.time() - t0)
+        try:
+            if self.sandbox_pool is not None:
+                with self.sandbox_pool.lease(spec.sandbox):
+                    output = run(spec.rendered, spec.task)
+            else:
+                output = run(spec.rendered, spec.task)
+            value = reward(spec.task, output)
+        except Exception as e:  # noqa: BLE001 -- a backend or candidate failure
+            return Result(spec.lease_id, spec.task.id,
+                          error=f"{type(e).__name__}: {str(e)[:200]}",
+                          kind="model", seconds=time.time() - t0)
+        seconds = time.time() - t0
+        if self.meter is not None:
+            self.meter.add("rollouts")
+            self.meter.add("rollout_seconds", seconds)
+        return Result(spec.lease_id, spec.task.id, output=output, reward=value,
+                      seconds=seconds)
+
+    def map_rollouts(self, specs: Sequence[RolloutSpec]) -> Iterator[Result]:
+        """Run every spec, yielding results **as they finish**.
+
+        Not in order: a caller that waits for the first spec before looking at the
+        second has serialised itself, and the long tail of rollout durations is
+        exactly what makes that expensive."""
+        if self._closed:
+            raise RuntimeError("executor is shut down")
+        specs = list(specs)
+        if not specs:
+            return
+        done: "queue.Queue[Result]" = queue.Queue()
+        gate = threading.Semaphore(min(self.max_workers, len(specs)))
+
+        def work(spec: RolloutSpec) -> None:
+            with gate:
+                done.put(self._one(spec))
+
+        threads = [threading.Thread(target=work, args=(s,), daemon=True)
+                   for s in specs]
+        for t in threads:
+            t.start()
+        for _ in specs:
+            yield done.get()
+
+    def shutdown(self, grace: float = 5.0) -> None:
+        """Release anything still held. Idempotent.
+
+        The threads are daemons and cannot be cancelled, so this does not wait for
+        them: what it must do is make sure no sandbox is still leased, because
+        those are bounded and an abandoned one is a slot nobody can use."""
+        self._closed = True
+        if self.sandbox_pool is not None:
+            self.sandbox_pool.close()

--- a/agentdescent/supervisor.py
+++ b/agentdescent/supervisor.py
@@ -1,0 +1,381 @@
+"""Rollouts in other processes, supervised by this one.
+
+The code being evolved is written by a model, so the interesting failures are not
+exceptions. They are a worker that segfaults, gets OOM-killed, or stops answering
+while holding a sandbox. A pool that treats those as "the pool is broken" -- which
+`ProcessPoolExecutor` does -- turns one bad candidate into a dead run, which is
+the opposite of why anyone reaches for processes.
+
+So this is not a pool. It is a set of long-lived workers with a supervisor that
+decides, on its own, when one of them is gone.
+
+Four decisions worth stating, because each replaced something that looked
+reasonable:
+
+**`spawn`, never `fork`.** The engine is threaded. A `fork` from a process whose
+other threads hold locks produces a child holding locks that nothing will ever
+release, and the symptom is an occasional hang rather than an error. The cost is
+that a worker re-imports on start, which is why workers are persistent rather
+than per-task.
+
+**Liveness is `is_alive()`, not a heartbeat.** A worker is single-threaded: once
+it is inside a rollout it cannot send anything, and a rollout can legitimately
+take ten minutes. A heartbeat TTL short enough to detect death quickly would kill
+workers that are merely working. `multiprocessing` already knows whether a
+process is alive, exactly and for free. The heartbeat that remains is for the
+other failure -- alive but wedged -- and its timeout is therefore *longer* than
+any legitimate rollout, not shorter.
+
+**The results queue is unbounded, the task queue is not.** Back-pressure belongs
+on the work going in. Bounding results deadlocks: a full results queue blocks the
+worker in `put`, so it never takes another task, so the supervisor waits for a
+result that will never come.
+
+**Re-dispatch reuses the lease id.** A worker wrongly presumed dead has its task
+sent to somebody else; if the first one then finishes, both report. The lease id
+is what lets the caller drop the second, and without it one misjudged timeout
+puts two cards for the same task into the evidence pool.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import queue
+import signal
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterator, List, Optional, Sequence
+
+from .executor import Result
+from .metrics import Meter
+from .workspec import DEFAULT_ALLOWED_PREFIXES, RolloutSpec
+
+__all__ = ["ProcessExecutor", "worker_main"]
+
+_STOP = "__agentdescent_stop__"
+
+#: How long a worker may be inside one rollout before it is presumed wedged.
+#: Longer than any legitimate rollout on purpose -- see the module docstring. It
+#: is a deadlock detector, not a liveness check.
+DEFAULT_HANG_TIMEOUT = 900.0
+
+
+def _install_rlimits(memory_mb: Optional[int]) -> None:
+    """Cap what a worker can take, where the platform allows it.
+
+    POSIX only: Windows has no `resource` module. Rather than pretending
+    otherwise, the container provider is where a cross-platform memory ceiling
+    actually exists."""
+    if memory_mb is None:
+        return
+    try:
+        import resource
+    except ImportError:                       # pragma: no cover -- Windows
+        return
+    limit = int(memory_mb) * 1024 * 1024
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (limit, limit))
+    except (ValueError, OSError):             # pragma: no cover
+        pass
+
+
+def worker_main(wid: int, tasks, results, allowed: Sequence[str],
+                memory_mb: Optional[int] = None) -> None:
+    """A worker's whole life. Module-level because `spawn` imports it by name.
+
+    A closure could not be used here even if it were tidier -- which is the same
+    constraint that made `Ref` necessary, seen from the other side.
+    """
+    if os.name != "nt":
+        os.setsid()               # our own process group, so a kill takes the tree
+    _install_rlimits(memory_mb)
+
+    while True:
+        spec = tasks.get()
+        if spec == _STOP:
+            break
+        results.put(("START", wid, spec.lease_id, time.time()))
+        started = time.time()
+        try:
+            run, reward = spec.resolve(allowed)
+            output = run(spec.rendered, spec.task)
+            value = reward(spec.task, output)
+            results.put(("DONE", wid, spec.lease_id, spec.task.id, output, value,
+                         time.time() - started))
+        except Exception as e:  # noqa: BLE001
+            results.put(("FAILED", wid, spec.lease_id, spec.task.id,
+                         f"{type(e).__name__}: {str(e)[:200]}",
+                         _classify(e), time.time() - started))
+    results.put(("BYE", wid, None, 0.0))
+
+
+def _classify(exc: BaseException) -> str:
+    """Which counter a failure belongs to.
+
+    Infrastructure failures must not feed the worker-retirement rule: it only
+    fires while no worker has ever succeeded, which is precisely the window in
+    which a sandbox fails to start. Counting them together retires every worker
+    at startup and finishes the run clean at zero concurrency."""
+    from .workspec import RefError
+
+    if isinstance(exc, RefError):
+        return "caller"
+    name = type(exc).__name__
+    if name in ("EngineError", "SandboxLeak", "OSError", "MemoryError"):
+        return "infrastructure"
+    return "model"
+
+
+@dataclass
+class _Slot:
+    wid: int
+    process: Any
+    restarts: int = 0
+
+
+class ProcessExecutor:
+    """Persistent worker processes, with re-dispatch when one dies.
+
+    Requires specs whose `Ref`s resolve on the far side; a closure cannot cross,
+    and the failure says so before any rollout runs rather than as a pickling
+    error mid-flight.
+    """
+
+    def __init__(self, max_workers: int = 4, *, meter: Optional[Meter] = None,
+                 allowed_prefixes: Sequence[str] = DEFAULT_ALLOWED_PREFIXES,
+                 hang_timeout: float = DEFAULT_HANG_TIMEOUT,
+                 max_restarts: int = 3, memory_mb: Optional[int] = None) -> None:
+        if max_workers < 1:
+            raise ValueError(f"max_workers must be >= 1, got {max_workers}")
+        self.max_workers = max_workers
+        self.meter = meter
+        self.allowed_prefixes = tuple(allowed_prefixes)
+        self.hang_timeout = hang_timeout
+        self.max_restarts = max_restarts
+        self.memory_mb = memory_mb
+        self._ctx = mp.get_context("spawn")
+        self._tasks = self._ctx.Queue(maxsize=max_workers * 2)
+        self._results = self._ctx.Queue()          # unbounded on purpose
+        self._slots: Dict[int, _Slot] = {}
+        self._lock = threading.Lock()
+        self._closed = False
+
+    # -- workers --------------------------------------------------------------
+
+    def _spawn(self, wid: int) -> _Slot:
+        p = self._ctx.Process(
+            target=worker_main,
+            args=(wid, self._tasks, self._results, self.allowed_prefixes,
+                  self.memory_mb),
+            daemon=True)          # a stuck worker must not keep the process alive
+        p.start()
+        return _Slot(wid, p)
+
+    def start(self) -> None:
+        _refuse_to_recurse()
+        with self._lock:
+            for wid in range(self.max_workers):
+                if wid not in self._slots:
+                    self._slots[wid] = self._spawn(wid)
+
+    # -- running --------------------------------------------------------------
+
+    def map_rollouts(self, specs: Sequence[RolloutSpec]) -> Iterator[Result]:
+        if self._closed:
+            raise RuntimeError("executor is shut down")
+        specs = list(specs)
+        if not specs:
+            return
+        _refuse_closures(specs)
+        self.start()
+
+        pending: Dict[str, RolloutSpec] = {s.lease_id: s for s in specs}
+        inflight: Dict[str, float] = {}            # lease -> started at
+        owner: Dict[str, int] = {}                 # lease -> worker id
+        attempts: Dict[str, int] = {}
+        to_send = list(specs)
+
+        while pending:
+            while to_send and len(inflight) < self.max_workers * 2:
+                spec = to_send.pop(0)
+                self._tasks.put(spec)
+                inflight[spec.lease_id] = time.time()
+
+            try:
+                message = self._results.get(timeout=1.0)
+            except queue.Empty:
+                message = None
+
+            if message is not None:
+                kind = message[0]
+                if kind == "START":
+                    _, wid, lease, at = message
+                    owner[lease] = wid
+                    inflight[lease] = at
+                    continue
+                if kind == "BYE":
+                    continue
+                if kind == "DONE":
+                    _, wid, lease, task_id, output, value, seconds = message
+                    inflight.pop(lease, None)
+                    if pending.pop(lease, None) is None:
+                        continue            # a re-dispatch that came back twice
+                    if self.meter is not None:
+                        self.meter.add("rollouts")
+                        self.meter.add("rollout_seconds", seconds)
+                    yield Result(lease, task_id, output=output, reward=value,
+                                 seconds=seconds)
+                    continue
+                if kind == "FAILED":
+                    _, wid, lease, task_id, error, failure_kind, seconds = message
+                    inflight.pop(lease, None)
+                    if pending.pop(lease, None) is None:
+                        continue
+                    if self.meter is not None and failure_kind == "infrastructure":
+                        self.meter.add("sandbox_failures")
+                    yield Result(lease, task_id, error=error, kind=failure_kind,
+                                 seconds=seconds)
+                    continue
+
+            for result in self._reclaim(pending, inflight, owner, attempts, to_send):
+                yield result
+
+        return
+
+    def _reclaim(self, pending, inflight, owner, attempts, to_send) -> List[Result]:
+        """Notice dead or wedged workers and put their work back.
+
+        Death is checked first and cheaply: `is_alive()` is exact, and it covers
+        the OOM/segfault case that motivates processes at all. The hang timeout
+        is the fallback for a worker that is alive and stuck, and it is long
+        enough that no working rollout trips it."""
+        out: List[Result] = []
+        now = time.time()
+        dead = [wid for wid, slot in list(self._slots.items())
+                if not slot.process.is_alive()]
+        wedged = [lease for lease, started in list(inflight.items())
+                  if now - started > self.hang_timeout]
+
+        for lease in list(inflight):
+            wid = owner.get(lease)
+            if (wid is not None and wid in dead) or lease in wedged:
+                inflight.pop(lease, None)
+                spec = pending.get(lease)
+                if spec is None:
+                    continue
+                attempts[lease] = attempts.get(lease, 0) + 1
+                if attempts[lease] > 2:
+                    pending.pop(lease, None)
+                    out.append(Result(
+                        lease, spec.task.id,
+                        error=("worker died repeatedly while running this task"),
+                        kind="infrastructure"))
+                    continue
+                # Same lease id on purpose: if the original worker was only
+                # presumed dead and reports later, the caller can tell the two
+                # apart and drop one.
+                to_send.append(spec)
+
+        for wid in dead:
+            slot = self._slots.get(wid)
+            if slot is None:
+                continue
+            if slot.restarts >= self.max_restarts:
+                # A worker that keeps dying is a crash loop; leave the slot empty
+                # rather than burning CPU restarting it. At least one worker must
+                # survive, or the run silently becomes serial and then stalls.
+                if len(self._slots) > 1:
+                    self._slots.pop(wid, None)
+                    continue
+            new = self._spawn(wid)
+            new.restarts = slot.restarts + 1
+            self._slots[wid] = new
+        return out
+
+    # -- shutdown -------------------------------------------------------------
+
+    def shutdown(self, grace: float = 5.0) -> None:
+        """Stop the workers, in the one order that does not hang.
+
+        A child that has written to a queue cannot exit until the data is drained,
+        so joining before draining deadlocks. Drain, then stop, then join, then
+        kill whatever is left."""
+        if self._closed:
+            return
+        self._closed = True
+
+        deadline = time.time() + grace
+        while time.time() < deadline:                     # 1. drain
+            try:
+                self._results.get(timeout=0.05)
+            except queue.Empty:
+                break
+
+        for _ in self._slots:                             # 2. ask them to stop
+            try:
+                self._tasks.put(_STOP, timeout=1.0)
+            except Exception:
+                break
+
+        for slot in list(self._slots.values()):           # 3. join, then insist
+            slot.process.join(timeout=max(0.1, grace / 2))
+            if slot.process.is_alive():
+                _kill_tree(slot.process)
+        self._slots.clear()
+
+
+def _refuse_to_recurse() -> None:
+    """Refuse to spawn workers from inside a worker.
+
+    `spawn` starts a child by **re-importing `__main__`**. A script that builds a
+    `ProcessExecutor` at module level therefore builds one again in every child,
+    which builds one in every grandchild: the machine fills with processes and
+    nothing ever reports, so it reads as "slow" rather than as a fault.
+
+    Python's own guard for this only fires if the child gets as far as spawning,
+    which is too late to be useful. `parent_process()` is not `None` in any
+    spawned child, so this fires on the first one and names the fix.
+    """
+    if mp.parent_process() is not None:
+        raise RuntimeError(
+            "ProcessExecutor was constructed inside a worker process. With the "
+            "'spawn' start method each worker re-imports __main__, so anything "
+            "at module level runs again in every child -- including this. Put "
+            "the run behind `if __name__ == \"__main__\":`, or move it into a "
+            "function the module does not call on import.")
+
+
+def _kill_tree(process) -> None:
+    """Kill a worker and whatever it started."""
+    try:
+        if os.name != "nt":
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+        else:                                             # pragma: no cover
+            process.kill()
+    except (OSError, AttributeError):
+        try:
+            process.kill()
+        except Exception:
+            pass
+
+
+def _refuse_closures(specs: Sequence[RolloutSpec]) -> None:
+    """Fail before the first rollout if the work cannot cross a process.
+
+    The alternative is a pickling error from inside a queue's feeder thread,
+    minutes in, naming neither the argument nor what to do about it."""
+    import pickle
+
+    for spec in specs[:1]:            # they share a shape; one is enough
+        try:
+            pickle.dumps(spec)
+        except Exception as e:
+            raise TypeError(
+                f"this rollout cannot cross a process boundary: {e}. Every "
+                "factory in this package returns a closure, so `run=` and "
+                "`reward=` have to be given as `Ref(\"module:factory\", {...})` "
+                "for a process executor. In-process, ThreadExecutor takes them "
+                "as they are.") from None

--- a/agentdescent/workspec.py
+++ b/agentdescent/workspec.py
@@ -1,0 +1,202 @@
+"""A rollout as data, so it can be handed to a process that is not this one.
+
+Every attempt to run rollouts elsewhere hits the same wall first, and it is not
+the executor. It is that the work itself cannot be sent. Measured, on this
+package as it stands:
+
+    Task, Diff, EvidenceCard, AppendRules, SingleSlot   picklable
+    rewards.last_number()                               Can't pickle local object
+    reflector(model)                                    Can't pickle local object
+    LLMAgent(openai_compatible(...))                    Can't pickle local object
+    run=lambda rendered, task: ...                      Can't pickle <lambda>
+
+Every factory in the package returns a closure, and so does every example in the
+documentation. So swapping `ThreadPoolExecutor` for `ProcessPoolExecutor` fails
+on the first submit, and the fix is not a better executor -- it is a way to
+describe the work that does not embed the functions.
+
+`Ref` is that: a dotted target plus JSON configuration, resolved on the far side
+by the worker's own copy of the code.
+
+**Why not `cloudpickle`.** It sends closures directly, which is less work here
+and worse everywhere after. It serialises the *sending* process's code and
+executes it on the receiving side, so a version skew between the two becomes a
+silent wrong answer rather than an import error; and it is a third-party
+dependency in a package whose core has none. Resolving by name means the worker
+runs the code it actually has, and a mismatch surfaces as a missing attribute.
+
+**`resolve()` is arbitrary code execution**, and inside one process that is
+unremarkable -- it already shares a trust domain with its caller. Across a
+process or a machine boundary it is the boundary, so resolution is restricted to
+an allowlist of import prefixes and configuration is restricted to JSON scalars.
+Without both, anything that can write to a work queue can run code on every
+worker.
+
+**References nest.** `reflector(claude())` is the normal shape of an actor here,
+so a `Ref` may hold `Ref`s in its config and they are resolved innermost first.
+Without that, every composed actor would need a flattening factory whose only
+purpose is to make the arguments JSON.
+
+**Secrets do not travel in a spec.** A spec is pickled, logged, cached and
+journalled; a spec carrying an API key leaks it into all four. `SandboxSpec`
+carries variable *names*, and the values are read on the far side.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field, replace
+from importlib import import_module
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple
+
+from .evolution import Task
+from .policies import SandboxSpec
+
+__all__ = [
+    "DEFAULT_ALLOWED_PREFIXES",
+    "Ref",
+    "RefError",
+    "RolloutSpec",
+    "resolve_ref",
+]
+
+#: Import prefixes a worker will resolve without being told otherwise. Narrow on
+#: purpose: this package's own factories, and nothing else. A caller running
+#: their own code across processes widens it explicitly, which is the point at
+#: which they get to think about who can write to the queue.
+DEFAULT_ALLOWED_PREFIXES: Tuple[str, ...] = ("agentdescent.",)
+
+#: JSON scalars, and containers of them. A `Ref` whose config held an arbitrary
+#: object would be a closure again, wearing a different hat.
+_SCALARS = (str, int, float, bool, type(None))
+
+
+class RefError(ValueError):
+    """A reference could not be resolved, and why -- never a bare ImportError."""
+
+
+def _check_config(config: Mapping[str, Any], where: str) -> None:
+    for key, value in config.items():
+        if not isinstance(key, str):
+            raise RefError(f"{where}: config keys must be strings, got {key!r}")
+        if isinstance(value, Ref):
+            continue                      # a nested reference; resolved in order
+        if isinstance(value, _SCALARS):
+            continue
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                if not isinstance(item, _SCALARS):
+                    raise RefError(
+                        f"{where}: config[{key!r}] holds {type(item).__name__}; only "
+                        "JSON scalars survive the trip, and anything else is a "
+                        "closure in disguise")
+            continue
+        if isinstance(value, dict):
+            _check_config(value, f"{where}: config[{key!r}]")
+            continue
+        raise RefError(
+            f"{where}: config[{key!r}] is {type(value).__name__}; only JSON "
+            "scalars, lists and dicts of them are allowed")
+
+
+@dataclass(frozen=True)
+class Ref:
+    """A callable named rather than sent: ``"module:attribute"`` plus config.
+
+    ``target`` names a *factory*, and ``config`` is what to call it with, so the
+    common case -- ``rewards.last_number(gold_key="gold")`` -- round-trips as
+    data. Set ``call=False`` when the attribute is already the callable.
+    """
+
+    target: str
+    config: Dict[str, Any] = field(default_factory=dict)
+    #: Whether the resolved attribute is called with ``config`` to produce the
+    #: callable (a factory), or already is one.
+    call: bool = True
+
+    def __post_init__(self) -> None:
+        if ":" not in self.target:
+            raise RefError(
+                f"target {self.target!r} needs the form 'module:attribute' -- a "
+                "bare dotted path is ambiguous about where the module ends")
+        _check_config(self.config, f"Ref({self.target!r})")
+
+    def resolve(self, allowed: Sequence[str] = DEFAULT_ALLOWED_PREFIXES) -> Callable:
+        """Import and build the callable, on whichever side calls this."""
+        return resolve_ref(self, allowed)
+
+
+def resolve_ref(ref: Ref, allowed: Sequence[str] = DEFAULT_ALLOWED_PREFIXES) -> Callable:
+    """Resolve ``ref``, refusing anything outside ``allowed``.
+
+    The refusal happens **before the import**, not after: importing a module to
+    discover that it was not allowed has already run its top level.
+    """
+    module_name, _, attr = ref.target.partition(":")
+    if not any(module_name == p.rstrip(".") or module_name.startswith(p)
+               for p in allowed):
+        raise RefError(
+            f"refusing to resolve {ref.target!r}: {module_name!r} is outside the "
+            f"allowed prefixes {tuple(allowed)!r}. Widen them deliberately -- "
+            "resolution runs whatever it imports, so this is the trust boundary "
+            "between a work queue and the machine reading it.")
+    try:
+        module = import_module(module_name)
+    except ImportError as e:
+        raise RefError(
+            f"{ref.target!r}: cannot import {module_name!r} ({e}). The worker "
+            "resolves against its own copy of the code, so this usually means "
+            "the two sides do not have the same package installed.") from None
+    try:
+        obj = getattr(module, attr)
+    except AttributeError:
+        raise RefError(
+            f"{ref.target!r}: {module_name!r} has no attribute {attr!r}") from None
+    if not ref.call:
+        if not callable(obj):
+            raise RefError(f"{ref.target!r} is not callable and call=False")
+        return obj
+    # Resolve nested references first, innermost outwards. Composition is the
+    # normal shape here -- `reflector(claude())`, `LLMAgent(openai_compatible(...))`
+    # -- and without it every composed actor would need a bespoke factory whose
+    # only job is to flatten the arguments into JSON.
+    config = {k: (resolve_ref(v, allowed) if isinstance(v, Ref) else v)
+              for k, v in ref.config.items()}
+    try:
+        return obj(**config)
+    except TypeError as e:
+        raise RefError(
+            f"{ref.target!r}: calling it with {sorted(ref.config)} failed ({e}). "
+            "`config` is the factory's keyword arguments; set call=False if the "
+            "attribute is already the callable.") from None
+
+
+@dataclass(frozen=True)
+class RolloutSpec:
+    """One rollout, described completely enough to run somewhere else.
+
+    Complete matters: whatever is missing here is something the far side has to
+    guess, and a guess about which environment a measurement was taken in is how
+    two scores stop being comparable.
+    """
+
+    rendered: str
+    task: Task
+    run: Ref
+    reward: Ref
+    #: What environment this rollout needs. The default asks for nothing special,
+    #: which is what a local run has always got.
+    sandbox: SandboxSpec = field(default_factory=SandboxSpec)
+    #: Identifies this attempt. Re-dispatch after a worker is presumed lost
+    #: reuses it, so the merger can tell a retry from a second opinion -- without
+    #: that, one wrongly-presumed-dead worker puts two cards for the same task
+    #: into the pool.
+    lease_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+
+    def with_lease(self, lease_id: str) -> "RolloutSpec":
+        return replace(self, lease_id=lease_id)
+
+    def resolve(self, allowed: Sequence[str] = DEFAULT_ALLOWED_PREFIXES
+                ) -> Tuple[Callable, Callable]:
+        """Rebuild ``(run, reward)`` on this side of the boundary."""
+        return self.run.resolve(allowed), self.reward.resolve(allowed)

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ page and the code disagree, so a signature here is the signature you get.
 Each section links to the page that explains *why* the module is shaped the
 way it is; this page is the *what*.
 
-153 public names across 26 modules.
+160 public names across 29 modules.
 
 ---
 
@@ -760,6 +760,10 @@ Which of a batch of mutually contradictory changes survive.
 
 The multi-file proposal format a `FileTree` reflector is told to emit.
 
+### `Executor`
+
+Runs rollouts somewhere. Threads here, processes and hosts later.
+
 ### `FAST_MAX`
 
 The L2/L1 blast-radius boundary (`0.30`).
@@ -800,6 +804,10 @@ Everything an `AcceptancePolicy` is allowed to look at.
 
 Every replaceable piece, in one argument.
 
+### `ProcessExecutor`
+
+Persistent worker processes, with re-dispatch when one dies.
+
 ### `Promotion`
 
 One artifact the `PromotionPolicy` believes `stable` should hold.
@@ -815,6 +823,22 @@ What a `ProposalPolicy` is given for one rollout.
 ### `ProposalPolicy`
 
 How a rollout becomes candidate changes.
+
+### `Ref`
+
+A callable named rather than sent: `"module:attribute"` plus config.
+
+### `RefError`
+
+A reference could not be resolved, and why -- never a bare ImportError.
+
+### `Result`
+
+What one rollout produced, or why it did not.
+
+### `RolloutSpec`
+
+One rollout, described completely enough to run somewhere else.
 
 ### `SOLVED`
 
@@ -847,6 +871,10 @@ Defines *what evolves and how* -- the representation and the merge rule.
 ### `TEST_FAILURE_MARKER`
 
 Prefix of the output `code_runner` produces when the frozen gate fails, so the failure scores 0 and the reflector can read it.
+
+### `ThreadExecutor`
+
+The default: a bounded pool of threads in this process.
 
 ### `VerifierProtocol`
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -69,6 +69,8 @@ and *how*, that is *what*.
 | `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
+| `workspec` | a rollout as data: named callables instead of closures | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
+| `executor` · `supervisor` | where rollouts run: threads, or supervised worker processes | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
 | `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |
 | `defaults` | the shipped algorithm as replaceable pieces: conflict, fusion, acceptance, promotion | [Aggregator](aggregator.md) |
 | `sandbox_container` | the provider that makes a sandbox an actual boundary (needs docker/podman) | [Directory evolution](directory-evolution.md#isolation-strength-three-levels) |

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -26,6 +26,90 @@ Source:
 
 ---
 
+
+## Where rollouts run — the execution plane
+
+`evolve()` runs rollouts in threads, and for this workload that is the measured
+right answer: a rollout is almost entirely waiting on a model, and the numbers
+above are **7.1x** on I/O against **1.0x** on CPU. Nothing here is an attempt to
+make rollouts faster with processes.
+
+What processes buy is different and unavailable any other way:
+
+* **fault isolation** — the code being evolved is model-authored, so a segfault
+  or an OOM is ordinary. In a thread it takes the run with it;
+* **capacity beyond one machine**, and **heterogeneous workers**, later.
+
+```python
+from agentdescent import ProcessExecutor, Ref, RolloutSpec, ThreadExecutor
+```
+
+### Work has to be describable as data first
+
+The wall is not the executor. Measured on this package:
+
+| passed to `evolve()` | crosses a process? |
+|---|---|
+| `Task`, `Diff`, `EvidenceCard`, `AppendRules` | yes |
+| `rewards.last_number()` | **no** — `Can't pickle local object` |
+| `reflector(model)`, `LLMAgent(...)` | **no** |
+| `run=lambda rendered, task: ...` | **no** |
+
+Every factory in the package returns a closure, and so does every example in
+these docs. So a process pool fails on the first submit no matter how good the
+pool is, and the fix is a way to *describe* the work:
+
+```python
+Ref("agentdescent.rewards:last_number", {"gold_key": "gold"})
+Ref("agentdescent.runners:code_runner", {"entrypoint": ["python", "main.py"]})
+Ref("agentdescent.evolution:reflector",              # references nest
+    {"complete": Ref("agentdescent.agents:claude", {"model": "..."})})
+```
+
+The worker resolves these against **its own** copy of the code. `cloudpickle`
+would send the closure instead, which is less work here and worse afterwards: it
+executes the sending process's code on the receiving side, so a version skew
+becomes a wrong answer rather than an import error.
+
+`resolve()` runs whatever it imports, so across a boundary it *is* the boundary:
+targets are restricted to an allowlist (`agentdescent.*` by default) and config
+to JSON scalars. Widen it deliberately — that is the moment to think about who
+can write to the queue.
+
+### Why not `ProcessPoolExecutor`
+
+1. **One worker dying abruptly breaks the whole pool** (`BrokenProcessPool`) and
+   every in-flight task with it. Fault isolation built on something that fails as
+   a unit is not fault isolation — and this is the entire reason for processes
+   here;
+2. `max_tasks_per_child` is 3.11+; this package supports 3.9;
+3. it has no notion of a sandbox, so no way to say "this needs an environment
+   with fingerprint X, wait for one";
+4. its default start method is `fork` on Linux, and this engine is threaded — a
+   `fork` from a process holding locks in other threads produces a child holding
+   locks nothing will release.
+
+`ProcessExecutor` is persistent workers, a bounded task queue and a supervisor
+that decides on its own when a worker is gone.
+
+!!! warning "`spawn` re-imports `__main__`"
+    A script that builds a `ProcessExecutor` at module level builds one again in
+    every child, which builds one in every grandchild. The machine fills with
+    processes and nothing reports, so it reads as *slow* rather than as a fault.
+    Put the run behind `if __name__ == "__main__":`. Building one inside a worker
+    is refused outright.
+
+### Status
+
+The executors are usable directly and are covered by tests, including the
+assertion `ProcessPoolExecutor` cannot pass: killing one of three workers leaves
+the others producing and re-dispatches the dead one's task.
+
+They are **not yet wired into `evolve()`'s round loop**. Doing that now would
+mean writing it twice, once in each of the two loops that
+[#57](https://github.com/Birfy/agentdescent/issues/57) exists to unify — so it
+waits for that, rather than being duplicated and then de-duplicated.
+
 ## The interface
 
 A strategy answers one question: for round *r* with *N* workers, who works on

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,252 @@
+"""Rollouts run somewhere; that somewhere is replaceable, and it can die.
+
+The point of processes here is not speed -- `docs/efficiency.md` measures 7.1x on
+I/O against 1.0x on CPU, and a rollout is almost all waiting on a model. It is
+that the code being evolved is model-authored, so a worker that segfaults or gets
+OOM-killed is ordinary, and in a thread it takes the run with it.
+
+Which makes the interesting assertions here failure ones, not throughput ones.
+"""
+
+import multiprocessing as mp
+import os
+import sys
+import time
+
+import pytest
+
+from agentdescent import Task
+from agentdescent.executor import Executor, Result, ThreadExecutor
+from agentdescent.filetree import canonical
+from agentdescent.supervisor import ProcessExecutor, _refuse_to_recurse
+from agentdescent.workspec import Ref, RolloutSpec
+
+TREE = canonical({"main.py": "import os;print(f'42@{os.getpid()}')"})
+
+
+def spec(i=0, entrypoint=None):
+    return RolloutSpec(
+        rendered=TREE,
+        task=Task(f"t{i}", f"q{i}", meta={"gold": "42"}),
+        run=Ref("agentdescent.runners:code_runner",
+                {"entrypoint": entrypoint or [sys.executable, "main.py"]}),
+        reward=Ref("agentdescent.rewards:last_number"))
+
+
+# ---------------------------------------------------------------------------
+# Both executors satisfy the same contract
+# ---------------------------------------------------------------------------
+
+
+def test_both_executors_satisfy_the_protocol():
+    assert isinstance(ThreadExecutor(1), Executor)
+    assert isinstance(ProcessExecutor(1), Executor)
+
+
+def test_the_thread_executor_takes_the_callables_directly():
+    """In-process there is no boundary, so a closure is fine -- and staying that
+    way is what keeps every existing caller working untouched."""
+    ex = ThreadExecutor(2, run=lambda rendered, task: task.meta["gold"],
+                        reward=lambda task, out: 1.0 if out == "42" else 0.0)
+    try:
+        results = list(ex.map_rollouts([spec(i) for i in range(4)]))
+    finally:
+        ex.shutdown()
+    assert len(results) == 4
+    assert all(r.ok and r.reward == 1.0 for r in results)
+
+
+def test_results_arrive_as_they_finish_not_in_order():
+    """A caller that must wait for the first spec before seeing the second has
+    serialised itself, and rollout durations have a long tail."""
+    order = []
+
+    def slow(rendered, task):
+        delay = 0.30 if task.id == "t0" else 0.01
+        time.sleep(delay)
+        order.append(task.id)
+        return "42"
+
+    ex = ThreadExecutor(4, run=slow, reward=lambda t, o: 1.0)
+    try:
+        seen = [r.task_id for r in ex.map_rollouts([spec(i) for i in range(4)])]
+    finally:
+        ex.shutdown()
+    assert set(seen) == {"t0", "t1", "t2", "t3"}
+    assert seen[0] != "t0", f"the slow one blocked the rest: {seen}"
+
+
+def test_a_failing_rollout_is_reported_not_raised():
+    """One bad rollout is evidence, not the end of the run."""
+    def boom(rendered, task):
+        raise RuntimeError("the model said no")
+
+    ex = ThreadExecutor(2, run=boom, reward=lambda t, o: 1.0)
+    try:
+        results = list(ex.map_rollouts([spec(i) for i in range(3)]))
+    finally:
+        ex.shutdown()
+    assert len(results) == 3
+    assert all(not r.ok and "the model said no" in r.error for r in results)
+    assert all(r.kind == "model" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Crossing a process boundary
+# ---------------------------------------------------------------------------
+
+
+def test_the_start_method_is_spawn():
+    """`fork` from a threaded parent produces children holding locks nothing will
+    release. The engine is threaded, so this is not a preference."""
+    ex = ProcessExecutor(1)
+    try:
+        assert ex._ctx.get_start_method() == "spawn"
+    finally:
+        ex.shutdown()
+
+
+def test_work_really_runs_in_another_process():
+    ex = ProcessExecutor(2)
+    try:
+        results = list(ex.map_rollouts([spec(i) for i in range(4)]))
+    finally:
+        ex.shutdown()
+    assert len(results) == 4, [r.error for r in results]
+    assert all(r.ok for r in results), [r.error for r in results]
+    pids = {r.output.rsplit("@", 1)[1] for r in results}
+    assert str(os.getpid()) not in pids, "the rollout ran in the parent"
+
+
+def test_a_closure_is_refused_before_any_rollout_runs():
+    """The alternative is a pickling error from a queue's feeder thread, minutes
+    in, naming neither the argument nor the fix."""
+    bad = RolloutSpec(rendered="r", task=Task("t", "q"),
+                      run=Ref("agentdescent.rewards:last_number"),
+                      reward=Ref("agentdescent.rewards:last_number"))
+    object.__setattr__(bad, "run", lambda rendered, task: "x")   # a closure
+
+    ex = ProcessExecutor(1)
+    try:
+        with pytest.raises(TypeError, match="cannot cross a process boundary"):
+            list(ex.map_rollouts([bad]))
+    finally:
+        ex.shutdown()
+
+
+def test_building_an_executor_inside_a_worker_is_refused():
+    """`spawn` re-imports `__main__` in every child, so an executor built at
+    module level builds one in each child, which builds one in each grandchild.
+    The machine fills with processes and nothing reports -- it reads as slow
+    rather than as a fault, which is why this refuses rather than warns."""
+    assert _refuse_to_recurse() is None            # in the parent: fine
+
+    original = mp.parent_process
+
+    def pretend_child():
+        return object()
+
+    mp.parent_process = pretend_child
+    try:
+        with pytest.raises(RuntimeError, match="__main__"):
+            _refuse_to_recurse()
+    finally:
+        mp.parent_process = original
+
+
+def test_killing_one_worker_does_not_take_the_others_with_it():
+    """The assertion `ProcessPoolExecutor` cannot pass.
+
+    There, an abruptly-dead worker raises `BrokenProcessPool` and every in-flight
+    task dies with it -- so a single OOM from one model-authored candidate ends
+    the run. Here the survivors keep working and the dead one's task is sent
+    somewhere else."""
+    ex = ProcessExecutor(3)
+    ex.start()
+    victim = ex._slots[0].process
+    others = [ex._slots[i].process for i in (1, 2)]
+    try:
+        os.kill(victim.pid, 9)
+        deadline = time.time() + 10
+        while time.time() < deadline and victim.is_alive():
+            time.sleep(0.05)
+        assert not victim.is_alive(), "the victim survived SIGKILL"
+        assert all(p.is_alive() for p in others), (
+            "killing one worker killed the others -- this is the BrokenProcessPool "
+            "behaviour the supervisor exists to avoid")
+
+        results = list(ex.map_rollouts([spec(i) for i in range(4)]))
+        assert len(results) == 4, [r.error for r in results]
+        assert all(r.ok for r in results), [r.error for r in results]
+    finally:
+        ex.shutdown()
+
+
+def test_a_task_whose_worker_dies_is_re_dispatched_under_the_same_lease():
+    """Same lease id on purpose: a worker only *presumed* dead may still report,
+    and the id is what lets the caller drop the duplicate. Without it one
+    misjudged timeout puts two cards for the same task into the evidence pool."""
+    ex = ProcessExecutor(2, hang_timeout=0.5)
+    ex.start()
+    try:
+        pending = {"L1": spec(1)}
+        inflight = {"L1": time.time() - 60}       # long overdue
+        to_send = []
+        out = ex._reclaim(pending, inflight, {"L1": 0}, {}, to_send)
+        assert not out, "an overdue task should be retried, not failed"
+        assert [s.lease_id for s in to_send] == [pending["L1"].lease_id]
+    finally:
+        ex.shutdown()
+
+
+def test_a_task_that_keeps_killing_workers_is_given_up_on():
+    """Otherwise one poisonous candidate re-dispatches forever."""
+    ex = ProcessExecutor(2, hang_timeout=0.5)
+    try:
+        s = spec(9)
+        pending, to_send = {s.lease_id: s}, []
+        attempts = {s.lease_id: 2}
+        out = ex._reclaim(pending, {s.lease_id: time.time() - 60},
+                          {s.lease_id: 0}, attempts, to_send)
+        assert len(out) == 1 and out[0].kind == "infrastructure"
+        assert not to_send and not pending
+    finally:
+        ex.shutdown()
+
+
+def test_shutdown_leaves_no_workers_behind():
+    ex = ProcessExecutor(2)
+    ex.start()
+    processes = [slot.process for slot in ex._slots.values()]
+    assert processes and all(p.is_alive() for p in processes)
+    ex.shutdown(grace=3.0)
+    deadline = time.time() + 10
+    while time.time() < deadline and any(p.is_alive() for p in processes):
+        time.sleep(0.1)
+    assert not any(p.is_alive() for p in processes), "workers outlived shutdown"
+
+
+def test_shutdown_is_idempotent():
+    ex = ProcessExecutor(1)
+    ex.start()
+    ex.shutdown()
+    ex.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Failure classification
+# ---------------------------------------------------------------------------
+
+
+def test_infrastructure_failures_are_counted_apart_from_model_failures():
+    """`WorkerHealth` retires only while nothing has ever succeeded -- exactly
+    the window in which sandboxes fail to start. Counting the two together
+    retires every worker at startup and finishes the run clean at zero
+    concurrency."""
+    from agentdescent.supervisor import _classify
+    from agentdescent.workspec import RefError
+
+    assert _classify(RefError("nope")) == "caller"
+    assert _classify(OSError("no space left on device")) == "infrastructure"
+    assert _classify(MemoryError()) == "infrastructure"
+    assert _classify(RuntimeError("the model refused")) == "model"

--- a/tests/test_workspec.py
+++ b/tests/test_workspec.py
@@ -42,9 +42,15 @@ def test_the_things_a_caller_actually_passes_cannot_be_pickled():
     for name, obj in (("reward factory", rewards.last_number()),
                       ("reflector", reflector(echo())),
                       ("lambda", lambda rendered, task: "x")):
+        # The *fact* is asserted, not the wording. CPython raises
+        # `PicklingError` or `AttributeError` depending on the case, and 3.12
+        # rephrased "Can't pickle local object" to "Can't get local object" --
+        # an assertion on the sentence goes red on an upgrade and says nothing
+        # about whether the premise still holds.
         with pytest.raises(Exception) as excinfo:
             pickle.dumps(obj)
-        assert "pickle" in str(excinfo.value).lower(), (name, excinfo.value)
+        assert isinstance(excinfo.value, (pickle.PicklingError, AttributeError,
+                                          TypeError)), (name, excinfo.value)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_workspec.py
+++ b/tests/test_workspec.py
@@ -1,0 +1,208 @@
+"""Work has to be describable as data before it can be run anywhere else.
+
+The wall is not the executor. Every factory in this package returns a closure and
+so does every example in the docs, so a process pool fails on the first submit
+regardless of how good the pool is. These tests pin the alternative: name the
+callable, resolve it on the far side, and refuse anything that would make that
+resolution a way in.
+"""
+
+import json
+import pickle
+import sys
+import types
+
+import pytest
+
+from agentdescent import Task
+from agentdescent.policies import SandboxSpec
+from agentdescent.workspec import Ref, RefError, RolloutSpec, resolve_ref
+
+
+TASK = Task(id="t1", prompt="what is 6*7?", meta={"gold": "42"})
+
+
+# ---------------------------------------------------------------------------
+# The premise
+# ---------------------------------------------------------------------------
+
+
+def test_the_things_a_caller_actually_passes_cannot_be_pickled():
+    """Guard the premise. If this ever fails, `Ref` has lost its reason to exist.
+
+    Data crosses fine; every callable does not, because they are all closures --
+    which is why "just use ProcessPoolExecutor" is not a smaller version of this
+    change but a different one that does not work."""
+    from agentdescent import rewards
+    from agentdescent.agents import echo
+    from agentdescent.evolution import reflector
+
+    pickle.dumps(TASK)                       # data: fine
+
+    for name, obj in (("reward factory", rewards.last_number()),
+                      ("reflector", reflector(echo())),
+                      ("lambda", lambda rendered, task: "x")):
+        with pytest.raises(Exception) as excinfo:
+            pickle.dumps(obj)
+        assert "pickle" in str(excinfo.value).lower(), (name, excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def test_a_resolved_factory_behaves_like_the_direct_call():
+    from agentdescent import rewards
+
+    direct = rewards.last_number()
+    viaref = Ref("agentdescent.rewards:last_number").resolve()
+    for output in ("the answer is 42", "no digits here", "7"):
+        assert viaref(TASK, output) == direct(TASK, output)
+
+
+def test_config_is_the_factories_keyword_arguments():
+    from agentdescent import rewards
+
+    task = Task(id="t", prompt="p", meta={"expected": "42"})
+    direct = rewards.last_number(gold_key="expected")
+    viaref = Ref("agentdescent.rewards:last_number",
+                 {"gold_key": "expected"}).resolve()
+    assert viaref(task, "42") == direct(task, "42") == 1.0
+
+
+def test_call_false_takes_the_attribute_itself():
+    ref = Ref("agentdescent.filetree:canonical", call=False)
+    assert ref.resolve()({"a.txt": "x"}).strip()
+
+
+def test_a_spec_survives_pickle_and_resolves_the_same_on_the_far_side():
+    spec = RolloutSpec(rendered="rules", task=TASK,
+                       run=Ref("agentdescent.agents:echo"),
+                       reward=Ref("agentdescent.rewards:last_number"))
+    back = pickle.loads(pickle.dumps(spec))
+    assert back.task.id == TASK.id and back.rendered == "rules"
+    _, reward = back.resolve()
+    assert reward(TASK, "42") == 1.0
+
+
+def test_a_lease_id_is_stable_across_the_wire():
+    """Re-dispatch reuses it, which is how the merger tells a retry from a second
+    opinion -- a lease id that changed in transit would put two cards for one
+    task into the pool."""
+    spec = RolloutSpec(rendered="r", task=TASK,
+                       run=Ref("agentdescent.agents:echo"),
+                       reward=Ref("agentdescent.rewards:last_number"))
+    assert pickle.loads(pickle.dumps(spec)).lease_id == spec.lease_id
+    assert spec.with_lease("fixed").lease_id == "fixed"
+
+
+# ---------------------------------------------------------------------------
+# The trust boundary
+# ---------------------------------------------------------------------------
+
+
+def test_a_target_outside_the_allowlist_is_refused():
+    with pytest.raises(RefError, match="outside the allowed prefixes"):
+        Ref("os:system").resolve()
+
+
+def test_refusal_happens_before_the_import(tmp_path, monkeypatch):
+    """Importing to find out it was not allowed has already run its top level.
+
+    This is the difference between a check and a formality: a hostile target's
+    side effects happen at import, not at call."""
+    marker = tmp_path / "ran.txt"
+    module_src = f"open({str(marker)!r}, 'w').write('imported')\nhandler = lambda: None\n"
+    (tmp_path / "hostile_probe.py").write_text(module_src, encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    sys.modules.pop("hostile_probe", None)
+
+    with pytest.raises(RefError):
+        Ref("hostile_probe:handler").resolve()
+    assert not marker.exists(), "the module was imported despite being refused"
+
+
+def test_the_allowlist_can_be_widened_deliberately():
+    mod = types.ModuleType("widened_probe")
+    mod.make = lambda: (lambda task, output: 0.5)
+    sys.modules["widened_probe"] = mod
+    try:
+        fn = resolve_ref(Ref("widened_probe:make"), allowed=("widened_probe",))
+        assert fn(TASK, "x") == 0.5
+    finally:
+        del sys.modules["widened_probe"]
+
+
+def test_config_rejects_anything_that_is_not_json():
+    """An arbitrary object in `config` is a closure wearing a different hat."""
+    with pytest.raises(RefError, match="only JSON"):
+        Ref("agentdescent.rewards:last_number", {"fn": lambda: None})
+    with pytest.raises(RefError, match="closure in disguise"):
+        Ref("agentdescent.rewards:last_number", {"items": [object()]})
+    Ref("agentdescent.rewards:last_number",
+        {"a": 1, "b": [1, 2], "c": {"d": None}})        # allowed
+
+
+def test_a_malformed_target_says_which_part_is_wrong():
+    with pytest.raises(RefError, match="module:attribute"):
+        Ref("agentdescent.rewards.last_number")
+
+
+def test_failures_name_the_field_rather_than_raising_a_bare_import_error():
+    with pytest.raises(RefError, match="has no attribute"):
+        Ref("agentdescent.rewards:no_such_scorer").resolve()
+    with pytest.raises(RefError, match="cannot import"):
+        Ref("agentdescent.nonexistent:thing").resolve()
+    with pytest.raises(RefError, match="call=False"):
+        Ref("agentdescent.rewards:last_number", {"nope": 1}).resolve()
+
+
+def test_a_spec_carries_no_secret_values():
+    """A spec is pickled, logged, cached and journalled. One that held an API key
+    would leak it into all four."""
+    spec = RolloutSpec(
+        rendered="rules", task=TASK,
+        run=Ref("agentdescent.agents:echo"),
+        reward=Ref("agentdescent.rewards:last_number"),
+        sandbox=SandboxSpec(env_allowlist=("ANTHROPIC_API_KEY", "PATH")))
+    blob = pickle.dumps(spec)
+    assert b"ANTHROPIC_API_KEY" in blob            # the name is the whole point
+    assert b"sk-" not in blob                      # a value would not be
+    # and the sandbox half is JSON-clean, because it has to cross as JSON too
+    from dataclasses import asdict
+    json.dumps(asdict(spec.sandbox))
+
+
+# ---------------------------------------------------------------------------
+# Composition
+# ---------------------------------------------------------------------------
+
+
+def test_references_nest_so_composed_actors_can_cross():
+    """`reflector(claude())` is the normal shape of an actor here.
+
+    Without nesting, every composition would need a bespoke factory whose only
+    job is to flatten its arguments into JSON -- one per combination, written by
+    whoever hit the boundary first."""
+    ref = Ref("agentdescent.evolution:reflector",
+              {"complete": Ref("agentdescent.agents:echo")})
+    back = pickle.loads(pickle.dumps(ref))
+    assert callable(back.resolve())
+
+
+def test_a_nested_reference_is_checked_like_any_other():
+    """The allowlist is not a property of the outermost call."""
+    ref = Ref("agentdescent.evolution:reflector", {"complete": Ref("os:getcwd")})
+    with pytest.raises(RefError, match="outside the allowed prefixes"):
+        ref.resolve()
+
+
+def test_the_built_in_runners_are_already_addressable():
+    """`code_runner` takes argv and strings, so it needs no adapter to cross --
+    which is what makes the common directory-evolution case free."""
+    import sys
+    ref = Ref("agentdescent.runners:code_runner",
+              {"entrypoint": [sys.executable, "main.py"]})
+    pickle.loads(pickle.dumps(ref))
+    assert callable(ref.resolve())


### PR DESCRIPTION
Addresses #56 (Steps 1–4). Step 5 and the engine wiring are deliberately left — see **Scope** below.

## The wall is not the executor

Measured on this package, not assumed:

| passed to `evolve()` | crosses a process? |
|---|---|
| `Task`, `Diff`, `EvidenceCard`, `AppendRules` | yes |
| `rewards.last_number()` | **no** — `Can't pickle local object` |
| `reflector(model)`, `LLMAgent(openai_compatible(...))` | **no** |
| every documented `run=lambda rendered, task: ...` | **no** |

Every factory in the package returns a closure, and so does every example in the docs. Swapping in a process pool fails on the first submit no matter how good the pool is. A test pins this so the premise cannot rot.

`Ref` names the callable instead of sending it — a dotted target plus JSON config, resolved on the far side by the worker's **own** copy of the code.

**Not `cloudpickle`**: it ships the sending process's code to be executed elsewhere, so a version skew becomes a wrong answer instead of an import error — and it is a dependency in a package whose core has none.

**References nest**, because `reflector(claude())` is the ordinary shape of an actor here. Without it every composition needs a flattening factory whose only job is to make its arguments JSON.

**`resolve()` is the trust boundary.** Unremarkable in-process; across one it runs whatever it imports. Targets are restricted to an allowlist and config to JSON scalars, and refusal happens **before** the import — importing to discover it was not allowed has already run the module's top level. A test asserts the module was not imported.

## Why not `ProcessPoolExecutor`

1. **One worker dying abruptly breaks the whole pool** and every in-flight task with it. Fault isolation built on something that fails as a unit is not fault isolation — and that is the entire reason for processes here, since the code being evolved is model-authored and a segfault is ordinary;
2. `max_tasks_per_child` is 3.11+; this package supports 3.9;
3. it cannot express "this task needs a sandbox with fingerprint X, wait for one";
4. its default start method is `fork` on Linux while this engine is threaded — a `fork` from a process holding locks in other threads produces a child holding locks nothing will release.

The test that matters kills one of three workers and asserts the other two keep producing and the dead one's task is re-dispatched under the same lease id. That is the assertion `ProcessPoolExecutor` cannot pass.

**Liveness is `is_alive()`, not a heartbeat.** A worker inside a rollout cannot send anything and a rollout can legitimately take ten minutes, so a TTL short enough to detect death would kill workers that are merely working. `multiprocessing` already knows, exactly and for free. The remaining timeout detects a *wedge*, so it is deliberately longer than any legitimate rollout.

## Two failure modes found by using it

- **`spawn` re-imports `__main__`.** A script building an executor at module level builds one in every child, which builds one in every grandchild — the machine fills with processes and nothing reports, so it reads as "slow" rather than as a fault. I did this to myself while smoke-testing. Building one inside a worker is now refused outright, naming the missing `if __name__ == "__main__"`.
- **The results queue must be unbounded while the task queue is not.** Bounding results deadlocks: a full queue blocks the worker in `put`, so it takes no further tasks, so the supervisor waits for a result that cannot arrive. Back-pressure belongs on the way in.

## Scope

Not wired into `evolve()`'s round loop. The rollout half could move to an executor, but `propose` / `to_diff` / `ingest` touch shared state and must stay in the parent — and doing that split now means writing it **twice**, once in each of the two loops [#57](https://github.com/Birfy/agentdescent/issues/57) exists to unify. So it waits for #57 rather than being duplicated and then de-duplicated.

`docs/parallelism.md` says this plainly rather than implying the executors are already in the path.

## Verification

- **772 passed, 1 skipped** (742 before + 30 new).
- `run_demo` reproduces the `docs/usage.md` table verbatim; the default path is untouched.
- `mkdocs build --strict` and `gen_api_docs --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)