### PR TITLE
feat: the round's rollout goes through the executor seam

### DIFF
--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -612,7 +612,8 @@ def _publish_stable(aggregator) -> None:
 #: `Policies.require_supported`. The set grows as the implementations land.
 _WIRED_POLICIES = ("task_sampler", "proposal", "conflict", "fusion", "acceptance",
                    "promotion", "staleness", "verifier", "ledger",
-                   "aggregator_factory", "eval_cache", "sandbox_spec", "evaluator")
+                   "aggregator_factory", "eval_cache", "sandbox_spec", "evaluator",
+                   "executor")
 
 
 def _propose_via_policy(policy):
@@ -650,6 +651,34 @@ def _resolve_policies(policies: Optional[Policies], where: str, **shortcuts) -> 
     merged = (policies or Policies()).merged_with(**shortcuts)
     merged.require_supported(_WIRED_POLICIES, where)
     return merged
+
+
+def _spec_for(engine: "_Engine", artifact, task: Task):
+    """Describe one rollout so an executor can run it anywhere.
+
+    The `Ref`s name this package's own entry points, which is enough for an
+    in-process executor (it holds the actors directly) and is what a
+    cross-process one resolves on the far side."""
+    from .policies import SandboxSpec
+    from .workspec import Ref, RolloutSpec
+
+    return RolloutSpec(
+        rendered=artifact.render(), task=task,
+        run=Ref("agentdescent.agents:echo"), reward=Ref("agentdescent.rewards:contains"),
+        sandbox=engine.sandbox_spec or SandboxSpec())
+
+
+def _rollout_failure(outcome) -> BaseException:
+    """Turn a reported failure back into the exception the round body expects.
+
+    The executor reports rather than raises, because one bad rollout is evidence
+    and not the end of a run. The round body's error handling predates that and
+    is written against exceptions -- and it distinguishes a caller's broken
+    contract, which must stop the run, from a backend transient, which must not.
+    That distinction is carried in `Result.kind`, so it survives the trip."""
+    if outcome.kind == "caller":
+        return ProposalContractError(outcome.error or "contract violation")
+    return RuntimeError(outcome.error or "rollout failed")
 
 
 def notify(on_round: Optional[Callable[["RoundInfo"], None]],
@@ -1099,6 +1128,12 @@ class _Engine:
     train_ids: List[str]
     artifact_id: str
     blast_radius: float
+    #: Where rollouts run. Always present, defaulting to this process, so the
+    #: round body has one path rather than one per substrate.
+    executor: Any = None
+    #: What environment a rollout asks for. Empty by default; it is what a
+    #: cross-process executor hands its sandbox pool.
+    sandbox_spec: Any = None
     #: Every counter this run accumulates. Always present: an optional meter
     #: would mean every recording site grows an `if`, and the sites are the hot
     #: path.
@@ -1384,10 +1419,25 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
                 f"no callable {method}(). An aggregator needs ingest(card) and "
                 "step() -> list[MergeReport] (see AggregatorProtocol).")
 
+    # Imported here rather than at module scope: `executor` reaches `workspec`,
+    # which reaches back here for `Task`.
+    from .executor import ThreadExecutor
+
+    # In-process by default, taking the actors directly: a closure crosses no
+    # boundary here, and resolving a `Ref` per rollout would rebuild a model
+    # client every time.
+    executor = (policies_bundle.executor
+                if policies_bundle is not None and policies_bundle.executor is not None
+                else ThreadExecutor(max(1, eval_concurrency), meter=meter,
+                                    run=run, reward=reward))
+    # A supplied executor was built before this run existed, so it has no meter.
+    attach = getattr(executor, "attach_meter", None)
+    if callable(attach):
+        attach(meter)
     return _Engine(ledger, runtime, verifier, aggregator, strategy, run, reward,
                    propose, train, held_out, {t.id: t for t in train},
                    [t.id for t in train], artifact_id, blast_radius,
-                   meter=meter, scratch_repo=scratch)
+                   executor=executor, meter=meter, scratch_repo=scratch)
 
 
 def evolve(
@@ -1826,11 +1876,14 @@ def evolve(
             if not unit.keys:
                 return
             task = by_id[sampler.pick(unit.keys, r)]     # a task from this worker's shard
-            _t0 = time.time()
-            output = run(artifact.render(), task)
-            score = _checked_reward(reward(task, output), task)
-            eng.meter.add("rollouts")
-            eng.meter.add("rollout_seconds", time.time() - _t0)
+            # The rollout is the part that can move elsewhere. Everything around
+            # it -- which task, what the output implies, who is told about it --
+            # reads or writes state that has to stay in this process.
+            outcome = eng.executor.rollout(_spec_for(eng, artifact, task))
+            if not outcome.ok:
+                raise _rollout_failure(outcome)
+            output = outcome.output
+            score = _checked_reward(outcome.reward, task)
             sampler.record(task.id, score)               # learn which tasks carry signal
             with unit_lock:
                 ok_units[0] += 1

--- a/agentdescent/executor.py
+++ b/agentdescent/executor.py
@@ -77,6 +77,17 @@ class Executor(Protocol):
 
     def shutdown(self, grace: float = 5.0) -> None: ...
 
+    def rollout(self, spec: RolloutSpec) -> Result:
+        """One rollout, wherever this executor runs them.
+
+        The engine's round body already has its own concurrency -- a thread per
+        worker unit under a semaphore -- and the work either side of the rollout
+        (choosing the task, turning an output into a diff, handing it to the
+        aggregator) touches state that has to stay in this process. So the seam
+        is the rollout itself, not the batch: routing one at a time is what lets
+        `run` move to another process without moving the control plane with it.
+        """
+
 
 class ThreadExecutor:
     """The default: a bounded pool of threads in this process.
@@ -155,6 +166,19 @@ class ThreadExecutor:
             t.start()
         for _ in specs:
             yield done.get()
+
+    def attach_meter(self, meter: Meter) -> None:
+        """Report into this run's counters.
+
+        A supplied executor is built before the engine exists, so it has no
+        meter -- and then `rollouts` reads zero for the configuration whose whole
+        point was to move rollouts somewhere else. The same shape of mistake the
+        evaluation cache made, in the next seam along."""
+        self.meter = meter
+
+    def rollout(self, spec: RolloutSpec) -> Result:
+        """One rollout in this process. Same path `map_rollouts` takes."""
+        return self._one(spec)
 
     def shutdown(self, grace: float = 5.0) -> None:
         """Release anything still held. Idempotent.

--- a/agentdescent/policies.py
+++ b/agentdescent/policies.py
@@ -47,6 +47,7 @@ from typing import (
 if TYPE_CHECKING:                                   # pragma: no cover
     from .aggregator import AggregatorFactory, MergeReport
     from .evalcache import CacheProtocol
+    from .executor import Executor
     from .evaluator import EvaluatorGroup
     from .evolvable import Diff, EvidenceCard, Evolvable
     from .sampling import TaskSampler
@@ -379,6 +380,11 @@ class Policies:
     #: Where evaluations are memoised. The default is in-process; a shared one
     #: lets separate processes stop paying twice for the same gate.
     eval_cache: Optional["CacheProtocol"] = None
+    #: Where rollouts run. `None` is in-process threads. Listed in #54's design
+    #: and missed in its implementation, which nothing noticed until the round
+    #: body tried to read it -- a bundle field that does not exist and a bundle
+    #: field that is ignored fail in opposite ways, and only one of them is loud.
+    executor: Optional["Executor"] = None
     #: The gate's own concurrency, separate from the rollouts'. Evaluation is
     #: batched, cacheable and decides commits; a rollout is long-tailed, often
     #: fails, and is one opinion among many. Sizing them together means sizing

--- a/agentdescent/supervisor.py
+++ b/agentdescent/supervisor.py
@@ -308,6 +308,16 @@ class ProcessExecutor:
 
     # -- shutdown -------------------------------------------------------------
 
+    def attach_meter(self, meter: Meter) -> None:
+        """Report into this run's counters. See `ThreadExecutor.attach_meter`."""
+        self.meter = meter
+
+    def rollout(self, spec: RolloutSpec) -> Result:
+        """One rollout in a worker process, with the same recovery as a batch."""
+        for result in self.map_rollouts([spec]):
+            return result
+        raise RuntimeError("the executor returned no result for a rollout")
+
     def shutdown(self, grace: float = 5.0) -> None:
         """Stop the workers, in the one order that does not hang.
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -316,3 +316,59 @@ def test_the_loop_never_blocks_forever_on_a_result_that_cannot_come():
         assert not pending, "the task stayed pending and the loop would not end"
     finally:
         ex.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# The seam, in the round body
+# ---------------------------------------------------------------------------
+
+
+def test_the_round_body_routes_its_rollout_through_the_executor():
+    """The seam is load-bearing, not decorative: a counting executor sees every
+    rollout the round performs."""
+    from agentdescent import AppendRules, Policies, evolve
+    from agentdescent.executor import ThreadExecutor
+
+    seen = []
+
+    class Counting(ThreadExecutor):
+        def rollout(self, spec):
+            seen.append(spec.task.id)
+            return super().rollout(spec)
+
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(6)]
+    ex = Counting(2, run=lambda r, t: t.meta["gold"] if t.id in r else "?",
+                  reward=lambda t, o: 1.0 if o == t.meta["gold"] else 0.0)
+    try:
+        result = evolve(tasks, lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+                        run=lambda r, t: "unused", propose=lambda r, t, o, s: t.id,
+                        strategy=AppendRules(), rounds=3, n_workers=2,
+                        held_out_frac=0.5, seed=0, policies=Policies(executor=ex))
+    finally:
+        ex.shutdown()
+    assert seen, "the round body never asked the executor for a rollout"
+    assert result.rollouts == len(seen), (
+        f"{result.rollouts} rollouts counted but {len(seen)} went through the seam")
+
+
+def test_a_caller_contract_failure_still_stops_the_run():
+    """The executor reports rather than raises, because one bad rollout is
+    evidence. But a broken contract is not evidence -- it makes the whole run
+    meaningless -- and that distinction has to survive the trip through
+    `Result.kind`."""
+    from agentdescent import AppendRules, Policies, evolve
+    from agentdescent.evolution import ProposalContractError
+    from agentdescent.executor import ThreadExecutor
+
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(6)]
+    ex = ThreadExecutor(2, run=lambda r, t: "x",
+                        reward=lambda t, o: 5.0)      # outside [0, 1]: a caller bug
+    try:
+        with pytest.raises(Exception) as excinfo:
+            evolve(tasks, lambda t, o: 5.0, run=lambda r, t: "x",
+                   propose=lambda r, t, o, s: None, strategy=AppendRules(),
+                   rounds=2, n_workers=1, held_out_frac=0.5, seed=0,
+                   policies=Policies(executor=ex))
+        assert "range" in str(excinfo.value).lower() or "0, 1" in str(excinfo.value)
+    finally:
+        ex.shutdown()


### PR DESCRIPTION
The last of the three things I deferred. #56 built `ThreadExecutor` and `ProcessExecutor` and left them unreachable from `evolve()`, because wiring them meant writing the split twice across two loops. #57's inventory and the merges since made that no longer true.

## The seam is the rollout, not the round

Choosing the task, turning an output into a diff, handing it to the aggregator — all of it reads or writes state that has to stay in this process: the sampler learns, the strategy renders, the aggregator buffers. `run` and `reward` are the pair that can move.

So `Executor.rollout` takes one spec and the round body keeps its own threading.

**Batching the whole round through `map_rollouts`** would use the executor more fully — and would serialise `propose` in the parent, which is a real regression on any workload where proposing costs a model call. Not done, and not for lack of noticing.

The default is a `ThreadExecutor` holding the actors directly: in-process there is no boundary for a closure to fail to cross, and resolving a `Ref` per rollout would rebuild a model client every time. The default path is what it was, and the golden trace says so.

## Two things it found

**`Policies.executor` did not exist.** #54 lists it in the bundle's design; the implementation missed it. Nothing noticed until the round body tried to read it — a bundle field that is *absent* and one that is *ignored* fail in opposite ways, and only one of them is loud.

**An injected executor lost the meter**, so `rollouts` read **zero** for the configuration whose entire purpose is moving rollouts elsewhere. Exactly the mistake the evaluation cache made one seam along, which is why both now take the run's meter — and why the test asserts the count matches what went through the seam rather than merely that something did.

## Failures keep their meaning

`Result.kind` is what turns a reported failure back into the right exception. The executor reports rather than raises because one bad rollout is evidence and not the end of a run — but a caller's broken contract makes the whole run meaningless and still has to stop it.

## Verification

- **854 passed, 1 skipped.**
- Golden merge trace unchanged; `run_demo` reproduces `docs/usage.md` verbatim.
- A counting executor sees every rollout the round performs, and `result.rollouts` equals what it saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)