### PR TITLE
feat: a ledger that survives more than one writing process

### DIFF
--- a/agentdescent/ledger.py
+++ b/agentdescent/ledger.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import time
+from contextlib import contextmanager
 import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
@@ -137,6 +139,64 @@ def _git(repo: str, *args: str) -> str:
     return out.stdout.strip()
 
 
+#: Guards the repository between processes. Lives in `.git/` -- see `_exclusive`
+#: -- and is named so a human who finds it knows what left it behind.
+_LOCK_NAME = ".agentdescent-repo.lock"
+
+
+def _acquire_file_lock(path: str, timeout: float = 120.0):
+    """Block until this process owns the repository."""
+    try:
+        import fcntl
+    except ImportError:                       # pragma: no cover -- Windows
+        return _acquire_dir_lock(path, timeout)
+    handle = open(path, "w")
+    deadline = time.time() + timeout
+    while True:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return handle
+        except OSError:
+            if time.time() >= deadline:
+                handle.close()
+                raise LedgerFailure(
+                    f"could not lock {path} within {timeout:g}s; another process "
+                    "is holding the ledger. If none is running, remove the file.")
+            time.sleep(0.01)
+
+
+def _release_file_lock(handle, path: str) -> None:
+    if handle is None:
+        return
+    if isinstance(handle, str):               # the directory fallback
+        try:
+            os.rmdir(handle)
+        except OSError:
+            pass
+        return
+    try:
+        import fcntl
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except (ImportError, OSError):            # pragma: no cover
+        pass
+    handle.close()
+
+
+def _acquire_dir_lock(path: str, timeout: float) -> str:  # pragma: no cover
+    """`mkdir` is atomic everywhere; that is the whole requirement."""
+    directory = path + ".d"
+    deadline = time.time() + timeout
+    while True:
+        try:
+            os.mkdir(directory)
+            return directory
+        except FileExistsError:
+            if time.time() >= deadline:
+                raise LedgerFailure(
+                    f"could not lock {directory} within {timeout:g}s")
+            time.sleep(0.01)
+
+
 class Ledger:
     """A git-backed, version-vectored artifact store with dual branches."""
 
@@ -202,6 +262,39 @@ class Ledger:
 
     # -- low-level version bookkeeping ---------------------------------------
 
+    @contextmanager
+    def _exclusive(self):
+        """Hold the repository against other **processes**, not just threads.
+
+        `self._lock` is a `threading.Lock`: it makes one process's workers take
+        turns and says nothing to a second process. Two of those interleave a
+        read-modify-write of `versions.json` and one commit disappears -- the
+        lost update CAS exists to prevent, arriving by a route CAS cannot see,
+        because both writers read the same head and both were right when they
+        read it.
+
+        An advisory file lock, held across read-check-write-commit, makes the
+        section atomic between processes. CAS still does its job: a writer that
+        read the head before the other's commit finds it advanced and is told to
+        rebase.
+
+        `fcntl` where there is one, an atomically-created directory where there
+        is not -- `mkdir` is atomic on every filesystem worth running this on,
+        which is the only property required.
+        """
+        # Inside `.git/`, not the working tree: a lock file in the tree gets
+        # committed by `add -A`, and then blocks the next `checkout` as an
+        # untracked file that would be overwritten. `.git/` is git's own space
+        # and is never part of a branch.
+        path = os.path.join(self.repo_path, ".git", _LOCK_NAME)
+        with self._lock:                      # threads first: cheaper, and nested
+            handle = None
+            try:
+                handle = _acquire_file_lock(path)
+                yield
+            finally:
+                _release_file_lock(handle, path)
+
     def _versions_path(self) -> str:
         return os.path.join(self.repo_path, "versions.json")
 
@@ -213,8 +306,17 @@ class Ledger:
             return {}
 
     def _write_versions(self, vv: VersionVector) -> None:
-        with open(self._versions_path(), "w") as f:
+        """Write, then rename. A truncated `versions.json` is a lost ledger.
+
+        `open(..., "w")` truncates first and fills after, so a reader in another
+        process -- or the same one after a crash -- can see an empty or partial
+        file where the version vector should be. Renaming over the target is
+        atomic on POSIX, so a reader sees the old vector or the new one."""
+        path = self._versions_path()
+        tmp = f"{path}.{os.getpid()}.tmp"
+        with open(tmp, "w") as f:
             json.dump(vv, f, indent=2, sort_keys=True)
+        os.replace(tmp, path)
 
     def _artifact_path(self, artifact_id: str) -> str:
         return os.path.join(self.repo_path, "artifacts", f"{artifact_id}.json")
@@ -228,9 +330,13 @@ class Ledger:
         matter how many workers were running. All callers hold the lock, so this
         instance is the only writer of the working tree and can track it.
 
-        The cached branch assumes this ``Ledger`` owns ``repo_path``; two
-        instances sharing one path already race over the working tree (use one
-        ``Ledger`` per repo).
+        The cache is safe because every caller reaches this inside
+        :meth:`_exclusive`, which holds the repository against other processes as
+        well as other threads -- so while this instance is looking at the working
+        tree, it is the only thing that is. Before that lock existed, two
+        instances sharing a path raced over the tree and lost commits to git
+        rather than to CAS: `index.lock`, or a checkout refusing to overwrite a
+        file the other had just written.
         """
         if self._current_branch == branch:
             return
@@ -246,7 +352,7 @@ class Ledger:
         Re-registering an existing artifact is a no-op for its state, and is the
         one supported way to move a contract to a new major."""
         self._contracts[artifact.id] = getattr(artifact, "contract", None)
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             for br in (self.STABLE, self.DEV):
                 self._checkout(br)
@@ -272,7 +378,7 @@ class Ledger:
 
     def snapshot(self, branch: str = DEV) -> Snapshot:
         """Materialize every artifact on ``branch`` into live Evolvables."""
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             self._checkout(branch)
             vv = self._read_versions()
@@ -286,7 +392,7 @@ class Ledger:
             return Snapshot(artifacts=artifacts, version=dict(vv))
 
     def head_version(self, branch: str = DEV) -> VersionVector:
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             self._checkout(branch)
             return self._read_versions()
@@ -308,7 +414,7 @@ class Ledger:
         the current head would make the check unfalsifiable, so a writer that
         declared no base would always win -- precisely the lost update CAS
         exists to prevent."""
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             self._checkout(branch)
             vv = self._read_versions()
@@ -366,7 +472,7 @@ class Ledger:
         adapter diffs (design doc, section 6, "atomic adaptation transaction").
         Phase 1 validates every CAS precondition; phase 2 writes and commits in
         a single git commit."""
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             self._checkout(branch)
             vv = self._read_versions()
@@ -400,7 +506,7 @@ class Ledger:
         regression (design doc, section 4.5). A commit restarts that clock -- the
         new version has survived nothing yet -- so a *converged* artifact is the
         one most likely to be promoted, which is the point."""
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             self._checkout(self.DEV)
             dev_vv = self._read_versions()
@@ -421,7 +527,7 @@ class Ledger:
             return nv
 
     def log(self, branch: str = DEV, limit: int = 20) -> List[str]:
-        with self._lock:
+        with self._exclusive():
             self._ensure_open()
             self._checkout(branch)
             out = _git(

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -15,6 +15,47 @@ branch dev              where the loop commits
 branch stable           what production reads
 ```
 
+
+## More than one writer
+
+CAS plus a version vector was already the right primitive; what it lacked was a
+critical section that spans **processes**. `threading.Lock` makes one process's
+workers take turns and says nothing to a second process, so two of them could
+interleave a read-modify-write of `versions.json` — and lose a commit by a route
+CAS cannot see, because both writers read the same head and both were right when
+they read it.
+
+In practice the failure arrived even earlier, as git: `index.lock`, or a
+checkout refusing to overwrite a file the other process had just written.
+
+Every path that touches the repository now holds an advisory file lock —
+`fcntl` where there is one, an atomically-created directory where there is not —
+kept in `.git/` rather than the working tree, because a lock file in the tree is
+committed by `add -A` and then blocks the next checkout.
+
+`versions.json` is written to a sibling and renamed. `open(..., "w")` truncates
+first and fills after, so a reader in another process can see an empty file where
+the version vector should be.
+
+**CAS still does its job.** The lock serialises writers; it does not make them
+agree. A writer holding a version that has moved is told to rebase exactly as
+before — which is what the retry loop in any multi-writer caller is for:
+
+```python
+for _ in range(attempts):
+    head = ledger.head_version(Ledger.DEV)
+    candidate = ledger.snapshot(Ledger.DEV).get(aid).apply(diff)
+    try:
+        ledger.commit(candidate, base_version=head)
+        break
+    except CASConflict:
+        continue        # somebody committed first; rebase onto their head
+```
+
+!!! note "Keep the ledger outside the sandbox"
+    A ledger inside a sandbox is destroyed with it. Point `repo_path` at a
+    location the sandbox does not own.
+
 ## Why git, and why that is not overkill
 
 Three properties are needed and git already has all of them: an append-only

--- a/tests/test_ledger_multiwriter.py
+++ b/tests/test_ledger_multiwriter.py
@@ -1,0 +1,167 @@
+"""Two processes, one ledger, and no lost updates.
+
+CAS plus a version vector is already the right primitive; what it did not have
+was a critical section that spans processes. `self._lock` is a `threading.Lock`:
+it makes one process's workers take turns and says nothing to a second process.
+Two of those interleave a read-modify-write of `versions.json` and one commit
+disappears -- the lost update CAS exists to prevent, arriving by a route CAS
+cannot see, because both writers read the same head and both were right when they
+read it.
+
+These use real processes. A threading test would pass against the old code.
+"""
+
+import json
+import multiprocessing as mp
+import os
+import time
+
+import pytest
+
+from agentdescent.evolvable import Contract, Diff, Evolvable
+from agentdescent.ledger import CASConflict, Ledger
+
+CTX = mp.get_context("spawn")
+
+
+class Tiny:
+    """A minimal Evolvable: the ledger only needs id, version and state."""
+
+    def __init__(self, id="a", state=None, version=1):
+        self.id = id
+        self.state = dict(state or {})
+        self.version = version
+        self.blast_radius = 0.2
+        self.contract = Contract(input_schema="task", output_schema="text", major=1)
+
+    def render(self):
+        return json.dumps(self.state, sort_keys=True)
+
+    def apply(self, diff):
+        new = dict(self.state)
+        for k, v in diff.ops.items():
+            if v is None:
+                new.pop(k, None)
+            else:
+                new[k] = v
+        return Tiny(self.id, new, self.version + 1)
+
+
+def _serialize(a):
+    return {"state": dict(a.state)}
+
+
+def _deserialize(aid, version, data):
+    return Tiny(aid, data.get("state", {}), version)
+
+
+def ledger_at(path):
+    return Ledger(path, _serialize, _deserialize)
+
+
+def _commit_many(repo, worker, attempts, out):
+    """One process, hammering the same artifact. Returns commits that stuck."""
+    led = ledger_at(repo)
+    won = 0
+    for i in range(attempts):
+        for _ in range(50):                       # bounded rebase-and-retry
+            head = led.head_version(Ledger.DEV)
+            art = led.snapshot(Ledger.DEV).get("a")
+            candidate = art.apply(Diff(diff_id=f"w{worker}-{i}", target="a",
+                                       ops={f"k{worker}-{i}": "v"}))
+            try:
+                led.commit(candidate, base_version=head, branch=Ledger.DEV)
+                won += 1
+                break
+            except CASConflict:
+                continue                          # somebody else got there first
+    led.close()
+    out.put(won)
+
+
+@pytest.mark.parametrize("processes,attempts", [(4, 5)])
+def test_concurrent_processes_do_not_lose_updates(tmp_path, processes, attempts):
+    """The core CAS assertion, across processes.
+
+    Final version must equal the number of commits that reported success. Any
+    shortfall is a lost update: two writers read the same head, both were right,
+    and one of them overwrote the other.
+    """
+    repo = str(tmp_path / "repo")
+    led = ledger_at(repo)
+    led.register(Tiny("a", {}))
+    led.close()
+
+    out = CTX.Queue()
+    procs = [CTX.Process(target=_commit_many, args=(repo, w, attempts, out))
+             for w in range(processes)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=180)
+        assert p.exitcode == 0, f"a writer died: exitcode={p.exitcode}"
+
+    reported = sum(out.get() for _ in procs)
+    led = ledger_at(repo)
+    try:
+        final = led.head_version(Ledger.DEV)["a"]
+        state = led.snapshot(Ledger.DEV).get("a").state
+    finally:
+        led.close()
+
+    assert reported == processes * attempts, "a writer gave up before finishing"
+    assert final == 1 + reported, (
+        f"final version {final} but {reported} commits succeeded: "
+        f"{1 + reported - final} update(s) were lost")
+    assert len(state) == reported, "a committed key is missing from the state"
+
+
+def test_the_version_file_is_never_seen_half_written(tmp_path):
+    """`open(..., 'w')` truncates first and fills after, so a reader in another
+    process can see an empty file where the version vector should be. Renaming
+    over the target is atomic, so a reader sees the old vector or the new one."""
+    repo = str(tmp_path / "repo")
+    led = ledger_at(repo)
+    led.register(Tiny("a", {}))
+    try:
+        for i in range(20):
+            head = led.head_version(Ledger.DEV)
+            art = led.snapshot(Ledger.DEV).get("a")
+            led.commit(art.apply(Diff(diff_id=f"d{i}", target="a", ops={f"k{i}": "v"})),
+                       base_version=head, branch=Ledger.DEV)
+            with open(os.path.join(repo, "versions.json"), encoding="utf-8") as fh:
+                json.load(fh)                     # parses every time
+    finally:
+        led.close()
+    assert not [p for p in os.listdir(repo) if p.endswith(".tmp")]
+
+
+def test_a_stale_base_is_still_refused(tmp_path):
+    """The lock serialises writers; it must not make CAS unnecessary. A writer
+    holding a version that has moved is told to rebase, exactly as before."""
+    repo = str(tmp_path / "repo")
+    led = ledger_at(repo)
+    led.register(Tiny("a", {}))
+    try:
+        stale = led.head_version(Ledger.DEV)
+        art = led.snapshot(Ledger.DEV).get("a")
+        led.commit(art.apply(Diff(diff_id="d1", target="a", ops={"x": "1"})),
+                   base_version=stale, branch=Ledger.DEV)
+        with pytest.raises(CASConflict):
+            led.commit(art.apply(Diff(diff_id="d2", target="a", ops={"y": "2"})),
+                       base_version=stale, branch=Ledger.DEV)
+    finally:
+        led.close()
+
+
+def test_the_lock_lives_outside_the_working_tree(tmp_path):
+    """A lock file in the tree is committed by `add -A` and then blocks the next
+    `checkout` as an untracked file that would be overwritten."""
+    repo = str(tmp_path / "repo")
+    led = ledger_at(repo)
+    led.register(Tiny("a", {}))
+    try:
+        assert not [p for p in os.listdir(repo) if "lock" in p], \
+            "the repository lock is inside the working tree"
+    finally:
+        led.close()


### PR DESCRIPTION
#58's **5c**.

## What was missing

CAS plus a version vector was already the right primitive. What it lacked was a critical section that spans **processes**.

`self._lock` is a `threading.Lock` — it makes one process's workers take turns and says nothing to a second process. Two of those interleave a read-modify-write of `versions.json` and a commit disappears: the lost update CAS exists to prevent, arriving by a route CAS **cannot see**, because both writers read the same head and both were right when they read it.

In practice it arrives even earlier, as git: the first concurrent writer dies on `index.lock`, or on a checkout refusing to overwrite a file the other just wrote. `_checkout`'s docstring already said two instances sharing a path would race over the working tree. This is that race, with a lock instead of a warning.

## The fix

- **An advisory file lock** around every path that touches the repository — `fcntl` where there is one, an atomically-created directory where there is not (`mkdir` is atomic on any filesystem worth running this on, and that is the only property required).
- **In `.git/`, not the working tree.** The first version was not, and a lock file in the tree gets committed by `add -A` and then blocks the next checkout as an untracked file that would be overwritten. The existing ledger tests caught it immediately.
- **`versions.json` written to a sibling and renamed.** `open(..., "w")` truncates first and fills after, so a reader in another process can see an empty file where the version vector should be.

## The test was checked against the unfixed code

Four real processes, committing to one artifact, asserting the final version equals the number of commits that reported success — any shortfall is a lost update.

Reverted to the threading lock, it fails:

```
AssertionError: a writer died: exitcode=1
```

A test that passes before and after proves nothing about either. A threading-only test would have been exactly that.

**CAS is still doing its job**, asserted separately: the lock serialises writers, it does not make them agree, and a writer holding a version that has moved is told to rebase as before. A lock that made conflicts impossible would have turned the version check into dead code.

## Not in this PR

The aggregator-side bounded retry with jitter. That needs the candidate re-derived on the new head, which is a merge-path change with golden-trace implications; the ledger half is the foundation and stands alone. `docs/ledger.md` shows the rebase-and-retry loop a multi-writer caller writes today.

## Verification

- **789 passed, 1 skipped** (785 before + 4 new).
- `run_demo` reproduces `docs/usage.md` verbatim; the golden merge trace is unchanged.
- `test_ledger_resilience.py` passes unchanged — including `index.lock`, a full disk, and a missing git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)