### PR TITLE
feat: make task-level recovery observable, and say what it is not

### DIFF
--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -664,6 +664,8 @@ def _cost_fields(meter: Meter) -> Dict[str, Any]:
         "eval_seconds": m.eval_seconds,
         "stale_considered": m.stale_considered,
         "stale_discarded": m.stale_discarded,
+        "redispatched": m.redispatched,
+        "duplicates_dropped": m.duplicates_dropped,
         "cache_hits": m.cache_hits,
         "cache_misses": m.cache_misses,
         "sandbox_wait_s": m.sandbox_wait_s,
@@ -775,6 +777,12 @@ class EvolutionResult:
     #: denominator a stale count cannot be read at all.
     stale_considered: int = 0
     stale_discarded: int = 0
+    #: Task-level recovery: tasks sent out again after their worker was presumed
+    #: lost, and results that arrived for a task already answered. The second
+    #: being non-zero means re-dispatch is firing on workers that were still
+    #: alive -- correct, and paid for twice.
+    redispatched: int = 0
+    duplicates_dropped: int = 0
     #: Evaluation cache. ``misses`` is the number of evaluations actually
     #: performed; the ratio is the duplicate-computation figure a multi-process
     #: run has to report.
@@ -903,6 +911,8 @@ class EvolutionResult:
             "eval_seconds": self.eval_seconds,
             "stale_considered": self.stale_considered,
             "stale_discarded": self.stale_discarded,
+            "redispatched": self.redispatched,
+            "duplicates_dropped": self.duplicates_dropped,
             "cache_hits": self.cache_hits,
             "cache_misses": self.cache_misses,
             "sandbox_wait_s": self.sandbox_wait_s,
@@ -1023,6 +1033,8 @@ class EvolutionResult:
             eval_seconds=d.get("eval_seconds", 0.0),
             stale_considered=d.get("stale_considered", 0),
             stale_discarded=d.get("stale_discarded", 0),
+            redispatched=d.get("redispatched", 0),
+            duplicates_dropped=d.get("duplicates_dropped", 0),
             cache_hits=d.get("cache_hits", 0),
             cache_misses=d.get("cache_misses", 0),
             sandbox_wait_s=d.get("sandbox_wait_s", 0.0),

--- a/agentdescent/metrics.py
+++ b/agentdescent/metrics.py
@@ -60,6 +60,8 @@ class MeterSnapshot:
     cache_inflight_joins: int = 0
     stale_considered: int = 0
     stale_discarded: int = 0
+    redispatched: int = 0
+    duplicates_dropped: int = 0
     sandbox_wait_s: float = 0.0
     sandbox_setup_s: float = 0.0
     sandboxes_created: int = 0
@@ -75,6 +77,7 @@ _COUNTERS = frozenset({
     "rollouts", "rollout_seconds", "eval_seconds", "merge_seconds",
     "cache_hits", "cache_misses", "cache_inflight_joins",
     "stale_considered", "stale_discarded",
+    "redispatched", "duplicates_dropped",
     "sandbox_wait_s", "sandbox_setup_s", "sandboxes_created",
     "sandboxes_reused", "sandbox_failures", "env_mismatch",
 })
@@ -127,6 +130,17 @@ class Meter:
     #: lag budget is too tight" from "barely anything was proposed".
     stale_considered: int = 0
     stale_discarded: int = 0
+
+    #: Task-level recovery. `redispatched` counts tasks sent out again after
+    #: their worker was presumed lost; `duplicates_dropped` counts results that
+    #: arrived for a task already answered -- a worker that was only *presumed*
+    #: dead, finishing after its work had been given to somebody else.
+    #:
+    #: The second is the one worth watching. Dropping the duplicate is correct
+    #: and invisible, so without a counter a re-dispatch policy that is
+    #: needlessly aggressive looks exactly like one that is well tuned.
+    redispatched: int = 0
+    duplicates_dropped: int = 0
 
     #: Sandbox accounting. Zero on the default single-workspace path; filled once
     #: the sandbox pool exists. Kept here from the start so the result schema
@@ -188,6 +202,8 @@ class Meter:
                 cache_inflight_joins=self.cache_inflight_joins,
                 stale_considered=self.stale_considered,
                 stale_discarded=self.stale_discarded,
+                redispatched=self.redispatched,
+                duplicates_dropped=self.duplicates_dropped,
                 sandbox_wait_s=self.sandbox_wait_s,
                 sandbox_setup_s=self.sandbox_setup_s,
                 sandboxes_created=self.sandboxes_created,

--- a/agentdescent/scheduler.py
+++ b/agentdescent/scheduler.py
@@ -249,9 +249,19 @@ class ResumeItem:
 class ResumeQueue:
     """Turn-level checkpoints of timed-out rollouts (partial rollout).
 
-    Write-only in every shipped path: the runtimes push, nothing pops. Kept as
-    the primitive the resume path would need, and counted so a run reports how
-    much work it abandoned -- see the module docstring."""
+    Write-only in every shipped path, and only one of them writes: the reference
+    runtime pushes, nothing pops, and `async_evolve` -- the loop a real workload
+    reaches -- does not checkpoint at all.
+
+    That is deliberate, and it is not what task-level recovery uses. Recovery
+    re-dispatches the **task**: the supervisor notices a worker is gone, sends its
+    work somewhere else under the same lease id, and drops the original's answer
+    if it turns up late. Resuming a partial rollout instead would require
+    `run(rendered, task) -> output` to become an inspectable conversation, and
+    that contract is what lets any agent at all be plugged in.
+
+    So this stays the turn-level primitive it always was, unwired, rather than
+    being repurposed as a task-level channel because it happens to be a queue."""
 
     def __init__(self, p90_multiplier: float = 2.0) -> None:
         self.p90_multiplier = p90_multiplier

--- a/agentdescent/supervisor.py
+++ b/agentdescent/supervisor.py
@@ -222,7 +222,14 @@ class ProcessExecutor:
                     _, wid, lease, task_id, output, value, seconds = message
                     inflight.pop(lease, None)
                     if pending.pop(lease, None) is None:
-                        continue            # a re-dispatch that came back twice
+                        # A worker that was only *presumed* dead, finishing after
+                        # its task had been given to somebody else. Dropping it is
+                        # correct and invisible, so it is counted: an over-eager
+                        # re-dispatch policy otherwise looks exactly like a
+                        # well-tuned one.
+                        if self.meter is not None:
+                            self.meter.add("duplicates_dropped")
+                        continue
                     if self.meter is not None:
                         self.meter.add("rollouts")
                         self.meter.add("rollout_seconds", seconds)
@@ -233,6 +240,8 @@ class ProcessExecutor:
                     _, wid, lease, task_id, error, failure_kind, seconds = message
                     inflight.pop(lease, None)
                     if pending.pop(lease, None) is None:
+                        if self.meter is not None:
+                            self.meter.add("duplicates_dropped")
                         continue
                     if self.meter is not None and failure_kind == "infrastructure":
                         self.meter.add("sandbox_failures")
@@ -277,6 +286,8 @@ class ProcessExecutor:
                 # Same lease id on purpose: if the original worker was only
                 # presumed dead and reports later, the caller can tell the two
                 # apart and drop one.
+                if self.meter is not None:
+                    self.meter.add("redispatched")
                 to_send.append(spec)
 
         for wid in dead:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,6 +123,7 @@ r.duplicate_rate()        # evaluation cache hit rate
 | work | `rollouts`, `rollout_seconds` (a **sum** across workers, so it exceeds `wallclock` when they overlap), `eval_seconds` |
 | model | `usage.calls` / `.seconds` / `.failures` |
 | staleness | `stale_considered`, `stale_discarded` |
+| recovery | `redispatched`, `duplicates_dropped` |
 | recomputation | `cache_hits`, `cache_misses` |
 | sandboxes | `sandbox_wait_s`, `sandbox_setup_s`, `sandboxes_created` / `_reused` / `_failures` |
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -250,3 +250,69 @@ def test_infrastructure_failures_are_counted_apart_from_model_failures():
     assert _classify(OSError("no space left on device")) == "infrastructure"
     assert _classify(MemoryError()) == "infrastructure"
     assert _classify(RuntimeError("the model refused")) == "model"
+
+
+# ---------------------------------------------------------------------------
+# Task-level recovery
+# ---------------------------------------------------------------------------
+
+
+def test_a_late_result_from_a_presumed_dead_worker_is_dropped_and_counted():
+    """The idempotency that makes re-dispatch safe.
+
+    A worker declared lost may simply have been slow. When it finishes, its
+    result arrives for a task somebody else has already answered -- and accepting
+    both would put two cards for one task into the evidence pool, which is a
+    quiet doubling of one worker's vote.
+
+    Dropping it is correct and invisible, so it is counted: an over-eager
+    re-dispatch policy otherwise looks exactly like a well-tuned one."""
+    from agentdescent.metrics import Meter
+
+    meter = Meter()
+    ex = ProcessExecutor(2, meter=meter)
+    try:
+        specs = [spec(i) for i in range(2)]
+        results = list(ex.map_rollouts(specs))
+        assert len(results) == 2
+
+        # the straggler reports, after its lease has already been answered
+        ex._results.put(("DONE", 0, specs[0].lease_id, specs[0].task.id,
+                         "late", 1.0, 0.1))
+        again = list(ex.map_rollouts([spec(9)]))
+        assert len(again) == 1 and again[0].task_id == "t9", (
+            "a duplicate for an answered task was reported as a result")
+    finally:
+        ex.shutdown()
+    assert meter.snapshot().duplicates_dropped >= 1
+
+
+def test_re_dispatch_is_counted():
+    ex = ProcessExecutor(2, hang_timeout=0.5)
+    from agentdescent.metrics import Meter
+    ex.meter = Meter()
+    ex.start()
+    try:
+        s = spec(3)
+        to_send = []
+        ex._reclaim({s.lease_id: s}, {s.lease_id: time.time() - 60},
+                    {s.lease_id: 0}, {}, to_send)
+        assert to_send and ex.meter.snapshot().redispatched == 1
+    finally:
+        ex.shutdown()
+
+
+def test_the_loop_never_blocks_forever_on_a_result_that_cannot_come():
+    """If a worker dies holding the only copy of a task, the run must end -- with
+    a failure for that task -- rather than wait for a message nobody will send."""
+    ex = ProcessExecutor(1, hang_timeout=0.2)
+    try:
+        s = spec(5)
+        pending, to_send = {s.lease_id: s}, []
+        out = ex._reclaim(pending, {s.lease_id: time.time() - 60},
+                          {s.lease_id: 0}, {s.lease_id: 5}, to_send)
+        assert len(out) == 1 and not out[0].ok
+        assert out[0].kind == "infrastructure"
+        assert not pending, "the task stayed pending and the loop would not end"
+    finally:
+        ex.shutdown()

--- a/tests/test_sandbox_container.py
+++ b/tests/test_sandbox_container.py
@@ -363,26 +363,37 @@ def test_the_local_provider_does_not_stop_what_this_one_does(engine, shared_root
 @needs_engine
 @every_engine
 def test_the_network_is_off_by_default_and_on_when_asked(engine, shared_root):
+    """Asserted on the network namespace, not by dialling out.
+
+    An earlier version connected to 1.1.1.1. That made the test depend on the
+    machine having working egress, so it went red when this laptop's DNS dropped
+    and would go red in any CI without outbound access -- reporting "isolation is
+    broken" when the isolation was fine and the internet was not.
+
+    `--network none` leaves a container with loopback and nothing else. That is
+    the property being claimed, and it is observable from inside without a single
+    packet leaving."""
     p = ContainerProvider(IMAGE, engine=engine)
     probe = ("import socket;"
-             "socket.setdefaulttimeout(4);"
-             "socket.create_connection(('1.1.1.1', 80));"
-             "print('connected')")
+             "print(sorted(i[1] for i in socket.if_nameindex()))")
 
     closed = p.acquire(SandboxSpec(workspace_root=shared_root))
     try:
         out = subprocess.run([*closed.exec_prefix(), "python", "-c", probe],
-                     capture_output=True, text=True, timeout=120)
-        assert out.returncode != 0, "the default sandbox reached the network"
+                             capture_output=True, text=True, timeout=120)
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() == "['lo']", (
+            f"a container with --network none had more than loopback: {out.stdout}")
     finally:
         p.release(closed)
 
     opened = p.acquire(SandboxSpec(workspace_root=shared_root, network="inherit"))
     try:
         out = subprocess.run([*opened.exec_prefix(), "python", "-c", probe],
-                     capture_output=True, text=True, timeout=120)
-        assert "connected" in out.stdout, (
-            f"network=inherit did not connect: {out.stderr[-300:]}")
+                             capture_output=True, text=True, timeout=120)
+        assert out.returncode == 0, out.stderr
+        assert out.stdout.strip() != "['lo']", (
+            "network=inherit gave the container no interface but loopback")
     finally:
         p.release(opened)
 


### PR DESCRIPTION
#58's **5d**.

## The mechanism was there; the visibility was not

Re-dispatch landed with the supervisor: a worker presumed lost has its task sent out again under the **same lease id**, and a result arriving for a task already answered is dropped. That is what makes re-dispatch safe — a worker declared lost may simply have been slow, and accepting both answers puts two cards for one task into the evidence pool, quietly doubling one worker's vote.

What was missing: dropping a duplicate is correct and **invisible**. A re-dispatch policy firing on workers that were still alive looks exactly like a well-tuned one — same results, same rewards, twice the rollouts.

Both are counted now, and reach `EvolutionResult`:

| field | meaning |
|---|---|
| `redispatched` | tasks sent out again after their worker was presumed lost |
| `duplicates_dropped` | results for a task already answered — **work paid for twice** |

Plus three assertions the mechanism did not have: a late duplicate is dropped rather than reported, re-dispatch is counted, and a task whose worker keeps dying ends the loop with a failure rather than waiting for a message nobody will send.

## What this deliberately does not do

`ResumeQueue` stays unwired. Its docstring now says *why* rather than only *that*: turn-level resume would require `run(rendered, task) -> output` to become an inspectable conversation, and that opaque contract is what lets any agent be plugged in at all.

Repurposing a turn-level queue as a task-level channel because it happens to be a queue would have made the module look finished without recovering anything.

## A flaky test fixed rather than re-run

The container network assertion connected to `1.1.1.1`, so it depended on the machine having egress. It went red when this laptop's DNS dropped mid-session, and would go red in any CI without outbound access — reporting "isolation is broken" when the isolation was fine and the internet was not.

`--network none` leaves a container with loopback and nothing else. That is the property being claimed, and it is observable from inside without a packet leaving. Stable across three consecutive runs against both engines.

## Verification

- **801 passed, 1 skipped** (798 before + 3 new).
- `run_demo` reproduces `docs/usage.md` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)