### PR TITLE
fix: a supplied executor ran nothing, and the run said it went fine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,37 @@ All notable changes to AgentDescent are documented here. The format follows
   merge.
 
 ### Changed
+- **The documentation grew an execution-and-resource plane, because the code
+  had one and the pages did not.** Eight modules — `executor`, `supervisor`,
+  `workspec`, `sandbox`, `sandbox_shared`, `sandbox_container` and the two
+  evaluation ones — were reachable only through pages named for something else:
+  where a rollout runs was a section inside *Customizable parallelism*, and how a
+  sandbox is isolated was a section inside *Evolving a directory*. A reader
+  running `evolve()` against a container had no reason to open either.
+
+  There are now two pages, [Where rollouts run](docs/execution.md) and
+  [Sandboxes](docs/sandboxes.md), grouped with async and scheduling under a
+  *Running at scale* section; the pages they came from keep a pointer. The module
+  map is redrawn along the same four planes — its ASCII diagram had listed
+  `sandbox` twice and filed six execution modules under *how a change is
+  accepted*.
+
+  Also corrected against the code, rather than moved: the executors' status
+  ("not yet wired into `evolve()`'s round loop" — they were wired in #89), a
+  paragraph in the container warning that had escaped its admonition mid-sentence
+  since #67, and three docstrings that described behaviour the code does not have
+  (`Ledger._exclusive` calling its `RLock` a `Lock` and claiming the section
+  nests — `flock` is per-open-file-description, so it does not;
+  `EvaluatorGroup.map` claiming to report rather than raise; `bench.harness`
+  claiming every row carries a fingerprint when `bench.run` populates none).
+
+  Two limits that were true and unwritten are now written down: the shared
+  sandbox pool's ceiling is [advisory](docs/sandboxes.md#one-ceiling-across-processes)
+  — admission reads the lease directory and then acquires, with nothing holding it
+  still in between — and `Ledger` [initialises its repository before the lock
+  exists](docs/ledger.md#more-than-one-writer), so concurrent *creation* of one
+  path still races.
+
 - **Faithful algorithm ports now share one tested CLI contract.** Their provider,
   model, seed, async, dry-run and confirmation flags come from
   `examples._common`; upstream iteration vocabulary and per-port defaults remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **`policies=Policies(executor=...)` produced a finished run that measured
+  nothing.** `evolve()` describes each rollout as a `RolloutSpec`, and the
+  `Ref`s in it named `agents:echo` / `rewards:contains` as stand-ins — the
+  caller's `run` and `reward` are closures and cannot be named. The built-in
+  `ThreadExecutor` holds the actors directly and never resolved them, so nothing
+  noticed; a *supplied* executor resolved the stand-ins, failed every rollout on
+  an argument-count mismatch, and returned `rollouts=0` with a plausible
+  `final_reward` from the gate and no exception raised.
+
+  A supplied executor is now handed the run's actors via `attach_actors(run,
+  reward)` — `evolve()`'s win over any passed to the constructor, so which actor
+  runs does not depend on how the executor was built. One that cannot accept
+  them (any cross-process executor: a closure does not cross a boundary) is
+  **refused at build time** naming the fix, rather than producing a wrong answer
+  in the shape of a right one. The spec's placeholder `Ref`s now point at
+  `evolution:undescribable_actor`, which raises and explains itself if anything
+  else resolves them.
+
 - **`cheap_eval_tasks` could veto a commit, while four places promised it could
   not.** The aggregator's acceptance step refuses a candidate that scores worse
   than the incumbent — a guard worth having — but it read the *cheap* layer,

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Full docs live in [`docs/`](https://github.com/Birfy/agentdescent/tree/main/docs
 | [Connecting agents & LLMs](https://github.com/Birfy/agentdescent/blob/main/docs/agents.md) | The provider-agnostic completion layer |
 | [Loading datasets](https://github.com/Birfy/agentdescent/blob/main/docs/dataloader.md) | The `agentdescent.dataloader` data layer — HF datasets-server + raw-file fetch, cached, dependency-free |
 | [Customizable parallelism](https://github.com/Birfy/agentdescent/blob/main/docs/parallelism.md) | Pluggable DP / TP / PP strategies — or write your own |
+| [Where rollouts run](https://github.com/Birfy/agentdescent/blob/main/docs/execution.md) | The executor seam: threads, supervised worker processes, and describing a rollout as data |
+| [Sandboxes](https://github.com/Birfy/agentdescent/blob/main/docs/sandboxes.md) | Workspace leases, one ceiling across processes, and the three isolation levels |
 | [Duration-aware scheduling](https://github.com/Birfy/agentdescent/blob/main/docs/duration-scheduling.md) | Estimate rollout cost from task size; LPT dispatch + straggler checkpointing |
 | [Efficiency experiments](https://github.com/Birfy/agentdescent/blob/main/docs/efficiency.md) | Measured parallel scaling and async tail-hiding |
 | [Example: skill evolution](https://github.com/Birfy/agentdescent/blob/main/docs/skill-evolution.md) | One complete run — real dataset, real LLM, every module |

--- a/agentdescent/evaluator.py
+++ b/agentdescent/evaluator.py
@@ -12,8 +12,16 @@ every call -- 83 of them in a six-round run over twelve tasks -- so it had a siz
 and nothing else. No identity means nothing to bound, nothing to observe, and no
 way to hand evaluation a different substrate from rollouts.
 
-This is that pool, kept. It is deliberately small: one bounded group, its own
-failure domain, and a `map` that reports rather than raises.
+This is that pool, kept. It is deliberately small: one bounded group with its own
+lifetime, and a `map` that preserves order.
+
+`map` **propagates** the first exception, deliberately. A rollout that fails is
+one opinion missing from a pool of them; a failed *evaluation* is a missing term
+in the mean a commit gate reads, and averaging over the ones that happened to
+succeed answers the gate's question with a number that is not the answer. The
+caller decides what an unmeasurable gate means -- `_Runtime.eval_one` retries,
+and `evolve()` counts the round as unmeasurable -- and it can only decide that if
+it is told.
 """
 
 from __future__ import annotations
@@ -91,6 +99,14 @@ class EvaluatorGroup:
                 self._inflight -= len(items)
 
     def stats(self) -> dict:
+        """What this group has been asked to do.
+
+        `in_flight` and `peak_inflight` count evaluations **submitted and not yet
+        returned**, which is what a caller sizing `eval_concurrency` wants to
+        know: how much work arrived at once. They are not a thread count and
+        exceed `max_workers` whenever a batch is bigger than the pool -- the
+        pool is the ceiling on how many of them are *running*.
+        """
         with self._lock:
             return {"max_workers": self.max_workers, "peak_inflight": self._peak,
                     "in_flight": self._inflight, "closed": self._closed}

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -653,18 +653,47 @@ def _resolve_policies(policies: Optional[Policies], where: str, **shortcuts) -> 
     return merged
 
 
-def _spec_for(engine: "_Engine", artifact, task: Task):
-    """Describe one rollout so an executor can run it anywhere.
+def undescribable_actor(which: str = "run"):
+    """The ``Ref`` a spec carries when ``evolve()`` cannot name the caller's actor.
 
-    The `Ref`s name this package's own entry points, which is enough for an
-    in-process executor (it holds the actors directly) and is what a
-    cross-process one resolves on the far side."""
+    Module-level and public because a `Ref` is resolved *by name*, including on
+    the far side of a process boundary -- which is exactly the case this exists
+    to report.
+
+    `evolve()` is handed `run` and `reward` as callables. In this process that is
+    all an executor needs, and `ThreadExecutor` is given them directly. There is
+    no way to turn a closure back into `Ref("module:factory", {...})`, so a spec
+    built here cannot describe them for anybody else, and the honest thing for
+    the spec to carry is a reference that says so when it is resolved.
+    """
+    from .workspec import RefError
+
+    raise RefError(
+        f"evolve() cannot describe its `{which}` argument as a Ref: it was passed "
+        "as a callable, and a closure has no name to resolve on the other side. "
+        "The built-in ThreadExecutor is handed the callables directly and never "
+        "reaches this. An executor that resolves the spec instead -- anything "
+        "across a process boundary -- needs the rollout described as data; build "
+        "the RolloutSpecs yourself and drive the executor directly (see "
+        "docs/execution.md).")
+
+
+def _spec_for(engine: "_Engine", artifact, task: Task):
+    """Describe one rollout, as completely as `evolve()`'s arguments allow.
+
+    Everything the far side needs is here except the two things `evolve()` was
+    given as closures. Those are carried as a reference that raises when it is
+    resolved, rather than as a plausible-looking default: a spec that quietly
+    names *some* actor turns "this executor cannot be driven from `evolve()`"
+    into a finished run measuring the wrong thing.
+    """
     from .policies import SandboxSpec
     from .workspec import Ref, RolloutSpec
 
     return RolloutSpec(
         rendered=artifact.render(), task=task,
-        run=Ref("agentdescent.agents:echo"), reward=Ref("agentdescent.rewards:contains"),
+        run=Ref("agentdescent.evolution:undescribable_actor", {"which": "run"}),
+        reward=Ref("agentdescent.evolution:undescribable_actor", {"which": "reward"}),
         sandbox=engine.sandbox_spec or SandboxSpec())
 
 
@@ -1426,11 +1455,29 @@ def _build_engine(tasks, reward, *, agent, run, propose, strategy, initial_state
     # In-process by default, taking the actors directly: a closure crosses no
     # boundary here, and resolving a `Ref` per rollout would rebuild a model
     # client every time.
-    executor = (policies_bundle.executor
-                if policies_bundle is not None and policies_bundle.executor is not None
-                else ThreadExecutor(max(1, eval_concurrency), meter=meter,
-                                    run=run, reward=reward))
-    # A supplied executor was built before this run existed, so it has no meter.
+    supplied = (policies_bundle.executor
+                if policies_bundle is not None else None)
+    executor = supplied if supplied is not None else ThreadExecutor(
+        max(1, eval_concurrency), meter=meter, run=run, reward=reward)
+    if supplied is not None:
+        # A supplied executor was built before this run existed, so it has
+        # neither the meter nor the actors. The meter is optional -- an executor
+        # that cannot report simply reports nothing. The actors are not: without
+        # them the executor falls back to resolving the spec, and `evolve()`
+        # cannot describe a closure as a `Ref`, so every rollout would fail. That
+        # was the behaviour, and it produced a finished run with `rollouts=0` and
+        # a plausible reward from the gate -- a wrong answer wearing the shape of
+        # a right one. Refuse instead, and say what would work.
+        if not callable(getattr(supplied, "attach_actors", None)):
+            raise TypeError(
+                f"policies.executor is a {type(supplied).__name__}, which cannot "
+                "be driven by evolve(): it has no attach_actors(run, reward), so "
+                "it would have to resolve the rollout spec -- and evolve() is "
+                "given `run` and `reward` as callables, which have no name to "
+                "resolve. Pass an in-process executor (ThreadExecutor), or "
+                "describe the rollouts yourself as RolloutSpecs and drive the "
+                "executor directly (see docs/execution.md).")
+        supplied.attach_actors(run, reward)
     attach = getattr(executor, "attach_meter", None)
     if callable(attach):
         attach(meter)

--- a/agentdescent/executor.py
+++ b/agentdescent/executor.py
@@ -176,6 +176,26 @@ class ThreadExecutor:
         evaluation cache made, in the next seam along."""
         self.meter = meter
 
+    def attach_actors(self, run: Callable[[str, Any], str],
+                      reward: Callable[[Any, str], float]) -> None:
+        """Take the run's actors directly, rather than from the spec.
+
+        Same reason as `attach_meter`: an executor passed to `evolve()` was built
+        before the run existed, so it has neither. Without this it would fall
+        back to resolving the spec's `Ref`s -- and `evolve()` is handed its actors
+        as closures, which have no name to resolve, so every rollout would fail
+        for a reason that has nothing to do with the caller's code.
+
+        Only in-process executors can accept this. A closure does not cross a
+        boundary, which is the whole reason `workspec` exists.
+
+        `evolve()`'s actors **win** over any passed to the constructor. Which
+        actor a rollout uses would otherwise depend on how the executor happened
+        to be built, which is not something a reader of the `evolve()` call can
+        see.
+        """
+        self._run, self._reward = run, reward
+
     def rollout(self, spec: RolloutSpec) -> Result:
         """One rollout in this process. Same path `map_rollouts` takes."""
         return self._one(spec)

--- a/agentdescent/ledger.py
+++ b/agentdescent/ledger.py
@@ -266,7 +266,7 @@ class Ledger:
     def _exclusive(self):
         """Hold the repository against other **processes**, not just threads.
 
-        `self._lock` is a `threading.Lock`: it makes one process's workers take
+        `self._lock` is a `threading.RLock`: it makes one process's workers take
         turns and says nothing to a second process. Two of those interleave a
         read-modify-write of `versions.json` and one commit disappears -- the
         lost update CAS exists to prevent, arriving by a route CAS cannot see,
@@ -281,13 +281,20 @@ class Ledger:
         `fcntl` where there is one, an atomically-created directory where there
         is not -- `mkdir` is atomic on every filesystem worth running this on,
         which is the only property required.
+
+        **This section does not nest.** `self._lock` is an `RLock` and would let
+        the same thread back in, but `flock` is held by an *open file
+        description*: a second `open()` from this process is a different one, so
+        a nested acquire blocks against itself and fails after the timeout rather
+        than deadlocking outright. Every public method holds it exactly once and
+        calls no other public method, which is what keeps that unreachable.
         """
         # Inside `.git/`, not the working tree: a lock file in the tree gets
         # committed by `add -A`, and then blocks the next `checkout` as an
         # untracked file that would be overwritten. `.git/` is git's own space
         # and is never part of a branch.
         path = os.path.join(self.repo_path, ".git", _LOCK_NAME)
-        with self._lock:                      # threads first: cheaper, and nested
+        with self._lock:                      # threads first, and cheaper
             handle = None
             try:
                 handle = _acquire_file_lock(path)

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -18,9 +18,11 @@ point estimate that moved 4.8 points between two runs of one configuration
 not a result.
 
 **One environment, recorded.** Two configurations measured under different
-toolchains differ by more than the variable being studied. Every row carries the
+toolchains differ by more than the variable being studied. A row can carry the
 fingerprint it ran under, and a run whose acceptance saw mixed environments is
-marked rather than averaged in.
+marked rather than averaged in. `bench.run` leaves both empty on purpose: it runs
+a single environment, and a fingerprint invented for a comparison that has only
+one of them would be decoration.
 
 None of this makes a conclusion come out positive. `docs/results.md` carries a
 row reading "lift not yet measured" for exactly that reason, and a harness whose

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,6 +195,9 @@ Two consequences worth knowing when you write a policy:
     same idea at task granularity. Partial-rollout **resume** is unimplemented on
     both paths — `run(rendered, task) -> output` is opaque, so there is no
     continuation state to check point; both now *detect* and count stragglers.
+    What does exist is recovery one level coarser: a
+    [task whose worker is lost is re-dispatched whole](execution.md#recovery-is-at-task-granularity),
+    under the same lease id so a late answer from the original can be dropped.
 
 AgentDescent separates *what to merge* (the Aggregator, identical in both) from
 *when workers and the aggregator run relative to each other* (the runtime).

--- a/docs/directory-evolution.md
+++ b/docs/directory-evolution.md
@@ -218,102 +218,19 @@ Both halves of `frozen` are needed and they do different jobs:
 * the **overlay** stops the *candidate* from rewriting it at run time
   (a `conftest.py`, a monkeypatched assertion, an early `exit(0)`).
 
-## How workspaces are managed
+## Where a candidate runs
 
-Every rollout leases a workspace from a pool and gives it back. That is a change
-of ownership rather than of behaviour: the default is still one fresh directory
-per call, deleted afterwards.
+A candidate that is code needs somewhere to run, and that is its own subject:
+lifetime (who owns a workspace, when it comes back, what happens if its owner
+dies) and isolation (what the candidate can reach while it runs) are independent
+questions with different answers. Both are on the [Sandboxes](sandboxes.md) page:
 
-```python
-from agentdescent.sandbox import SandboxPool, WorkspaceProvider
-
-pool = SandboxPool(WorkspaceProvider(), max_sandboxes=8)
-run = code_runner([...], sandbox_pool=pool)     # share it, and the cap is shared
-```
-
-**One ceiling, not two.** `max_concurrency` worker threads and
-`eval_concurrency` scoring threads both stage workspaces. Sharing one pool is
-what makes the limit a limit; with a pool each, the real ceiling is their sum.
-`acquire` blocks when the pool is full — failing would push retry logic into
-every caller, and growing would make the ceiling a suggestion.
-
-**Reuse is opt-in.** `SandboxSpec(reuse=True)` hands back a warm workspace,
-reset to empty first. The default is a fresh one because `code_runner`'s frozen
-overlay assumes a clean directory: a workspace still holding the previous
-candidate's files produces a score that looks entirely ordinary and is wrong.
-
-**Reclaiming what an owner abandoned.** Each workspace holds a
-`.agentdescent-lease.json` naming its owner, and the owner renews it while
-working. `WorkspaceProvider.reap()` deletes the ones nobody is renewing.
-
-That replaces "delete anything older than six hours", which was wrong in both
-directions. A directory's mtime does not change while a process works *inside*
-it, so a long rollout looked abandoned; and on a shared `$TMPDIR` — a parameter
-sweep, several containers on one volume — one run's live workspace looked
-collectable to every other run on the machine. Renewal is a statement by the
-owner; its absence is the thing worth acting on.
-
-A live owner gets one grace period: between one and two TTLs, an expired lease
-whose process is still running is left alone. Past that it goes regardless, so a
-recycled pid cannot keep a dead run's directory alive forever.
-
-!!! note "Where the numbers are"
-    `sandbox_wait_s`, `sandbox_setup_s` and the created/reused/failure counts
-    reach `EvolutionResult` when you pass the pool a `Meter`. Wiring that
-    automatically needs the engine to know a rollout's environment, which is
-    what `RolloutSpec` is for — until then the fields on a default `evolve()`
-    run stay zero rather than being quietly approximate.
-
-## One ceiling across processes
-
-`SandboxPool` bounds what a **process** creates. Two runs on one machine each
-respect their own limit and together exceed the machine's — the same mistake
-`max_concurrency` and `eval_concurrency` made before they shared a gate, one
-level up.
-
-```python
-from agentdescent.sandbox_shared import SharedSandboxPool
-
-pool = SharedSandboxPool(root="/var/tmp/agentdescent-pool",
-                         capacity=8,      # the machine's ceiling
-                         holders=2)       # how many runs expect to share it
-```
-
-No server. Every sandbox already carries a lease file naming its owner and when
-it was last renewed — the file `reap` reads to decide what is abandoned. Counting
-those answers a different question with the same data: how many sandboxes are
-alive on this machine right now.
-
-**Quota, not just capacity.** A ceiling alone lets whoever asks first take
-everything, so a long run starves a short one. Each holder is guaranteed
-`capacity // holders` (at least one) and may exceed it only while others are
-under theirs. Without that, sharing a ceiling is worse than not sharing: the runs
-interfere and none of them can tell.
-
-**A dead holder's slot comes back.** Its lease stops being renewed and stops
-being counted — the same rule that reclaims its directory.
-
-!!! note "One machine, verified; several, not"
-    Nothing here assumes a single machine, and nothing here has been run on two.
-    The lease directory would have to be somewhere both can see, and shared
-    filesystems have their own opinions about atomicity. That is the work a
-    cross-machine claim needs, and it has not been done.
-
-## Isolation strength — three levels
-
-Lifetime and isolation are different questions. The pool answers the first for
-every provider; which provider you choose answers the second.
-
-| provider | filesystem | network | privileges | limits |
-|---|---|---|---|---|
-| `WorkspaceProvider` (default) | **the whole host** | **the host's** | your user's | timeout only (POSIX: rlimits) |
-| `ContainerProvider` | the workspace only | off unless asked | no capabilities, not root | memory / CPU, every platform |
-| remote / microVM | — | — | — | not implemented |
-
-**What the default does not stop.** A trimmed environment redirects a *lookup*,
-not a *path*. `HOME` points inside the workspace, so `~/.aws/credentials` misses
-— and `open("/Users/you/.aws/credentials")` does not. The default provider is
-appropriate for code you would run yourself; it is not a boundary.
+* [leases rather than deletion by age](sandboxes.md#lifetime-leases-not-deletion-by-age),
+  and one ceiling shared by rollouts and the gate;
+* [one ceiling across processes](sandboxes.md#one-ceiling-across-processes), read
+  from the lease directory rather than from a server;
+* [three isolation levels](sandboxes.md#isolation-strength-three-levels) — a
+  trimmed environment is **not** a boundary; `ContainerProvider` is.
 
 ```python
 from agentdescent.sandbox import SandboxPool
@@ -323,41 +240,6 @@ pool = SandboxPool(ContainerProvider("python:3.11-slim"), max_sandboxes=8)
 run = code_runner(["python", "main.py"], test_cmd=["pytest", "-q"],
                   sandbox_pool=pool)
 ```
-
-**Docker or podman, whichever is there.** The engine is detected unless you name
-one (`engine="podman"`); the flags used are the ones both accept, and the test
-suite runs the same isolation assertions against each engine that is installed.
-No Python dependency — the core still installs with none.
-
-!!! warning "macOS and Windows: the workspace must be in a shared path"
-    The engine runs inside a VM there, and it shares only part of the host. The
-    system temporary directory — where a workspace goes by default — is usually
-    outside it, and the container then starts with an empty `/work`, so the first
-    symptom is the candidate failing to open its own files.
-
-    The provider checks for this at acquire time and says so. Stage under your
-    home directory (`workspace_root=`), or add the path to the VM
-    (`colima start --mount <path>:w`, or Docker Desktop's File Sharing). Staging is unchanged: the tree is materialised on the
-host and bind-mounted at `/work`, so `FileTree`, the frozen overlay and fixtures
-all behave exactly as before. Only execution moves.
-
-Defaults are closed and opened one field at a time:
-
-| `SandboxSpec` field | effect |
-|---|---|
-| `network` | `None`/`"none"` → `--network none`. Only `"inherit"` connects it |
-| `memory_mb` / `cpu` | `--memory` / `--cpus`; unset means no flag, not a default ceiling |
-| `env_allowlist` | variable **names**; values are read on the host and passed one at a time. Nothing is inherited in bulk |
-| `image` | overrides the provider's image per rollout |
-
-Always on: read-only root with a writable `/work` and `/tmp`, `--cap-drop ALL`,
-`no-new-privileges`, a pids limit, and the container runs as your uid so the
-files it writes are yours to delete.
-
-!!! warning "Stronger, not absolute"
-    Containers share the host kernel and escapes exist. This is a large step up
-    from a trimmed environment and it is not a licence to run deliberately
-    hostile code. For that you want a VM boundary, which this does not provide.
 
 ## Cost — the first-order design constraint
 

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -129,6 +129,20 @@ at from the other direction.
     question needs a real port against a real model, which is the step that has
     not been run.
 
+### What the matrix does not vary yet
+
+`Config` carries `executor=` and `sandbox=` fields, and `bench.run`'s workload
+reads neither: every row is the in-process default on a local workspace. They are
+there because the matrix is the right place for those dimensions, not because
+they have been measured — and a row for "processes" produced by ignoring the
+field would be the worst kind of number in this table.
+
+For the same reason the `fingerprint` and `env_mismatch` columns are populated by
+`harness.run_config` but not by the `bench.run` entry point, which runs one
+environment and says so by leaving them empty. The ⚠︎ marker that flags a
+mixed-environment row is machinery waiting for a comparison that has more than
+one environment in it.
+
 ### One thing the harness found about the engine
 
 The async path filters staleness inline and never reaches `Aggregator`'s filter,

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -1,0 +1,199 @@
+# Where rollouts run — the execution plane
+
+> **Plugs into [`evolve`](evolution.md) via** `policies=Policies(executor=...)`.
+
+[Parallelism](parallelism.md) decides **how a round's work is split**. This page
+is about **where each piece of it then runs** — the seam between the engine's
+control plane and the process that performs a rollout.
+
+`evolve()` runs rollouts in threads, and for this workload that is the measured
+right answer: a rollout is almost entirely waiting on a model, and
+[the numbers](efficiency.md#where-the-parallelism-actually-goes) are **7.1x** on
+I/O against **1.0x** on CPU. Nothing here is an attempt to make rollouts faster
+with processes.
+
+What processes buy is different and unavailable any other way:
+
+* **fault isolation** — the code being evolved is model-authored, so a segfault
+  or an OOM is ordinary. In a thread it takes the run with it;
+* **capacity beyond one machine**, and **heterogeneous workers**, later.
+
+```python
+from agentdescent import ProcessExecutor, Ref, RolloutSpec, ThreadExecutor
+```
+
+## The seam is one rollout, not one round
+
+```
+      round body                          executor
+  ┌────────────────────┐            ┌────────────────────┐
+  │ pick a task        │            │                    │
+  │ render the artifact│──spec────► │  run(rendered,task)│
+  │                    │            │  reward(task, out) │
+  │ output → diff      │◄──Result───│                    │
+  │ hand to aggregator │            │                    │
+  └────────────────────┘            └────────────────────┘
+     stays in-process                  free to move
+```
+
+Everything either side of the rollout — choosing the task, turning an output into
+a diff, ingesting evidence — reads or writes state that has to stay in this
+process. The rollout does not. So the seam is `rollout(spec) -> Result`, one at a
+time, and that is what lets `run` move elsewhere without moving the control plane
+with it.
+
+`Result` reports rather than raises: one bad rollout is evidence, not the end of
+a run. It carries a `kind` (`ok` · `model` · `infrastructure` · `caller`) because
+the round body has to tell a backend transient — which must not stop the run —
+from a broken caller contract, which must.
+
+## Work has to be describable as data first
+
+The wall is not the executor. Measured on this package:
+
+| passed to `evolve()` | crosses a process? |
+|---|---|
+| `Task`, `Diff`, `EvidenceCard`, `AppendRules` | yes |
+| `rewards.last_number()` | **no** — `Can't pickle local object` |
+| `reflector(model)`, `LLMAgent(...)` | **no** |
+| `run=lambda rendered, task: ...` | **no** |
+
+Every factory in the package returns a closure, and so does every example in
+these docs. So a process pool fails on the first submit no matter how good the
+pool is, and the fix is a way to *describe* the work:
+
+```python
+Ref("agentdescent.rewards:last_number", {"gold_key": "gold"})
+Ref("agentdescent.runners:code_runner", {"entrypoint": ["python", "main.py"]})
+Ref("agentdescent.evolution:reflector",              # references nest
+    {"complete": Ref("agentdescent.agents:claude", {"model": "..."})})
+```
+
+The worker resolves these against **its own** copy of the code. `cloudpickle`
+would send the closure instead, which is less work here and worse afterwards: it
+executes the sending process's code on the receiving side, so a version skew
+becomes a wrong answer rather than an import error.
+
+`resolve()` runs whatever it imports, so across a boundary it *is* the boundary:
+targets are restricted to an allowlist (`agentdescent.*` by default) and config
+to JSON scalars. Widen it deliberately — that is the moment to think about who
+can write to the queue.
+
+!!! note "Secrets do not travel in a spec"
+    A spec is pickled, logged, cached and journalled, so one carrying an API key
+    leaks it into all four. `SandboxSpec` carries variable **names**; the values
+    are read on the far side.
+
+## What `evolve()` can and cannot hand an executor
+
+`evolve()` builds a `ThreadExecutor` and gives it the `run` and `reward` you
+passed, **as callables**. In this process nothing needs describing, and resolving
+a `Ref` per rollout would rebuild a model client every time.
+
+That is also the limit. A closure has no name, so `evolve()` cannot turn your
+`run=` into a `Ref` — the spec it builds carries a reference that *raises when
+resolved* and says why. So:
+
+| `policies=Policies(executor=...)` | what happens |
+|---|---|
+| omitted | a `ThreadExecutor` sized from `eval_concurrency` |
+| a `ThreadExecutor` you built | accepted; `evolve()`'s `run`/`reward` are attached to it and **win** over any passed to its constructor |
+| anything without `attach_actors` (e.g. `ProcessExecutor`) | **refused at build time**, naming the fix |
+
+!!! warning "Why the refusal, rather than a best effort"
+    It used to be a best effort, and the spec named `agents:echo` /
+    `rewards:contains` as stand-ins. Every rollout then failed on an argument-count
+    mismatch, the gate still scored the artifact from `evolve()`'s own actors, and
+    the run returned `rollouts=0` with a plausible `final_reward` and **no
+    exception**. A wrong answer in the shape of a right one is worse than a
+    refusal.
+
+To run rollouts in processes today, describe them yourself and drive the
+executor directly:
+
+```python
+if __name__ == "__main__":                      # required — see the warning below
+    specs = [RolloutSpec(rendered=artifact.render(), task=t,
+                         run=Ref("agentdescent.runners:code_runner",
+                                 {"entrypoint": ["python", "main.py"]}),
+                         reward=Ref("agentdescent.rewards:last_number"))
+             for t in tasks]
+    with_executor = ProcessExecutor(4)
+    for result in with_executor.map_rollouts(specs):
+        ...
+    with_executor.shutdown()
+```
+
+## Why not `ProcessPoolExecutor`
+
+1. **One worker dying abruptly breaks the whole pool** (`BrokenProcessPool`) and
+   every in-flight task with it. Fault isolation built on something that fails as
+   a unit is not fault isolation — and this is the entire reason for processes
+   here;
+2. `max_tasks_per_child` is 3.11+; this package supports 3.9;
+3. it has no notion of a sandbox, so no way to say "this needs an environment
+   with fingerprint X, wait for one";
+4. its default start method is `fork` on Linux, and this engine is threaded — a
+   `fork` from a process holding locks in other threads produces a child holding
+   locks nothing will release.
+
+`ProcessExecutor` is persistent workers, a bounded task queue and a supervisor
+that decides on its own when a worker is gone. Four decisions in it are worth
+knowing, because each replaced something that looked reasonable:
+
+| decision | why |
+|---|---|
+| `spawn`, never `fork` | the engine is threaded; a forked child inherits locks nothing will release, and the symptom is an occasional hang rather than an error |
+| liveness is `is_alive()`, not a heartbeat | a worker inside a rollout cannot answer, and a rollout can legitimately take ten minutes. The heartbeat that remains catches *alive but wedged*, so its timeout is **longer** than any real rollout |
+| results queue unbounded, task queue bounded | back-pressure belongs on work going in. A full results queue blocks the worker in `put`, so it never takes another task, so the supervisor waits forever |
+| re-dispatch reuses the lease id | a worker only *presumed* dead may still finish. The lease id is what lets the caller drop the second answer instead of putting two cards for one task into the evidence pool |
+
+!!! warning "`spawn` re-imports `__main__`"
+    A script that builds a `ProcessExecutor` at module level builds one again in
+    every child, which builds one in every grandchild. The machine fills with
+    processes and nothing reports, so it reads as *slow* rather than as a fault.
+    Put the run behind `if __name__ == "__main__":`. Building one inside a worker
+    is refused outright.
+
+## Recovery is at task granularity
+
+The supervisor notices a worker is gone — dead, or alive and wedged past
+`hang_timeout` — and sends its task somewhere else under the same lease id. A
+task whose worker dies repeatedly is given up on after two re-dispatches and
+reported as an infrastructure failure rather than retried forever.
+
+Two counters make the policy visible, and the second is the one worth watching:
+
+```python
+r.redispatched          # tasks sent out again after a worker was presumed lost
+r.duplicates_dropped    # answers that arrived for a task already answered
+```
+
+Dropping a duplicate is correct and invisible, so without the count an
+over-eager re-dispatch policy looks exactly like a well-tuned one — it is simply
+paying twice.
+
+!!! note "Not partial-rollout resume"
+    Resuming a half-finished rollout would need `run(rendered, task) -> output` to
+    become an inspectable conversation, and that opaque contract is what lets any
+    agent be plugged in at all. [`ResumeQueue`](async.md) stays the turn-level
+    primitive it always was, unwired, rather than being repurposed as a
+    task-level channel because it happens to be a queue.
+
+## The gate has its own concurrency
+
+Rollouts and evaluations are different workloads that call the same function. A
+rollout is long-tailed, often fails, and is one opinion among many. An evaluation
+is batched, cacheable, and decides whether a change is committed — losing one
+costs the decision, not a little evidence.
+
+So they are sized separately: `max_concurrency` bounds rollouts,
+`eval_concurrency` bounds the [evaluation group](verifier.md#the-evaluation-group).
+Sizing them together means sizing them for whichever matters less.
+
+## Related
+
+* [Parallelism (DP / TP)](parallelism.md) — how a round's work is *split*
+* [Sandboxes](sandboxes.md) — the environment a rollout runs *in*
+* [Async](async.md) — whether rounds have a barrier at all
+* [The verifier](verifier.md) — the evaluation group and its cache

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -72,6 +72,13 @@ multi-writer configuration is actually producing.
     A ledger inside a sandbox is destroyed with it. Point `repo_path` at a
     location the sandbox does not own.
 
+!!! warning "The lock starts after the repository does"
+    `Ledger(...)` initialises the repo in its constructor, before there is a
+    `.git/` to put a lock file in — so two processes *creating* the same ledger
+    at the same instant race over `git init`. Every path after that is covered.
+    Create the ledger once (or let the first run create it) and share the path;
+    do not start N processes against a directory that does not exist yet.
+
 ## Why git, and why that is not overkill
 
 Three properties are needed and git already has all of them: an append-only

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,20 +5,23 @@ Every module, what it is for, and where its design is explained. The
 and *how*, that is *what*.
 
 ```
-                     evolve()  ── the one entry point
-                        │
-   ┌────────────────────┼────────────────────────────────────┐
-   │                    │                                    │
- what evolves      who does the work                  how it merges
-   │                    │                                    │
- strategy           agents / backends                   aggregator
- filetree           runners                             ledger
- treestrategy       sampling                            verifier
-                    parallel                            staleness
-                    scheduler                           governance
-                    dataloader / rewards                  metrics · policies
-                    sandbox                              defaults
-                    sandbox
+                          evolve()  ── the one entry point
+                              │
+   ┌───────────────┬──────────┴──────────┬────────────────────┐
+   │               │                     │                    │
+ what evolves   who does the work    where it runs        how it merges
+   │               │                     │                    │
+ strategies      agents               executor             aggregator
+ filetree        backends             supervisor           defaults
+ treestrategy    runners              workspec             ledger
+                 sampling             sandbox              verifier
+                 dataloader           sandbox_container    evaluator
+                 rewards              sandbox_shared       evalcache
+                 parallel             pipeline             staleness
+                 scheduler                                 governance
+
+              policies ── the contracts, across all four
+              metrics · bench ── what a run cost, and comparing runs
 ```
 
 ## The loop
@@ -57,29 +60,40 @@ and *how*, that is *what*.
 | `parallel` | DP / TP / PP — how a round's work is split | [Parallelism](parallelism.md) |
 | `sampling` | which task a worker rolls out next | [Sampling](sampling.md) |
 | `scheduler` | duration-aware dispatch, stragglers, the audit queue | [Scheduling](duration-scheduling.md) |
+| `pipeline` | the retirement, early-stop and backpressure rules both runtimes share | [Async](async.md) |
+
+## Where it runs
+
+| module | what it is | page |
+|---|---|---|
+| `executor` | the `rollout(spec) -> Result` seam, and the in-process default | [Execution](execution.md) |
+| `supervisor` | persistent worker processes, and deciding when one is gone | [Execution](execution.md#why-not-processpoolexecutor) |
+| `workspec` | a rollout as data: named callables instead of closures | [Execution](execution.md#work-has-to-be-describable-as-data-first) |
+| `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Sandboxes](sandboxes.md#lifetime-leases-not-deletion-by-age) |
+| `sandbox_shared` | one ceiling across processes, counted from the lease directory | [Sandboxes](sandboxes.md#one-ceiling-across-processes) |
+| `sandbox_container` | the provider that makes a sandbox an actual boundary (needs docker/podman) | [Sandboxes](sandboxes.md#isolation-strength-three-levels) |
 
 ## How a change is accepted
 
 | module | what it is | page |
 |---|---|---|
 | `aggregator` | the optimizer: staleness → conflict → fusion → acceptance → commit | [Aggregator](aggregator.md) |
+| `defaults` | the shipped algorithm as replaceable pieces: conflict, fusion, acceptance, promotion | [Aggregator](aggregator.md) |
 | `stats` | the acceptance maths: Beta posterior, `P(Δ>0)`, annealed δ, UCB, difficulty weight | [Aggregator](aggregator.md) |
 | `verifier` | rule / learned / oracle, and the budget on the expensive one | [Verifier](verifier.md) |
+| `evaluator` | the gate's own bounded, reusable concurrency, separate from the rollouts' | [Verifier](verifier.md#the-evaluation-group) |
+| `evalcache` | memoised evaluations: single-flight, environment-aware, shareable across processes | [Verifier](verifier.md#the-evaluation-cache) |
 | `staleness` | what to do with a diff whose base version moved | [Staleness](staleness.md) |
-| `pipeline` | the retirement and backpressure policies the two barrier-free runtimes share | [Async](async.md) |
 | `ledger` | the git-backed, compare-and-swap artifact store | [Ledger](ledger.md) |
 | `governance` | L0 frozen / L1 slow / L2 fast, by blast radius | [Governance](governance.md) |
-| `bench` | the configuration matrix and the rules that make comparing them mean something | [Efficiency](efficiency.md#the-configuration-matrix-bench) |
-| `evaluator` | the gate's own bounded, reusable concurrency, separate from the rollouts' | [Verifier](verifier.md#the-evaluation-group) |
-| `evalcache` | memoised evaluations: single-flight, environment-aware, shareable across processes | [Verifier](verifier.md) |
-| `workspec` | a rollout as data: named callables instead of closures | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
-| `executor` · `supervisor` | where rollouts run: threads, or supervised worker processes | [Parallelism](parallelism.md#where-rollouts-run-the-execution-plane) |
-| `sandbox` | workspace leases: one ceiling, one release path, reclaim what an owner abandoned | [Directory evolution](directory-evolution.md#how-workspaces-are-managed) |
-| `defaults` | the shipped algorithm as replaceable pieces: conflict, fusion, acceptance, promotion | [Aggregator](aggregator.md) |
-| `sandbox_shared` | one ceiling across processes, counted from the lease directory | [Directory evolution](directory-evolution.md#one-ceiling-across-processes) |
-| `sandbox_container` | the provider that makes a sandbox an actual boundary (needs docker/podman) | [Directory evolution](directory-evolution.md#isolation-strength-three-levels) |
+
+## Across all of it
+
+| module | what it is | page |
+|---|---|---|
 | `policies` | the contracts: which decisions are replaceable, and what each is given | [Architecture](architecture.md#35-what-the-infrastructure-owns-and-what-the-algorithm-owns) |
 | `metrics` | what the run cost: time, calls, staleness ratio, cache hits, sandbox waits | [Usage](usage.md#what-a-run-cost) |
+| `bench` | the configuration matrix and the rules that make comparing them mean something | [Efficiency](efficiency.md#the-configuration-matrix-bench) |
 
 ## Reading order
 

--- a/docs/parallelism.md
+++ b/docs/parallelism.md
@@ -27,88 +27,14 @@ Source:
 ---
 
 
-## Where rollouts run — the execution plane
+## Where rollouts run
 
-`evolve()` runs rollouts in threads, and for this workload that is the measured
-right answer: a rollout is almost entirely waiting on a model, and the numbers
-above are **7.1x** on I/O against **1.0x** on CPU. Nothing here is an attempt to
-make rollouts faster with processes.
-
-What processes buy is different and unavailable any other way:
-
-* **fault isolation** — the code being evolved is model-authored, so a segfault
-  or an OOM is ordinary. In a thread it takes the run with it;
-* **capacity beyond one machine**, and **heterogeneous workers**, later.
-
-```python
-from agentdescent import ProcessExecutor, Ref, RolloutSpec, ThreadExecutor
-```
-
-### Work has to be describable as data first
-
-The wall is not the executor. Measured on this package:
-
-| passed to `evolve()` | crosses a process? |
-|---|---|
-| `Task`, `Diff`, `EvidenceCard`, `AppendRules` | yes |
-| `rewards.last_number()` | **no** — `Can't pickle local object` |
-| `reflector(model)`, `LLMAgent(...)` | **no** |
-| `run=lambda rendered, task: ...` | **no** |
-
-Every factory in the package returns a closure, and so does every example in
-these docs. So a process pool fails on the first submit no matter how good the
-pool is, and the fix is a way to *describe* the work:
-
-```python
-Ref("agentdescent.rewards:last_number", {"gold_key": "gold"})
-Ref("agentdescent.runners:code_runner", {"entrypoint": ["python", "main.py"]})
-Ref("agentdescent.evolution:reflector",              # references nest
-    {"complete": Ref("agentdescent.agents:claude", {"model": "..."})})
-```
-
-The worker resolves these against **its own** copy of the code. `cloudpickle`
-would send the closure instead, which is less work here and worse afterwards: it
-executes the sending process's code on the receiving side, so a version skew
-becomes a wrong answer rather than an import error.
-
-`resolve()` runs whatever it imports, so across a boundary it *is* the boundary:
-targets are restricted to an allowlist (`agentdescent.*` by default) and config
-to JSON scalars. Widen it deliberately — that is the moment to think about who
-can write to the queue.
-
-### Why not `ProcessPoolExecutor`
-
-1. **One worker dying abruptly breaks the whole pool** (`BrokenProcessPool`) and
-   every in-flight task with it. Fault isolation built on something that fails as
-   a unit is not fault isolation — and this is the entire reason for processes
-   here;
-2. `max_tasks_per_child` is 3.11+; this package supports 3.9;
-3. it has no notion of a sandbox, so no way to say "this needs an environment
-   with fingerprint X, wait for one";
-4. its default start method is `fork` on Linux, and this engine is threaded — a
-   `fork` from a process holding locks in other threads produces a child holding
-   locks nothing will release.
-
-`ProcessExecutor` is persistent workers, a bounded task queue and a supervisor
-that decides on its own when a worker is gone.
-
-!!! warning "`spawn` re-imports `__main__`"
-    A script that builds a `ProcessExecutor` at module level builds one again in
-    every child, which builds one in every grandchild. The machine fills with
-    processes and nothing reports, so it reads as *slow* rather than as a fault.
-    Put the run behind `if __name__ == "__main__":`. Building one inside a worker
-    is refused outright.
-
-### Status
-
-The executors are usable directly and are covered by tests, including the
-assertion `ProcessPoolExecutor` cannot pass: killing one of three workers leaves
-the others producing and re-dispatches the dead one's task.
-
-They are **not yet wired into `evolve()`'s round loop**. Doing that now would
-mean writing it twice, once in each of the two loops that
-[#57](https://github.com/Birfy/agentdescent/issues/57) exists to unify — so it
-waits for that, rather than being duplicated and then de-duplicated.
+`parallel=` decides how a round's work is **split**. Where each piece then
+**runs** — threads here, supervised worker processes, hosts later — is a separate
+plane with its own page: [Where rollouts run](execution.md). It covers the
+`rollout(spec) -> Result` seam, why a rollout has to be describable as data
+before it can leave the process, and what `policies=Policies(executor=...)`
+does and does not accept.
 
 ## The interface
 

--- a/docs/sandboxes.md
+++ b/docs/sandboxes.md
@@ -1,0 +1,188 @@
+# Sandboxes — the environment a rollout runs in
+
+> **Plugs into [`evolve`](evolution.md) via** `code_runner(..., sandbox_pool=...)`,
+> or `policies=Policies(sandbox_provider=..., sandbox_spec=...)`.
+
+Once a candidate is *code* rather than text — [evolving a
+directory](directory-evolution.md), [DGM](algo-dgm.md), a
+[`code_runner`](directory-evolution.md#3-runners-giving-a-real-agent-the-candidate)
+of any kind — running it needs somewhere to run. Two questions follow, and they
+are independent:
+
+* **lifetime** — who owns a workspace, when does it come back, what happens if
+  its owner dies. The pool answers this for every provider;
+* **isolation** — what the candidate can reach while it runs. The *provider*
+  answers this, and the answers differ by a lot.
+
+## Lifetime: leases, not deletion by age
+
+Every rollout leases a workspace from a pool and gives it back. That is a change
+of ownership rather than of behaviour: the default is still one fresh directory
+per call, deleted afterwards.
+
+```python
+from agentdescent.sandbox import SandboxPool, WorkspaceProvider
+
+pool = SandboxPool(WorkspaceProvider(), max_sandboxes=8)
+run = code_runner([...], sandbox_pool=pool)     # share it, and the cap is shared
+```
+
+**One ceiling, not two.** `max_concurrency` worker threads and
+`eval_concurrency` scoring threads both stage workspaces. Sharing one pool is
+what makes the limit a limit; with a pool each, the real ceiling is their sum.
+`acquire` blocks when the pool is full — failing would push retry logic into
+every caller, and growing would make the ceiling a suggestion.
+
+**Reuse is opt-in.** `SandboxSpec(reuse=True)` hands back a warm workspace,
+reset to empty first. The default is a fresh one because `code_runner`'s frozen
+overlay assumes a clean directory: a workspace still holding the previous
+candidate's files produces a score that looks entirely ordinary and is wrong.
+
+**Reclaiming what an owner abandoned.** Each workspace holds a
+`.agentdescent-lease.json` naming its owner, and the owner renews it while
+working. `WorkspaceProvider.reap()` deletes the ones nobody is renewing.
+
+That replaces "delete anything older than six hours", which was wrong in both
+directions. A directory's mtime does not change while a process works *inside*
+it, so a long rollout looked abandoned; and on a shared `$TMPDIR` — a parameter
+sweep, several containers on one volume — one run's live workspace looked
+collectable to every other run on the machine. Renewal is a statement by the
+owner; its absence is the thing worth acting on.
+
+A live owner gets one grace period: between one and two TTLs, an expired lease
+whose process is still running is left alone. Past that it goes regardless, so a
+recycled pid cannot keep a dead run's directory alive forever.
+
+!!! note "Where the numbers are"
+    `sandbox_wait_s`, `sandbox_setup_s` and the created/reused/failure counts
+    reach `EvolutionResult` when you pass the pool a `Meter`. `evolve()` does not
+    wire one automatically: its default [executor](execution.md) is handed the
+    actors directly and never opens a pool of its own, so on a default run these
+    fields stay zero rather than being quietly approximate.
+
+## One ceiling across processes
+
+`SandboxPool` bounds what a **process** creates. Two runs on one machine each
+respect their own limit and together exceed the machine's — the same mistake
+`max_concurrency` and `eval_concurrency` made before they shared a gate, one
+level up.
+
+```python
+from agentdescent.sandbox_shared import SharedSandboxPool
+
+pool = SharedSandboxPool(root="/var/tmp/agentdescent-pool",
+                         capacity=8,      # the machine's ceiling
+                         holders=2)       # how many runs expect to share it
+```
+
+No server. Every sandbox already carries a lease file naming its owner and when
+it was last renewed — the file `reap` reads to decide what is abandoned. Counting
+those answers a different question with the same data: how many sandboxes are
+alive on this machine right now.
+
+**Quota, not just capacity.** A ceiling alone lets whoever asks first take
+everything, so a long run starves a short one. Each holder is guaranteed
+`capacity // holders` (at least one) and may exceed it only while others are
+under theirs. Without that, sharing a ceiling is worse than not sharing: the runs
+interfere and none of them can tell.
+
+**A dead holder's slot comes back.** Its lease stops being renewed and stops
+being counted — the same rule that reclaims its directory.
+
+!!! warning "Advisory, and cooperative"
+    Admission reads the lease directory and then acquires; nothing holds the
+    directory still in between. Two processes admitting at the same instant can
+    both see room and both take it, so the ceiling is a strong tendency rather
+    than a hard cap. That is the right trade for a bound whose job is to stop a
+    machine thrashing — but do not use it where an exact limit is a correctness
+    property.
+
+!!! note "One machine, verified; several, not"
+    Nothing here assumes a single machine, and nothing here has been run on two.
+    The lease directory would have to be somewhere both can see, and shared
+    filesystems have their own opinions about atomicity. That is the work a
+    cross-machine claim needs, and it has not been done.
+
+## Isolation strength — three levels
+
+Lifetime and isolation are different questions. The pool answers the first for
+every provider; which provider you choose answers the second.
+
+| provider | filesystem | network | privileges | limits |
+|---|---|---|---|---|
+| `WorkspaceProvider` (default) | **the whole host** | **the host's** | your user's | timeout only (POSIX: rlimits) |
+| `ContainerProvider` | the workspace only | off unless asked | no capabilities, not root | memory / CPU, every platform |
+| remote / microVM | — | — | — | not implemented |
+
+**What the default does not stop.** A trimmed environment redirects a *lookup*,
+not a *path*. `HOME` points inside the workspace, so `~/.aws/credentials` misses
+— and `open("/Users/you/.aws/credentials")` does not. The default provider is
+appropriate for code you would run yourself; it is not a boundary.
+
+```python
+from agentdescent.sandbox import SandboxPool
+from agentdescent.sandbox_container import ContainerProvider
+
+pool = SandboxPool(ContainerProvider("python:3.11-slim"), max_sandboxes=8)
+run = code_runner(["python", "main.py"], test_cmd=["pytest", "-q"],
+                  sandbox_pool=pool)
+```
+
+**Docker or podman, whichever is there.** The engine is detected unless you name
+one (`engine="podman"`); the flags used are the ones both accept, and the test
+suite runs the same isolation assertions against each engine that is installed.
+No Python dependency — the core still installs with none.
+
+Staging is unchanged: the tree is materialised on the host and bind-mounted at
+`/work`, so `FileTree`, the frozen overlay and fixtures all behave exactly as
+before. Only execution moves.
+
+!!! warning "macOS and Windows: the workspace must be in a shared path"
+    The engine runs inside a VM there, and it shares only part of the host. The
+    system temporary directory — where a workspace goes by default — is usually
+    outside it, and the container then starts with an empty `/work`, so the first
+    symptom is the candidate failing to open its own files.
+
+    The provider checks for this at acquire time and says so. Stage under your
+    home directory (`workspace_root=`), or add the path to the VM
+    (`colima start --mount <path>:w`, or Docker Desktop's File Sharing).
+
+Defaults are closed and opened one field at a time:
+
+| `SandboxSpec` field | effect |
+|---|---|
+| `network` | `None`/`"none"` → `--network none`. Only `"inherit"` connects it |
+| `memory_mb` / `cpu` | `--memory` / `--cpus`; unset means no flag, not a default ceiling |
+| `env_allowlist` | variable **names**; values are read on the host and passed one at a time. Nothing is inherited in bulk |
+| `image` | overrides the provider's image per rollout |
+
+Always on: read-only root with a writable `/work` and `/tmp`, `--cap-drop ALL`,
+`no-new-privileges`, a pids limit, and the container runs as your uid so the
+files it writes are yours to delete.
+
+!!! warning "Stronger, not absolute"
+    Containers share the host kernel and escapes exist. This is a large step up
+    from a trimmed environment and it is not a licence to run deliberately
+    hostile code. For that you want a VM boundary, which this does not provide.
+
+## The environment is part of a measurement
+
+A score is a statement about a candidate *under a toolchain*. Two rollouts run
+under different images are not two samples of one quantity, and averaging them
+produces a number that answers no question anyone asked.
+
+So `SandboxSpec.fingerprint()` becomes part of the [evaluation cache
+key](verifier.md#the-evaluation-cache) — one environment's measurement can never
+answer another's question — and a run whose acceptance decision compared
+measurements from different environments raises `env_mismatch`, which
+[`bench/`](efficiency.md#the-configuration-matrix-bench) marks rather than
+averaging in.
+
+The fingerprint is empty while there is only one environment, which is why a
+default run's cache keys are unchanged.
+
+## Related
+
+* [Evolving a directory](directory-evolution.md) — what puts code in a sandbox
+* [Where rollouts run](execution.md) — the process a sandbox is acquired from
+* [Efficiency](efficiency.md) — what sandbox setup and waiting actually cost

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,13 +52,16 @@ nav:
     - The ledger: ledger.md
     - The verifier: verifier.md
     - Staleness policies: staleness.md
-    - Parallelism (DP / TP): parallelism.md
-    - Task sampling: sampling.md
-    - Duration-aware scheduling: duration-scheduling.md
     - The data layer: dataloader.md
     - Rewards: rewards.md
-    - Async — no round barrier: async.md
     - Reference orchestrator & domain: orchestrator.md
+  - Running at scale:
+    - Parallelism (DP / TP): parallelism.md
+    - Where rollouts run: execution.md
+    - Sandboxes: sandboxes.md
+    - Async — no round barrier: async.md
+    - Task sampling: sampling.md
+    - Duration-aware scheduling: duration-scheduling.md
   - API reference: api.md
   - Run everything, and extend it: usage.md
   - Examples and results:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -372,3 +372,70 @@ def test_a_caller_contract_failure_still_stops_the_run():
         assert "range" in str(excinfo.value).lower() or "0, 1" in str(excinfo.value)
     finally:
         ex.shutdown()
+
+
+def test_a_supplied_executor_runs_the_callers_actors():
+    """`evolve()` hands its actors to whatever executor it was given.
+
+    Without that the executor falls back to resolving the spec's `Ref`s -- and
+    `evolve()` is handed `run` and `reward` as closures, which have no name to
+    resolve. The failure was silent in the worst way: every rollout failed, the
+    gate still scored the artifact, and the run returned `rollouts=0` with a
+    plausible `final_reward` and no exception.
+    """
+    from agentdescent import AppendRules, Policies, evolve
+    from agentdescent.executor import ThreadExecutor
+
+    calls = []
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(6)]
+
+    def run(rendered, task):
+        calls.append(task.id)
+        return task.meta["gold"]
+
+    ex = ThreadExecutor(2)                    # no actors: only evolve() has them
+    try:
+        result = evolve(tasks, lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+                        run=run, propose=lambda r, t, o, s: t.id,
+                        strategy=AppendRules(), rounds=3, n_workers=2,
+                        held_out_frac=0.5, seed=0, policies=Policies(executor=ex))
+    finally:
+        ex.shutdown()
+    assert calls, "the caller's `run` was never invoked through the executor"
+    assert result.rollouts > 0, "a supplied executor produced no rollouts at all"
+    assert result.error is None, result.error
+
+
+def test_an_executor_evolve_cannot_drive_is_refused_not_run():
+    """A cross-process executor cannot take closures, and `evolve()` has nothing
+    else to give it. Refusing at build time is the only honest answer: the run it
+    would otherwise produce measures nothing and says so nowhere."""
+    from agentdescent import AppendRules, Policies, evolve
+    from agentdescent.supervisor import ProcessExecutor
+
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)}) for i in range(6)]
+    with pytest.raises(TypeError) as excinfo:
+        evolve(tasks, lambda t, o: 1.0, run=lambda r, t: "x",
+               propose=lambda r, t, o, s: None, strategy=AppendRules(),
+               rounds=1, n_workers=1, held_out_frac=0.5, seed=0,
+               policies=Policies(executor=ProcessExecutor(1)))
+    assert "attach_actors" in str(excinfo.value)
+
+
+def test_a_spec_built_by_evolve_refuses_to_resolve_its_actors():
+    """The spec carries a reference that raises, not a plausible default.
+
+    It used to name `agents:echo` and `rewards:contains` -- real callables with
+    the wrong signature -- so the failure arrived as a `TypeError` about argument
+    counts, naming neither the cause nor the fix.
+    """
+    from agentdescent.evolution import undescribable_actor
+    from agentdescent.workspec import Ref, RefError
+
+    ref = Ref("agentdescent.evolution:undescribable_actor", {"which": "reward"})
+    with pytest.raises(RefError) as excinfo:
+        ref.resolve()
+    assert "reward" in str(excinfo.value)
+    assert "closure" in str(excinfo.value)
+    with pytest.raises(RefError):
+        undescribable_actor("run")


### PR DESCRIPTION
## What

`policies=Policies(executor=...)` was accepted and produced a run that measured nothing.

`evolve()` describes each rollout as a `RolloutSpec`, and the `Ref`s in it named `agents:echo` / `rewards:contains` as stand-ins — the caller's `run` and `reward` arrive as **closures**, and a closure has no name to resolve. The built-in `ThreadExecutor` is handed the actors directly and never resolved them, so nothing noticed. A *supplied* executor did:

```
default    run_calls=8  rollouts=6  error=None
supplied   run_calls=2  rollouts=0  error=TypeError: complete() takes 1 positional argument but 2 were given
```

Every rollout failed on an argument-count mismatch, the gate still scored the artifact from `evolve()`'s own actors, and the call returned a plausible `final_reward` with **no exception raised**. The two `run_calls` are gate evaluations; the caller's actor never ran a single rollout.

## Why this shape of fix

- **`attach_actors(run, reward)`** on `ThreadExecutor`, called for a supplied executor. `evolve()`'s actors **win** over any passed to the constructor — otherwise which actor runs depends on how the executor happened to be built, which no reader of the `evolve()` call can see.
- **Refused at build time** for an executor that cannot accept them. Every cross-process executor is in that category by construction (a closure does not cross a boundary — that is the whole reason `workspec` exists), and a best effort there is exactly what produced the run above. The message names the two things that do work.
- **The placeholder `Ref`s now point at `evolution:undescribable_actor`**, which raises and explains itself. A reference resolving to a real callable with the wrong signature reports an argument count; one that refuses reports the cause.

## Also: three docstrings describing behaviour the code does not have

| where | claimed | actual |
|---|---|---|
| `Ledger._exclusive` | `self._lock` is a `threading.Lock`; the section nests | it is an `RLock`, and `flock` is held by an *open file description* — a second `open()` from this process conflicts with the first, so it does **not** nest. What keeps that unreachable is that no public method calls another |
| `EvaluatorGroup.map` | "reports rather than raises" | it propagates — which is right (a missing term in the mean a commit gate reads is not a missing opinion), so the docstring now says that instead. `stats()` likewise counts *submitted* work, not threads, and can exceed `max_workers` |
| `bench.harness` | "every row carries the fingerprint it ran under" | `bench.run` runs one environment and populates none |

## Tests

Three regressions in `tests/test_executor.py`: a supplied executor runs the caller's actors; an executor `evolve()` cannot drive is refused rather than run; a spec built by `evolve()` refuses to resolve its actors.

`pytest -q` (858) and `mkdocs build --strict` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)