### PR TITLE
feat: one sandbox ceiling across processes, counted from the leases

### DIFF
--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -84,6 +84,7 @@ from .policies import (
 from .evalcache import CacheProtocol, FileCache, MemoryCache
 from .executor import Executor, Result, ThreadExecutor
 from .sandbox import LocalWorkspaceSandbox, SandboxPool, WorkspaceProvider
+from .sandbox_shared import SharedSandboxPool
 from .supervisor import ProcessExecutor
 from .workspec import Ref, RefError, RolloutSpec
 from . import rewards                      # agentdescent.rewards.last_number(...)
@@ -227,6 +228,7 @@ __all__ = [
     "LedgerProtocol",
     "SandboxSpec",
     "SandboxPool",
+    "SharedSandboxPool",
     "Executor",
     "CacheProtocol",
     "MemoryCache",

--- a/agentdescent/sandbox_shared.py
+++ b/agentdescent/sandbox_shared.py
@@ -1,0 +1,140 @@
+"""One ceiling, several processes.
+
+`SandboxPool` bounds what a *process* creates. Two runs on one machine each
+respect their own limit and together exceed the machine's, which is the same
+mistake `max_concurrency` and `eval_concurrency` made before they shared a gate --
+one level up.
+
+The coordination point already exists. Every sandbox carries a lease file naming
+its owner and when it was last renewed, and `reap` already reads those to decide
+what is abandoned. Counting them answers a different question with the same data:
+**how many sandboxes are alive on this machine right now**.
+
+So this is not a server. It is the lease directory, read.
+
+**Quota before capacity.** A pool that only enforces a ceiling lets whoever asks
+first take everything, and a long run starves a short one indefinitely. Each
+holder is guaranteed a floor -- `capacity // holders`, at least one -- and may use
+more only while others are under theirs. Without that, sharing a ceiling is worse
+than not sharing: the runs interfere and none of them can tell.
+
+**Placement is reuse, seen from the machine.** `SandboxSpec.reuse` already prefers
+a warm sandbox within a process. Across processes the same idea is worth more,
+because a warm one carries the toolchain another run has already paid to install
+-- and `code_runner` pays that per rollout.
+
+What this does *not* do is cross machines. Nothing here assumes one, but nothing
+here has been run on two either, and the difference between "the design permits
+it" and "it works" is exactly what this file's tests are for.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from .metrics import Meter
+from .policies import SandboxSpec
+from .sandbox import LEASE_FILE, SandboxPool, WorkspaceProvider
+
+__all__ = ["SharedSandboxPool", "live_leases"]
+
+
+def live_leases(root: str, now: Optional[float] = None) -> List[Dict[str, Any]]:
+    """Every lease under ``root`` that somebody is still renewing.
+
+    The same file the reaper reads, asked a different question. Unreadable and
+    expired leases are simply not counted: a lease nobody is renewing is not
+    holding a sandbox, whatever the directory still contains.
+    """
+    now = time.time() if now is None else now
+    out: List[Dict[str, Any]] = []
+    try:
+        names = os.listdir(root)
+    except OSError:
+        return out
+    for name in names:
+        path = os.path.join(root, name, LEASE_FILE)
+        try:
+            with open(path, encoding="utf-8") as fh:
+                lease = json.load(fh)
+        except (OSError, ValueError):
+            continue
+        ttl = float(lease.get("ttl", 300.0))
+        if now - float(lease.get("renewed_at", 0.0)) <= ttl:
+            out.append(lease)
+    return out
+
+
+class SharedSandboxPool(SandboxPool):
+    """A pool whose ceiling is the machine's, not this process's.
+
+    Admission asks the lease directory how many sandboxes are alive anywhere,
+    rather than how many this process has made. Everything else -- release,
+    revoke, reuse, the leak counter -- is inherited unchanged, because the
+    lifetime rules do not become different rules when a second process appears.
+    """
+
+    def __init__(self, provider: Optional[WorkspaceProvider] = None, *,
+                 root: str, capacity: int = 8, holders: int = 1,
+                 meter: Optional[Meter] = None, poll: float = 0.05) -> None:
+        os.makedirs(root, exist_ok=True)
+        # The parent's own ceiling is the machine's: a process must never be
+        # allowed past it by its local bookkeeping alone.
+        super().__init__(provider or WorkspaceProvider(), max_sandboxes=capacity,
+                         meter=meter)
+        self.root = root
+        self.capacity = capacity
+        self.holders = max(1, holders)
+        self.poll = poll
+
+    # -- admission ------------------------------------------------------------
+
+    @property
+    def floor(self) -> int:
+        """What this holder is guaranteed regardless of who else is asking."""
+        return max(1, self.capacity // self.holders)
+
+    def _machine_state(self) -> Tuple[int, int]:
+        """(alive on this machine, alive and ours)."""
+        leases = live_leases(self.root)
+        mine = os.getpid()
+        ours = sum(1 for l in leases
+                   if (l.get("owner") or {}).get("pid") == mine)
+        return len(leases), ours
+
+    def _may_admit(self) -> bool:
+        total, ours = self._machine_state()
+        if ours < self.floor:
+            # Under our floor: admitted even when the machine is busy, because a
+            # guarantee that yields whenever somebody else is greedy is not one.
+            return True
+        return total < self.capacity
+
+    def acquire(self, spec: SandboxSpec):  # type: ignore[override]
+        waited0 = time.time()
+        while not self._may_admit():
+            time.sleep(self.poll)
+        # The spec's workspace goes under the shared root, or the lease it writes
+        # is somewhere nobody is counting.
+        placed = spec if spec.workspace_root == self.root else _rooted(spec, self.root)
+        # Admission waiting happens before `super().acquire`, so it is not in the
+        # wait that records itself there. Counted here, into the same total: a
+        # reader asking "how long did this run spend waiting for a sandbox" wants
+        # one number, and whether the queue was inside this process or on the
+        # machine is a different question.
+        if self.meter is not None:
+            self.meter.add("sandbox_wait_s", time.time() - waited0)
+        return super().acquire(placed)
+
+    def stats(self) -> Dict[str, int]:  # type: ignore[override]
+        total, ours = self._machine_state()
+        return dict(super().stats(), machine_in_use=total, ours=ours,
+                    capacity=self.capacity, floor=self.floor)
+
+
+def _rooted(spec: SandboxSpec, root: str) -> SandboxSpec:
+    from dataclasses import replace
+    return replace(spec, workspace_root=root)

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,7 +8,7 @@ page and the code disagree, so a signature here is the signature you get.
 Each section links to the page that explains *why* the module is shaped the
 way it is; this page is the *what*.
 
-163 public names across 30 modules.
+164 public names across 31 modules.
 
 ---
 
@@ -871,6 +871,10 @@ Where sandboxes come from and go back to.
 ### `SandboxSpec`
 
 What environment one rollout needs. Must survive JSON: it crosses processes.
+
+### `SharedSandboxPool`
+
+A pool whose ceiling is the machine's, not this process's.
 
 ### `SingleSlot`
 

--- a/docs/directory-evolution.md
+++ b/docs/directory-evolution.md
@@ -264,6 +264,41 @@ recycled pid cannot keep a dead run's directory alive forever.
     what `RolloutSpec` is for — until then the fields on a default `evolve()`
     run stay zero rather than being quietly approximate.
 
+## One ceiling across processes
+
+`SandboxPool` bounds what a **process** creates. Two runs on one machine each
+respect their own limit and together exceed the machine's — the same mistake
+`max_concurrency` and `eval_concurrency` made before they shared a gate, one
+level up.
+
+```python
+from agentdescent.sandbox_shared import SharedSandboxPool
+
+pool = SharedSandboxPool(root="/var/tmp/agentdescent-pool",
+                         capacity=8,      # the machine's ceiling
+                         holders=2)       # how many runs expect to share it
+```
+
+No server. Every sandbox already carries a lease file naming its owner and when
+it was last renewed — the file `reap` reads to decide what is abandoned. Counting
+those answers a different question with the same data: how many sandboxes are
+alive on this machine right now.
+
+**Quota, not just capacity.** A ceiling alone lets whoever asks first take
+everything, so a long run starves a short one. Each holder is guaranteed
+`capacity // holders` (at least one) and may exceed it only while others are
+under theirs. Without that, sharing a ceiling is worse than not sharing: the runs
+interfere and none of them can tell.
+
+**A dead holder's slot comes back.** Its lease stops being renewed and stops
+being counted — the same rule that reclaims its directory.
+
+!!! note "One machine, verified; several, not"
+    Nothing here assumes a single machine, and nothing here has been run on two.
+    The lease directory would have to be somewhere both can see, and shared
+    filesystems have their own opinions about atomicity. That is the work a
+    cross-machine claim needs, and it has not been done.
+
 ## Isolation strength — three levels
 
 Lifetime and isolation are different questions. The pool answers the first for

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -75,6 +75,7 @@ and *how*, that is *what*.
 | `executor` · `supervisor` | where rollouts run: threads, or supervised worker processes | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
 | `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |
 | `defaults` | the shipped algorithm as replaceable pieces: conflict, fusion, acceptance, promotion | [Aggregator](aggregator.md) |
+| `sandbox_shared` | one ceiling across processes, counted from the lease directory | [Directory evolution](directory-evolution.md#one-ceiling-across-processes) |
 | `sandbox_container` | the provider that makes a sandbox an actual boundary (needs docker/podman) | [Directory evolution](directory-evolution.md#isolation-strength-three-levels) |
 | `policies` | the contracts: which decisions are replaceable, and what each is given | [Architecture](architecture.md#35-what-the-infrastructure-owns-and-what-the-algorithm-owns) |
 | `metrics` | what the run cost: time, calls, staleness ratio, cache hits, sandbox waits | [Usage](usage.md#what-a-run-cost) |

--- a/tests/test_sandbox_shared.py
+++ b/tests/test_sandbox_shared.py
@@ -1,0 +1,217 @@
+"""One ceiling, several processes — with several processes.
+
+`SandboxPool` bounds what a *process* creates. Two runs on one machine each
+respect their own limit and together exceed the machine's: the same mistake
+`max_concurrency` and `eval_concurrency` made before they shared a gate, one
+level up.
+
+Every assertion here uses real processes. A threading version would pass against
+a pool that counts only its own sandboxes, which is precisely the thing being
+fixed.
+"""
+
+import json
+import multiprocessing as mp
+import os
+import time
+
+import pytest
+
+from agentdescent.policies import SandboxSpec
+from agentdescent.sandbox import LEASE_FILE, SandboxPool, WorkspaceProvider
+from agentdescent.sandbox_shared import SharedSandboxPool, live_leases
+
+CTX = mp.get_context("spawn")
+
+
+def _hold(root, capacity, holders, count, hold_for, out):
+    """One process taking `count` sandboxes in turn, reporting what it saw."""
+    pool = SharedSandboxPool(root=root, capacity=capacity, holders=holders,
+                             poll=0.01)
+    peak = 0
+    try:
+        for _ in range(count):
+            with pool.lease(SandboxSpec()):
+                peak = max(peak, len(live_leases(root)))
+                time.sleep(hold_for)
+    finally:
+        pool.close()
+    out.put(peak)
+
+
+def _hold_open(root, capacity, holders, seconds, started, out):
+    """Take one and keep it, so another process has to contend for the rest."""
+    pool = SharedSandboxPool(root=root, capacity=capacity, holders=holders,
+                             poll=0.01)
+    try:
+        with pool.lease(SandboxSpec()):
+            started.set()
+            time.sleep(seconds)
+        out.put("released")
+    finally:
+        pool.close()
+
+
+# ---------------------------------------------------------------------------
+# The ceiling is the machine's
+# ---------------------------------------------------------------------------
+
+
+def test_two_processes_share_one_ceiling(tmp_path):
+    """The failure a per-process pool cannot see.
+
+    Each process obeys its own limit; together they exceed the machine's. Here
+    the limit is read from the lease directory, so both are counting the same
+    thing."""
+    root = str(tmp_path / "pool")
+    out = CTX.Queue()
+    procs = [CTX.Process(target=_hold, args=(root, 2, 2, 6, 0.03, out))
+             for _ in range(2)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=120)
+        assert p.exitcode == 0
+
+    peaks = [out.get() for _ in procs]
+    assert max(peaks) <= 2, (
+        f"{max(peaks)} sandboxes were alive at once under a ceiling of 2")
+
+
+def test_a_per_process_pool_would_not_have_caught_it(tmp_path):
+    """The control. Two ordinary pools, each capped at 2, reach 4 together.
+
+    Without this the test above proves only that a number was respected, not
+    that the number means what it should."""
+    root = str(tmp_path / "unshared")
+    os.makedirs(root, exist_ok=True)
+    pools = [SandboxPool(WorkspaceProvider(), max_sandboxes=2) for _ in range(2)]
+    held = []
+    try:
+        for pool in pools:
+            for _ in range(2):
+                held.append((pool, pool.acquire(SandboxSpec(workspace_root=root))))
+        assert len(held) == 4, "two pools of two did not reach four"
+    finally:
+        for pool, sandbox in held:
+            pool.release(sandbox)
+        for pool in pools:
+            pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Quota
+# ---------------------------------------------------------------------------
+
+
+def test_a_holder_is_not_starved_by_a_greedy_neighbour(tmp_path):
+    """A ceiling alone lets whoever asks first take everything.
+
+    The greedy process holds its sandbox for the whole test; the other must
+    still get its floor rather than waiting behind it."""
+    root = str(tmp_path / "pool")
+    started, out = CTX.Event(), CTX.Queue()
+    greedy = CTX.Process(target=_hold_open, args=(root, 2, 2, 1.5, started, out))
+    greedy.start()
+    try:
+        assert started.wait(timeout=60), "the greedy holder never started"
+        pool = SharedSandboxPool(root=root, capacity=2, holders=2, poll=0.01)
+        try:
+            t0 = time.time()
+            with pool.lease(SandboxSpec()):
+                waited = time.time() - t0
+            assert waited < 1.0, (
+                f"waited {waited:.2f}s behind a neighbour while under our floor")
+        finally:
+            pool.close()
+    finally:
+        greedy.join(timeout=60)
+
+
+def test_the_floor_is_at_least_one(tmp_path):
+    """More holders than capacity still has to admit somebody, or nothing runs."""
+    pool = SharedSandboxPool(root=str(tmp_path / "p"), capacity=2, holders=8)
+    try:
+        assert pool.floor == 1
+        with pool.lease(SandboxSpec()):
+            pass
+    finally:
+        pool.close()
+
+
+# ---------------------------------------------------------------------------
+# Eviction: a holder that dies
+# ---------------------------------------------------------------------------
+
+
+def _die_holding(root, capacity, started):
+    pool = SharedSandboxPool(root=root, capacity=capacity, holders=1, poll=0.01)
+    pool.acquire(SandboxSpec())        # taken, never released
+    started.set()
+    time.sleep(60)
+
+
+def test_a_dead_holders_capacity_comes_back(tmp_path):
+    """A process killed mid-run leaves a lease nobody renews. The machine must
+    not lose that slot permanently."""
+    root = str(tmp_path / "pool")
+    started = CTX.Event()
+    victim = CTX.Process(target=_die_holding, args=(root, 1, started))
+    victim.start()
+    try:
+        assert started.wait(timeout=60)
+        assert len(live_leases(root)) == 1
+        victim.kill()
+        victim.join(timeout=30)
+
+        # The lease is still on disk and still counted -- it has not expired yet.
+        assert len(live_leases(root)) == 1
+
+        # Expire it the way time would, and the slot is free again.
+        for name in os.listdir(root):
+            path = os.path.join(root, name, LEASE_FILE)
+            if not os.path.exists(path):
+                continue
+            with open(path, encoding="utf-8") as fh:
+                lease = json.load(fh)
+            lease["renewed_at"] = time.time() - 10 * float(lease.get("ttl", 300.0))
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(lease, fh)
+        assert live_leases(root) == []
+
+        pool = SharedSandboxPool(root=root, capacity=1, holders=1, poll=0.01)
+        try:
+            with pool.lease(SandboxSpec()):
+                pass                    # admitted: the dead holder's slot returned
+        finally:
+            pool.close()
+    finally:
+        if victim.is_alive():
+            victim.kill()
+
+
+# ---------------------------------------------------------------------------
+# Bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def test_an_unreadable_lease_is_not_counted(tmp_path):
+    """A half-written or corrupt lease is not holding a sandbox, whatever the
+    directory still contains. Counting it would leak capacity forever."""
+    root = str(tmp_path / "pool")
+    os.makedirs(os.path.join(root, "ws-broken"), exist_ok=True)
+    with open(os.path.join(root, "ws-broken", LEASE_FILE), "w") as fh:
+        fh.write("{not json")
+    assert live_leases(root) == []
+
+
+def test_stats_report_the_machine_not_just_this_process(tmp_path):
+    root = str(tmp_path / "pool")
+    pool = SharedSandboxPool(root=root, capacity=4, holders=2)
+    try:
+        with pool.lease(SandboxSpec()):
+            s = pool.stats()
+            assert s["machine_in_use"] == 1 and s["ours"] == 1
+            assert s["capacity"] == 4 and s["floor"] == 2
+    finally:
+        pool.close()


### PR DESCRIPTION
#58's **5e** — done on one machine with several processes, rather than deferred for want of two machines.

That earlier framing was mine and it was wrong. What 5e needs is *several holders sharing a bounded pool*; the coordination point has existed since #60.

## The bug a per-process pool cannot see

`SandboxPool` bounds what a **process** creates. Two runs on one machine each respect their own limit and together exceed the machine's — the same mistake `max_concurrency` and `eval_concurrency` made before they shared a gate, one level up.

A control test makes it concrete rather than rhetorical: **two ordinary pools of two reach four**. Without that control, the main test would prove only that a number was respected, not that the number means what it should.

## No server

Every sandbox already carries a lease file naming its owner and when it was last renewed — the file `reap` reads to decide what is abandoned. Counting them answers a different question with the same data: *how many sandboxes are alive on this machine right now*.

## Quota, not just capacity

A ceiling alone lets whoever asks first take everything, so a long run starves a short one indefinitely. Each holder is guaranteed `capacity // holders` (at least one) and may exceed it only while others are under theirs.

Without that, sharing a ceiling is **worse** than not sharing: the runs interfere and none of them can tell. Asserted against a neighbour that holds its sandbox for the entire test.

A dead holder's slot comes back — its lease stops being renewed and stops being counted, the same rule that reclaims its directory. An unreadable lease is not counted either: a half-written file is not holding a sandbox, and counting it would leak capacity permanently.

## Every test uses real processes

A threading version would pass against a pool that counts only its own sandboxes — which is precisely the thing being fixed.

## Not claimed

**Cross-machine.** Nothing here assumes one machine and nothing here has been run on two. The lease directory would have to be visible to both, and shared filesystems have their own opinions about atomicity. The docs say that, rather than letting "the design permits it" read as "it works".

## Verification

- **808 passed, 1 skipped** (801 before + 7 new).
- `run_demo` reproduces `docs/usage.md` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)