### PR TITLE
feat: a harness for comparing parallel configurations, and what it found

### DIFF
--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -648,6 +648,27 @@ def async_evolve(
             print(f"async run ended with a backend failure: {run_error[:140]}")
         warnings.warn(f"async_evolve() ended with a backend failure: {run_error}",
                       RuntimeWarning, stacklevel=2)
+    # A run that discarded most of its evidence is misconfigured, and every
+    # number it reports is a number about the fraction that survived. `stale_rate`
+    # makes that visible to anyone who looks; this says it to anyone who does not.
+    #
+    # Not a reason to lower the default: `async_ratio` is a lag budget in
+    # *versions*, and how much wall-clock a version represents depends entirely on
+    # how long a rollout takes. Three is sensible when a rollout is a model call
+    # taking seconds; on a workload where rollouts are near-instant, a worker
+    # drifts three versions behind almost immediately and stays there.
+    _considered = eng.meter.snapshot().stale_considered
+    _discarded = eng.meter.snapshot().stale_discarded
+    if _considered >= 20 and _discarded / _considered > 0.5:
+        warnings.warn(
+            f"async_evolve discarded {_discarded}/{_considered} "
+            f"({_discarded / _considered:.0%}) of its evidence as stale. "
+            f"async_ratio={async_ratio} is a lag budget in artifact versions, so "
+            "it is too high whenever a worker finishes several rollouts in the "
+            "time the merger takes one sweep. Lower it (0 resyncs every rollout) "
+            "or use a staleness policy that rebases rather than discards.",
+            RuntimeWarning, stacklevel=2)
+
     result = EvolutionResult(state=dict(final.state), rendered=final.render(),
                              final_reward=final_reward, history=history,
                              ledger_log=_safe_log(eng.ledger),

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -464,6 +464,13 @@ def async_evolve(
         head_vv = eng.ledger.head_version(Ledger.DEV)
         head_art = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
         # staleness gate: hand the aggregator only rebased (η=0) cards.
+        #
+        # Counted here because this path never reaches `Aggregator`'s own filter,
+        # which is where the synchronous loop's ratio comes from. Without these
+        # two lines the async rows of any comparison report a stale rate of 0% --
+        # not "no staleness", but "not measured", and the two look identical in a
+        # table.
+        eng.meter.add("stale_considered", len(batch))
         for card in batch:
             eta = vv_staleness(head_vv, card.base_version)
             action = policy.decide(eta, alpha, card.diff.contract_breaking)
@@ -473,7 +480,10 @@ def async_evolve(
                 cand = head_art.apply(card.diff)         # cheap re-verify on current head
                 if head_art.evidence_eval(card) <= cand.evidence_eval(card):
                     eng.aggregator.ingest(card.rebased_onto(head_vv))
-            # DISCARD -> drop the card
+                else:
+                    eng.meter.add("stale_discarded")
+            else:
+                eng.meter.add("stale_discarded")         # DISCARD -> drop the card
         reports = check_reports(eng.aggregator.step(), eng.aggregator)
         committed = sum(1 for x in reports if x.committed_version is not None)
         dev = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
@@ -488,7 +498,8 @@ def async_evolve(
         _m = eng.meter.snapshot()
         history.append(RoundInfo(len(history), r, len(dev.state), committed,
                                  len(reports) - committed, _tally(reports),
-                                 elapsed_s=_m.elapsed_s, rollouts=_m.rollouts))
+                                 elapsed_s=_m.elapsed_s, rollouts=_m.rollouts,
+                                 calls=_m.calls))
         # A stalled pipeline: cards keep arriving and none of them commits. Under
         # Guarded with async_ratio > alpha that is a livelock, not slow progress.
         # A sweep with no cards in it is neither, so it is not counted -- and this

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -711,6 +711,12 @@ class RoundInfo:
     #: denominator: a configuration that reaches the same reward having spent
     #: twice the rollouts has not done as well.
     rollouts: int = 0
+    #: Actor invocations by the end of this round, cumulative. Recorded per round
+    #: because a budget fixed in *rounds* hands the wider configuration more
+    #: model and then reports the extra model as a win for parallelism -- so a
+    #: comparison has to be able to ask "where was each configuration after N
+    #: calls", which needs the number at every round rather than only at the end.
+    calls: int = 0
 
 
 @dataclass
@@ -892,7 +898,8 @@ class EvolutionResult:
                 {"round": h.round, "held_out_reward": h.held_out_reward,
                  "n_items": h.n_items, "committed": h.committed,
                  "rejected": h.rejected, "reasons": h.reasons,
-                 "elapsed_s": h.elapsed_s, "rollouts": h.rollouts}
+                 "elapsed_s": h.elapsed_s, "rollouts": h.rollouts,
+                 "calls": h.calls}
                 for h in self.history
             ],
             "retired_workers": self.retired_workers,
@@ -1946,7 +1953,8 @@ def evolve(
                 section_violations[0] = 0
         _m = eng.meter.snapshot()
         info = RoundInfo(r, round_reward, len(dev.state), committed, rejected,
-                         reasons, elapsed_s=_m.elapsed_s, rollouts=_m.rollouts)
+                         reasons, elapsed_s=_m.elapsed_s, rollouts=_m.rollouts,
+                         calls=_m.calls)
         history.append(info)
         # Early stopping: an LLM rollout costs money, so do not keep buying them
         # once the artifact has converged or clearly stalled.

--- a/bench/__init__.py
+++ b/bench/__init__.py
@@ -1,0 +1,1 @@
+"""Comparing parallel configurations, under conditions that make the comparison mean something."""

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -1,0 +1,204 @@
+"""Comparing parallel configurations, under conditions that make it mean something.
+
+The question is whether parallelism buys quality per unit of time and money. The
+easy way to answer it produces a table that looks like evidence and is not, so
+the constraints below are enforced here rather than described in a footnote.
+
+**Budget in model calls, not rounds.** Configurations differ in how many calls a
+round makes. Fixing rounds hands the wider configuration more model, and then
+reports the extra model as a win for parallelism.
+
+**Quality on a set the gate never saw.** `evolve()` optimises against its
+held-out split and stops when that split says so. Reporting the same number is
+reporting a training score.
+
+**Several seeds, and an interval.** This repository has already published a
+point estimate that moved 4.8 points between two runs of one configuration
+(`docs/algo-ace.md` says so in as many words). One number per configuration is
+not a result.
+
+**One environment, recorded.** Two configurations measured under different
+toolchains differ by more than the variable being studied. Every row carries the
+fingerprint it ran under, and a run whose acceptance saw mixed environments is
+marked rather than averaged in.
+
+None of this makes a conclusion come out positive. `docs/results.md` carries a
+row reading "lift not yet measured" for exactly that reason, and a harness whose
+output can only support one answer is not measuring anything.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from agentdescent import EvolutionResult
+
+__all__ = ["Config", "Measurement", "Summary", "run_config", "summarise", "to_markdown"]
+
+
+@dataclass(frozen=True)
+class Config:
+    """One point in the configuration space, and nothing about the workload.
+
+    Deliberately narrow: the whole design is that only these vary. A config that
+    could also change the model or the data would let a comparison move two
+    things at once, which is the failure this file exists to prevent.
+    """
+
+    name: str
+    n_workers: int = 1
+    asynchronous: bool = False
+    eval_concurrency: int = 1
+    #: Where rollouts run. `None` is in-process threads.
+    executor: Optional[str] = None
+    #: Which sandbox provider. `None` is a local workspace.
+    sandbox: Optional[str] = None
+
+    def as_row(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Measurement:
+    """What one seed of one configuration produced."""
+
+    config: str
+    seed: int
+    #: Wall-clock and rollouts to reach the quality bar. `None` means it never
+    #: did -- which is a result, not a missing value, and must not be filled in
+    #: with the total.
+    time_to_quality: Optional[float]
+    cost_to_quality: Optional[int]
+    wallclock: float
+    rollouts: int
+    calls: int
+    stale_rate: float
+    duplicate_rate: float
+    sandbox_wait_s: float
+    sandbox_setup_s: float
+    sandboxes_created: int
+    #: Quality on the split the gate never saw.
+    test_quality: Optional[float]
+    #: Non-zero means acceptance compared measurements from different
+    #: environments, and this row's quality number needs a caveat.
+    env_mismatch: int = 0
+    fingerprint: str = ""
+
+    @classmethod
+    def of(cls, config: str, seed: int, result: EvolutionResult, target: float,
+           test_quality: Optional[float] = None, fingerprint: str = "") -> "Measurement":
+        return cls(
+            config=config, seed=seed,
+            time_to_quality=result.time_to_quality(target),
+            cost_to_quality=result.cost_to_quality(target),
+            wallclock=result.wallclock, rollouts=result.rollouts,
+            calls=result.usage.calls,
+            stale_rate=result.stale_rate(), duplicate_rate=result.duplicate_rate(),
+            sandbox_wait_s=result.sandbox_wait_s,
+            sandbox_setup_s=result.sandbox_setup_s,
+            sandboxes_created=result.sandboxes_created,
+            test_quality=test_quality, fingerprint=fingerprint)
+
+
+@dataclass
+class Summary:
+    """Several seeds of one configuration, as an interval."""
+
+    config: str
+    seeds: int
+    time_to_quality: Optional[Sequence[float]] = None
+    cost_to_quality: Optional[Sequence[float]] = None
+    test_quality: Optional[Sequence[float]] = None
+    #: How many seeds reached the bar at all. A median over the ones that did,
+    #: without this, silently reports the easy seeds.
+    reached: int = 0
+    stale_rate: float = 0.0
+    duplicate_rate: float = 0.0
+    sandbox_share: float = 0.0
+    heterogeneous: bool = False
+
+    def as_row(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _interval(values: Sequence[float]) -> Optional[List[float]]:
+    """(min, median, max). Not a confidence interval, and not labelled as one.
+
+    Three seeds cannot support a real one. Reporting the spread that was actually
+    observed is honest; reporting a t-interval over three points is arithmetic
+    dressed as statistics."""
+    values = [v for v in values if v is not None]
+    if not values:
+        return None
+    return [min(values), statistics.median(values), max(values)]
+
+
+def run_config(config: Config, workload: Callable[[Config, int], EvolutionResult],
+               *, seeds: Sequence[int], target: float,
+               test_eval: Optional[Callable[[EvolutionResult], float]] = None,
+               fingerprint: str = "") -> List[Measurement]:
+    """Run one configuration across seeds and collect what each produced."""
+    out: List[Measurement] = []
+    for seed in seeds:
+        result = workload(config, seed)
+        quality = test_eval(result) if test_eval is not None else None
+        out.append(Measurement.of(config.name, seed, result, target, quality,
+                                  fingerprint))
+    return out
+
+
+def summarise(measurements: Sequence[Measurement]) -> List[Summary]:
+    """Group by configuration and report intervals rather than point estimates."""
+    by_config: Dict[str, List[Measurement]] = {}
+    for m in measurements:
+        by_config.setdefault(m.config, []).append(m)
+
+    summaries = []
+    for name, group in by_config.items():
+        reached = [m for m in group if m.time_to_quality is not None]
+        total_wall = sum(m.wallclock for m in group) or 1.0
+        sandbox = sum(m.sandbox_wait_s + m.sandbox_setup_s for m in group)
+        summaries.append(Summary(
+            config=name, seeds=len(group), reached=len(reached),
+            time_to_quality=_interval([m.time_to_quality for m in reached]),
+            cost_to_quality=_interval([m.cost_to_quality for m in reached]),
+            test_quality=_interval([m.test_quality for m in group
+                                    if m.test_quality is not None]),
+            stale_rate=statistics.median([m.stale_rate for m in group]),
+            duplicate_rate=statistics.median([m.duplicate_rate for m in group]),
+            sandbox_share=sandbox / total_wall,
+            heterogeneous=any(m.env_mismatch for m in group)))
+    return summaries
+
+
+def to_markdown(summaries: Sequence[Summary]) -> str:
+    """A table that shows what was not reached, rather than omitting it."""
+    lines = ["| config | seeds | reached | time-to-quality (min/med/max) | "
+             "cost-to-quality | test quality | stale% | dup% | sandbox% |",
+             "|---|---|---|---|---|---|---|---|---|"]
+    for s in summaries:
+        def fmt(interval, spec="{:.2f}"):
+            if not interval:
+                return "—"
+            return " / ".join(spec.format(v) for v in interval)
+
+        note = " ⚠︎" if s.heterogeneous else ""
+        lines.append(
+            f"| {s.config}{note} | {s.seeds} | {s.reached}/{s.seeds} | "
+            f"{fmt(s.time_to_quality)} | {fmt(s.cost_to_quality, '{:.0f}')} | "
+            f"{fmt(s.test_quality, '{:.3f}')} | {s.stale_rate:.0%} | "
+            f"{s.duplicate_rate:.0%} | {s.sandbox_share:.0%} |")
+    if any(s.heterogeneous for s in summaries):
+        lines.append("")
+        lines.append("⚠︎ acceptance compared measurements from different "
+                     "environments; that row's quality is not comparable.")
+    if any(s.reached < s.seeds for s in summaries):
+        lines.append("")
+        lines.append("A configuration that did not reach the bar on every seed "
+                     "has no time-to-quality for those seeds. The interval covers "
+                     "the ones that did, and `reached` says how many that was.")
+    return "\n".join(lines)

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -57,6 +57,12 @@ class Config:
     executor: Optional[str] = None
     #: Which sandbox provider. `None` is a local workspace.
     sandbox: Optional[str] = None
+    #: The barrier-free path's lag budget, in **versions**. How much wall-clock a
+    #: version represents depends entirely on how long a rollout takes, so a
+    #: value tuned for one workload is not a value at all for another -- which is
+    #: why it is a dimension of the matrix rather than a constant in it.
+    async_ratio: int = 3
+    staleness: str = "guarded"
 
     def as_row(self) -> Dict[str, Any]:
         return asdict(self)

--- a/bench/run.py
+++ b/bench/run.py
@@ -18,7 +18,7 @@ import sys
 import time
 from typing import Callable, Dict, List, Optional, Sequence
 
-from agentdescent import AppendRules, EvolutionResult, Task, evolve
+from agentdescent import AppendRules, EvolutionResult, Task, evolve, get_policy
 
 from .harness import Config, Measurement, run_config, summarise, to_markdown
 
@@ -30,6 +30,16 @@ CONFIGS: Dict[str, Config] = {
     "sync-8": Config("sync-8", n_workers=8, eval_concurrency=8),
     "async-4": Config("async-4", n_workers=4, eval_concurrency=4, asynchronous=True),
     "async-8": Config("async-8", n_workers=8, eval_concurrency=8, asynchronous=True),
+    # The lag budget is a dimension, not a constant. Reporting one arbitrary
+    # value for the barrier-free path while the synchronous one runs at its
+    # natural setting is not a comparison between paths, it is a comparison
+    # between one path and a misconfiguration of the other.
+    "async-4-lag1": Config("async-4-lag1", n_workers=4, eval_concurrency=4,
+                           asynchronous=True, async_ratio=1),
+    "async-4-lag0": Config("async-4-lag0", n_workers=4, eval_concurrency=4,
+                           asynchronous=True, async_ratio=0),
+    "async-8-lag1": Config("async-8-lag1", n_workers=8, eval_concurrency=8,
+                           asynchronous=True, async_ratio=1),
 }
 
 #: The quality bar time- and cost-to-quality are measured against. A bar every
@@ -97,7 +107,8 @@ def workload(config: Config, seed: int) -> EvolutionResult:
         rounds=30, n_workers=config.n_workers,
         max_concurrency=config.n_workers,
         eval_concurrency=config.eval_concurrency,
-        asynchronous=config.asynchronous,
+        asynchronous=config.asynchronous, async_ratio=config.async_ratio,
+        staleness_policy=get_policy(config.staleness),
         held_out_frac=0.4, seed=seed, max_seconds=60.0)
 
 

--- a/bench/run.py
+++ b/bench/run.py
@@ -1,0 +1,192 @@
+"""Run the configuration matrix and print the table.
+
+    python -m bench.run --config sync-1 --config sync-4 --config async-4 \
+                        --budget-calls 400 --seeds 0,1,2
+
+Defaults to the offline router domain: deterministic, no network, seconds. That
+is what makes the harness's own self-check possible -- same seed twice must give
+the same numbers, and if it does not, nothing the harness measures about anything
+else can be believed either.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+import time
+from typing import Callable, Dict, List, Optional, Sequence
+
+from agentdescent import AppendRules, EvolutionResult, Task, evolve
+
+from .harness import Config, Measurement, run_config, summarise, to_markdown
+
+#: The configurations the matrix knows how to build. Names are what `--config`
+#: takes, so adding one here is the only edit a new comparison needs.
+CONFIGS: Dict[str, Config] = {
+    "sync-1": Config("sync-1", n_workers=1, eval_concurrency=1),
+    "sync-4": Config("sync-4", n_workers=4, eval_concurrency=4),
+    "sync-8": Config("sync-8", n_workers=8, eval_concurrency=8),
+    "async-4": Config("async-4", n_workers=4, eval_concurrency=4, asynchronous=True),
+    "async-8": Config("async-8", n_workers=8, eval_concurrency=8, asynchronous=True),
+}
+
+#: The quality bar time- and cost-to-quality are measured against. A bar every
+#: configuration clears immediately measures nothing; one nothing clears reports
+#: `—` for every row and is equally uninformative.
+DEFAULT_TARGET = 0.75
+
+
+# ---------------------------------------------------------------------------
+# The workload: fixed data, fixed semantics, fixed model
+# ---------------------------------------------------------------------------
+
+
+def _dataset(seed: int, n_keywords: int = 16, per_keyword: int = 6):
+    """train / val / test over the repository's deterministic router domain.
+
+    Split once per seed and never re-split per configuration: splitting inside
+    one would let two configurations see different data and let the difference be
+    called parallelism.
+
+    The domain matters as much as the split. An earlier version of this file
+    invented one where a rule named a *task*, so nothing learned on train could
+    apply to test and every quality column was structurally zero -- a table full
+    of honest numbers measuring nothing. Here a rule names a **keyword** shared by
+    many tasks, so learning generalises and the test column can move.
+    """
+    from agentdescent.domains.router import make_task_universe
+
+    universe = make_task_universe(n_keywords=n_keywords,
+                                  tasks_per_keyword=per_keyword, seed=seed)
+    tasks = [Task(id=f"{t.keyword}-{i}", prompt=t.text,
+                  meta={"gold": t.label, "keyword": t.keyword})
+             for i, t in enumerate(universe.tasks)]
+    rng = random.Random(seed)
+    rng.shuffle(tasks)
+    cut = int(len(tasks) * 0.7)
+    return tasks[:cut], tasks[cut:]
+
+
+def _run(rendered: str, task: Task) -> str:
+    """Deterministic 'agent': answer from the rule table, if it has the keyword."""
+    for line in rendered.splitlines():
+        if "->" not in line:
+            continue
+        keyword, _, label = line.partition("->")
+        if keyword.strip().lstrip("- ") == task.meta["keyword"]:
+            return label.strip()
+    return "?"
+
+
+def _reward(task: Task, output: str) -> float:
+    return 1.0 if output == task.meta["gold"] else 0.0
+
+
+def _propose(rendered: str, task: Task, output: str, reward: float) -> Optional[str]:
+    """The rule this failure implies -- about the keyword, not the task."""
+    return f"{task.meta['keyword']} -> {task.meta['gold']}"
+
+
+def workload(config: Config, seed: int) -> EvolutionResult:
+    """One run. Only `config` varies; data, actors and semantics do not."""
+    train, _test = _dataset(seed)
+    return evolve(
+        train, _reward, run=_run, propose=_propose, strategy=AppendRules(),
+        rounds=30, n_workers=config.n_workers,
+        max_concurrency=config.n_workers,
+        eval_concurrency=config.eval_concurrency,
+        asynchronous=config.asynchronous,
+        held_out_frac=0.4, seed=seed, max_seconds=60.0)
+
+
+def test_quality(seed: int) -> Callable[[EvolutionResult], float]:
+    """Score the finished artifact on the split the gate never saw.
+
+    `evolve()` stops when *its* held-out split says so, so reporting that number
+    is reporting a training score."""
+    def evaluate(result: EvolutionResult) -> float:
+        _train, held = _dataset(seed)
+        return sum(_reward(t, _run(result.rendered, t)) for t in held) / len(held)
+    return evaluate
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+
+def truncate_to_budget(result: EvolutionResult, budget_calls: int) -> EvolutionResult:
+    """The run as it stood when the budget ran out.
+
+    Configurations differ in how many calls a round makes, so a budget fixed in
+    rounds hands the wider one more model and then reports the extra model as a
+    win for parallelism. Truncating on the recorded per-round call count asks all
+    of them the same question: where were you after N calls?
+
+    Not a cap applied during the run: stopping mid-round would leave a partial
+    round in the history, and the comparison is between completed states.
+    """
+    if budget_calls <= 0:
+        return result
+    kept = [h for h in result.history if h.calls <= budget_calls]
+    if len(kept) == len(result.history):
+        return result
+    import dataclasses
+
+    last = kept[-1] if kept else None
+    return dataclasses.replace(
+        result, history=kept,
+        final_reward=last.held_out_reward if last else 0.0,
+        rollouts=last.rollouts if last else 0,
+        wallclock=last.elapsed_s if last else 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", action="append", dest="configs",
+                        choices=sorted(CONFIGS), help="repeatable")
+    parser.add_argument("--seeds", default="0,1,2",
+                        help="comma-separated; three is the minimum that shows a spread")
+    parser.add_argument("--budget-calls", type=int, default=0,
+                        help="0 runs each configuration to its own stopping point")
+    parser.add_argument("--target", type=float, default=DEFAULT_TARGET)
+    parser.add_argument("--json", dest="json_out", help="write raw measurements here")
+    args = parser.parse_args(argv)
+
+    names = args.configs or ["sync-1", "sync-4", "async-4"]
+    seeds = [int(s) for s in args.seeds.split(",") if s.strip()]
+    if len(seeds) < 3:
+        print(f"warning: {len(seeds)} seed(s). This repository has published a "
+              "point estimate that moved 4.8 points between two runs of one "
+              "configuration; one number per configuration is not a result.",
+              file=sys.stderr)
+
+    measurements: List[Measurement] = []
+    for name in names:
+        config = CONFIGS[name]
+        for seed in seeds:
+            result = workload(config, seed)
+            if args.budget_calls:
+                result = truncate_to_budget(result, args.budget_calls)
+            measurements.append(Measurement.of(
+                name, seed, result, args.target, test_quality(seed)(result)))
+
+    summaries = summarise(measurements)
+    print(to_markdown(summaries))
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump({"measurements": [m.__dict__ for m in measurements],
+                       "summaries": [s.as_row() for s in summaries]}, fh, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -77,25 +77,45 @@ configuration. Quality is scored on a split `evolve()`'s gate never saw.
 | config | seeds | reached | time-to-quality (min/med/max) | cost-to-quality | test quality | stale% |
 |---|---|---|---|---|---|---|
 | sync-1 | 3 | 2/3 | 1.06 / 1.10 / 1.13 | 21 / 22 / 22 | 0.793 / 0.862 / 0.897 | 0% |
-| sync-4 | 3 | 3/3 | 0.42 / 0.50 / 0.70 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
+| sync-4 | 3 | 3/3 | 0.41 / 0.50 / 0.71 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
 | sync-8 | 3 | 3/3 | 0.25 / 0.26 / 0.42 | 24 / 24 / 40 | 0.931 / 1.000 / 1.000 | 0% |
-| async-4 | 3 | **0/3** | — | — | 0.379 / 0.414 / 0.448 | **83%** |
+| async-4 (lag 3, the default) | 3 | **0/3** | — | — | 0.345 / 0.379 / 0.448 | **86%** |
+| async-4 (lag 1) | 3 | 3/3 | 0.49 / 0.56 / 0.59 | 35 / 38 / 76 | 0.931 / 1.000 / 1.000 | 10% |
+| async-4 (lag 0) | 3 | 3/3 | 0.59 / 0.66 / 0.83 | 21 / 23 / 35 | 0.897 / 0.931 / 1.000 | 0% |
 
 ### What it says
 
-**Parallelism buys time, not rollouts.** Time-to-quality falls 1.10 → 0.50 →
-0.26 from 1 to 4 to 8 workers, while cost-to-quality *rises* slightly (22 → 24).
-More workers reach the bar sooner and more reliably (2/3 → 3/3), and they spend
-marginally more rollouts doing it. Anyone hoping parallelism reduces total work
-should read the second column.
+**Parallelism buys time, not rollouts.** Time-to-quality falls 1.10 → 0.50 → 0.26
+from 1 to 4 to 8 workers, while cost-to-quality *rises* slightly (22 → 24). More
+workers reach the bar sooner and more reliably (2/3 → 3/3), and spend marginally
+more rollouts doing it. Anyone hoping parallelism reduces total work should read
+the second column.
 
-**The barrier-free path is worse here, and the reason is in the table.** 83% of
-its evidence is stale. Its whole advantage is that workers never wait for the
-merge — and on this domain a rollout is instant string matching, so there is no
-waiting to avoid. It pays the coordination cost and collects none of the benefit.
+**The barrier-free path's default lag budget is wrong for this domain, and the
+first version of this table blamed the path.** At `async_ratio=3` it discards 86%
+of its evidence and never reaches the bar. At 1 it matches the synchronous path
+on quality; at 0 it is the cheapest configuration in the table.
 
-That is a property of the domain, not a verdict on the async path. It is also the
-sharpest possible illustration of the caveat below.
+`async_ratio` is a lag budget in **artifact versions**, and how much wall-clock a
+version represents depends entirely on how long a rollout takes. Three is
+sensible when a rollout is a model call taking seconds. Here a rollout is a
+dictionary lookup, so a worker drifts three versions behind almost immediately
+and stays there.
+
+The default has not been changed — it is tuned for the workload this framework is
+for, not for the one that is cheap to measure. Instead, a run that discards more
+than half its evidence now says so:
+
+```
+RuntimeWarning: async_evolve discarded 110/130 (85%) of its evidence as stale.
+async_ratio=3 is a lag budget in artifact versions, so it is too high whenever a
+worker finishes several rollouts in the time the merger takes one sweep.
+```
+
+**Even correctly tuned, async does not beat sync here** — 0.56 against 0.50. Its
+advantage is that workers never wait for the merge, and on a domain with no
+rollout latency there is no waiting to avoid. That is the caveat below, arrived
+at from the other direction.
 
 !!! danger "These numbers are not an answer to the parallelism question"
     **No model was called.** The router domain's rollout is a dictionary lookup,

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -62,6 +62,62 @@ raise it if yours is large and your provider allows the concurrency.
     that, the barrier is meeting a heavy tail, which is what `asynchronous=True`
     addresses.
 
+
+## The configuration matrix — `bench/`
+
+```bash
+python -m bench.run --config sync-1 --config sync-4 --config sync-8                     --config async-4 --seeds 0,1,2
+```
+
+Fixed data, fixed actors, fixed semantics; only the configuration varies. Three
+seeds, reported as the spread that was observed rather than a point estimate —
+this repository has published one that moved 4.8 points between two runs of one
+configuration. Quality is scored on a split `evolve()`'s gate never saw.
+
+| config | seeds | reached | time-to-quality (min/med/max) | cost-to-quality | test quality | stale% |
+|---|---|---|---|---|---|---|
+| sync-1 | 3 | 2/3 | 1.06 / 1.10 / 1.13 | 21 / 22 / 22 | 0.793 / 0.862 / 0.897 | 0% |
+| sync-4 | 3 | 3/3 | 0.42 / 0.50 / 0.70 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
+| sync-8 | 3 | 3/3 | 0.25 / 0.26 / 0.42 | 24 / 24 / 40 | 0.931 / 1.000 / 1.000 | 0% |
+| async-4 | 3 | **0/3** | — | — | 0.379 / 0.414 / 0.448 | **83%** |
+
+### What it says
+
+**Parallelism buys time, not rollouts.** Time-to-quality falls 1.10 → 0.50 →
+0.26 from 1 to 4 to 8 workers, while cost-to-quality *rises* slightly (22 → 24).
+More workers reach the bar sooner and more reliably (2/3 → 3/3), and they spend
+marginally more rollouts doing it. Anyone hoping parallelism reduces total work
+should read the second column.
+
+**The barrier-free path is worse here, and the reason is in the table.** 83% of
+its evidence is stale. Its whole advantage is that workers never wait for the
+merge — and on this domain a rollout is instant string matching, so there is no
+waiting to avoid. It pays the coordination cost and collects none of the benefit.
+
+That is a property of the domain, not a verdict on the async path. It is also the
+sharpest possible illustration of the caveat below.
+
+!!! danger "These numbers are not an answer to the parallelism question"
+    **No model was called.** The router domain's rollout is a dictionary lookup,
+    so a rollout costs microseconds where a real one costs seconds. Parallelism
+    exists to hide rollout latency; a benchmark with no latency to hide measures
+    the cost of coordination and none of what it buys.
+
+    Read this table as evidence that the *harness* works — deterministic, budget
+    matched in calls, quality on an unseen split, spread rather than point
+    estimates. Answering [#52](https://github.com/Birfy/agentdescent/issues/52)'s
+    question needs a real port against a real model, which is the step that has
+    not been run.
+
+### One thing the harness found about the engine
+
+The async path filters staleness inline and never reaches `Aggregator`'s filter,
+which is where the synchronous ratio is counted. Its stale column read **0%** —
+not "no staleness" but "not measured", and the two are indistinguishable in a
+table. Now counted at the inline gate, it reads 83%, which is the explanation for
+the row above it.
+
+
 ## Threads and the GIL — is this *really* parallel?
 
 Yes, for this workload, and no amount of arguing about the GIL settles it — so

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -69,6 +69,7 @@ and *how*, that is *what*.
 | `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
+| `bench` | the configuration matrix and the rules that make comparing them mean something | [Efficiency](efficiency.md#the-configuration-matrix-bench) |
 | `evaluator` | the gate's own bounded, reusable concurrency, separate from the rollouts' | [Verifier](verifier.md#the-evaluation-group) |
 | `evalcache` | memoised evaluations: single-flight, environment-aware, shareable across processes | [Verifier](verifier.md) |
 | `workspec` | a rollout as data: named callables instead of closures | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -196,3 +196,32 @@ def test_staleness_is_measured_on_both_paths():
     assert sync.stale_considered > 0, "the synchronous path stopped counting"
     assert asyn.stale_considered > 0, (
         "the async path reports a stale rate it never measured")
+
+
+def test_the_lag_budget_is_what_made_the_async_row_look_broken():
+    """The first version of this matrix reported `async-4` as 0/3 and concluded
+    the barrier-free path was worse. The path was fine; its default lag budget is
+    a budget in *versions*, and a version is worth no wall-clock at all when a
+    rollout is a dictionary lookup.
+
+    Pinned because the conclusion in `docs/efficiency.md` rests on it."""
+    default = workload(CONFIGS["async-4"], 0)
+    tight = workload(CONFIGS["async-4-lag1"], 0)
+    assert default.stale_rate() > 0.5, (
+        "the default lag budget no longer produces chronic staleness here; the "
+        "documented explanation needs re-checking")
+    assert tight.stale_rate() < default.stale_rate()
+    assert tight.final_reward > default.final_reward
+
+
+def test_a_run_that_discards_most_of_its_evidence_says_so():
+    """Every number such a run reports is a number about the fraction that
+    survived, and it used to say nothing."""
+    import warnings as _warnings
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        workload(CONFIGS["async-4"], 0)
+    messages = [str(w.message) for w in caught if "stale" in str(w.message)]
+    assert messages, "a run discarding most of its evidence reported nothing"
+    assert "async_ratio" in messages[0], "the warning must name the knob"

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,0 +1,198 @@
+"""The harness has to be trustworthy before anything it measures is.
+
+Every test here is about the measuring instrument, not the thing measured. The
+one that matters most is determinism: on a deterministic domain, the same seed
+twice must produce the same numbers. If it does not, every difference the harness
+reports between two configurations could be that instead.
+"""
+
+import json
+
+import pytest
+
+from bench.harness import Config, Measurement, Summary, summarise, to_markdown
+from bench.run import CONFIGS, main, truncate_to_budget, workload
+
+
+def _measure(config_name="sync-1", seed=0, target=0.75):
+    from bench.run import test_quality
+
+    result = workload(CONFIGS[config_name], seed)
+    return Measurement.of(config_name, seed, result, target,
+                          test_quality(seed)(result))
+
+
+# ---------------------------------------------------------------------------
+# The instrument
+# ---------------------------------------------------------------------------
+
+
+def test_the_same_seed_twice_gives_the_same_numbers():
+    """The harness's self-check.
+
+    The domain is deterministic, so any difference between two runs of one seed
+    is the harness's own noise -- and every difference it reports between two
+    configurations could be that instead."""
+    a, b = _measure(seed=0), _measure(seed=0)
+    assert a.rollouts == b.rollouts
+    assert a.calls == b.calls
+    assert a.cost_to_quality == b.cost_to_quality
+    assert a.test_quality == b.test_quality
+    assert a.stale_rate == b.stale_rate
+
+
+def test_quality_is_measured_on_a_split_the_gate_never_saw():
+    """`evolve()` stops when *its* held-out split says so. Reporting that number
+    would be reporting a training score."""
+    from bench.run import _dataset
+
+    train, test = _dataset(0)
+    assert train and test
+    train_ids = {t.id for t in train}
+    assert not (train_ids & {t.id for t in test}), "the splits overlap"
+
+
+def test_the_split_does_not_move_between_configurations():
+    """Splitting inside a configuration would let two of them see different data
+    and let the difference be called parallelism."""
+    from bench.run import _dataset
+
+    a_train, a_test = _dataset(3)
+    b_train, b_test = _dataset(3)
+    assert [t.id for t in a_train] == [t.id for t in b_train]
+    assert [t.id for t in a_test] == [t.id for t in b_test]
+
+
+def test_learning_generalises_in_this_domain():
+    """A domain where a rule names a *task* cannot generalise, so every quality
+    column is structurally zero -- a table of honest numbers measuring nothing.
+    An earlier version of this harness had exactly that."""
+    m = _measure("sync-4", seed=0)
+    assert m.test_quality is not None and m.test_quality > 0.0, (
+        "nothing learned on train applied to test; the domain cannot show a "
+        "quality difference between configurations")
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+
+def test_the_budget_is_counted_in_calls_not_rounds():
+    """Configurations differ in how many calls a round makes, so a budget fixed
+    in rounds hands the wider one more model -- and then reports the extra model
+    as a win for parallelism."""
+    result = workload(CONFIGS["sync-4"], 0)
+    assert result.history and result.history[-1].calls > 0
+
+    budget = result.history[0].calls
+    cut = truncate_to_budget(result, budget)
+    assert all(h.calls <= budget for h in cut.history)
+    assert len(cut.history) < len(result.history) or len(result.history) == 1
+
+
+def test_a_budget_nobody_exceeds_changes_nothing():
+    result = workload(CONFIGS["sync-1"], 0)
+    assert truncate_to_budget(result, 10 ** 9) is result
+
+
+def test_per_round_calls_are_cumulative_and_monotonic():
+    """The budget is applied against them, so a non-monotonic sequence would
+    truncate somewhere arbitrary."""
+    result = workload(CONFIGS["sync-4"], 1)
+    calls = [h.calls for h in result.history]
+    assert calls == sorted(calls)
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def test_a_configuration_that_never_reached_the_bar_says_so():
+    """`—` and `0/3`, not a number borrowed from the total wall-clock. A
+    configuration that never converged has no time-to-quality, and filling one in
+    would make the slowest row look like the fastest."""
+    never = [Measurement(config="c", seed=s, time_to_quality=None,
+                         cost_to_quality=None, wallclock=5.0, rollouts=10,
+                         calls=20, stale_rate=0.0, duplicate_rate=0.0,
+                         sandbox_wait_s=0.0, sandbox_setup_s=0.0,
+                         sandboxes_created=0, test_quality=0.1) for s in range(3)]
+    [summary] = summarise(never)
+    assert summary.reached == 0 and summary.time_to_quality is None
+    table = to_markdown([summary])
+    assert "0/3" in table and "—" in table
+
+
+def test_the_interval_reports_the_spread_that_was_observed():
+    """Three seeds cannot support a confidence interval, and one dressed up as
+    arithmetic would be worse than the spread it hides."""
+    ms = [Measurement(config="c", seed=s, time_to_quality=t,
+                      cost_to_quality=10 * s + 10, wallclock=t, rollouts=5,
+                      calls=10, stale_rate=0.1, duplicate_rate=0.2,
+                      sandbox_wait_s=0.0, sandbox_setup_s=0.0,
+                      sandboxes_created=0, test_quality=0.5)
+          for s, t in enumerate([1.0, 4.0, 2.0])]
+    [summary] = summarise(ms)
+    assert summary.time_to_quality == [1.0, 2.0, 4.0]        # min, median, max
+
+
+def test_a_heterogeneous_run_is_marked_rather_than_averaged_in():
+    """`env_mismatch` non-zero means acceptance compared measurements from
+    different environments, so that row's quality is not comparable."""
+    ms = [Measurement(config="c", seed=0, time_to_quality=1.0, cost_to_quality=5,
+                      wallclock=1.0, rollouts=5, calls=10, stale_rate=0.0,
+                      duplicate_rate=0.0, sandbox_wait_s=0.0, sandbox_setup_s=0.0,
+                      sandboxes_created=0, test_quality=0.9, env_mismatch=3)]
+    [summary] = summarise(ms)
+    assert summary.heterogeneous
+    assert "⚠︎" in to_markdown([summary])
+
+
+def test_the_sandbox_share_is_reported():
+    """"8 workers only bought 2x" reads as staleness, a slow model, and a queue
+    of containers installing dependencies. The share is what tells them apart."""
+    ms = [Measurement(config="c", seed=0, time_to_quality=1.0, cost_to_quality=5,
+                      wallclock=10.0, rollouts=5, calls=10, stale_rate=0.0,
+                      duplicate_rate=0.0, sandbox_wait_s=2.0, sandbox_setup_s=3.0,
+                      sandboxes_created=4, test_quality=0.9)]
+    [summary] = summarise(ms)
+    assert summary.sandbox_share == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# The command
+# ---------------------------------------------------------------------------
+
+
+def test_the_cli_runs_offline_and_writes_its_measurements(tmp_path, capsys):
+    out = tmp_path / "bench.json"
+    assert main(["--config", "sync-1", "--seeds", "0,1,2",
+                 "--json", str(out)]) == 0
+    printed = capsys.readouterr().out
+    assert "| config |" in printed and "sync-1" in printed
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert len(payload["measurements"]) == 3
+    assert payload["summaries"][0]["seeds"] == 3
+
+
+def test_too_few_seeds_is_warned_about(tmp_path, capsys):
+    """This repository has published a point estimate that moved 4.8 points
+    between two runs of one configuration."""
+    main(["--config", "sync-1", "--seeds", "0"])
+    assert "not a result" in capsys.readouterr().err
+
+
+def test_staleness_is_measured_on_both_paths():
+    """A counter that is never written reports 0%, which in a table is
+    indistinguishable from "there was no staleness".
+
+    The async path filters staleness inline and never reaches `Aggregator`'s
+    filter, so its stale column read 0% while 83% of its evidence was being
+    discarded -- and that 83% is the explanation for its row."""
+    sync = workload(CONFIGS["sync-4"], 0)
+    asyn = workload(CONFIGS["async-4"], 0)
+    assert sync.stale_considered > 0, "the synchronous path stopped counting"
+    assert asyn.stale_considered > 0, (
+        "the async path reports a stale rate it never measured")


### PR DESCRIPTION
Closes #61. The last of the eight. Its dependencies all landed first: per-round metrics (#59), parallel configurations (#56), pool counters (#60), cross-process cache counts (#58 5b).

## The methodology is in the code, not the footnotes

| rule | why |
|---|---|
| budget in **model calls**, not rounds | configurations differ in calls per round; fixing rounds hands the wider one more model, then reports the extra model as a win for parallelism |
| quality on a split **the gate never saw** | `evolve()` stops when its own held-out split says so — reporting that number reports a training score |
| three seeds, **observed spread** | this repo has published a point estimate that moved 4.8 points between two runs of one configuration |
| never reached the bar → `0/3` and `—` | borrowing a number from total wall-clock makes the slowest row look like the fastest |

`RoundInfo.calls` is now cumulative per round, so "where were you after N calls" can be asked of every configuration.

## The matrix

| config | seeds | reached | time-to-quality | cost-to-quality | test quality | stale% |
|---|---|---|---|---|---|---|
| sync-1 | 3 | 2/3 | 1.06 / 1.10 / 1.13 | 21 / 22 / 22 | 0.793 / 0.862 / 0.897 | 0% |
| sync-4 | 3 | 3/3 | 0.41 / 0.50 / 0.71 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
| sync-8 | 3 | 3/3 | 0.25 / 0.26 / 0.42 | 24 / 24 / 40 | 0.931 / 1.000 / 1.000 | 0% |
| async-4 (lag 3, **the default**) | 3 | **0/3** | — | — | 0.345 / 0.379 / 0.448 | **86%** |
| async-4 (lag 1) | 3 | 3/3 | 0.49 / 0.56 / 0.59 | 35 / 38 / 76 | 0.931 / 1.000 / 1.000 | 10% |
| async-4 (lag 0) | 3 | 3/3 | 0.59 / 0.66 / 0.83 | 21 / 23 / 35 | 0.897 / 0.931 / 1.000 | 0% |

**Parallelism buys time, not rollouts.** Time-to-quality falls 1.10 → 0.50 → 0.26 from 1 to 4 to 8 workers while cost-to-quality *rises* (22 → 24). More workers reach the bar sooner and more reliably; they spend slightly more rollouts doing it.

## The async row was a misconfiguration, and the first version of this PR blamed the path

The matrix originally ran the barrier-free path only at its default and concluded it was worse here. It is not. `async_ratio` is a lag budget in **artifact versions**, and how much wall-clock a version represents depends entirely on how long a rollout takes:

```
lag  final  stale%  commits
  0  1.000      0%       10
  1  1.000      4%        9
  3  0.556     83%        2      <- the default
  8  0.667     76%        2
```

Three is sensible when a rollout is a model call taking seconds. Here a rollout is a dictionary lookup, so a worker drifts three versions behind almost immediately and stays there.

So the lag budget is a **dimension** of the matrix now, not a constant in it. Reporting one arbitrary value for one path while the other runs at its natural setting is not a comparison between paths — it is a comparison between one path and a misconfiguration of the other.

**The default is unchanged.** It is tuned for the workload this framework is for, not the one that is cheap to measure, and lowering it so a synthetic benchmark looks better would be exactly backwards.

What changed instead — a run that discards most of its evidence now says so:

```
RuntimeWarning: async_evolve discarded 113/131 (86%) of its evidence as stale.
async_ratio=3 is a lag budget in artifact versions, so it is too high whenever a
worker finishes several rollouts in the time the merger takes one sweep.
```

**The corrected conclusion is weaker, and stated that way**: even correctly tuned, async does not beat sync here (0.56 vs 0.50). Its advantage is that workers never wait for the merge, and there is no waiting to avoid when a rollout is instant.

## Two things the harness found about the engine

**The async stale rate was never measured.** That path filters staleness inline and never reaches `Aggregator`'s filter, where the synchronous ratio is counted — so its column read **0%**. Not "no staleness": *not measured*, and the two are indistinguishable in a table.

**And once measured, the 86% was still invisible to whoever ran it.** Hence the warning above.

## Its first domain could not generalise

A rule named a *task*, so nothing learned on train applied to test and every quality column was structurally zero — a table of honest numbers measuring nothing. Replaced with the repository's router domain, where a rule names a keyword shared by many tasks. A test asserts the domain can move the quality column at all.

## The caveat, which is the point

**No model was called.** Anywhere in this PR. The router domain's rollout costs microseconds where a real one costs seconds, and parallelism exists to hide rollout latency — so a benchmark with no latency to hide measures the cost of coordination and none of the benefit.

This table is evidence that the **harness** works: deterministic on re-run, budget matched in calls, quality on an unseen split, spread rather than point estimates. It is **not** an answer to [#52](https://github.com/Birfy/agentdescent/issues/52). That needs a real port against a real model, which has not been run, and `docs/efficiency.md` says so in a danger admonition rather than in small print.

## Verification

- **822 passed, 1 skipped**; the bench file itself runs in 23s.
- Harness self-check: same seed twice, identical numbers.
- The lag-budget finding is pinned by a test, because the documented conclusion rests on it.
- `run_demo` reproduces `docs/usage.md` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
