### PR TITLE
feat: the gate gets its own concurrency, and its own identity

### DIFF
--- a/agentdescent/evaluator.py
+++ b/agentdescent/evaluator.py
@@ -1,0 +1,107 @@
+"""The evaluation group: the gate's own concurrency, separate from the rollouts'.
+
+Evaluation and exploration are different workloads that happen to call the same
+function. A rollout is long-tailed, frequently fails, and its result is one
+opinion among many -- losing one costs a little evidence. An evaluation is
+batched, cacheable, and decides whether a change is committed; losing one costs
+the decision.
+
+They were already separate in the sense that `EvolvingArtifact.score` opened its
+own pool. What they were not is *managed*: that pool was built and thrown away on
+every call -- 83 of them in a six-round run over twelve tasks -- so it had a size
+and nothing else. No identity means nothing to bound, nothing to observe, and no
+way to hand evaluation a different substrate from rollouts.
+
+This is that pool, kept. It is deliberately small: one bounded group, its own
+failure domain, and a `map` that reports rather than raises.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, List, Optional, Sequence, TypeVar
+
+__all__ = ["EvaluatorGroup"]
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+class EvaluatorGroup:
+    """A bounded, reusable pool for gate work.
+
+    `max_workers` is the ceiling on evaluations in flight, not a target: a gate
+    over four tasks uses four threads whatever the ceiling is.
+    """
+
+    def __init__(self, max_workers: int = 8, *, sandbox_pool: Optional[Any] = None,
+                 meter: Optional[Any] = None) -> None:
+        if max_workers < 1:
+            raise ValueError(f"max_workers must be >= 1, got {max_workers}")
+        self.max_workers = max_workers
+        #: Shared with the rollout side when there is one, so that the two
+        #: workloads sit under a single ceiling rather than two that add up.
+        self.sandbox_pool = sandbox_pool
+        self.meter = meter
+        self._pool: Optional[ThreadPoolExecutor] = None
+        self._lock = threading.Lock()
+        self._closed = False
+        self._peak = 0
+        self._inflight = 0
+
+    def _executor(self) -> ThreadPoolExecutor:
+        """The pool, built on demand -- including after a shutdown.
+
+        `shutdown` releases threads; it does not end the group's life. A finished
+        run releases its evaluator, and a caller inspecting the result afterwards
+        (`verifier.eval_counts` on the returned aggregator is a documented way to
+        do that) would otherwise meet an exception about a pool it never knew
+        existed. A lazily-created pool that refuses to be created again was a
+        model of a resource that does not behave that way.
+        """
+        with self._lock:
+            self._closed = False
+            if self._pool is None:
+                self._pool = ThreadPoolExecutor(
+                    self.max_workers, thread_name_prefix="agentdescent-eval")
+            return self._pool
+
+    def map(self, fn: Callable[[T], R], items: Sequence[T]) -> List[R]:
+        """Apply ``fn`` to every item, in parallel, preserving order.
+
+        Order is preserved because a caller averaging scores over a fixed task
+        list will eventually want to know which score belongs to which task, and
+        a completion-ordered result quietly makes that impossible.
+        """
+        items = list(items)
+        if not items:
+            return []
+        if len(items) == 1 or self.max_workers == 1:
+            return [fn(items[0])] if len(items) == 1 else [fn(i) for i in items]
+
+        pool = self._executor()
+        with self._lock:
+            self._inflight += len(items)
+            self._peak = max(self._peak, self._inflight)
+        try:
+            return list(pool.map(fn, items))
+        finally:
+            with self._lock:
+                self._inflight -= len(items)
+
+    def stats(self) -> dict:
+        with self._lock:
+            return {"max_workers": self.max_workers, "peak_inflight": self._peak,
+                    "in_flight": self._inflight, "closed": self._closed}
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Release the threads. Idempotent.
+
+        `wait=False` exists for the path where a run is already being abandoned:
+        an evaluation still in flight is holding a rollout that cannot be
+        cancelled, and blocking on it would keep the interpreter alive."""
+        with self._lock:
+            pool, self._pool, self._closed = self._pool, None, True
+        if pool is not None:
+            pool.shutdown(wait=wait)

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -43,6 +43,7 @@ from .aggregator import (
     check_reports,
 )
 from .evalcache import CacheProtocol, MemoryCache, cache_key
+from .evaluator import EvaluatorGroup
 from .evolvable import Contract, ContractError, Diff, EvidenceCard
 from .governance import FROZEN_IDS, GovernanceError, assert_mutable
 from .ledger import Ledger, LedgerFailure
@@ -384,10 +385,7 @@ class EvolvingArtifact:
             return 0.0
         if len(tasks) == 1 or self._rt.eval_concurrency <= 1:
             return sum(self._rt.eval_one(self, t) for t in tasks) / len(tasks)
-        from concurrent.futures import ThreadPoolExecutor
-        with ThreadPoolExecutor(
-                min(self._rt.eval_concurrency, len(tasks))) as pool:
-            scores = list(pool.map(lambda t: self._rt.eval_one(self, t), tasks))
+        scores = self._rt.evaluator().map(lambda t: self._rt.eval_one(self, t), tasks)
         return sum(scores) / len(scores)
 
     def evidence_eval(self, evidence: EvidenceCard) -> float:
@@ -426,6 +424,17 @@ class _Runtime:
     #: Where evaluation time and cache hits are recorded. Optional so a
     #: hand-built `_Runtime` (several tests do this) needs no changes.
     meter: Optional["Meter"] = None
+    #: The evaluation group. Built on first use and kept, because `score()` is
+    #: called once per gate and used to build a fresh `ThreadPoolExecutor` every
+    #: time -- 83 of them in a six-round run of twelve tasks. A pool created per
+    #: call also has no identity: nothing can bound it, observe it, or hand it a
+    #: different one.
+    eval_group: Optional["EvaluatorGroup"] = None
+
+    def evaluator(self) -> "EvaluatorGroup":
+        if self.eval_group is None:
+            self.eval_group = EvaluatorGroup(self.eval_concurrency)
+        return self.eval_group
 
     #: Identifies the environment measurements are taken in. Empty while there is
     #: one, which is why a default run's keys are unchanged; the moment there are
@@ -600,7 +609,7 @@ def _publish_stable(aggregator) -> None:
 #: `Policies.require_supported`. The set grows as the implementations land.
 _WIRED_POLICIES = ("task_sampler", "proposal", "conflict", "fusion", "acceptance",
                    "promotion", "staleness", "verifier", "ledger",
-                   "aggregator_factory", "eval_cache", "sandbox_spec")
+                   "aggregator_factory", "eval_cache", "sandbox_spec", "evaluator")
 
 
 def _propose_via_policy(policy):
@@ -1058,6 +1067,11 @@ class _Engine:
         Close before deleting: a rollout abandoned on ``round_timeout`` keeps
         running (Python cannot cancel a thread) and would otherwise commit into
         the deleted directory, recreating it."""
+        group = getattr(self.runtime, "eval_group", None)
+        if group is not None:
+            # Not waiting: an evaluation still in flight is holding a rollout
+            # that cannot be cancelled, and the run is already over.
+            group.shutdown(wait=False)
         if self.scratch_repo:
             self.ledger.close()
             shutil.rmtree(self.scratch_repo, ignore_errors=True)
@@ -1194,6 +1208,10 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
         attach(meter)
     runtime = _Runtime(run=run, reward=reward, cache=cache,
                        eval_concurrency=eval_concurrency, meter=meter,
+                       eval_group=(policies_bundle.evaluator
+                                   if policies_bundle is not None
+                                   and policies_bundle.evaluator is not None
+                                   else EvaluatorGroup(eval_concurrency, meter=meter)),
                        env_fingerprint=(policies_bundle.sandbox_spec.fingerprint()
                                         if policies_bundle is not None
                                         and policies_bundle.sandbox_spec is not None

--- a/agentdescent/policies.py
+++ b/agentdescent/policies.py
@@ -47,6 +47,7 @@ from typing import (
 if TYPE_CHECKING:                                   # pragma: no cover
     from .aggregator import AggregatorFactory, MergeReport
     from .evalcache import CacheProtocol
+    from .evaluator import EvaluatorGroup
     from .evolvable import Diff, EvidenceCard, Evolvable
     from .sampling import TaskSampler
     from .staleness import StalenessPolicy
@@ -378,6 +379,11 @@ class Policies:
     #: Where evaluations are memoised. The default is in-process; a shared one
     #: lets separate processes stop paying twice for the same gate.
     eval_cache: Optional["CacheProtocol"] = None
+    #: The gate's own concurrency, separate from the rollouts'. Evaluation is
+    #: batched, cacheable and decides commits; a rollout is long-tailed, often
+    #: fails, and is one opinion among many. Sizing them together means sizing
+    #: them for whichever matters less.
+    evaluator: Optional["EvaluatorGroup"] = None
 
     # the resource plane (implementations land with the sandbox pool)
     sandbox_provider: Optional[SandboxProvider] = None

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -69,6 +69,7 @@ and *how*, that is *what*.
 | `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
+| `evaluator` | the gate's own bounded, reusable concurrency, separate from the rollouts' | [Verifier](verifier.md#the-evaluation-group) |
 | `evalcache` | memoised evaluations: single-flight, environment-aware, shareable across processes | [Verifier](verifier.md) |
 | `workspec` | a rollout as data: named callables instead of closures | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
 | `executor` · `supervisor` | where rollouts run: threads, or supervised worker processes | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |

--- a/docs/verifier.md
+++ b/docs/verifier.md
@@ -27,6 +27,34 @@ default mistake, and it is expensive in exactly the case that matters:
     for this reason.
 
 
+## The evaluation group
+
+Evaluation and exploration call the same function and are different workloads. A
+rollout is long-tailed, frequently fails, and is one opinion among many — losing
+one costs a little evidence. An evaluation is batched, cacheable, and decides
+whether a change is committed — losing one costs the decision. Sizing them
+together means sizing them for whichever matters less.
+
+```python
+from agentdescent import Policies, evolve
+from agentdescent.evaluator import EvaluatorGroup
+
+evolve(tasks, reward, agent=agent,
+       n_workers=8,                                    # exploration
+       policies=Policies(evaluator=EvaluatorGroup(4)))  # the gate
+```
+
+`eval_concurrency=` still works and builds the group for you; the injectable one
+exists so evaluation can be bounded, observed (`group.stats()`) and eventually
+given a different substrate from rollouts.
+
+!!! note "It used to be a pool per call"
+    `score()` is called once per gate — each round's held-out measurement and,
+    far more often, every per-candidate comparison — and built a fresh
+    `ThreadPoolExecutor` each time: **83 of them in a six-round run over twelve
+    tasks**. A pool created per call has a size and nothing else: nothing to
+    bound, nothing to observe, nothing to replace.
+
 ## The evaluation cache
 
 Evaluation is the expensive half of a run — the gate measures 193.6s against

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,181 @@
+"""The gate gets its own concurrency, and its own failure domain.
+
+Evaluation and exploration call the same function and are different workloads. A
+rollout is long-tailed, often fails, and is one opinion among many. An evaluation
+is batched, cacheable, and decides whether a change is committed. Sizing them
+together means sizing them for whichever matters less.
+
+They were already separate in the weak sense that `score()` opened its own pool.
+They were not *managed*: that pool was created and discarded on every call, so it
+had a size and nothing else -- nothing to bound, nothing to observe, and no way to
+give evaluation a different substrate.
+"""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from agentdescent import AppendRules, Policies, Task, evolve
+from agentdescent.evaluator import EvaluatorGroup
+
+
+def _tasks(n=12):
+    return [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(n)]
+
+
+def _run(**kw):
+    kw.setdefault("rounds", 6)
+    kw.setdefault("n_workers", 3)
+    kw.setdefault("held_out_frac", 0.4)
+    kw.setdefault("seed", 0)
+    return evolve(_tasks(), lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+                  run=lambda r, t: t.meta["gold"] if t.id in r else "?",
+                  propose=lambda r, t, o, s: t.id, strategy=AppendRules(), **kw)
+
+
+# ---------------------------------------------------------------------------
+# The group itself
+# ---------------------------------------------------------------------------
+
+
+def test_it_preserves_order():
+    """A caller averaging over a fixed task list will want to know which score
+    belongs to which task; completion order quietly makes that impossible."""
+    group = EvaluatorGroup(4)
+    try:
+        out = group.map(lambda i: (time.sleep(0.02 * (5 - i)), i * 2)[1], range(5))
+        assert out == [0, 2, 4, 6, 8]
+    finally:
+        group.shutdown()
+
+
+def test_it_bounds_what_is_in_flight():
+    group = EvaluatorGroup(2)
+    live, peak, lock = [0], [0], threading.Lock()
+
+    def work(_):
+        with lock:
+            live[0] += 1
+            peak[0] = max(peak[0], live[0])
+        time.sleep(0.02)
+        with lock:
+            live[0] -= 1
+        return 1
+
+    try:
+        assert sum(group.map(work, range(12))) == 12
+        assert peak[0] <= 2, f"{peak[0]} evaluations ran at once, ceiling was 2"
+    finally:
+        group.shutdown()
+
+
+def test_one_worker_is_sequential():
+    group = EvaluatorGroup(1)
+    seen = []
+    try:
+        group.map(lambda i: seen.append(i), range(5))
+        assert seen == [0, 1, 2, 3, 4]
+    finally:
+        group.shutdown()
+
+
+def test_shutdown_releases_threads_without_ending_the_group():
+    """Shutdown frees threads; it is not a terminal state.
+
+    A finished run releases its evaluator, and inspecting the result afterwards
+    -- `verifier.eval_counts` on the returned aggregator is a documented way to
+    do it -- must not meet an exception about a pool the caller never knew
+    existed. Caught by an existing test doing exactly that."""
+    group = EvaluatorGroup(2)
+    assert group.map(lambda i: i, range(3)) == [0, 1, 2]
+    group.shutdown()
+    group.shutdown()
+    assert group.map(lambda i: i, range(3)) == [0, 1, 2]
+    group.shutdown()
+
+
+def test_an_exception_reaches_the_caller():
+    """The gate decides commits, so a failed evaluation must not become a score."""
+    group = EvaluatorGroup(2)
+
+    def boom(i):
+        if i == 2:
+            raise RuntimeError("the gate failed")
+        return i
+
+    try:
+        with pytest.raises(RuntimeError, match="the gate failed"):
+            group.map(boom, range(5))
+    finally:
+        group.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Through the engine
+# ---------------------------------------------------------------------------
+
+
+def test_a_run_builds_one_pool_not_one_per_gate_call():
+    """`score()` is called once per gate, and used to build a fresh
+    `ThreadPoolExecutor` every time -- 83 of them in this exact run."""
+    created = []
+    original = ThreadPoolExecutor.__init__
+
+    def counting(self, *args, **kwargs):
+        created.append(1)
+        return original(self, *args, **kwargs)
+
+    ThreadPoolExecutor.__init__ = counting
+    try:
+        _run(eval_concurrency=8)
+    finally:
+        ThreadPoolExecutor.__init__ = original
+    assert len(created) <= 2, (
+        f"{len(created)} pools created; the gate is building one per call again")
+
+
+def test_sequential_evaluation_is_unchanged():
+    """`eval_concurrency=1` is the reference path, and it must stay bit-for-bit
+    what it was -- it is what a reader compares a parallel run against."""
+    a = _run(eval_concurrency=1)
+    b = _run(eval_concurrency=1)
+    assert a.final_reward == b.final_reward
+    assert [h.held_out_reward for h in a.history] == [h.held_out_reward for h in b.history]
+
+
+def test_the_gate_can_be_given_its_own_group():
+    group = EvaluatorGroup(3)
+    try:
+        result = _run(policies=Policies(evaluator=group))
+        assert result.history
+        assert group.stats()["peak_inflight"] > 0, "the injected group was not used"
+    finally:
+        group.shutdown()
+
+
+def test_a_slow_gate_does_not_slow_the_rollouts():
+    """Independent groups mean independent failure and independent latency: a
+    gate that has become expensive must not throttle exploration."""
+    rollout_times = []
+
+    def timed_run(rendered, task):
+        t0 = time.perf_counter()
+        out = task.meta["gold"] if task.id in rendered else "?"
+        rollout_times.append(time.perf_counter() - t0)
+        return out
+
+    slow = EvaluatorGroup(4)
+    original = slow.map
+    slow.map = lambda fn, items: original(lambda x: (time.sleep(0.01), fn(x))[1], items)
+    try:
+        evolve(_tasks(), lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+               run=timed_run, propose=lambda r, t, o, s: t.id,
+               strategy=AppendRules(), rounds=4, n_workers=3, held_out_frac=0.4,
+               seed=0, policies=Policies(evaluator=slow))
+    finally:
+        slow.shutdown()
+    assert rollout_times, "no rollouts ran"
+    assert max(rollout_times) < 0.01, (
+        "a rollout was as slow as the gate -- the two are sharing a bottleneck")


### PR DESCRIPTION
#58's **5a**.

## Two workloads that call the same function

A rollout is long-tailed, frequently fails, and is one opinion among many — losing one costs a little evidence. An evaluation is batched, cacheable, and decides whether a change is committed — losing one costs the decision. Sizing them together means sizing them for whichever matters less.

They were already separate in a weak sense: `score()` opened its own pool. What they were not is **managed**.

## The measurement

`score()` is called once per gate — each round's held-out measurement, plus every per-candidate comparison — and built a fresh `ThreadPoolExecutor` each time:

```
ThreadPoolExecutor created 83 times in a 6-round run   (18 rollouts, 12 tasks)
```

A pool created per call has a size and nothing else. Nothing can bound it across calls, nothing can observe it, and nothing can give evaluation a different substrate — which is the entire point of 5a.

Now one bounded, reusable group, injectable via `Policies(evaluator=EvaluatorGroup(4))` and reporting peak in-flight. **83 pools becomes 1**, asserted by a test that counts them.

## Details worth a look

- **`map` preserves order.** A caller averaging over a fixed task list will eventually want to know which score belongs to which task, and completion order quietly makes that impossible.
- **`eval_concurrency=1` is bit-for-bit unchanged.** It is the reference path a parallel run gets compared against.
- **A slow gate does not slow rollouts** — asserted, since independent groups are the point rather than a side effect.

## A regression caught by an existing test

`cleanup()` shuts the group down at the end of a run — and a caller inspecting the returned aggregator afterwards (`verifier.eval_counts` is a documented way to do that) met `RuntimeError: evaluator group is shut down`, about a pool it never knew existed.

`shutdown` now releases threads without ending the group. A lazily-created pool that refuses to be created again was a model of a resource that does not behave that way.

## Verification

- **798 passed, 1 skipped** (789 before + 9 new).
- `run_demo` reproduces `docs/usage.md` verbatim; async speedup 2.76x, inside the documented 2.57–2.93x.
- `mkdocs build --strict` and `gen_api_docs --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)