### PR TITLE
refactor: one retirement rule, asked by both loops

### DIFF
--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -46,6 +46,7 @@ from .evolvable import Contract, ContractError, Diff, EvidenceCard
 from .governance import FROZEN_IDS, GovernanceError, assert_mutable
 from .ledger import Ledger, LedgerFailure
 from .metrics import Meter, measured
+from .pipeline import WorkerHealth
 from .policies import Policies
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import AuditScheduler
@@ -1663,7 +1664,11 @@ def evolve(
     unit_lock = threading.Lock()
     first_error: List[Optional[str]] = [None]
     contract_error: List[Optional[BaseException]] = [None]   # caller bug -> re-raise
-    any_success = [False]      # has ANY worker ever completed a rollout?
+    # The retirement rule lives in `pipeline.WorkerHealth`, shared with the
+    # barrier-free runtimes. It used to be re-implemented here from the same
+    # description, which is the arrangement `pipeline.py`'s docstring records as
+    # having already cost one hand-ported fix.
+    health = WorkerHealth(max_errors=max_worker_errors)
     dead_rounds = 0            # consecutive rounds where every worker failed
     deadline = time.time() + max_seconds if max_seconds else None
     stop_reason = "rounds"
@@ -1681,6 +1686,14 @@ def evolve(
             # the one guarantee the result contract makes ("a run that died still
             # returns a partial result"). Treat it like an unmeasurable round: the
             # same tally decides whether to keep going or give up.
+            #
+            # Note the tally is shared but the *rule* is not: a repeatedly failing
+            # ledger gives up after `max_worker_errors` rounds whether or not
+            # workers have succeeded, while a repeatedly failing worker gives up
+            # only while nothing ever has (`health.should_retire`). Defensible --
+            # a ledger that cannot be read is not going to start working because a
+            # rollout succeeded -- but it is a second rule, and this comment is
+            # here because the sentence above claims there is one.
             if first_error[0] is None:
                 first_error[0] = f"ledger read failed: {type(e).__name__}: {str(e)[:200]}"
             dead_rounds += 1
@@ -1735,7 +1748,7 @@ def evolve(
             sampler.record(task.id, score)               # learn which tasks carry signal
             with unit_lock:
                 ok_units[0] += 1
-                any_success[0] = True
+                health.record_success()
             if score >= solved_threshold:
                 return
             proposal = _checked_proposal(
@@ -1831,7 +1844,7 @@ def evolve(
             # and the run keeps going on the evidence it did gather.
             if failed_units[0] and not ok_units[0]:
                 dead_rounds += 1
-                if not any_success[0] and dead_rounds >= max_worker_errors:
+                if health.should_retire(dead_rounds):
                     run_error = first_error[0]
                     if verbose:
                         print(f"round {r:>3}  giving up: {dead_rounds} rounds with no "
@@ -1887,7 +1900,9 @@ def evolve(
             if first_error[0] is None:
                 first_error[0] = f"{type(e).__name__}: {str(e)[:200]}"
             dead_rounds += 1
-            if not any_success[0] and dead_rounds >= max_worker_errors:
+            # Same rule as the worker path: scoring held-out runs the agent, so an
+            # unmeasurable round is a backend failure like any other.
+            if health.should_retire(dead_rounds):
                 run_error = first_error[0]
                 if verbose:
                     print(f"round {r:>3}  giving up: held-out unmeasurable "

--- a/agentdescent/pipeline.py
+++ b/agentdescent/pipeline.py
@@ -13,6 +13,10 @@ module touches a ledger, a thread or a task: it is arithmetic over counters,
 which is exactly why it can be shared by two pipelines that agree on nothing
 else.
 
+Both loops now ask :class:`WorkerHealth` the retirement question rather than
+describing it twice: `evolve` had re-grown its own copy (`any_success` plus a
+round counter), which is the arrangement this page was written to record.
+
 What is actually shared, so this page cannot claim more than the code does:
 
 * :class:`WorkerHealth` -- both runtimes call ``should_retire`` /

--- a/tests/test_async_parity.py
+++ b/tests/test_async_parity.py
@@ -188,3 +188,25 @@ def test_the_new_diagnostics_survive_save_and_load(tmp_path):
     loaded = EvolutionResult.load(str(path))
     assert loaded.forced_refreshes == res.forced_refreshes
     assert loaded.stragglers == res.stragglers
+
+
+def test_both_loops_retire_workers_through_the_same_object():
+    """The rule that was hand-ported once must not be re-implemented again.
+
+    `pipeline.py`'s module docstring records that these two runtimes implemented
+    the same shape independently, and that a measured fix had to be carried
+    across by hand. The synchronous loop had re-grown its own copy
+    (`any_success` + `dead_rounds >= max_worker_errors`); this asserts there is
+    one implementation, by name, in both.
+    """
+    import re
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parent.parent / "agentdescent"
+    for module in ("evolution.py", "async_evolve.py"):
+        text = (src / module).read_text(encoding="utf-8")
+        assert "WorkerHealth" in text, f"{module} does not use the shared rule"
+        assert "should_retire" in text, f"{module} does not ask it the question"
+        # the shape of the re-implementation, so it cannot come back quietly
+        assert not re.search(r"any_success\[0\]\s*and", text), (
+            f"{module} has re-implemented the retirement rule inline")


### PR DESCRIPTION
Addresses #57, **narrowed by its own Step 0**. The inventory is posted as an [issue comment](https://github.com/Birfy/agentdescent/issues/57#issuecomment-5172572743); this PR is what it concluded.

## What the inventory found

Comparing `evolve` (678 lines) and `async_evolve` (602 lines) concern by concern:

| category | items |
|---|---|
| **already shared** | engine build, result assembly, promotion/cleanup, sampler, metering |
| **historical duplication** | worker health, early stopping, contract-error propagation |
| **deliberate** | worker backoff (async waits a quarter of the merger's cap, with a comment explaining a previous mis-copy) |
| **essential** | `StallGuard` (async only — a barrier loop cannot reach the state it detects), TP sections (sync only), the barrier itself |

The headline: **`evolve()` referenced `WorkerHealth` zero times.** It had re-implemented the rule inline — `any_success` plus a round counter — in four places. `pipeline.py`'s module docstring exists precisely to record that these two runtimes once implemented the same shape independently and that a measured fix had to be hand-ported. The copy it warns about had grown back inside the loop it is about.

## What this PR does

Both loops ask the same object. A test asserts it by name in both modules *and* rejects the shape of the re-implementation, because a comment did not hold that line the first time.

It also names a discrepancy rather than silently preserving it: the tally is shared between the worker path and the two ledger paths, but the **rule** is not. A repeatedly failing ledger gives up after `max_worker_errors` rounds regardless of past success; a repeatedly failing worker gives up only while nothing has ever succeeded. Defensible — a ledger that cannot be read will not start working because a rollout succeeded — but the comment above it claimed there was one rule. Behaviour unchanged; the comment now matches the code.

## What it does not do, and why

**No `Engine` / `Scheduler`.** The inventory put the remaining historical duplication at **120–180 lines**, not the 1204 the issue implied — because #54, #55, #56 and #60 have already collected the sandbox, the policies, the execution substrate and the metering into one copy each. Two new abstractions for 150 lines, on the one step that can move published numbers, is not a trade worth making. #57's own rule for this case is to shrink the issue, which is what the inventory comment does.

This weakens, without cancelling, the argument that #57 blocks #58: 5a/5c/5d now attach to `Executor` and `SandboxPool`, which exist once each. What would still be written twice is the evidence-deduplication hook — a real risk, and a much smaller one.

## Verification

- **774 passed, 1 skipped.**
- `run_demo` reproduces `docs/usage.md` **verbatim**.
- Barrier utilization **38%** (documented 36–40%), async speedup **2.62x** (documented 2.57–2.93x), `rq2_staleness` cost columns unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)