### PR TITLE
feat: standardize faithful port entrypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,13 @@ All notable changes to AgentDescent are documented here. The format follows
   merge.
 
 ### Changed
+- **Faithful algorithm ports now share one tested CLI contract.** Their provider,
+  model, seed, async, dry-run and confirmation flags come from
+  `examples._common`; upstream iteration vocabulary and per-port defaults remain
+  local. A copyable code/test template and a short porting checklist make the
+  same contract the starting point for future ports. All six `--dry-run` paths
+  now return before dataset/model setup, so they are genuinely zero-network on a
+  cold machine, and the candidate backlog records mechanism gaps and owners.
 - **The two barrier-free runtimes share their policies.** `async_evolve` and
   `AsyncAgentDescent` implemented the same shape independently; a previous
   release had to hand-port two measured fixes between them. The parts that are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,22 @@ pip install -e ".[dev]"     # core engine has zero runtime deps; [dev] adds pyte
 
 Python ≥ 3.9 is required.
 
+## Shortest verification path
+
+From a fresh checkout, the shortest environment and behavior check is:
+
+```bash
+git clone https://github.com/Birfy/agentdescent
+cd agentdescent
+pip install -e ".[dev]"
+pytest -q
+python -m examples.run_demo
+```
+
+Then temporarily change `rounds = 40` to `rounds = 8` in
+`examples/run_demo.py`, run the demo again, observe the shorter curve, and
+restore the line. That proves you are executing the checkout you are editing.
+
 ## Running the tests
 
 The suite is **offline and deterministic** (no network, no model API):
@@ -35,8 +51,8 @@ python -m examples.efficiency                     # parallel scaling + async tai
 python -m examples.skill_evolution --dry-run      # the flagship LLM example, no API
 ```
 
-Every LLM-backed example has a `--dry-run` mode that exercises the code paths
-without calling a model.
+Every faithful algorithm port has a zero-network `--dry-run` mode for inspecting
+its CLI configuration without loading a dataset or calling a model.
 
 ## Building the docs
 
@@ -54,7 +70,8 @@ mkdocs build --strict   # must pass with no warnings (CI enforces this)
   not silent averaging.
 - **Faithful ports stay faithful.** The algorithm examples follow each source
   repo's *released code* (not just the paper). If code and paper disagree, follow
-  the code and note it.
+  the code and note it. Start from the [porting checklist](docs/porting-checklist.md)
+  and `examples/_TEMPLATE.py`.
 - **No hidden network in tests.** Anything requiring an API or heavy infra
   (SWE-bench Docker, gated datasets) must be gated behind a flag and documented.
 - Match the style and comment density of the surrounding code.

--- a/README.md
+++ b/README.md
@@ -240,8 +240,8 @@ Guide: [evolving a directory](https://github.com/Birfy/agentdescent/blob/main/do
 To show the engine is faithful to the field, AgentDescent ships one runnable example
 per representative **skill** and **harness** self-evolution algorithm — each
 faithful to the original repo's *algorithm* and *dataset choice*, each with a
-`--dry-run` (no-API) mode and an offline test suite. Every one loads its benchmark
-through the shared [`agentdescent.dataloader`](https://github.com/Birfy/agentdescent/blob/main/docs/dataloader.md) data layer
+zero-network `--dry-run` mode and an offline test suite. Real runs load their
+benchmarks through the shared [`agentdescent.dataloader`](https://github.com/Birfy/agentdescent/blob/main/docs/dataloader.md) data layer
 (HF datasets-server + raw files, cached, dependency-free). Full guide:
 [docs/self-evolution-examples.md](https://github.com/Birfy/agentdescent/blob/main/docs/self-evolution-examples.md).
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -75,9 +75,9 @@ python -m examples.adas_meta_agent_search --provider claude --model claude-haiku
 ```
 
 Put the `export` lines in your shell profile to keep them across sessions. Every
-example also takes `--dry-run`, which loads the dataset and prints the plan
-**without a single API call** — the cheapest way to confirm your setup before
-paying for a run:
+faithful algorithm port also takes a zero-network `--dry-run`, which prints the
+configuration without reading these credentials — the cheapest way to inspect a
+run before paying for it:
 
 ```bash
 python -m examples.adas_meta_agent_search --dry-run

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -148,8 +148,9 @@ export OPENAI_BASE_URL=https://api.deepseek.com     # or your gateway
 export OPENAI_API_KEY=sk-...
 ```
 
-Then confirm the setup costs nothing before it costs something — `--dry-run`
-loads MGSM, prints the plan and the budget, and makes **no API calls**:
+Inspect the setup before it costs something: `--dry-run` prints the requested
+MGSM/runtime configuration and returns before loading data or models, so it needs
+neither network nor an API key:
 
 ```bash
 python -m examples.adas_meta_agent_search --dry-run

--- a/docs/dataloader.md
+++ b/docs/dataloader.md
@@ -107,7 +107,8 @@ def download_hotpotqa(limit):
   the examples install nothing extra. The `datasets` library is imported lazily,
   and *only* inside `load_gated_hf`, for gated datasets that need auth.
 * **Cache-first.** Every page and file is cached under `~/.cache/agentdescent/`;
-  re-runs and `--dry-run` are offline after the first fetch.
+  real re-runs are offline after the first fetch. Faithful-port `--dry-run`
+  returns before the loader and is offline even with an empty cache.
 * **Not in the engine.** Nothing in `agentdescent.evolution` / `agentdescent.aggregator`
   imports this — it is a convenience for examples and experiments, exactly like
   `agentdescent.agents`.

--- a/docs/install.md
+++ b/docs/install.md
@@ -90,11 +90,12 @@ For Claude, `pip install anthropic` and use `claude(model="claude-haiku-4-5")`
 instead — same call everywhere else. Full walkthrough:
 [quickstart](quickstart-skill.md).
 
-!!! tip "Every LLM-backed example has `--dry-run`"
-    It loads the dataset and estimates the API cost **without calling a model**:
+!!! tip "Inspect a faithful port with `--dry-run`"
+    The six faithful algorithm ports print their configuration with no dataset
+    download, model call, or API key. Other examples may still load or download data:
 
     ```bash
-    python -m examples.skill_evolution --dry-run
+    python -m examples.ace_context_evolution --dry-run
     python -m examples.gepa_prompt_evolution --dry-run
     ```
 

--- a/docs/porting-checklist.md
+++ b/docs/porting-checklist.md
@@ -1,0 +1,16 @@
+# Porting checklist
+
+Use this before calling an algorithm example a faithful port.
+
+- [ ] Start from **released code**, not only the paper; follow code on conflicts and document each conflict in `docs/algo-<name>.md`.
+- [ ] Use the original repository's dataset rather than substituting an easier benchmark.
+- [ ] Build the CLI with `examples._common.add_standard_args`; keep the upstream iteration term (`rounds`, `generations`, `iterations`, or `steps`).
+- [ ] Load data through `agentdescent.dataloader`, never port-specific HTTP.
+- [ ] Choose an explicit `Strategy` (`AppendRules`, `KeyedRules`, `SingleSlot`, `FileTree`, or a justified custom strategy).
+- [ ] Prefer an existing scorer from `agentdescent.rewards` when it matches the benchmark.
+- [ ] Make `--dry-run` return before data/model setup: zero network and zero API key.
+- [ ] Add `tests/test_<name>_example.py`; all tests must run offline.
+- [ ] Add `docs/algo-<name>.md`: algorithm summary, every deviation, runnable command, and measured result (or why none exists).
+- [ ] Add one row to both the README and `docs/self-evolution-examples.md`.
+- [ ] State heavy-infrastructure boundaries such as Docker or gated data instead of hiding them.
+- [ ] Record the port author/maintainer so later fidelity decisions have an owner.

--- a/docs/results.md
+++ b/docs/results.md
@@ -116,9 +116,9 @@ python -m examples.gepa_prompt_evolution --provider openai --model deepseek-v4-f
     --rounds 5 --fetch 40 --yes
 ```
 
-Every example takes `--dry-run` (loads the dataset, prints the plan, no API calls)
-and `--provider openai` for any OpenAI-compatible endpoint via `OPENAI_BASE_URL` +
-`OPENAI_API_KEY`. Sample sizes are deliberately small so a run costs minutes; they
+Every faithful port takes a zero-network `--dry-run` and `--provider openai` for
+any OpenAI-compatible endpoint via `OPENAI_BASE_URL` + `OPENAI_API_KEY`. Sample
+sizes are deliberately small so a run costs minutes; they
 are **not** the papers' full setups, and where a full setup needs heavy
 infrastructure (SWE-bench in Docker, gated data) the boundary is stated on the
 algorithm's page.

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -33,18 +33,19 @@ python -m examples.ace_context_evolution --model claude-haiku-4-5           # sy
 python -m examples.ace_context_evolution --model claude-haiku-4-5 --async   # barrier-free
 ```
 
-| Algorithm | Kind | Dataset (faithful) | `evolve()` plug-ins | Page |
-|---|---|---|---|---|
-| **ACE** (Agentic Context Engineering) | skill / context | FiNER-139 (XBRL tagging) | `strategy=ACEPlaybook`; Curator = default aggregator | [→](algo-ace.md) |
-| **GEPA** (Reflective Prompt Evolution) | skill / prompt | HotpotQA (EM) | `aggregator_factory=` Pareto optimizer | [→](algo-gepa.md) |
-| **EvoSkill** (Automated Skill Discovery) | skill library | OfficeQA (Treasury) | `strategy` + `aggregator_factory=` top-K frontier (sync) / SGD descent (async) | [→](algo-evoskill.md) |
-| **SkillOpt** (ReflACT) | skill document | SearchQA (EM/F1) | `strategy` (edits) + `aggregator_factory=` strict gate | [→](algo-skillopt.md) |
-| **ADAS** (Meta Agent Search) | harness (L1) | MGSM | `strategy` + `aggregator_factory=` keep-all archive | [→](algo-adas.md) |
-| **DGM** (Darwin Gödel Machine) | harness (L1) | SWE-bench Verified | `strategy` + `aggregator_factory=` archive + selection | [→](algo-dgm.md) |
+| Algorithm | Port author | Kind | Dataset (faithful) | `evolve()` plug-ins | Page |
+|---|---|---|---|---|---|
+| **ACE** (Agentic Context Engineering) | chendanyang | skill / context | FiNER-139 (XBRL tagging) | `strategy=ACEPlaybook`; Curator = default aggregator | [→](algo-ace.md) |
+| **GEPA** (Reflective Prompt Evolution) | chendanyang | skill / prompt | HotpotQA (EM) | `aggregator_factory=` Pareto optimizer | [→](algo-gepa.md) |
+| **EvoSkill** (Automated Skill Discovery) | chendanyang | skill library | OfficeQA (Treasury) | `strategy` + `aggregator_factory=` top-K frontier (sync) / SGD descent (async) | [→](algo-evoskill.md) |
+| **SkillOpt** (ReflACT) | chendanyang | skill document | SearchQA (EM/F1) | `strategy` (edits) + `aggregator_factory=` strict gate | [→](algo-skillopt.md) |
+| **ADAS** (Meta Agent Search) | chendanyang | harness (L1) | MGSM | `strategy` + `aggregator_factory=` keep-all archive | [→](algo-adas.md) |
+| **DGM** (Darwin Gödel Machine) | chendanyang | harness (L1) | SWE-bench Verified | `strategy` + `aggregator_factory=` archive + selection | [→](algo-dgm.md) |
 
-Every example takes `--dry-run` (load the dataset, print the plan, **no API
-calls**) and has an offline test suite (`tests/test_<name>_example.py`) exercising
-its pure logic. Datasets load through the shared
+Every example takes `--dry-run`, which prints its configuration and returns with
+**zero network access and no API key**, and has an offline test suite
+(`tests/test_<name>_example.py`) exercising its pure logic. Real runs load their
+datasets through the shared
 [**`agentdescent.dataloader`**](dataloader.md) data layer — dependency-free
 (`urllib` only), cached under `~/.cache/agentdescent/`, from each benchmark's
 canonical source. Where a paper's full setup needs heavy infrastructure, the
@@ -217,7 +218,25 @@ python -m examples.dgm_self_improve --generations 12 --archive keep_all
 
 ---
 
-## Not yet ported
+## Candidate ports
+
+The backlog is organised by missing mechanism, not paper popularity. Assign an
+owner before implementation so fidelity questions have a person who read the
+released code.
+
+| Mechanism | Candidates | Existing coverage | Owner |
+|---|---|---|---|
+| Evolution / program search | AlphaEvolve (OpenEvolve), PromptBreeder, AFlow | none | TBD |
+| Reflection / textual gradients | TextGrad, Reflexion, Self-Refine | partial (GEPA is reflective, not textual-gradient) | TBD |
+| Skills / lifelong learning | Voyager, SkillWeaver | adjacent (EvoSkill) | TBD |
+| Self-play / unlabeled data | Absolute Zero, R-Zero, Agent0 | **none; highest priority** | TBD |
+| Self-modifying code | SICA, Gödel Agent | DGM | TBD |
+
+The unlabeled path is the most important gap: all six current ports derive reward
+from a benchmark with gold labels, although `evolve()` only requires a score in
+`[0, 1]` and does not require labels.
+
+### Deferred pending released code
 
 * **CoEvoSkills** (arXiv:2604.01687, "Self-Evolving Agent Skills via
   Co-Evolutionary Verification") — the Skill Generator + co-evolving Surrogate
@@ -228,6 +247,8 @@ python -m examples.dgm_self_improve --generations 12 --archive keep_all
   release code, rather than reconstructed and mislabelled as faithful.
 
 ## Fidelity principles
+
+Use the short [porting checklist](porting-checklist.md) before adding a row here.
 
 1. **Faithful to the repo, not just the paper.** Where the released code diverges
    from the paper's claims (e.g. EvoSkill's frontier is top-K aggregate, not

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,9 +68,9 @@ offline in seconds; `--agent claude-code` swaps in the real CLI agent, and
 Faithful ports of the latest skill- and harness-self-evolution algorithms — ACE,
 GEPA, EvoSkill, SkillOpt, ADAS, DGM (see
 [the catalog](self-evolution-examples.md)). Each loads a real benchmark through
-the [`agentdescent.dataloader`](dataloader.md) data layer. `--dry-run` previews
-the dataset and estimates the API cost **without calling a model** — note that it
-still downloads the benchmark, and does not run the evolution loop:
+the [`agentdescent.dataloader`](dataloader.md) data layer on a real run.
+`--dry-run` prints the requested dataset and runtime configuration, then returns
+before loading data or models: it needs no network and no API key.
 
 ```bash
 python -m examples.ace_context_evolution --dry-run     # ACE   / FiNER-139

--- a/examples/_TEMPLATE.py
+++ b/examples/_TEMPLATE.py
@@ -1,0 +1,109 @@
+"""Template for a faithful self-evolution algorithm port.
+
+Copy this file to ``examples/<algorithm>.py`` and replace every ``PORT_*`` /
+``DATASET_*`` value. Keep the upstream algorithm's vocabulary for its iteration
+flag: ``--rounds``, ``--generations``, ``--iterations``, or ``--steps``. Record
+every deviation from released code in ``docs/algo-<algorithm>.md``.
+
+The control-flow order is part of the template: ``--dry-run`` returns before
+the dataset loader and model adapter, so it is safe on a cold, offline machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agentdescent.agents import Usage, claude, openai_compatible
+from agentdescent.dataloader import hf_rows
+from agentdescent.evolution import AppendRules, LLMAgent, Task, evolve
+from agentdescent.rewards import exact_match
+from examples._common import add_standard_args
+
+
+PORT_NAME = "replace-with-algorithm-name"
+PORT_AUTHOR = "TODO: GitHub handle"
+UPSTREAM_RELEASED_CODE = "TODO: released repository URL and revision"
+DATASET_NAME = "replace-me/dataset"
+DATASET_CONFIG = "default"
+DATASET_SPLIT = "train"
+
+# Pick the representation that matches the released implementation. Alternatives
+# include KeyedRules, SingleSlot, and FileTree; do not invent a custom Strategy
+# when one of those already expresses the upstream state.
+STRATEGY = AppendRules()
+REWARD = exact_match()
+
+
+def load_tasks(limit: int):
+    """Load through agentdescent.dataloader; never implement HTTP in a port."""
+    if DATASET_NAME.startswith("replace-me/"):
+        raise RuntimeError("replace the DATASET_* placeholders before a real run")
+    rows = hf_rows(DATASET_NAME, DATASET_SPLIT, config=DATASET_CONFIG, limit=limit)
+    return [
+        Task(id=str(i), prompt=str(row["prompt"]), meta={"gold": row["gold"]})
+        for i, row in enumerate(rows)
+    ]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_standard_args(parser, max_seconds_default=30.0)
+    # Keep the released implementation's term here; do not standardise it.
+    parser.add_argument("--iterations", type=int, default=6)
+    parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--limit", type=int, default=40)
+    return parser
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
+    print(f"Algorithm: {PORT_NAME} (port author: {PORT_AUTHOR})")
+    print(f"Upstream : {UPSTREAM_RELEASED_CODE}")
+    print(f"Dataset  : {DATASET_NAME}")
+    print(f"Plan     : model={args.model}, iterations={args.iterations}, "
+          f"workers={args.workers}")
+
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
+    tasks = load_tasks(args.limit)
+    if len(tasks) < 4:
+        raise ValueError("a port needs at least four tasks for train/held-out splitting")
+    if not args.yes and sys.stdin.isatty():
+        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
+            print("aborted.")
+            return
+
+    usage = Usage()
+    completion = (
+        openai_compatible(model=args.model, usage=usage)
+        if args.provider in ("openai", "glm")
+        else claude(model=args.model, usage=usage)
+    )
+    result = evolve(
+        tasks,
+        REWARD,
+        agent=LLMAgent(completion),
+        strategy=STRATEGY,
+        rounds=args.iterations,
+        n_workers=args.workers,
+        max_concurrency=1 if args.asynchronous else args.workers,
+        asynchronous=args.asynchronous,
+        async_ratio=args.async_ratio,
+        max_seconds=args.max_seconds if args.asynchronous else None,
+        seed=args.seed,
+        usage=usage,
+    )
+    print(result.rendered)
+    print(f"reward      : {result.final_reward:.3f}")
+    print(f"outcomes    : {result.outcomes()}")
+    print(f"stop reason : {result.stop_reason}")
+    print(f"error       : {result.error or 'none'}")
+    print(f"model usage : {usage.summary()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,0 +1,66 @@
+"""Shared command-line arguments for the faithful algorithm ports.
+
+Algorithm-specific vocabulary stays in each port. In particular, iteration
+flags such as ``--rounds``, ``--generations``, ``--iterations``, and ``--steps``
+must not be normalised here: they are part of the upstream algorithm's language.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+PROVIDER_CHOICES = ("claude", "openai", "glm")
+DEFAULT_MODEL = "claude-haiku-4-5"
+
+
+def add_standard_args(
+    parser: argparse.ArgumentParser,
+    *,
+    model_default=DEFAULT_MODEL,
+    max_seconds_default: float = 30.0,
+) -> argparse.ArgumentParser:
+    """Add the provider/runtime flags shared by every algorithm port.
+
+    Defaults that describe an algorithm's measured setup remain caller-owned.
+    DGM, for example, deliberately defaults ``model`` to ``None`` because its
+    surrogate can run without an API, while async wall-clock budgets differ by
+    workload.
+    """
+    parser.add_argument(
+        "--provider",
+        default="claude",
+        choices=PROVIDER_CHOICES,
+        help=("claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, "
+              "vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a "
+              "legacy alias"),
+    )
+    parser.add_argument(
+        "--model", default=model_default,
+        help="model id (DGM may omit it for deterministic proposals)")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--async",
+        dest="asynchronous",
+        action="store_true",
+        help="run barrier-free (async_evolve)",
+    )
+    parser.add_argument(
+        "--async-ratio", type=int, default=3, help="staleness lag budget")
+    parser.add_argument(
+        "--max-seconds",
+        type=float,
+        default=max_seconds_default,
+        help="async wall-clock budget",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="show the plan without loading data or accessing the network",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="skip confirmation before real model API calls",
+    )
+    return parser

--- a/examples/ace_context_evolution.py
+++ b/examples/ace_context_evolution.py
@@ -32,7 +32,7 @@ ACE's per-bullet *helpful / harmful* counters become the aggregator's per-diff
 reward (evidence it was helpful), and rejected otherwise -- the discrete-space
 analogue ACE's counters approximate. Skill layer -> `blast_radius=0.2` (L2).
 
-    python -m examples.ace_context_evolution --dry-run          # dataset + estimate, no API
+    python -m examples.ace_context_evolution --dry-run          # plan only, zero network
     python -m examples.ace_context_evolution --model claude-haiku-4-5
     python -m examples.ace_context_evolution --top-k 10 --rounds 6
 
@@ -59,6 +59,7 @@ from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rul
 from agentdescent.governance import classify
 from agentdescent.parallel import DataParallel
 from agentdescent.sampling import DifficultyWeighted, RoundRobin
+from examples._common import add_standard_args
 
 FINER = ("nlpaueb/finer-139", "validation", "finer-139")   # (dataset, split, config)
 
@@ -282,11 +283,9 @@ def evaluate(agent, rendered: str, tasks: List[Task], reward) -> float:
 # ===========================================================================
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--provider", default="claude",
-                   choices=["claude", "openai", "glm"], help="claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a legacy alias")
-    p.add_argument("--model", default="claude-haiku-4-5")
+    add_standard_args(p, max_seconds_default=30.0)
     p.add_argument("--rounds", type=int, default=6)
     p.add_argument("--workers", type=int, default=2)
     p.add_argument("--top-k", type=int, default=120,
@@ -297,20 +296,29 @@ def main() -> None:
                         "bullet beats the baseline); at 120 it goes 0.844 -> 0.889")
     p.add_argument("--pool", type=int, default=800,
                    help="FiNER validation rows to scan for single-entity sentences")
-    p.add_argument("--seed", type=int, default=0)
     p.add_argument("--sampler", choices=["round-robin", "difficulty"],
                    default="round-robin",
                    help="which task a worker rolls out next (agentdescent.sampling)")
-    p.add_argument("--async", dest="asynchronous", action="store_true",
-                   help="run barrier-free (async_evolve): workers never wait for the merge")
-    p.add_argument("--async-ratio", type=int, default=3, help="staleness lag budget")
-    p.add_argument("--max-seconds", type=float, default=30.0, help="async wall-clock budget")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--yes", action="store_true")
-    args = p.parse_args()
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
 
     print("Algorithm: ACE (Agentic Context Engineering) -- skill/context self-evolution")
     print("Dataset  : FiNER-139 (financial XBRL tagging)")
+    print(f"\nPlan     : model={args.model}, rounds={args.rounds}, workers={args.workers}")
+    if args.asynchronous:
+        print(f"Async    : {args.workers} workers, barrier-free (async_ratio={args.async_ratio}, "
+              f"max {args.max_seconds:.0f}s); staleness policy rebases/discards stale diffs")
+    else:
+        print(f"Parallel : {args.workers} workers run concurrently each round "
+              f"(synchronous DP; the aggregator merge is the barrier)")
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
     ds = load_dataset(args.pool, args.top_k, seed=args.seed)
     if len(ds) < 4:
         print(f"Only {len(ds)} single-entity tasks in the pool; raise --pool.")
@@ -331,18 +339,7 @@ def main() -> None:
     print("  A:", ds.train[0].meta["target"])
 
     est = estimate_calls(args.rounds, args.workers, nva) + nte
-    print(f"\nPlan     : model={args.model}, rounds={args.rounds}, workers={args.workers}")
-    if args.asynchronous:
-        print(f"Async    : {args.workers} workers, barrier-free (async_ratio={args.async_ratio}, "
-              f"max {args.max_seconds:.0f}s); staleness policy rebases/discards stale diffs")
-    else:
-        print(f"Parallel : {args.workers} workers run concurrently each round "
-              f"(synchronous DP; the aggregator merge is the barrier)")
     print(f"Budget   : up to ~{est} model calls (cached repeats are free)")
-
-    if args.dry_run:
-        print("\n[dry-run] not calling the API. Drop --dry-run to evolve the playbook.")
-        return
 
     if not args.yes and sys.stdin.isatty():
         if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -36,7 +36,7 @@ archive; `--select dgm` instead samples which prior agents to surface using the
 setting (a self-modifying coding agent on SWE-bench) needs Docker and is out of
 scope, but its open-ended selection rule ports directly and is unit-tested.
 
-    python -m examples.adas_meta_agent_search --dry-run       # dataset + seeds, no API
+    python -m examples.adas_meta_agent_search --dry-run       # plan only, zero network
     python -m examples.adas_meta_agent_search --model claude-haiku-4-5 --generations 6
     python -m examples.adas_meta_agent_search --select dgm --langs en,es
 """
@@ -61,6 +61,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from examples._common import add_standard_args
 
 MGSM_URL = "https://raw.githubusercontent.com/ShengranHu/ADAS/main/dataset/mgsm/mgsm_{lang}.tsv"
 # ADAS's MGSM language set (utils.ALL_LANGUAGES).
@@ -963,22 +964,15 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
 # ===========================================================================
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--provider", default="claude",
-                   choices=["claude", "openai", "glm"], help="claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a legacy alias")
-    p.add_argument("--model", default="claude-haiku-4-5")
+    add_standard_args(p, max_seconds_default=60.0)
     p.add_argument("--generations", type=int, default=6)
     p.add_argument("--langs", default="en,es,fr",
                    help=f"comma-separated MGSM languages (of {','.join(ALL_LANGUAGES)})")
     p.add_argument("--per-lang", type=int, default=8, help="validation examples per language")
     p.add_argument("--select", default="adas", choices=["adas", "dgm"],
                    help="archive conditioning: adas (whole archive) or dgm (sampled)")
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--async", dest="asynchronous", action="store_true",
-                   help="run barrier-free (async_evolve)")
-    p.add_argument("--async-ratio", type=int, default=3, help="staleness lag budget")
-    p.add_argument("--max-seconds", type=float, default=60.0, help="async wall-clock budget")
     p.add_argument("--hard-keep", type=int, default=None,
                    help="cap the hard subset -- evaluation cost is candidates x "
                         "items x (multi-step calls), so this is the strongest lever "
@@ -1015,9 +1009,12 @@ def main() -> None:
                         "else -- everything left over measures fitness instead")
     p.add_argument("--test-frac", type=float, default=0.35,
                    help="share of the pool held out for the final number")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--yes", action="store_true")
-    args = p.parse_args()
+    return p
+
+
+def main(argv=None) -> None:
+    p = build_parser()
+    args = p.parse_args(argv)
 
     langs = [l.strip() for l in args.langs.split(",") if l.strip() in ALL_LANGUAGES]
     if not 0.0 < args.train_frac and 0.0 < args.test_frac and args.train_frac + args.test_frac < 1.0:
@@ -1025,6 +1022,21 @@ def main() -> None:
     ratios = (args.train_frac, 1.0 - args.train_frac - args.test_frac, args.test_frac)
     print("Algorithm: ADAS Meta Agent Search -- harness (agentic-system) self-evolution")
     print("Dataset  : MGSM (Multilingual Grade-School Math)")
+    print(f"\nPlan     : model={args.model}, generations={args.generations}, "
+          f"select={args.select}")
+    if args.asynchronous:
+        print(f"Async    : {args.workers} meta-agents, barrier-free "
+              f"(async_ratio={args.async_ratio}, max {args.max_seconds:.0f}s); "
+              f"the archive rebases/discards stale designs")
+    else:
+        print(f"Parallel : {args.workers} meta-agents propose concurrently each "
+              "generation (synchronous DP; the archive merge is the barrier)")
+    if args.dry_run:
+        print(f"Data     : langs={langs}, per-lang={args.per_lang}; deferred "
+              "(dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
     langmap = language_of(langs, args.per_lang, seed=args.seed)
     pool = build_examples(langs, args.per_lang, seed=args.seed)
     ds = split_dataset(pool, ratios=ratios, seed=args.seed, name="MGSM",
@@ -1037,21 +1049,6 @@ def main() -> None:
     print("\nExample problem:")
     print("  Q:", ds.train[0][0][:150])
     print("  A:", ds.train[0][1])
-    print(f"\nPlan     : model={args.model}, generations={args.generations}, select={args.select}")
-    if args.asynchronous:
-        print(f"Async    : {args.workers} meta-agents, barrier-free "
-              f"(async_ratio={args.async_ratio}, max {args.max_seconds:.0f}s); "
-              f"the archive rebases/discards stale designs")
-    else:
-        print(f"Parallel : {args.workers} meta-agents propose concurrently each "
-              "generation (synchronous DP; the archive merge is the barrier)")
-
-    if args.dry_run:
-        lo, hi = estimate_calls(args.generations, *ds.sizes(), args.workers)
-        print(f"\nBudget   : ~{lo}-{hi} model calls on this (unfiltered) split")
-        print("\n[dry-run] not calling the API. Drop --dry-run to run Meta Agent Search.")
-        return
-
     if not args.yes and sys.stdin.isatty():
         if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
             print("aborted.")

--- a/examples/dgm_self_improve.py
+++ b/examples/dgm_self_improve.py
@@ -45,6 +45,7 @@ escalation, keep-all) is therefore fully runnable and testable offline; the
 `run_dgm` to plug in the actual Docker harness.
 
     python -m examples.dgm_self_improve                 # runs offline (surrogate objective)
+    python -m examples.dgm_self_improve --dry-run       # plan only, zero network
     python -m examples.dgm_self_improve --generations 12 --archive keep_all
     python -m examples.dgm_self_improve --model claude-haiku-4-5   # LLM proposes modifications
 """
@@ -57,6 +58,7 @@ import argparse
 import hashlib
 import math
 import random
+import sys
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Tuple
 
@@ -67,6 +69,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from examples._common import add_standard_args
 
 SWEBENCH = ("princeton-nlp/SWE-bench_Verified", "test", "default")   # (dataset, split, config)
 
@@ -427,25 +430,36 @@ def load_dataset(limit: int, seed: int = 0, ratios=(0.5, 0.25, 0.25)) -> Dataset
 # ===========================================================================
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
+    add_standard_args(p, model_default=None, max_seconds_default=15.0)
     p.add_argument("--generations", type=int, default=12)
     p.add_argument("--selfimprove-size", type=int, default=2)
     p.add_argument("--archive", default="keep_all", choices=["keep_all", "keep_better"])
-    p.add_argument("--provider", default="claude",
-                   choices=["claude", "openai", "glm"], help="claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a legacy alias")
-    p.add_argument("--model", default=None,
-                   help="optional: let an LLM propose self-modifications (else deterministic)")
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--async", dest="asynchronous", action="store_true",
-                   help="run barrier-free (async_evolve)")
-    p.add_argument("--async-ratio", type=int, default=3, help="staleness lag budget")
-    p.add_argument("--max-seconds", type=float, default=15.0, help="async wall-clock budget")
-    p.add_argument("--dry-run", action="store_true", help="load dataset + show plan only")
-    args = p.parse_args()
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
 
     print("Algorithm: Darwin Godel Machine (DGM) -- harness self-evolution")
     print("Dataset  : SWE-bench Verified (real instance ids; surrogate objective)")
+    print(f"Plan     : model={args.model or 'deterministic'}, "
+          f"generations={args.generations}, archive={args.archive}")
+    if args.asynchronous:
+        print(f"Async    : {args.selfimprove_size} agents, barrier-free (async_ratio="
+              f"{args.async_ratio}, max {args.max_seconds:.0f}s); "
+              "archive rebases/discards stale")
+    else:
+        print(f"Parallel : {args.selfimprove_size} agents self-modify concurrently each "
+              "generation (synchronous DP; the archive merge is the barrier)")
+    print("\nObjective: SURROGATE (capability-cover) -- real DGM runs SWE-bench in "
+          "Docker.\n           The archive + selection + staged escalation are faithful.")
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
     ds = load_dataset(STAGE_BIG, seed=args.seed)
     art = EvolvingArtifact("coding_agent", blast_radius=0.6)
     ntr, nva, nte = ds.sizes()
@@ -454,21 +468,12 @@ def main() -> None:
     print(f"Loaded   : {len(ds)} SWE-bench Verified instances; "
           f"{ntr} train / {nva} val (staged eval) / {nte} test")
     print(f"Example  : {ds.train[0]['instance_id']} ({ds.train[0]['repo']})")
-    if args.asynchronous:
-        print(f"Async    : {args.selfimprove_size} agents, barrier-free (async_ratio="
-              f"{args.async_ratio}, max {args.max_seconds:.0f}s); archive rebases/discards stale")
-    else:
-        print(f"Parallel : {args.selfimprove_size} agents self-modify concurrently each "
-              "generation (synchronous DP; the archive merge is the barrier)")
-    print("\nObjective: SURROGATE (capability-cover) -- real DGM runs SWE-bench in "
-          "Docker.\n           The archive + selection + staged escalation are faithful.")
-
-    if args.dry_run:
-        print("\n[dry-run] not running the loop.")
-        return
-
     complete = None
     if args.model:
+        if not args.yes and sys.stdin.isatty():
+            if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
+                print("aborted.")
+                return
         complete = (openai_compatible(model=args.model) if args.provider in ("openai", "glm")
                     else claude(model=args.model))
         try:

--- a/examples/evoskill_skill_discovery.py
+++ b/examples/evoskill_skill_discovery.py
@@ -28,7 +28,7 @@ proposed `SKILL.md` into a `Diff`, and a custom `aggregator_factory`
 (`TopKFrontierAggregator`) is the bounded top-K frontier. A skill is an **L2**
 artifact -> `blast_radius=0.2` (via `classify`).
 
-    python -m examples.evoskill_skill_discovery --dry-run     # dataset + scorer, no API
+    python -m examples.evoskill_skill_discovery --dry-run     # plan only, zero network
     python -m examples.evoskill_skill_discovery --model claude-haiku-4-5
 
 Dataset caveat (you asked to use the real OfficeQA): the full set is HF-**gated**
@@ -60,6 +60,7 @@ from agentdescent.filetree import parse_tree
 from agentdescent.treestrategy import FileTree
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from examples._common import add_standard_args
 
 RAW = "https://raw.githubusercontent.com/sentient-agi/EvoSkill/main/examples/officeqa/data"
 Completion = Callable[[str], str]
@@ -785,11 +786,9 @@ def evaluate(complete: Completion, docs: Dict[str, str], skills: Dict[str, str],
 # ===========================================================================
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--provider", default="claude",
-                   choices=["claude", "openai", "glm"], help="claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a legacy alias")
-    p.add_argument("--model", default="claude-haiku-4-5")
+    add_standard_args(p, max_seconds_default=40.0)
     p.add_argument("--iterations", type=int, default=6)
     p.add_argument("--frontier", type=int, default=5,
                    help="bounded top-K frontier size "
@@ -804,16 +803,27 @@ def main() -> None:
                         "(OpenHands SDK, Claude Code CLI, Codex CLI) -- all of which "
                         "are the same Completion contract, staged into a workspace "
                         "by backends.document_agent")
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--async", dest="asynchronous", action="store_true",
-                   help="run barrier-free (async_evolve)")
-    p.add_argument("--async-ratio", type=int, default=3, help="staleness lag budget")
-    p.add_argument("--max-seconds", type=float, default=40.0, help="async wall-clock budget")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--yes", action="store_true")
-    args = p.parse_args()
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
 
     print("Algorithm: EvoSkill -- failure-driven skill discovery (top-K frontier)")
+    print(f"Dataset  : selection={args.dataset} (OfficeQA preferred; FinQA fallback)")
+    print(f"\nPlan     : model={args.model}, iterations={args.iterations}, "
+          f"frontier={args.frontier}")
+    if args.asynchronous:
+        print(f"Async    : up to 3 workers, barrier-free (async_ratio={args.async_ratio}, "
+              f"max {args.max_seconds:.0f}s); the frontier rebases/discards stale skills")
+    else:
+        print("Parallel : up to 3 workers run concurrently each round "
+              "(synchronous DP; the frontier merge is the barrier)")
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
     ds, docs, src = load_dataset(seed=args.seed, dataset=args.dataset)
     print(f"Dataset  : {ds.name} (financial documents, deterministic numeric scorer)")
     art = EvolvingArtifact("skill_library", blast_radius=0.2)
@@ -826,18 +836,8 @@ def main() -> None:
     print("  A:", ds.train[0]["answer"], f"(difficulty={ds.train[0]['difficulty']})")
 
     calls = args.iterations * (3 + 2 + nva) + nte
-    print(f"\nPlan     : model={args.model}, iterations={args.iterations}, frontier={args.frontier}")
-    if args.asynchronous:
-        print(f"Async    : {min(3, ntr)} workers, barrier-free (async_ratio={args.async_ratio}, "
-              f"max {args.max_seconds:.0f}s); the frontier rebases/discards stale skills")
-    else:
-        print(f"Parallel : {min(3, ntr)} workers run concurrently each round "
-              f"(synchronous DP; the frontier merge is the barrier)")
+    print(f"Workers  : dataset provides {min(3, ntr)} active workers")
     print(f"Budget   : up to ~{calls} model calls")
-
-    if args.dry_run:
-        print("\n[dry-run] not calling the API. Drop --dry-run to discover skills.")
-        return
 
     if not args.yes and sys.stdin.isatty():
         if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):

--- a/examples/gepa_prompt_evolution.py
+++ b/examples/gepa_prompt_evolution.py
@@ -28,7 +28,7 @@ Only the parent-selection optimizer changes; the ledger, governance, staleness,
 and statistical-acceptance machinery are the framework's. Prompt = L2 skill ->
 `blast_radius=0.2`.
 
-    python -m examples.gepa_prompt_evolution --dry-run           # dataset + estimate, no API
+    python -m examples.gepa_prompt_evolution --dry-run           # plan only, zero network
     python -m examples.gepa_prompt_evolution --model claude-haiku-4-5
     python -m examples.gepa_prompt_evolution --rounds 10 --workers 3
 
@@ -56,6 +56,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from examples._common import add_standard_args
 
 HOTPOTQA = ("hotpotqa/hotpot_qa", "validation", "distractor")   # (dataset, split, config)
 
@@ -387,25 +388,32 @@ def evaluate(agent, instruction: str, tasks: List[Task], reward) -> float:
 # ===========================================================================
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--provider", default="claude",
-                   choices=["claude", "openai", "glm"], help="claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a legacy alias")
-    p.add_argument("--model", default="claude-haiku-4-5")
+    add_standard_args(p, max_seconds_default=45.0)
     p.add_argument("--rounds", type=int, default=10)
     p.add_argument("--workers", type=int, default=3)
     p.add_argument("--fetch", type=int, default=48, help="HotpotQA rows to fetch")
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--async", dest="asynchronous", action="store_true",
-                   help="run barrier-free (async_evolve): workers never wait for the merge")
-    p.add_argument("--async-ratio", type=int, default=3, help="staleness lag budget")
-    p.add_argument("--max-seconds", type=float, default=45.0, help="async wall-clock budget")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--yes", action="store_true")
-    args = p.parse_args()
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
 
     print("Algorithm: GEPA (Reflective Prompt Evolution) -- skill/prompt self-evolution")
     print("Dataset  : HotpotQA (multi-hop QA, distractor), exact-match")
+    print(f"\nPlan     : model={args.model}, rounds={args.rounds}, workers={args.workers}")
+    if args.asynchronous:
+        print(f"Async    : {args.workers} workers, barrier-free (async_ratio={args.async_ratio}, "
+              f"max {args.max_seconds:.0f}s); staleness policy rebases/discards stale diffs")
+    else:
+        print(f"Parallel : {args.workers} workers run concurrently each round "
+              f"(synchronous DP; the aggregator merge is the barrier)")
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
     ds = load_dataset(args.fetch, seed=args.seed)
     reward = make_reward()
 
@@ -419,18 +427,7 @@ def main() -> None:
     print("  A:", ds.train[0].meta["target"])
 
     est = estimate_calls(args.rounds, args.workers, nva) + nte
-    print(f"\nPlan     : model={args.model}, rounds={args.rounds}, workers={args.workers}")
-    if args.asynchronous:
-        print(f"Async    : {args.workers} workers, barrier-free (async_ratio={args.async_ratio}, "
-              f"max {args.max_seconds:.0f}s); staleness policy rebases/discards stale diffs")
-    else:
-        print(f"Parallel : {args.workers} workers run concurrently each round "
-              f"(synchronous DP; the aggregator merge is the barrier)")
     print(f"Budget   : up to ~{est} model calls (cached repeats are free)")
-
-    if args.dry_run:
-        print("\n[dry-run] not calling the API. Drop --dry-run to evolve the prompt.")
-        return
 
     if not args.yes and sys.stdin.isatty():
         if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):

--- a/examples/skillopt_skill_training.py
+++ b/examples/skillopt_skill_training.py
@@ -34,7 +34,7 @@ buffer. A skill doc is an **L2** artifact (`blast_radius=0.2`, via `classify`).
 The epoch-level *slow-update* and *meta-skill* stabilisers are optional in the
 repo and omitted from this minimal-but-faithful slice (noted, not hidden).
 
-    python -m examples.skillopt_skill_training --dry-run        # dataset + seed doc, no API
+    python -m examples.skillopt_skill_training --dry-run        # plan only, zero network
     python -m examples.skillopt_skill_training --model claude-haiku-4-5
     python -m examples.skillopt_skill_training --steps 8 --lr 4
 """
@@ -58,6 +58,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from examples._common import add_standard_args
 
 SEARCHQA = ("lucadiliello/searchqa", "default")   # (dataset, config)
 Completion = Callable[[str], str]
@@ -491,32 +492,41 @@ def load_dataset(n_train: int, n_val: int, seed: int = 0, hard: bool = False,
 # ===========================================================================
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--provider", default="claude",
-                   choices=["claude", "openai", "glm"], help="claude, or any OpenAI-compatible endpoint (DeepSeek, GLM, vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a legacy alias")
-    p.add_argument("--model", default="claude-haiku-4-5")
+    add_standard_args(p, max_seconds_default=40.0)
     p.add_argument("--steps", type=int, default=8)
     p.add_argument("--lr", type=int, default=4, help="max edits/step (learning rate)")
     p.add_argument("--lr-mode", default="cosine", choices=["constant", "linear", "cosine"])
     p.add_argument("--minibatch", type=int, default=4)
     p.add_argument("--train", type=int, default=40)
     p.add_argument("--val", type=int, default=20)
-    p.add_argument("--seed", type=int, default=0)
-    p.add_argument("--async", dest="asynchronous", action="store_true",
-                   help="run barrier-free (async_evolve)")
-    p.add_argument("--async-ratio", type=int, default=3, help="staleness lag budget")
-    p.add_argument("--max-seconds", type=float, default=40.0, help="async wall-clock budget")
     p.add_argument("--hard", action="store_true",
                    help="keep only questions the seed skill answers wrong -- plain "
                         "SearchQA is already ~0.900 for a strong model, so there is "
                         "nothing for a skill document to add")
-    p.add_argument("--dry-run", action="store_true")
-    p.add_argument("--yes", action="store_true")
-    args = p.parse_args()
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
 
     print("Algorithm: SkillOpt / ReflACT -- skill-document self-evolution")
     print("Dataset  : SearchQA (single-turn text QA, EM/F1)")
+    print(f"\nPlan     : model={args.model}, steps={args.steps}, lr={args.lr} "
+          f"({args.lr_mode})")
+    if args.asynchronous:
+        print(f"Async    : {args.minibatch} workers, barrier-free "
+              f"(async_ratio={args.async_ratio}, max {args.max_seconds:.0f}s); "
+              "the strict gate rebases/discards stale edits")
+    else:
+        print(f"Parallel : {args.minibatch} workers run concurrently each step "
+              f"(synchronous DP; the strict-gate merge is the barrier)")
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
     ds = load_dataset(args.train, args.val, seed=args.seed)
     art = EvolvingArtifact("skill_document", blast_radius=0.2)
     ntr, nva, nte = ds.sizes()
@@ -529,18 +539,7 @@ def main() -> None:
     print("  A:", ds.train[0]["answers"])
 
     calls = args.steps * (args.minibatch + 1 + nva) + nte
-    print(f"\nPlan     : model={args.model}, steps={args.steps}, lr={args.lr} ({args.lr_mode})")
-    if args.asynchronous:
-        print(f"Async    : {args.minibatch} workers, barrier-free (async_ratio={args.async_ratio}, "
-              f"max {args.max_seconds:.0f}s); the strict gate rebases/discards stale edits")
-    else:
-        print(f"Parallel : {args.minibatch} workers run concurrently each step "
-              f"(synchronous DP; the strict-gate merge is the barrier)")
     print(f"Budget   : up to ~{calls} model calls (rollouts dominate)")
-
-    if args.dry_run:
-        print("\n[dry-run] not calling the API. Drop --dry-run to train the skill.")
-        return
 
     if not args.yes and sys.stdin.isatty():
         if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - Measured results: results.md
   - Self-evolution algorithms (faithful ports):
     - Overview: self-evolution-examples.md
+    - Porting checklist: porting-checklist.md
     - ACE — context evolution: algo-ace.md
     - GEPA — prompt evolution: algo-gepa.md
     - EvoSkill — skill discovery: algo-evoskill.md

--- a/tests/_TEMPLATE_example.py
+++ b/tests/_TEMPLATE_example.py
@@ -1,0 +1,41 @@
+"""Test template for ``examples/_TEMPLATE.py``.
+
+Copy to ``tests/test_<algorithm>_example.py`` and change the import. Keep the
+tests offline: patch dataset rows and completions instead of using real services.
+"""
+
+from examples import _TEMPLATE as port
+from agentdescent.evolution import Task
+
+
+def test_strategy_turns_one_proposal_into_one_diff():
+    diff = port.STRATEGY.to_diff({}, "one general rule", "test", 0, "artifact")
+    assert diff is not None
+    assert len(diff.ops) == 1
+
+
+def test_reward_matches_the_benchmark_contract():
+    task = Task(id="1", prompt="question", meta={"gold": "answer"})
+    assert port.REWARD(task, "answer") == 1.0
+    assert port.REWARD(task, "wrong") == 0.0
+
+
+def test_loader_shapes_cached_rows(monkeypatch):
+    monkeypatch.setattr(port, "DATASET_NAME", "test/dataset")
+    monkeypatch.setattr(
+        port, "hf_rows",
+        lambda *_args, **_kwargs: [{"prompt": "q", "gold": "a"}],
+    )
+    tasks = port.load_tasks(1)
+    assert [(task.prompt, task.meta["gold"]) for task in tasks] == [("q", "a")]
+
+
+def test_dry_run_stops_before_loading_data(monkeypatch, capsys):
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("dry-run must be offline")
+
+    monkeypatch.setattr(port, "load_tasks", forbidden)
+    monkeypatch.setattr(port, "claude", forbidden)
+    monkeypatch.setattr(port, "openai_compatible", forbidden)
+    port.main(["--dry-run"])
+    assert "dry-run" in capsys.readouterr().out.lower()

--- a/tests/test_example_entrypoints.py
+++ b/tests/test_example_entrypoints.py
@@ -1,0 +1,121 @@
+"""The command-line contract shared by the six faithful algorithm ports."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import socket
+import urllib.request
+
+import pytest
+
+from examples import ace_context_evolution as ace
+from examples import adas_meta_agent_search as adas
+from examples import dgm_self_improve as dgm
+from examples import evoskill_skill_discovery as evoskill
+from examples import gepa_prompt_evolution as gepa
+from examples import skillopt_skill_training as skillopt
+from examples import _TEMPLATE as port_template
+from examples import _common as common
+from examples._common import add_standard_args
+
+
+PORTS = (
+    (ace, "rounds", "claude-haiku-4-5", 30.0, "load_dataset"),
+    (gepa, "rounds", "claude-haiku-4-5", 45.0, "load_dataset"),
+    (evoskill, "iterations", "claude-haiku-4-5", 40.0, "load_dataset"),
+    (skillopt, "steps", "claude-haiku-4-5", 40.0, "load_dataset"),
+    (adas, "generations", "claude-haiku-4-5", 60.0, "build_examples"),
+    (dgm, "generations", None, 15.0, "load_dataset"),
+)
+
+
+def test_standard_args_have_one_definition():
+    parser = add_standard_args(argparse.ArgumentParser())
+    args = parser.parse_args([
+        "--provider", "openai",
+        "--model", "test-model",
+        "--seed", "7",
+        "--async",
+        "--async-ratio", "5",
+        "--max-seconds", "9.5",
+        "--dry-run",
+        "--yes",
+    ])
+    assert args.provider == "openai"
+    assert args.model == "test-model"
+    assert args.seed == 7
+    assert args.asynchronous is True
+    assert args.async_ratio == 5
+    assert args.max_seconds == 9.5
+    assert args.dry_run is True
+    assert args.yes is True
+
+
+@pytest.mark.parametrize("module,iteration,model,seconds,_loader", PORTS)
+def test_every_port_uses_the_standard_contract(module, iteration, model, seconds,
+                                                _loader):
+    parser = module.build_parser()
+    args = parser.parse_args([])
+    assert args.provider == "claude"
+    assert args.model == model
+    assert args.seed == 0
+    assert args.asynchronous is False
+    assert args.async_ratio == 3
+    assert args.max_seconds == seconds
+    assert args.dry_run is False
+    assert args.yes is False
+    assert hasattr(args, iteration)
+
+    option_strings = [opt for action in parser._actions for opt in action.option_strings]
+    for option in ("--provider", "--model", "--seed", "--async", "--async-ratio",
+                   "--max-seconds", "--dry-run", "--yes"):
+        assert option_strings.count(option) == 1, f"{module.__name__}: {option}"
+    iteration_options = {"--rounds", "--generations", "--iterations", "--steps"}
+    assert iteration_options.intersection(option_strings) == {f"--{iteration}"}
+
+
+@pytest.mark.parametrize("module,_iteration,_model,_seconds,_loader", PORTS)
+def test_every_port_calls_the_shared_helper_once(
+        module, _iteration, _model, _seconds, _loader, monkeypatch):
+    calls = []
+
+    def recording_helper(parser, **kwargs):
+        calls.append(kwargs)
+        return common.add_standard_args(parser, **kwargs)
+
+    monkeypatch.setattr(module, "add_standard_args", recording_helper)
+    module.build_parser()
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize("module,_iteration,_model,_seconds,loader", PORTS)
+def test_dry_run_never_touches_data_network_or_models(
+        module, _iteration, _model, _seconds, loader, monkeypatch, capsys):
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("dry-run crossed an external boundary")
+
+    monkeypatch.setattr(module, loader, forbidden)
+    monkeypatch.setattr(module, "claude", forbidden)
+    monkeypatch.setattr(module, "openai_compatible", forbidden)
+    monkeypatch.setattr(urllib.request, "urlopen", forbidden)
+    monkeypatch.setattr(socket, "create_connection", forbidden)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    module.main(["--dry-run"])
+    assert "dry-run" in capsys.readouterr().out.lower()
+
+
+def test_porting_checklist_stays_short():
+    root = pathlib.Path(__file__).resolve().parent.parent
+    lines = (root / "docs" / "porting-checklist.md").read_text().splitlines()
+    assert len(lines) <= 20
+
+
+def test_port_template_is_importable_and_offline(capsys):
+    args = port_template.build_parser().parse_args([])
+    assert args.iterations == 6
+    assert args.provider == "claude"
+    port_template.main(["--dry-run"])
+    assert "no dataset or model api was accessed" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary

- centralize the shared provider/runtime CLI flags in `examples._common.add_standard_args`
- migrate all six faithful ports while preserving their upstream iteration vocabulary and per-port defaults
- make every faithful-port `--dry-run` return before dataset/model setup, with tests enforcing zero-network behavior
- add a runnable port template, an offline test stub, and a 16-line fidelity checklist
- document candidate ports by missing mechanism, current port authors, and the shortest contributor verification path

## Verification

- `pytest -q` (820 tests collected, 0 failed, 11 skipped)
- `pytest -q tests/test_example_entrypoints.py tests/_TEMPLATE_example.py tests/test_docs_examples.py tests/test_docs_links.py tests/test_api_docs.py`
- `mkdocs build --strict`
- `python -m compileall -q examples tests`
- `python -m pip check`
- keyless cold-environment dry-runs for all six ports and the template, with no network syscalls under `strace`

## Notes

- no changes to the `agentdescent/` core engine
- DGM keeps its deterministic `model=None` default and now supports `--yes` when a model is requested
- ACE/GEPA keep `--rounds`, EvoSkill keeps `--iterations`, SkillOpt keeps `--steps`, and ADAS/DGM keep `--generations`

Closes #74
