### PR TITLE
refactor: share the last two duplicated policies between the loops

### DIFF
--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -49,7 +49,7 @@ from .evolvable import ContractError, EvidenceCard, vv_staleness
 from .ledger import Ledger, LedgerFailure
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import DurationEstimator
-from .pipeline import StallGuard, WorkerHealth
+from .pipeline import EarlyStop, FirstError, StallGuard, WorkerHealth
 from .staleness import StaleAction, StalenessPolicy, get_policy
 
 
@@ -267,13 +267,14 @@ def async_evolve(
     history: List[RoundInfo] = []
     # [best held-out reward so far, sweeps since it last improved] -- a list so
     # the merger closure can mutate it without a `nonlocal` per field.
-    best: List[float] = [float('-inf'), 0]
+    # Shared with the barrier-free loop's sibling: one tracker, one epsilon.
+    early = EarlyStop(target_reward=target_reward, patience=patience)
     errors: List[Optional[str]] = [None]      # first backend failure seen (diagnostic)
     # Most recent artifact read from the ledger, so a failing final read still
     # yields a result instead of an exception (same reasoning as the sync path).
     last_good: List[object] = [None]
     died = [False]                            # True only if the run ENDED on failure
-    contract_error: List[Optional[BaseException]] = [None]   # caller bug -> re-raise
+    contract_error = FirstError()          # caller bug -> re-raise on this thread
     stop_reason = ["max_seconds"]             # overwritten by whichever bound fires
     # Backpressure: bumped when the pipeline stalls (evidence keeps arriving and
     # nothing commits), which forces every worker to resync regardless of the ratio.
@@ -383,7 +384,7 @@ def async_evolve(
                     if errors[0] is None:
                         errors[0] = f"{type(e).__name__}: {e}"
                     died[0] = True
-                    contract_error[0] = e
+                contract_error.record(e)      # first one wins; this site overwrote
                 stop.set()
                 return
             except Exception as e:  # noqa: BLE001 - a backend failure (API error,
@@ -483,10 +484,7 @@ def async_evolve(
         # is not a redundant eval -- `_Runtime.eval_one` memoises on
         # (artifact signature, task id), so re-scoring an unchanged head is free.
         r = dev.score(eng.held_out)
-        if r > best[0] + 1e-12:
-            best[0], best[1] = r, 0
-        else:
-            best[1] += 1
+        early_stop = early.observe(r)
         _m = eng.meter.snapshot()
         history.append(RoundInfo(len(history), r, len(dev.state), committed,
                                  len(reports) - committed, _tally(reports),
@@ -508,11 +506,8 @@ def async_evolve(
             except Exception as e:  # noqa: BLE001
                 warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
                               RuntimeWarning, stacklevel=2)
-        if target_reward is not None and r >= target_reward:
-            stop_reason[0] = "target_reward"
-            stop.set()
-        elif patience is not None and best[1] >= patience:
-            stop_reason[0] = "patience"
+        if early_stop is not None:
+            stop_reason[0] = early_stop
             stop.set()
 
     def _merger() -> None:
@@ -534,9 +529,7 @@ def async_evolve(
             except ContractError as e:
                 # A caller bug (a broken aggregator, a bad reward) must propagate,
                 # not be absorbed and reported as if the provider had failed.
-                with counter_lock:
-                    if contract_error[0] is None:
-                        contract_error[0] = e
+                contract_error.record(e)
                 stop.set()
                 return
             except Exception as e:  # noqa: BLE001 - surface, don't hang
@@ -589,8 +582,7 @@ def async_evolve(
             "rollouts are abandoned (results already merged are kept)",
             RuntimeWarning, stacklevel=2)
 
-    if contract_error[0] is not None:
-        raise contract_error[0]
+    contract_error.raise_if_set()
     if not died[0]:
         # Same reason as the synchronous path: confirmation takes
         # `promote_after_k` sweeps and `target_reward` stops the run on the very

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -46,7 +46,7 @@ from .evolvable import Contract, ContractError, Diff, EvidenceCard
 from .governance import FROZEN_IDS, GovernanceError, assert_mutable
 from .ledger import Ledger, LedgerFailure
 from .metrics import Meter, measured
-from .pipeline import WorkerHealth
+from .pipeline import EarlyStop, FirstError, WorkerHealth
 from .policies import Policies
 from .sampling import RoundRobin, TaskSampler
 from .scheduler import AuditScheduler
@@ -1659,11 +1659,12 @@ def evolve(
     #: read fails there is still a real result to hand back instead of an exception.
     last_good: Optional[EvolvingArtifact] = None
     straggler_rounds = 0
-    best_reward = float('-inf')
-    stalled = 0
+    # Shared with the barrier-free loop: the same two questions, the same
+    # tracker, and now the same epsilon (they had two).
+    early = EarlyStop(target_reward=target_reward, patience=patience)
     unit_lock = threading.Lock()
     first_error: List[Optional[str]] = [None]
-    contract_error: List[Optional[BaseException]] = [None]   # caller bug -> re-raise
+    contract_error = FirstError()          # caller bug -> re-raise on this thread
     # The retirement rule lives in `pipeline.WorkerHealth`, shared with the
     # barrier-free runtimes. It used to be re-implemented here from the same
     # description, which is the arrangement `pipeline.py`'s docstring records as
@@ -1724,9 +1725,7 @@ def evolve(
                 # A caller bug: the run is meaningless. It has to travel back to the
                 # main thread by hand -- an exception raised in a plain worker thread
                 # goes to the thread excepthook and is lost, not propagated.
-                with unit_lock:
-                    if contract_error[0] is None:
-                        contract_error[0] = e
+                contract_error.record(e)          # its own lock; first one wins
             except Exception as e:  # noqa: BLE001 - a backend failure
                 with unit_lock:
                     if first_error[0] is None:
@@ -1833,8 +1832,7 @@ def evolve(
             # letting it propagate directly, because on the threaded path a raise
             # inside a worker never reaches here. Re-raise before any evidence is
             # read: a broken contract makes the round meaningless.
-            if contract_error[0] is not None:
-                raise contract_error[0]
+            contract_error.raise_if_set()
 
             # Decide on the round's tally rather than on the first exception. The
             # same global signal the async path uses: while NO worker has ever
@@ -1923,27 +1921,22 @@ def evolve(
         history.append(info)
         # Early stopping: an LLM rollout costs money, so do not keep buying them
         # once the artifact has converged or clearly stalled.
-        if info.held_out_reward > best_reward + 1e-9:
-            best_reward, stalled = info.held_out_reward, 0
-        else:
-            stalled += 1
+        early_stop = early.observe(info.held_out_reward)
         if verbose:
             print(f"round {r:>3}  reward={info.held_out_reward:.3f} on "
                   f"{len(held_out)}  size={info.n_items}  +{committed}/-{rejected}")
-        if target_reward is not None and info.held_out_reward >= target_reward:
-            stop_reason = "target_reward"
+        if early_stop is not None:
+            stop_reason = early_stop
             if verbose:
-                print(f"round {r:>3}  target_reward={target_reward} reached, stopping")
-            if on_round is not None:
+                print(f"round {r:>3}  "
+                      + (f"target_reward={target_reward} reached, stopping"
+                         if early_stop == "target_reward" else
+                         f"no improvement for {early.stalled} rounds, stopping"))
+            if early_stop == "target_reward" and on_round is not None:
                 try:
                     on_round(info)
                 except Exception:  # noqa: BLE001 - reported below on the normal path
                     pass
-            break
-        if patience is not None and stalled >= patience:
-            stop_reason = "patience"
-            if verbose:
-                print(f"round {r:>3}  no improvement for {stalled} rounds, stopping")
             break
         if on_round is not None:
             # A reporting callback must never take the run down with it.

--- a/agentdescent/pipeline.py
+++ b/agentdescent/pipeline.py
@@ -24,6 +24,12 @@ What is actually shared, so this page cannot claim more than the code does:
   and the one that matters. ``backoff`` is used by
   :class:`~agentdescent.async_runtime.AsyncAgentDescent`; ``async_evolve``
   deliberately waits a quarter of it and says so at the call site.
+* :class:`EarlyStop` -- both loops track "best so far" and "observations since
+  it improved" and ask the same two questions of them. They did it with
+  different epsilons until they shared this.
+* :class:`FirstError` -- carrying a caller's bug out of a worker thread, first
+  one wins. One of the three capture sites assigned unconditionally, so a later
+  worker replaced the original traceback.
 * :class:`StallGuard` -- both runtimes count their no-commit sweeps through it.
   Each decides for itself *which* sweeps count (a sweep with no evidence in it
   is neither progress nor a stall, and the two express "no evidence"
@@ -32,10 +38,11 @@ What is actually shared, so this page cannot claim more than the code does:
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass, field
 from typing import Optional
 
-__all__ = ["WorkerHealth", "StallGuard"]
+__all__ = ["EarlyStop", "FirstError", "WorkerHealth", "StallGuard"]
 
 
 @dataclass
@@ -110,3 +117,84 @@ class StallGuard:
         """A worker resynced because of the stall; count it and reset."""
         self.forced += 1
         self._idle = 0
+
+
+@dataclass
+class EarlyStop:
+    """When to stop buying rollouts: the target was reached, or nothing improves.
+
+    Both loops tracked "best so far" and "observations since it improved" and
+    then asked the same two questions of them. They did it with **different
+    epsilons** -- the synchronous loop counted an improvement above `1e-9`, the
+    barrier-free one above `1e-12` -- which nobody chose: one of them was written
+    first and the other was written again.
+
+    The value here is `1e-9`, the more conservative of the two and the one behind
+    the numbers in `docs/usage.md`. It makes no difference to any reachable
+    reward: a held-out score is a mean of 0/1 outcomes over n tasks, so two
+    distinguishable rewards differ by at least `1/n`, and n would have to exceed a
+    billion for either threshold to bite. It is worth having one anyway, because
+    "did this improve" is a question that should have a single answer.
+    """
+
+    target_reward: Optional[float] = None
+    patience: Optional[int] = None
+    #: Smallest improvement that counts as one. See the class docstring.
+    epsilon: float = 1e-9
+
+    best: float = float("-inf")
+    #: Observations since the best improved. Rounds in one loop, merger sweeps in
+    #: the other -- the counter does not care, which is why it can be shared.
+    stalled: int = 0
+
+    def observe(self, reward: float) -> Optional[str]:
+        """Record a measurement; return a ``stop_reason``, or ``None`` to continue.
+
+        Target is checked before patience: a run that reaches its target on the
+        same observation that exhausts its patience has converged, and reporting
+        it as a stall would be false."""
+        if reward > self.best + self.epsilon:
+            self.best, self.stalled = reward, 0
+        else:
+            self.stalled += 1
+        if self.target_reward is not None and reward >= self.target_reward:
+            return "target_reward"
+        if self.patience is not None and self.stalled >= self.patience:
+            return "patience"
+        return None
+
+
+class FirstError:
+    """Carries a caller's bug out of a worker thread, first one wins.
+
+    An exception raised in a plain worker thread goes to the thread excepthook
+    and is lost, so a broken `reward` or `propose` -- which makes the whole run
+    meaningless -- would otherwise surface as "the backend failed" and be
+    retried. Both loops therefore stash it and re-raise on the main thread.
+
+    First one wins because the second is usually the same bug seen by another
+    worker, and the first has the more useful traceback. That was already the
+    intent everywhere; one of the three sites assigned unconditionally, so a
+    later worker's copy replaced the original.
+    """
+
+    def __init__(self) -> None:
+        self._exc: Optional[BaseException] = None
+        self._lock = threading.Lock()
+
+    def record(self, exc: BaseException) -> None:
+        with self._lock:
+            if self._exc is None:
+                self._exc = exc
+
+    @property
+    def exc(self) -> Optional[BaseException]:
+        return self._exc
+
+    def __bool__(self) -> bool:
+        return self._exc is not None
+
+    def raise_if_set(self) -> None:
+        """Re-raise on the caller's thread, where it can actually be seen."""
+        if self._exc is not None:
+            raise self._exc


### PR DESCRIPTION
Finishes the narrowed #57. The [Step 0 inventory](https://github.com/Birfy/agentdescent/issues/57#issuecomment-5172572743) listed three historical duplications; #70 merged the retirement rule, this is the other two.

## Early stopping — and a divergence nobody chose

Both loops tracked "best so far" and "observations since it improved", then asked the same two questions of them. With **different epsilons**:

```
evolve        r > best + 1e-9
async_evolve  r > best + 1e-12
```

That is not a decision, it is one being written and then written again. `EarlyStop` uses `1e-9` — the more conservative, and the one behind the numbers in `docs/usage.md`.

Neither threshold is reachable in practice: a held-out score is a mean of 0/1 outcomes over n tasks, so two distinguishable rewards differ by at least `1/n`, and n would have to exceed a billion for either to bite. The point is not that it mattered; it is that "did this improve" should have one answer.

Also collapses the target/patience branches, which were written out twice per loop. Target is checked before patience, because a run that reaches its target on the same observation that exhausts its patience has converged — reporting a stall would be false.

## Contract errors — five sites, three guards

An exception raised in a plain worker thread goes to the thread excepthook and is lost, so a broken `reward` or `propose` — which makes the whole run meaningless — would otherwise surface as "the backend failed" and get retried. Both loops stashed it and re-raised on the main thread.

Across five sites with three different guards. One of them assigned **unconditionally**:

```python
contract_error[0] = e          # async worker: overwrites
if contract_error[0] is None:  # the other four: first one wins
    contract_error[0] = e
```

So a second worker hitting the same bug replaced the first one's traceback — and the first is the more useful one, since the second is usually the same bug seen from another thread. `FirstError` keeps the first, which was the intent at four of the five sites.

## Verification

- **774 passed, 1 skipped.**
- `run_demo` reproduces `docs/usage.md` **verbatim**.
- async speedup **2.81x** (documented 2.57–2.93x); `run_async`'s three-policy ordering and the `async_ratio` sweep unchanged; `rq2_staleness` cost columns unchanged.

`pipeline.py`'s docstring — the page that exists to record what is genuinely shared, and to avoid claiming more than the code does — now lists all four policies and what each one's divergence had been.

🤖 Generated with [Claude Code](https://claude.com/claude-code)