### PR TITLE
refactor: closing out a round is one thing both loops do

### DIFF
--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -494,12 +494,13 @@ def async_evolve(
         # is not a redundant eval -- `_Runtime.eval_one` memoises on
         # (artifact signature, task id), so re-scoring an unchanged head is free.
         r = dev.score(eng.held_out)
-        early_stop = early.observe(r)
-        _m = eng.meter.snapshot()
-        history.append(RoundInfo(len(history), r, len(dev.state), committed,
-                                 len(reports) - committed, _tally(reports),
-                                 elapsed_s=_m.elapsed_s, rollouts=_m.rollouts,
-                                 calls=_m.calls))
+        # Same three steps as the barrier loop; the round index is a merger sweep
+        # here and a barrier there, which is the only part that differs.
+        _info, early_stop = eng.record_round(
+            index=len(history), reward=r, n_items=len(dev.state),
+            committed=committed, rejected=len(reports) - committed,
+            reasons=_tally(reports), history=history, early=early,
+            on_round=on_round)
         # A stalled pipeline: cards keep arriving and none of them commits. Under
         # Guarded with async_ratio > alpha that is a livelock, not slow progress.
         # A sweep with no cards in it is neither, so it is not counted -- and this
@@ -511,12 +512,6 @@ def async_evolve(
         if verbose:
             print(f"sweep {len(history):>3}  reward={r:.3f}  merged={len(batch)}  "
                   f"+{committed}  pending={len(intake)}")
-        if on_round is not None:
-            try:                       # a reporting callback must not kill the merger
-                on_round(history[-1])
-            except Exception as e:  # noqa: BLE001
-                warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
-                              RuntimeWarning, stacklevel=2)
         if early_stop is not None:
             stop_reason[0] = early_stop
             stop.set()

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -35,7 +35,10 @@ import threading
 import time
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Protocol, Sequence, runtime_checkable
+from typing import (
+    Any, Callable, Dict, List, Optional, Protocol, Sequence, Tuple,
+    runtime_checkable,
+)
 
 from .agents import Completion, Usage, claude
 from .aggregator import (
@@ -649,6 +652,25 @@ def _resolve_policies(policies: Optional[Policies], where: str, **shortcuts) -> 
     return merged
 
 
+def notify(on_round: Optional[Callable[["RoundInfo"], None]],
+           info: "RoundInfo") -> None:
+    """Run a reporting callback without letting it take the run down.
+
+    One behaviour, because there were two: every site warned except the one on
+    `evolve`'s target-reached path, which swallowed the exception with a comment
+    saying the normal path would report it -- and that path `break`s immediately
+    after, so nothing ever did. A callback that raises on the last round of a
+    successful run was the one case where the user heard nothing.
+    """
+    if on_round is None:
+        return
+    try:
+        on_round(info)
+    except Exception as e:  # noqa: BLE001
+        warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
+                      RuntimeWarning, stacklevel=2)
+
+
 def _cost_fields(meter: Meter) -> Dict[str, Any]:
     """The meter's counters, keyed as :class:`EvolutionResult` fields.
 
@@ -1085,6 +1107,29 @@ class _Engine:
     #: ``None`` when the caller passed ``repo_path`` (theirs to keep, and how a run
     #: is resumed).
     scratch_repo: Optional[str] = None
+
+    def record_round(self, *, index: int, reward: float, n_items: int,
+                     committed: int, rejected: int, reasons: Dict[str, int],
+                     history: List["RoundInfo"], early: "EarlyStop",
+                     on_round: Optional[Callable[["RoundInfo"], None]],
+                     ) -> Tuple["RoundInfo", Optional[str]]:
+        """Close out one round: record it, ask whether to stop, tell the caller.
+
+        The two loops disagree about what a round *is* -- a barrier sweep in one,
+        a merger sweep in the other -- and agreed on everything that happens once
+        one has finished. That agreement was written twice.
+
+        Returns the round and a stop reason, or `None` to continue. The caller
+        stops; this does not, because "should we stop" and "how do we stop" are
+        different questions and only the loop knows the second.
+        """
+        m = self.meter.snapshot()
+        info = RoundInfo(index, reward, n_items, committed, rejected, reasons,
+                         elapsed_s=m.elapsed_s, rollouts=m.rollouts, calls=m.calls)
+        history.append(info)
+        stop_reason = early.observe(info.held_out_reward)
+        notify(on_round, info)
+        return info, stop_reason
 
     def cleanup(self) -> None:
         """Remove the scratch ledger, if this call created one. Idempotent.
@@ -1957,14 +2002,12 @@ def evolve(
             if section_violations[0]:
                 reasons["section-violation"] = section_violations[0]
                 section_violations[0] = 0
-        _m = eng.meter.snapshot()
-        info = RoundInfo(r, round_reward, len(dev.state), committed, rejected,
-                         reasons, elapsed_s=_m.elapsed_s, rollouts=_m.rollouts,
-                         calls=_m.calls)
-        history.append(info)
-        # Early stopping: an LLM rollout costs money, so do not keep buying them
-        # once the artifact has converged or clearly stalled.
-        early_stop = early.observe(info.held_out_reward)
+        # Recording the round, deciding whether to stop, and telling the caller
+        # are the same three steps in both loops; only "what is a round" differs.
+        info, early_stop = eng.record_round(
+            index=r, reward=round_reward, n_items=len(dev.state),
+            committed=committed, rejected=rejected, reasons=reasons,
+            history=history, early=early, on_round=on_round)
         if verbose:
             print(f"round {r:>3}  reward={info.held_out_reward:.3f} on "
                   f"{len(held_out)}  size={info.n_items}  +{committed}/-{rejected}")
@@ -1975,19 +2018,7 @@ def evolve(
                       + (f"target_reward={target_reward} reached, stopping"
                          if early_stop == "target_reward" else
                          f"no improvement for {early.stalled} rounds, stopping"))
-            if early_stop == "target_reward" and on_round is not None:
-                try:
-                    on_round(info)
-                except Exception:  # noqa: BLE001 - reported below on the normal path
-                    pass
             break
-        if on_round is not None:
-            # A reporting callback must never take the run down with it.
-            try:
-                on_round(info)
-            except Exception as e:  # noqa: BLE001
-                warnings.warn(f"on_round callback raised: {type(e).__name__}: {e}",
-                              RuntimeWarning, stacklevel=2)
 
     if run_error is None:
         # A clean run publishes the head it produced (see `_publish_stable`);

--- a/tests/test_progress_hooks.py
+++ b/tests/test_progress_hooks.py
@@ -70,3 +70,29 @@ def test_evolve_forwards_on_round_to_the_async_path():
            asynchronous=True, n_workers=2, max_seconds=3.0, rounds=3,
            on_round=seen.append)
     assert seen, "on_round must survive the delegation to async_evolve"
+
+
+def test_a_callback_that_raises_on_the_last_round_is_still_reported():
+    """The one case that used to be silent.
+
+    `evolve`'s target-reached path swallowed the exception with a comment saying
+    the normal path would report it -- and that path `break`s immediately after,
+    so nothing ever did. A callback failing on the final round of a *successful*
+    run was the single place the user heard nothing."""
+    import warnings as _warnings
+
+    from agentdescent import AppendRules, Task, evolve
+
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(6)]
+
+    def boom(info):
+        raise RuntimeError("callback exploded")
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        evolve(tasks, lambda t, o: 1.0,          # everything scores 1.0
+               run=lambda r, t: t.meta["gold"], propose=lambda r, t, o, s: None,
+               strategy=AppendRules(), rounds=5, n_workers=1, held_out_frac=0.5,
+               target_reward=0.5, on_round=boom, seed=0)
+    messages = [str(w.message) for w in caught if "callback exploded" in str(w.message)]
+    assert messages, "the callback failed on the target round and nothing said so"


### PR DESCRIPTION
The second of the two deferrals — and the measurement shrank it again.

## What was actually left

#57's Step 0 put the remaining historical duplication at 120–180 lines. Three merges later (`WorkerHealth`, `EarlyStop`, `FirstError`) what remains is the fifteen lines each loop spends **closing out a round**: snapshot the meter, build a `RoundInfo`, ask early stopping whether to stop, tell the caller.

The two loops disagree about what a round *is* — a barrier sweep in one, a merger sweep in the other — and agree on everything that happens once one has finished. That agreement was written twice. `_Engine.record_round` holds it now.

It returns the round and a stop reason and **does not stop**: "should we stop" and "how do we stop" are different questions, and only the loop knows the second.

## Why this is not `Engine` + `Scheduler`

Measured after the merges: the two loops are **~356 and ~342 lines of code**, and what they still share is the fifteen above. What differs is a barrier, tensor-parallel sections, and a stall guard — none of which is duplicated.

Extracting a scheduler abstraction to hold those would be moving non-duplicated code into a structure that implies it was duplicated, on the one step that can move published measurements. The remaining difference between the loops is the difference between the loops.

I've now said this three times with a different measurement each time, so: **the door is open if you want it anyway** — Step 0's inventory is still accurate and the extraction points are the same. It is a maintenance-cost judgment and that cost is yours, not mine.

## One more quiet divergence, found by extracting

Every `on_round` call site warned when the callback raised — except `evolve`'s target-reached path, which swallowed it:

```python
except Exception:  # noqa: BLE001 - reported below on the normal path
    pass
```

That path `break`s immediately after, so nothing ever did. **A callback failing on the final round of a successful run was the single place the user heard nothing.** One `notify` helper now, and a test for exactly that case.

## Verification

- **852 passed, 1 skipped.**
- `run_demo` reproduces `docs/usage.md` **verbatim**.
- async speedup **2.80x**, inside the documented 2.57–2.93x; `run_async`'s three-policy ordering unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)