### PR TITLE
feat: an evaluation cache that survives concurrency and more than one environment

### DIFF
--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -81,6 +81,7 @@ from .policies import (
     SandboxSpec,
     VerifierProtocol,
 )
+from .evalcache import CacheProtocol, FileCache, MemoryCache
 from .executor import Executor, Result, ThreadExecutor
 from .sandbox import LocalWorkspaceSandbox, SandboxPool, WorkspaceProvider
 from .supervisor import ProcessExecutor
@@ -227,6 +228,9 @@ __all__ = [
     "SandboxSpec",
     "SandboxPool",
     "Executor",
+    "CacheProtocol",
+    "MemoryCache",
+    "FileCache",
     "ThreadExecutor",
     "ProcessExecutor",
     "Result",

--- a/agentdescent/evalcache.py
+++ b/agentdescent/evalcache.py
@@ -1,0 +1,189 @@
+"""Memoised evaluations, and what changes when more than one process wants them.
+
+Evaluation is the expensive half of a run: `docs/efficiency.md` measures the gate
+at 193.6s against 90.0s for the same work at `eval_concurrency` 1 and 8, and each
+of those seconds is a real rollout. So the cache is not a nicety, and it stops
+working in two specific ways as soon as there is more than one worker.
+
+**Two callers, one key, two computations.** The in-process dictionary checked for
+a key, released its lock, computed, and stored -- so N threads asking for the same
+uncomputed value all missed and all computed. Wasteful in one process; across
+processes it is N copies of an expensive gate. `single-flight` makes the first
+caller compute while the others wait for that result.
+
+**Two environments, one key, a wrong answer.** The key was `(rendered, task.id)`.
+That is complete only while every measurement comes from the same toolchain. Once
+one rollout runs under `python:3.11-slim` and another under a different image,
+sharing a cache between them means one environment's score answers the other's
+question -- and that score is what the commit gates read. The environment's
+fingerprint is part of the key, so those are simply different entries.
+
+**What the key is not** is the artifact's state. It is what the artifact
+*renders to*, because `eval_one` passes only `render()` to `run`: two states that
+render identically cannot score differently, and keying on state made a strategy
+that carries bookkeeping beside the artifact (ADAS keeps a design's name and
+rationale) re-evaluate the whole held-out set because a label changed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any, Callable, Dict, Optional, Protocol, Tuple, runtime_checkable
+
+__all__ = ["CacheProtocol", "FileCache", "MemoryCache", "cache_key"]
+
+
+def cache_key(rendered: str, task_id: str, fingerprint: str = "") -> Tuple[str, str, str]:
+    """The identity of one evaluation.
+
+    All three parts are needed, and the third is the one that is easy to leave
+    out: without it a shared cache answers a question asked in one environment
+    with a measurement taken in another."""
+    return (rendered, task_id, fingerprint)
+
+
+@runtime_checkable
+class CacheProtocol(Protocol):
+    """Somewhere to keep evaluations. In one process, across many, or on disk."""
+
+    def get_or_eval(self, key: Any, fn: Callable[[], float]) -> float: ...
+
+
+class _Inflight:
+    """One key being computed, and everyone waiting for it."""
+
+    __slots__ = ("event", "value", "error")
+
+    def __init__(self) -> None:
+        self.event = threading.Event()
+        self.value: Optional[float] = None
+        self.error: Optional[BaseException] = None
+
+
+class MemoryCache:
+    """In-process, single-flight, counted.
+
+    Single-flight is the difference from a plain dictionary: concurrent callers
+    for the same uncomputed key produce **one** computation, not one each. The
+    old code checked, released the lock, then computed -- correct, and wasteful
+    exactly when the value is expensive enough to be worth caching.
+    """
+
+    def __init__(self, meter: Optional[Any] = None) -> None:
+        self._values: Dict[Any, float] = {}
+        self._inflight: Dict[Any, _Inflight] = {}
+        self._lock = threading.Lock()
+        self._meter = meter
+
+    def get_or_eval(self, key: Any, fn: Callable[[], float]) -> float:
+        with self._lock:
+            if key in self._values:
+                self._count("cache_hits")
+                return self._values[key]
+            waiting = self._inflight.get(key)
+            if waiting is None:
+                waiting = self._inflight[key] = _Inflight()
+                mine = True
+            else:
+                mine = False
+
+        if not mine:
+            # Somebody is already computing this. Waiting counts as a hit for the
+            # duplicate-computation figure -- the work was not done twice -- but
+            # separately, because "waited for" and "found ready" have different
+            # costs and only one of them is free.
+            self._count("cache_hits")
+            self._count("cache_inflight_joins")
+            waiting.event.wait()
+            if waiting.error is not None:
+                raise waiting.error
+            return waiting.value           # type: ignore[return-value]
+
+        self._count("cache_misses")
+        try:
+            value = fn()
+        except BaseException as exc:       # noqa: BLE001 -- re-raised to everyone
+            waiting.error = exc
+            with self._lock:
+                self._inflight.pop(key, None)
+            waiting.event.set()
+            raise
+        with self._lock:
+            self._values[key] = value
+            self._inflight.pop(key, None)
+        waiting.value = value
+        waiting.event.set()
+        return value
+
+    def attach_meter(self, meter: Any) -> None:
+        """Report into *this* run's counters, replacing any earlier run's.
+
+        A caller-supplied cache is built before the engine exists, so it has no
+        meter -- and without this the duplicate-computation figure silently reads
+        zero for exactly the configuration the cache was added to measure.
+
+        It replaces rather than keeps the first, because a shared cache outlives
+        the run that created it: that is the point of sharing one. Keeping the
+        first meter sends the second run's hits into the first run's totals,
+        which is worse than not counting at all -- the number looks like a
+        measurement of the wrong run."""
+        self._meter = meter
+
+    def _count(self, counter: str) -> None:
+        if self._meter is not None:
+            self._meter.add(counter)
+
+
+class FileCache:
+    """A directory of evaluations, so separate processes can share them.
+
+    Deliberately files rather than a database: the point is that two processes on
+    one machine stop paying twice for the same gate, and that needs no server.
+    A network cache is the same protocol with a different backend, and it should
+    arrive with the cross-machine work that would justify running one.
+
+    Wraps a `MemoryCache`, so single-flight within a process still holds and the
+    file is only consulted once per process per key.
+    """
+
+    def __init__(self, directory: str, meter: Optional[Any] = None) -> None:
+        self.directory = directory
+        os.makedirs(directory, exist_ok=True)
+        self._memory = MemoryCache(meter)
+
+    def attach_meter(self, meter: Any) -> None:
+        self._memory.attach_meter(meter)
+
+    def _path(self, key: Any) -> str:
+        import hashlib
+
+        digest = hashlib.sha256(
+            json.dumps(key, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+        return os.path.join(self.directory, f"{digest}.json")
+
+    def get_or_eval(self, key: Any, fn: Callable[[], float]) -> float:
+        def from_disk_or_compute() -> float:
+            path = self._path(key)
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    return float(json.load(fh)["value"])
+            except (OSError, ValueError, KeyError, TypeError):
+                pass
+            value = fn()
+            # Write to a sibling and rename: a reader must never see half a file,
+            # and on POSIX rename is atomic. A cache that cannot be written is
+            # still a correct cache, so failures here are dropped rather than
+            # failing a run that has already paid for the answer.
+            try:
+                tmp = f"{path}.{os.getpid()}.tmp"
+                with open(tmp, "w", encoding="utf-8") as fh:
+                    json.dump({"key": list(key) if isinstance(key, tuple) else key,
+                               "value": value}, fh, default=str)
+                os.replace(tmp, path)
+            except OSError:
+                pass
+            return value
+
+        return self._memory.get_or_eval(key, from_disk_or_compute)

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -42,6 +42,7 @@ from .aggregator import (
     Aggregator, AggregatorConfig, AggregatorFactory, AggregatorContractError,
     check_reports,
 )
+from .evalcache import CacheProtocol, MemoryCache, cache_key
 from .evolvable import Contract, ContractError, Diff, EvidenceCard
 from .governance import FROZEN_IDS, GovernanceError, assert_mutable
 from .ledger import Ledger, LedgerFailure
@@ -298,31 +299,11 @@ def _checked_reward(value, task: "Task") -> float:
     return min(1.0, max(0.0, r))
 
 
-class _EvalCache:
-    """Memoised evaluations, and the only place that can tell a hit from a miss.
-
-    The counters live here rather than in `_Runtime` because by the time
-    `eval_one` has a value back it no longer knows whether the work happened:
-    that is precisely the "duplicate computation" figure a multi-process run
-    needs to report."""
-
-    def __init__(self, meter: Optional["Meter"] = None) -> None:
-        self._d: Dict[Any, float] = {}
-        self._lock = threading.Lock()
-        self._meter = meter
-
-    def get_or_eval(self, key: Any, fn: Callable[[], float]) -> float:
-        with self._lock:
-            if key in self._d:
-                if self._meter is not None:
-                    self._meter.add("cache_hits")
-                return self._d[key]
-        if self._meter is not None:
-            self._meter.add("cache_misses")
-        value = fn()
-        with self._lock:
-            self._d[key] = value
-        return value
+#: Kept as a name because tests and call sites use it; the implementation moved
+#: to `evalcache` when a second process made single-flight and an environment-
+#: aware key necessary. A plain dictionary is correct in one process and wasteful
+#: in the exact case caching is for.
+_EvalCache = MemoryCache
 
 
 class EvolvingArtifact:
@@ -446,8 +427,14 @@ class _Runtime:
     #: hand-built `_Runtime` (several tests do this) needs no changes.
     meter: Optional["Meter"] = None
 
+    #: Identifies the environment measurements are taken in. Empty while there is
+    #: one, which is why a default run's keys are unchanged; the moment there are
+    #: two, it is what stops one environment's score answering the other's
+    #: question.
+    env_fingerprint: str = ""
+
     def eval_one(self, artifact: EvolvingArtifact, task: Task) -> float:
-        key = (artifact._signature(), task.id)
+        key = cache_key(artifact._signature(), task.id, self.env_fingerprint)
 
         def _measure() -> float:
             for attempt in range(self.ATTEMPTS):
@@ -613,7 +600,7 @@ def _publish_stable(aggregator) -> None:
 #: `Policies.require_supported`. The set grows as the implementations land.
 _WIRED_POLICIES = ("task_sampler", "proposal", "conflict", "fusion", "acceptance",
                    "promotion", "staleness", "verifier", "ledger",
-                   "aggregator_factory")
+                   "aggregator_factory", "eval_cache", "sandbox_spec")
 
 
 def _propose_via_policy(policy):
@@ -1197,8 +1184,20 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     meter = Meter(usage=usage) if usage is not None else Meter()
     run, propose = measured(run, meter), measured(propose, meter)
 
-    runtime = _Runtime(run=run, reward=reward, cache=_EvalCache(meter),
-                       eval_concurrency=eval_concurrency, meter=meter)
+    cache = (policies_bundle.eval_cache if policies_bundle is not None
+             and policies_bundle.eval_cache is not None else MemoryCache(meter))
+    # A supplied cache was built before this run existed, so it has no meter. Ask
+    # it to take one; a cache that does not offer the hook simply reports nothing,
+    # which is better than a zero that looks like a measurement.
+    attach = getattr(cache, "attach_meter", None)
+    if callable(attach):
+        attach(meter)
+    runtime = _Runtime(run=run, reward=reward, cache=cache,
+                       eval_concurrency=eval_concurrency, meter=meter,
+                       env_fingerprint=(policies_bundle.sandbox_spec.fingerprint()
+                                        if policies_bundle is not None
+                                        and policies_bundle.sandbox_spec is not None
+                                        else ""))
 
     def serialize(a: EvolvingArtifact) -> dict:
         return {"state": a.state, "blast_radius": a.blast_radius}

--- a/agentdescent/policies.py
+++ b/agentdescent/policies.py
@@ -46,6 +46,7 @@ from typing import (
 
 if TYPE_CHECKING:                                   # pragma: no cover
     from .aggregator import AggregatorFactory, MergeReport
+    from .evalcache import CacheProtocol
     from .evolvable import Diff, EvidenceCard, Evolvable
     from .sampling import TaskSampler
     from .staleness import StalenessPolicy
@@ -374,6 +375,9 @@ class Policies:
     verifier: Optional[VerifierProtocol] = None
     ledger: Optional[LedgerProtocol] = None
     aggregator_factory: Optional["AggregatorFactory"] = None
+    #: Where evaluations are memoised. The default is in-process; a shared one
+    #: lets separate processes stop paying twice for the same gate.
+    eval_cache: Optional["CacheProtocol"] = None
 
     # the resource plane (implementations land with the sandbox pool)
     sandbox_provider: Optional[SandboxProvider] = None

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ page and the code disagree, so a signature here is the signature you get.
 Each section links to the page that explains *why* the module is shaped the
 way it is; this page is the *what*.
 
-160 public names across 29 modules.
+163 public names across 30 modules.
 
 ---
 
@@ -748,6 +748,10 @@ Whether a candidate is committed.
 
 Accumulate a deduped list of rules/lessons (append-only, content-addressed).
 
+### `CacheProtocol`
+
+Somewhere to keep evaluations. In one process, across many, or on disk.
+
 ### `Completion`
 
 `Callable[[str], str]` — the one contract every model and agent satisfies.
@@ -772,6 +776,10 @@ The L2/L1 blast-radius boundary (`0.30`).
 
 Artifact ids the loop may read but never mutate (L0).
 
+### `FileCache`
+
+A directory of evaluations, so separate processes can share them.
+
 ### `FusionPolicy`
 
 How complementary diffs become one candidate.
@@ -795,6 +803,10 @@ Seven methods: four the aggregator calls, three more the engine calls.
 ### `LocalWorkspaceSandbox`
 
 A throwaway directory on this machine -- what a rollout has always got.
+
+### `MemoryCache`
+
+In-process, single-flight, counted.
 
 ### `MergeContext`
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -69,6 +69,7 @@ and *how*, that is *what*.
 | `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
+| `evalcache` | memoised evaluations: single-flight, environment-aware, shareable across processes | [Verifier](verifier.md) |
 | `workspec` | a rollout as data: named callables instead of closures | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
 | `executor` · `supervisor` | where rollouts run: threads, or supervised worker processes | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
 | `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |

--- a/docs/verifier.md
+++ b/docs/verifier.md
@@ -26,6 +26,43 @@ default mistake, and it is expensive in exactly the case that matters:
     nothing else. The [directory entry points](directory-evolution.md) default it to 4
     for this reason.
 
+
+## The evaluation cache
+
+Evaluation is the expensive half of a run — the gate measures 193.6s against
+90.0s for the same work at `eval_concurrency` 1 and 8, and each of those seconds
+is a real rollout. So evaluations are memoised, keyed on **what the artifact
+renders to**, the task id, and the **environment's fingerprint**.
+
+```python
+from agentdescent import FileCache, Policies, evolve
+
+evolve(tasks, reward, agent=agent,
+       policies=Policies(eval_cache=FileCache("~/.cache/agentdescent")))
+```
+
+Three things the key and the cache have to get right, each of which was wrong at
+some point:
+
+* **Not the state — what it renders to.** `eval_one` passes only `render()` to
+  `run`, so two states that render identically cannot score differently. Keying
+  on state made a strategy carrying bookkeeping beside the artifact (ADAS keeps a
+  design's name and rationale) re-evaluate the whole held-out set because a label
+  changed.
+* **Single-flight.** A plain dictionary checks, releases its lock, then computes,
+  so N concurrent callers for one uncomputed key all miss and all compute — which
+  is wasteful in exactly the case caching exists for. The first caller computes
+  and the rest wait for that result.
+* **The environment is part of the identity.** A `code_runner` score depends on
+  what `setup_cmd` installed, the python minor version, whether there was a
+  network. Sharing a cache across images without the fingerprint means one
+  environment's measurement answers another environment's question — and that
+  number is what the commit gates read.
+
+`FileCache` is a directory, so two processes on one machine stop paying twice for
+the same gate without a server between them. A network backend is the same
+protocol and belongs with the cross-machine work that would justify running one.
+
 ## The three methods that matter
 
 ```python

--- a/tests/test_evalcache.py
+++ b/tests/test_evalcache.py
@@ -1,0 +1,205 @@
+"""The cache has to stay right when more than one thing is asking.
+
+Evaluation is the expensive half of a run -- the gate is 193.6s against 90.0s for
+the same work at `eval_concurrency` 1 and 8, and every one of those seconds is a
+real rollout. So the two ways the plain dictionary stopped being right under
+concurrency are worth pinning:
+
+* N callers for one uncomputed key produced N computations;
+* one key meant one answer, even when the answers came from different
+  environments and only one of them was the answer to the question being asked.
+"""
+
+import json
+import threading
+import time
+
+import pytest
+
+from agentdescent.evalcache import CacheProtocol, FileCache, MemoryCache, cache_key
+from agentdescent.metrics import Meter
+
+
+def test_both_backends_satisfy_the_protocol(tmp_path):
+    assert isinstance(MemoryCache(), CacheProtocol)
+    assert isinstance(FileCache(str(tmp_path)), CacheProtocol)
+
+
+def test_a_repeated_key_is_computed_once():
+    calls = {"n": 0}
+
+    def measure():
+        calls["n"] += 1
+        return 0.5
+
+    meter = Meter()
+    cache = MemoryCache(meter)
+    for _ in range(5):
+        assert cache.get_or_eval(("k", "t1", ""), measure) == 0.5
+    assert calls["n"] == 1
+    s = meter.snapshot()
+    assert (s.cache_misses, s.cache_hits) == (1, 4)
+
+
+def test_concurrent_callers_for_one_key_compute_once():
+    """Single-flight. The old dictionary checked, released its lock, then
+    computed -- so every thread that arrived before the first finished missed and
+    computed too. Correct, and wasteful in exactly the case caching is for."""
+    calls, started = {"n": 0}, threading.Event()
+
+    def slow():
+        calls["n"] += 1
+        started.set()
+        time.sleep(0.15)              # long enough for the others to pile up
+        return 1.0
+
+    meter = Meter()
+    cache = MemoryCache(meter)
+    out = []
+    threads = [threading.Thread(target=lambda: out.append(
+        cache.get_or_eval(("k", "t", ""), slow))) for _ in range(32)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert calls["n"] == 1, f"{calls['n']} threads computed the same value"
+    assert out == [1.0] * 32
+    assert meter.snapshot().cache_inflight_joins == 31
+
+
+def test_a_failing_computation_reaches_everyone_waiting():
+    """The waiters must not hang, and must not silently get a wrong value."""
+    def boom():
+        time.sleep(0.05)
+        raise RuntimeError("the gate failed")
+
+    cache = MemoryCache()
+    errors = []
+
+    def call():
+        try:
+            cache.get_or_eval(("k", "t", ""), boom)
+        except RuntimeError as e:
+            errors.append(str(e))
+
+    threads = [threading.Thread(target=call) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert len(errors) == 8 and all("the gate failed" in e for e in errors)
+    # and the key is free again, so a later attempt can succeed
+    assert cache.get_or_eval(("k", "t", ""), lambda: 0.25) == 0.25
+
+
+def test_two_environments_do_not_answer_each_others_questions():
+    """The poisoning case, and the reason the fingerprint is in the key.
+
+    `code_runner`'s score depends on what `setup_cmd` installed, the python minor
+    version, whether there was a network. Sharing a cache across images means one
+    environment's measurement answers another's question -- and that number is
+    what the commit gates read."""
+    meter = Meter()
+    cache = MemoryCache(meter)
+    calls = []
+
+    def measure(value):
+        def fn():
+            calls.append(value)
+            return value
+        return fn
+
+    a = cache.get_or_eval(cache_key("rendered", "t1", "image-a"), measure(1.0))
+    b = cache.get_or_eval(cache_key("rendered", "t1", "image-b"), measure(0.0))
+    assert (a, b) == (1.0, 0.0)
+    assert calls == [1.0, 0.0], "one environment's score was reused for the other"
+    assert meter.snapshot().cache_misses == 2
+
+
+def test_the_key_is_what_the_artifact_renders_to_not_its_state():
+    """A historical fix that must not regress.
+
+    `eval_one` passes only `render()` to `run`, so two states that render
+    identically cannot score differently. Keying on state made a strategy that
+    carries bookkeeping beside the artifact re-evaluate the whole held-out set
+    because a label changed."""
+    from agentdescent import AppendRules
+    from agentdescent.evolution import EvolvingArtifact
+
+    strategy = AppendRules()
+    a = EvolvingArtifact("x", {"r1": "always answer 4"}, 1, 0.2, None, strategy)
+    b = EvolvingArtifact("x", {"r1": "always answer 4"}, 7, 0.2, None, strategy)
+    assert a._signature() == b._signature(), (
+        "version is not part of what an evaluation depends on")
+
+
+# ---------------------------------------------------------------------------
+# Across processes
+# ---------------------------------------------------------------------------
+
+
+def test_a_file_cache_is_visible_to_a_second_reader(tmp_path):
+    """One process pays; the next one does not. That is the whole point of it."""
+    calls = {"n": 0}
+
+    def measure():
+        calls["n"] += 1
+        return 0.75
+
+    first = FileCache(str(tmp_path))
+    assert first.get_or_eval(cache_key("r", "t", "fp"), measure) == 0.75
+
+    second = FileCache(str(tmp_path))            # a fresh process would look like this
+    assert second.get_or_eval(cache_key("r", "t", "fp"), measure) == 0.75
+    assert calls["n"] == 1, "the second reader recomputed a value already on disk"
+
+
+def test_a_file_cache_separates_environments_too(tmp_path):
+    cache = FileCache(str(tmp_path))
+    cache.get_or_eval(cache_key("r", "t", "image-a"), lambda: 1.0)
+    assert cache.get_or_eval(cache_key("r", "t", "image-b"), lambda: 0.0) == 0.0
+
+
+def test_an_unwritable_cache_does_not_fail_the_run(tmp_path):
+    """The answer has already been paid for. Losing the chance to reuse it is a
+    smaller problem than losing the run."""
+    cache = FileCache(str(tmp_path / "gone"))
+    import shutil
+    shutil.rmtree(str(tmp_path / "gone"))
+    assert cache.get_or_eval(cache_key("r", "t", ""), lambda: 0.5) == 0.5
+
+
+def test_a_half_written_file_is_never_read(tmp_path):
+    """Written to a sibling and renamed, so a reader sees all of it or none."""
+    cache = FileCache(str(tmp_path))
+    key = cache_key("r", "t", "")
+    cache.get_or_eval(key, lambda: 0.5)
+    path = cache._path(key)
+    with open(path, encoding="utf-8") as fh:
+        json.load(fh)                            # parses: it was never partial
+    assert not [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+
+
+# ---------------------------------------------------------------------------
+# Through the engine
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_can_be_given_a_shared_cache(tmp_path):
+    from agentdescent import AppendRules, Policies, Task, evolve
+
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(6)]
+    shared = FileCache(str(tmp_path))
+
+    def run_it():
+        return evolve(tasks, lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+                      run=lambda r, t: t.meta["gold"] if t.id in r else "?",
+                      propose=lambda r, t, o, s: t.id, strategy=AppendRules(),
+                      rounds=3, n_workers=2, held_out_frac=0.5, seed=0,
+                      policies=Policies(eval_cache=shared))
+
+    first, second = run_it(), run_it()
+    assert first.final_reward == second.final_reward
+    # the second run found the first one's evaluations already on disk
+    assert second.cache_hits > 0

--- a/tests/test_policy_contract.py
+++ b/tests/test_policy_contract.py
@@ -332,11 +332,13 @@ def test_a_field_with_no_implementation_still_raises():
 
 
 def test_the_async_path_honours_the_same_bundle():
+    """`sandbox_spec` became honoured when it started keying the eval cache, so
+    the refusal is asserted against a field that still has no implementation."""
     from agentdescent import async_evolve
-    with pytest.raises(NotImplementedError, match="sandbox_spec"):
+    with pytest.raises(NotImplementedError, match="sandbox_provider"):
         async_evolve(_tasks(), lambda t, o: 0.0, run=lambda r, t: "x",
                      propose=lambda r, t, o, s: None, max_iters=1,
-                     policies=Policies(sandbox_spec=SandboxSpec()))
+                     policies=Policies(sandbox_provider=object()))
 
 
 def test_a_multi_proposal_policy_is_refused_rather_than_truncated():


### PR DESCRIPTION
#58's **5b**. Taken ahead of 5e, which needs machines I cannot verify against; this one is self-contained and produces the duplicate-computation figure #61 needs.

## Why the cache mattered enough to fix

Evaluation is the expensive half of a run: `docs/efficiency.md` measures the gate at **193.6s vs 90.0s** for the same work at `eval_concurrency` 1 and 8, and every one of those seconds is a real rollout. The in-process dictionary stopped being right in two specific ways as soon as more than one thing was asking.

### Two callers, one key, two computations

It checked for the key, released its lock, computed, and stored. So N concurrent callers for one uncomputed value all missed and all computed — correct, and wasteful in exactly the case caching exists for. A test runs 32 threads at one key and asserts the underlying function is called **once**.

A failure now reaches everyone waiting, and frees the key rather than poisoning it.

### Two environments, one key, a wrong answer

The key was `(rendered, task.id)`. That is complete only while every measurement comes from one toolchain. A `code_runner` score depends on what `setup_cmd` installed, the python minor version, whether there was a network — so a cache shared across images means **one environment's measurement answers another environment's question**, and that number is what the commit gates read.

The environment fingerprint is part of the key, so those are simply different entries.

The key is still *what the artifact renders to*, not its state — the historical fix that stopped ADAS-style strategies re-evaluating the whole held-out set because a label changed. It has a test now, not just a docstring.

## `FileCache`

A directory, so two processes on one machine stop paying twice for the same gate without a server between them. Written to a sibling and renamed, so a reader sees all of a file or none of it. A cache that cannot be written is still a correct cache, so those failures are dropped rather than failing a run that has already paid for the answer.

A network backend is the same protocol and belongs with the cross-machine work that would justify running one.

## Found by testing, not by writing

An injected cache is constructed **before** the engine exists, so it had no meter — and the duplicate-computation figure read **zero for exactly the configuration the cache was added to measure**.

It takes the meter now, and *replaces* rather than keeps the first one. A shared cache outlives the run that created it — that is the point of sharing it — so keeping the first meter sends the second run's hits into the first run's totals. That is worse than not counting: the number looks like a measurement of the wrong run.

## Verification

- **785 passed, 1 skipped** (774 before + 11 new).
- `run_demo` reproduces `docs/usage.md` verbatim; the golden merge trace is unchanged.
- `mkdocs build --strict` and `gen_api_docs --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)