### PR TITLE
fix: five things the merge path reported without measuring, and one field that never existed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **The async path counted every surviving card twice, so `stale_rate()` read
+  about half the truth.** `async_evolve` runs its own staleness gate — it has to,
+  because a custom `aggregator_factory` is promised only already-rebased cards —
+  and then `Aggregator` runs its own over the survivors, on the same `Meter`.
+  Measured: 20 cards reported `stale_considered = 40`. A true 50% stale rate read
+  as 33%, and the end-of-run "you are discarding most of your evidence" warning,
+  which fires at `discarded/considered > 0.5`, needed a *67%* true rate to trip.
+  Each side now counts only what the other cannot see: the gate's discards, the
+  aggregator's survivors.
+
+- **An async worker read the ledger once per rollout to measure its drift.** A
+  ledger read is a `git checkout` behind a process-wide file lock and an RLock
+  every worker and the merger queue on, so the cost of asking "am I far enough
+  behind to resync?" grew with the concurrency it exists to support. The merger
+  is the only writer, so it now publishes the head after each sweep and workers
+  read that — which is what `AsyncAgentDescent` has always done, and what the
+  general engine reached for git to do instead. Measured on a 21-rollout run: 46
+  ledger reads before, 22 after. A published head can lag by one sweep, delaying
+  a refresh by at most one rollout; the refresh still takes a real snapshot.
+
 - **An exhausted `oracle_budget` turned the audit gate into a sub-sample veto.**
   `oracle_eval` degrades to `rule_eval` once the budget is gone — by design, so a
   run cannot spend money it was told not to — but `rule_eval` is the
@@ -420,6 +440,23 @@ All notable changes to AgentDescent are documented here. The format follows
   larger file could be loaded but never changed: every diff touching it is
   rejected as `oversized`, which surfaces five rounds later as "my reflector
   emits junk" rather than "that file was never editable".
+
+### Removed
+- **`EvidenceCard.version_annotations`**, described as "per-turn version
+  annotations, used when the ledger hot-updates mid-rollout". Nothing wrote one
+  and nothing read one -- no producer in the package, no consumer, no test, no
+  doc page. A field on the object every worker constructs is not free: it reads
+  as a capability, and the mid-rollout hot-update it names does not exist (a
+  worker holds one snapshot for a whole rollout, by construction).
+
+### Documentation
+- **One table of everything provided, tested, and not in any engine path**, in
+  `docs/modules.md`: `Ledger.commit_atomic`, `L1SerialGate`, `ResumeQueue`,
+  `AuditScheduler.pop`, `EvidenceBuffer.settled`, `TaskScheduler`'s missing
+  artifact axis, `PipelineParallel`. Each already said so in its own docstring,
+  so finding out cost a read of the source, one class at a time. The rule they
+  share is worth stating once: a primitive that is implemented and unreachable is
+  honest, one that is reachable and silently does nothing is not.
 
 ## [0.3.0] — 2026-08-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ All notable changes to AgentDescent are documented here. The format follows
 ## [Unreleased]
 
 ### Fixed
+- **An exhausted `oracle_budget` turned the audit gate into a sub-sample veto.**
+  `oracle_eval` degrades to `rule_eval` once the budget is gone — by design, so a
+  run cannot spend money it was told not to — but `rule_eval` is the
+  `cheap_eval_tasks` sub-sample, and the audit gate vetoed on its verdict.
+  Measured: a candidate that took the full held-out rate from 0.5 to 1.0 came
+  back `oracle-rejected` because a two-task sample scored both sides at 0.5. Two
+  sections of `docs/verifier.md` promise sub-sampling can never decide a commit;
+  this was the path that made it false, and it is the same hole the acceptance
+  step's regression guard was fixed for one entry below.
+
+  The fix is that the audit stops buying a measurement it already has.
+  `ThreeLayerVerifier.oracle_shares_full_set` records what that class has always
+  done — `oracle_eval` and `eval_counts` are the same `eval_fn` over the same
+  held-out set — and the aggregator reuses the full-set rates the acceptance test
+  just computed. The verdict is identical while budget remains, and there is no
+  degraded path to fall onto when it does not. A custom verifier whose oracle is
+  genuinely independent leaves the attribute undefined and keeps being called.
+
+  Consequences worth knowing: with the shipped verifier an L1 run now reports
+  `oracle_calls_used == 0` — the audit ran, nothing had to be bought — so
+  `AuditScheduler.audits` was added to answer "did the gate open", which is the
+  question `oracle_calls_used` used to be a proxy for.
+
+- **`async_evolve()` accepted `Policies(executor=...)` and ignored it.** Both
+  engines shared one `_WIRED_POLICIES` tuple, and the barrier-free loop has no
+  executor seam — its worker calls `eng.run` directly. So the field was declared
+  supported for a loop that never read it: accepted, then dropped, which is the
+  single outcome `Policies.require_supported` exists to prevent. It got sharper
+  the moment a supplied executor started working under `evolve()`, because
+  flipping `asynchronous=True` would then silently stop honouring it. The async
+  path now has its own set and raises `NotImplementedError` naming the field.
+
+- **A "cheap re-verification" that verified nothing did so in silence.** The
+  staleness policies' `REBASE` branch keeps a rebased diff iff
+  `before <= after`, and `EvolvingArtifact.score` returns `0.0` for an empty task
+  list — so when an evidence card carries nothing the engine can score, the check
+  compares `0.0 <= 0.0` and keeps *every* diff, including one that makes the
+  artifact worse. `EvidenceCard.trajectory_refs` was annotated `List[str]` for a
+  while, so a domain that followed the annotation and stored ids landed here with
+  a non-empty list and nothing in it to score. The annotation was corrected
+  earlier; `evidence_eval` now warns once per run when it happens, which is what
+  would have made the original trap visible while it was running.
+
 - **`policies=Policies(executor=...)` produced a finished run that measured
   nothing.** `evolve()` describes each rollout as a `RolloutSpec`, and the
   `Ref`s in it named `agents:echo` / `rewards:contains` as stand-ins — the

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -559,20 +559,32 @@ class Aggregator:
             self.audit.update_trust(
                 artifact_id, (cand_full > base_full) == (cand_score > base_score))
         if self.audit.force_oracle(artifact.blast_radius, artifact_id):
-            oracle_base = self.verifier.oracle_eval(artifact)
-            oracle_cand = self.verifier.oracle_eval(best_state)
+            # A verifier whose oracle scores the same set `eval_counts` does has
+            # already been paid for: `base_full` / `cand_full` ARE that
+            # measurement. Re-buying it was not merely wasteful -- `oracle_eval`
+            # degrades to `rule_eval` once the budget is gone, so past that point
+            # the gate vetoed on the cheap SUB-SAMPLE. Measured: a candidate that
+            # took the full-set rate from 0.5 to 1.0 came back `oracle-rejected`
+            # because the two-task sample scored both at 0.5. The verifier page
+            # promises in two places that sub-sampling can never decide a commit;
+            # this was the path that made it false.
+            if getattr(self.verifier, "oracle_shares_full_set", False):
+                oracle_base, oracle_cand = base_full, cand_full
+            else:
+                oracle_base = self.verifier.oracle_eval(artifact)
+                oracle_cand = self.verifier.oracle_eval(best_state)
             agreed = (oracle_cand > oracle_base) == (cand_score > base_score)
             self.audit.update_trust(artifact_id, agreed)
             if oracle_cand <= oracle_base:
                 prior.observe_delta(oracle_cand - oracle_base)
+                # Not settled, unlike the CAS-conflict path below -- and the
+                # asymmetry is deliberate. A CAS-conflicted diff lost a race and
+                # was never judged against the new head, so it deserves another
+                # look; one rejected here was judged and lost, and its tournament
+                # rivals scored below it on the same held-out set. Re-filing them
+                # would just buy the same rejection again.
                 return True
         return False
-
-        # Not settled, unlike the CAS-conflict path below -- and the asymmetry is
-        # deliberate. A CAS-conflicted diff lost a race and was never judged against
-        # the new head, so it deserves another look; one rejected here was judged and
-        # lost, and its tournament rivals scored below it on the same held-out set.
-        # Re-filing them would just buy the same rejection again.
 
     def _commit_with_retry(self, artifact_id, candidate, diff, head):
         """CAS, rebasing onto whatever landed first. ``None`` when it kept losing.

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -263,6 +263,29 @@ def async_evolve(
 
     intake: List[EvidenceCard] = []
     intake_lock = threading.Lock()
+    # The head every worker measures its drift against, published by the merger.
+    #
+    # Workers used to read it from the ledger on **every rollout**, and a ledger
+    # read is a `git checkout` guarded by a process-wide file lock and an RLock
+    # that every worker and the merger queue behind -- so the cost of asking "am I
+    # far enough behind to resync?" grew with the concurrency it was there to
+    # support. The merger is the only writer, so it can simply say. This is what
+    # `AsyncAgentDescent._publish_head` has always done; the general engine reached
+    # for git instead.
+    #
+    # A published head can lag by at most one sweep, which delays a refresh by one
+    # rollout at worst. The refresh itself still takes a real `ledger.snapshot()`,
+    # so nothing downstream reads a cached version.
+    head_pub = [eng.ledger.head_version(Ledger.DEV).get(eng.artifact_id, 0)]
+    head_lock = threading.Lock()
+
+    def _publish_head(version: int) -> None:
+        with head_lock:
+            head_pub[0] = version
+
+    def _published_head() -> int:
+        with head_lock:
+            return head_pub[0]
     stop = threading.Event()
     counter = [0]
     counter_lock = threading.Lock()
@@ -317,7 +340,7 @@ def async_evolve(
                 if pending <= async_ratio:
                     break
                 time.sleep(0.05)
-            head_v = eng.ledger.head_version(Ledger.DEV).get(eng.artifact_id, 0)
+            head_v = _published_head()
             # Refresh on the lag budget, or when the merger has asked everyone to
             # sync. `concepts.md` documents that backpressure guard as what keeps a
             # mismatched `async_ratio > alpha` from livelocking under Guarded --
@@ -463,16 +486,28 @@ def async_evolve(
         if not batch:
             time.sleep(0.005)
             return
-        head_vv = eng.ledger.head_version(Ledger.DEV)
-        head_art = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
+        snap = eng.ledger.snapshot(Ledger.DEV)
+        head_vv, head_art = snap.version, snap.get(eng.artifact_id)
+
+        def _discarded() -> None:
+            """Record a card this gate is dropping, denominator included.
+
+            The denominator is split between here and `Aggregator`, and it has to
+            be: this gate sees every card but forwards only survivors, while the
+            aggregator sees only survivors and counts them on the **same meter**.
+            Counting the whole batch here as well counted every survivor twice --
+            measured, 20 cards reported `stale_considered = 40`, so a true 50%
+            stale rate came out as 33% and the "you are discarding most of your
+            evidence" warning at the end of this function needed a *67%* true rate
+            to fire at its documented 50% threshold.
+
+            So each side counts what only it can see: the discards here, the
+            survivors there. `D + (N - D) = N`.
+            """
+            eng.meter.add("stale_considered")
+            eng.meter.add("stale_discarded")
+
         # staleness gate: hand the aggregator only rebased (η=0) cards.
-        #
-        # Counted here because this path never reaches `Aggregator`'s own filter,
-        # which is where the synchronous loop's ratio comes from. Without these
-        # two lines the async rows of any comparison report a stale rate of 0% --
-        # not "no staleness", but "not measured", and the two look identical in a
-        # table.
-        eng.meter.add("stale_considered", len(batch))
         for card in batch:
             eta = vv_staleness(head_vv, card.base_version)
             action = policy.decide(eta, alpha, card.diff.contract_breaking)
@@ -483,12 +518,14 @@ def async_evolve(
                 if head_art.evidence_eval(card) <= cand.evidence_eval(card):
                     eng.aggregator.ingest(card.rebased_onto(head_vv))
                 else:
-                    eng.meter.add("stale_discarded")
+                    _discarded()
             else:
-                eng.meter.add("stale_discarded")         # DISCARD -> drop the card
+                _discarded()                             # DISCARD -> drop the card
         reports = check_reports(eng.aggregator.step(), eng.aggregator)
         committed = sum(1 for x in reports if x.committed_version is not None)
-        dev = eng.ledger.snapshot(Ledger.DEV).get(eng.artifact_id)
+        after = eng.ledger.snapshot(Ledger.DEV)
+        dev = after.get(eng.artifact_id)
+        _publish_head(after.version.get(eng.artifact_id, 0))
         last_good[0] = dev
         # Must be the real held-out reward: MergeReport.prob_improve is P(Δ>0)
         # from the Beta posterior, a *probability*, and reporting it here would

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -41,7 +41,7 @@ from .policies import Policies
 from .evolution import (
     _publish_stable, _safe_log,
     Agent, EvolutionResult, Propose, Reward, RoundInfo, Run, Strategy, Task,
-    _cost_fields, _resolve_policies, _tally,
+    _ASYNC_WIRED_POLICIES, _cost_fields, _resolve_policies, _tally,
     SOLVED, _build_engine, _checked_proposal, _checked_reward,
 )
 from .aggregator import AggregatorConfig, check_reports
@@ -228,7 +228,9 @@ def async_evolve(
         ``RoundInfo.round`` is the sweep index. Compare ``final_reward`` across the
         sync and async paths, not ``len(history)``.
     """
-    _pol = _resolve_policies(policies, "async_evolve()", task_sampler=task_sampler,
+    _pol = _resolve_policies(policies, "async_evolve()",
+                             supported=_ASYNC_WIRED_POLICIES,
+                             task_sampler=task_sampler,
                              staleness=staleness_policy,
                              aggregator_factory=aggregator_factory)
     task_sampler, staleness_policy = _pol.task_sampler, _pol.staleness

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -392,7 +392,42 @@ class EvolvingArtifact:
         return sum(scores) / len(scores)
 
     def evidence_eval(self, evidence: EvidenceCard) -> float:
-        return self.score([t for t in evidence.trajectory_refs if isinstance(t, Task)])
+        """Score this artifact on the trajectories an evidence card carries.
+
+        Says so out loud when there is nothing to score. This is the one call
+        behind the staleness policy's REBASE branch, which keeps a rebased diff
+        iff ``before <= after`` -- and :meth:`score` returns ``0.0`` for an empty
+        task list, so when the filter below empties it the branch compares
+        ``0.0 <= 0.0``, keeps *every* rebased diff, and the cheap re-verification
+        the policy is named for silently becomes a no-op. A diff that makes the
+        artifact worse survives it.
+
+        :class:`~agentdescent.evolvable.EvidenceCard.trajectory_refs` was
+        annotated ``List[str]`` for a while, so a custom domain that followed the
+        annotation and stored ids landed here with a non-empty list and nothing
+        in it to score. The annotation is fixed; this is the part that would have
+        made it visible at the time.
+        """
+        tasks = [t for t in evidence.trajectory_refs if isinstance(t, Task)]
+        if not tasks:
+            self._warn_unscorable(len(evidence.trajectory_refs))
+        return self.score(tasks)
+
+    def _warn_unscorable(self, n_refs: int) -> None:
+        """Warn once per run. The caller is a per-card loop, so once is the point."""
+        rt = self._rt
+        if rt is None or rt.warned_unscorable:
+            return
+        rt.warned_unscorable = True
+        detail = (f"its {n_refs} trajectory ref(s) are not Task objects"
+                  if n_refs else "it carries no trajectory refs")
+        warnings.warn(
+            f"an evidence card reached the staleness filter's re-verification with "
+            f"nothing to score ({detail}), so the check compares 0.0 <= 0.0 and "
+            "keeps the diff whatever it does to the artifact. Put the failing "
+            "Task objects in EvidenceCard.trajectory_refs -- ids are not enough, "
+            "the engine scores the tasks themselves.",
+            RuntimeWarning, stacklevel=3)
 
     def full_eval(self, task_set: Sequence[Task]) -> Dict[str, float]:
         """Score on a task set. No longer part of the `Evolvable` protocol -- the
@@ -444,6 +479,12 @@ class _Runtime:
     #: two, it is what stops one environment's score answering the other's
     #: question.
     env_fingerprint: str = ""
+
+    #: Has this run already reported an evidence card with nothing to score?
+    #: Lives here rather than on the artifact because artifacts are rebuilt from
+    #: the ledger constantly, and rather than at module scope because "once" has
+    #: to mean once per run, not once per interpreter.
+    warned_unscorable: bool = False
 
     def eval_one(self, artifact: EvolvingArtifact, task: Task) -> float:
         key = cache_key(artifact._signature(), task.id, self.env_fingerprint)
@@ -607,13 +648,22 @@ def _publish_stable(aggregator) -> None:
         pass
 
 
-#: What `evolve` / `async_evolve` can honour from a `Policies` bundle today.
-#: Everything else raises rather than being accepted and ignored -- see
+#: What `evolve` can honour from a `Policies` bundle today. Everything else
+#: raises rather than being accepted and ignored -- see
 #: `Policies.require_supported`. The set grows as the implementations land.
 _WIRED_POLICIES = ("task_sampler", "proposal", "conflict", "fusion", "acceptance",
                    "promotion", "staleness", "verifier", "ledger",
                    "aggregator_factory", "eval_cache", "sandbox_spec", "evaluator",
                    "executor")
+
+#: The same bundle, minus the one field the barrier-free loop does not read.
+#: `async_evolve`'s worker calls `eng.run` directly; there is no executor seam in
+#: it yet, so a supplied one was accepted and then dropped -- the exact outcome
+#: `require_supported` exists to make impossible, arriving through a *shared*
+#: constant rather than a missing check. It matters more since a supplied
+#: executor started working on the synchronous path: flipping
+#: `asynchronous=True` would otherwise silently stop honouring it.
+_ASYNC_WIRED_POLICIES = tuple(p for p in _WIRED_POLICIES if p != "executor")
 
 
 def _propose_via_policy(policy):
@@ -642,14 +692,20 @@ def _propose_via_policy(policy):
     return propose
 
 
-def _resolve_policies(policies: Optional[Policies], where: str, **shortcuts) -> Policies:
+def _resolve_policies(policies: Optional[Policies], where: str, *,
+                      supported: Optional[Sequence[str]] = None,
+                      **shortcuts) -> Policies:
     """Fold the legacy keyword arguments into a bundle and check it is honourable.
 
     The keyword arguments are shortcuts onto bundle fields, so an explicit
     argument has to beat a bundle default -- being silently dropped is the one
-    outcome a caller cannot detect."""
+    outcome a caller cannot detect.
+
+    ``supported`` is keyword-only and defaults to `evolve`'s set. The two engines
+    do not honour quite the same bundle, and sharing one constant meant the
+    narrower of them silently ignored a field."""
     merged = (policies or Policies()).merged_with(**shortcuts)
-    merged.require_supported(_WIRED_POLICIES, where)
+    merged.require_supported(supported or _WIRED_POLICIES, where)
     return merged
 
 

--- a/agentdescent/evolvable.py
+++ b/agentdescent/evolvable.py
@@ -138,8 +138,14 @@ class EvidenceCard:
     #: the cheap re-verification silently becomes a no-op, and a diff that makes
     #: the artifact worse survives it.
     trajectory_refs: List[Any] = field(default_factory=list)
-    # per-turn version annotations, used when the ledger hot-updates mid-rollout.
-    version_annotations: List[VersionVector] = field(default_factory=list)
+    # `version_annotations: List[VersionVector]` used to sit here, described as
+    # "per-turn version annotations, used when the ledger hot-updates
+    # mid-rollout". Nothing ever wrote one and nothing ever read one -- not a
+    # producer in the package, not a consumer, not a test, not a doc page. A field
+    # on the object every worker constructs is not free: it is read as a
+    # capability, and the mid-rollout hot-update it names does not exist (a worker
+    # holds one snapshot for a whole rollout, by construction). It would come back
+    # with the code that needs it.
     cost_tokens: int = 0
     cost_wallclock: float = 0.0
 

--- a/agentdescent/scheduler.py
+++ b/agentdescent/scheduler.py
@@ -172,6 +172,7 @@ class AuditScheduler:
         self._collect = collect
         self._max_queued = max_queued
         self._dropped = 0
+        self._audits = 0
         self._lock = threading.Lock()               # submitted from worker threads
 
     def trust(self, artifact_id: str) -> float:
@@ -218,9 +219,20 @@ class AuditScheduler:
         "High-impact" means L1, and the boundary belongs to
         :func:`~agentdescent.governance.classify` -- a third hand-written
         threshold here (``>= 0.5``) meant an artifact at 0.4 was L1 by governance
-        and audited like an L2 skill: never."""
+        and audited like an L2 skill: never.
+
+        Counts the audits it opens (:attr:`audits`). The obvious way to ask "did
+        the gate ever open" used to be ``verifier.budget.oracle_calls_used``, and
+        that stopped being the same question once the aggregator started reusing
+        a full-set measurement it had already paid for: the gate opens, the audit
+        runs, and no budget moves. A counter here answers it directly instead of
+        inferring it from what was spent."""
         from .governance import FAST_MAX
-        return blast_radius > FAST_MAX or self._trust[artifact_id] < 0.75
+        with self._lock:
+            opened = blast_radius > FAST_MAX or self._trust[artifact_id] < 0.75
+            if opened:
+                self._audits += 1
+            return opened
 
     def pop(self) -> Optional[_AuditItem]:
         with self._lock:
@@ -232,6 +244,12 @@ class AuditScheduler:
     def dropped(self) -> int:
         """How many low-priority audits were shed to stay under the cap."""
         return self._dropped
+
+    @property
+    def audits(self) -> int:
+        """How many times the oracle gate opened. See :meth:`force_oracle`."""
+        with self._lock:
+            return self._audits
 
     def __len__(self) -> int:
         return len(self._items)

--- a/agentdescent/verifier.py
+++ b/agentdescent/verifier.py
@@ -61,6 +61,25 @@ class ThreeLayerVerifier:
     budget: VerifierBudget = field(default_factory=VerifierBudget)
     _rng: random.Random = field(init=False, repr=False)
 
+    #: Does :meth:`oracle_eval` score exactly the set :meth:`eval_counts` scores?
+    #:
+    #: For this class it always does -- both are ``eval_fn(artifact, held_out)``,
+    #: which ``docs/verifier.md`` already noted when it explained that an L1 audit
+    #: costs no extra model calls. The aggregator reads this and **reuses** the
+    #: full-set rates it has already measured instead of buying them again.
+    #:
+    #: That is not only a saving. Re-buying them goes through :meth:`oracle_eval`,
+    #: which degrades to :meth:`rule_eval` once the budget is gone -- so an
+    #: exhausted budget silently turned the audit gate into a *sub-sample* veto,
+    #: which is the one thing sub-sampling is documented never to do. See
+    #: :meth:`oracle_eval`.
+    #:
+    #: Not annotated, so it is a plain class attribute rather than a
+    #: constructor field: it is a statement about how this class is written, not
+    #: a knob. A custom verifier whose oracle really is an independent
+    #: measurement simply does not define it, and keeps being called.
+    oracle_shares_full_set = True
+
     def __post_init__(self) -> None:
         self._rng = random.Random(self.seed)
         self._subsets: Dict[int, Sequence] = {}
@@ -124,7 +143,17 @@ class ThreeLayerVerifier:
         The budget is a real cap, not a counter: ``eval_fn`` is the caller's
         scorer, so on an LLM workload every oracle call is a full held-out sweep
         of real model calls. Once the budget is exhausted this falls back to the
-        cheap layer rather than spending money it was told not to spend."""
+        cheap layer rather than spending money it was told not to spend.
+
+        **That fallback is a downgrade, so the result must not decide a commit.**
+        Past the budget this returns a *sub-sample* score, and the aggregator's
+        audit gate used to veto on it: measured, a candidate that doubled the
+        full-set rate (0.5 -> 1.0) was reported ``oracle-rejected`` because a
+        two-task sample could not see the difference. The merge path no longer
+        reaches here at all -- see :attr:`oracle_shares_full_set` -- and a
+        substitute whose oracle degrades the same way should either set that
+        attribute or keep the measurement exact.
+        """
         if not self.budget.can_spend():
             return self.rule_eval(artifact)
         self.budget.spend()

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,6 +39,8 @@ An `Evolvable`: flat state + a strategy.
 
 | method | what it does |
 |---|---|
+| `cheap_eval(evidence: EvidenceCard) -> float` | Score this artifact on the trajectories an evidence card carries. |
+| `evidence_eval(evidence: EvidenceCard) -> float` | Score this artifact on the trajectories an evidence card carries. |
 | `full_eval(task_set: Sequence[Task]) -> Dict[str, float]` | Score on a task set. No longer part of the `Evolvable` protocol -- the engine reaches ground truth through the verifier's `eval_fn` -- and kept because it is a convenient thing for a caller to have. |
 | `score(tasks: Sequence[Task]) -> float` | Mean reward over `tasks`, evaluated concurrently. |
 

--- a/docs/async.md
+++ b/docs/async.md
@@ -88,6 +88,24 @@ Three properties are worth knowing before you tune anything:
   conflicts on this path, and a custom
   [`aggregator_factory`](aggregator.md) sees only already-rebased cards. Every
   optimizer that works synchronously works here unchanged.
+
+    Two consequences follow from "only writer", and both used to be paid for
+    rather than used:
+
+    * **The head is published, not fetched.** A worker measures its drift against
+      a version the merger publishes after each sweep, not against the ledger. It
+      used to read the ledger on *every rollout*, and a ledger read is a
+      `git checkout` behind a process-wide file lock plus an RLock the whole run
+      queues on — so the cost of asking "am I far enough behind?" grew with the
+      concurrency it exists to support (measured: 46 reads for a 21-rollout run,
+      22 after). The published head can lag by one sweep, which delays a refresh
+      by at most one rollout; the refresh itself still takes a real snapshot.
+    * **The staleness denominator is split.** This gate sees every card and
+      forwards only the survivors, and `Aggregator` then counts those survivors
+      on the same meter — so each survivor was counted as "considered" twice, and
+      `result.stale_rate()` came out at roughly half the truth (20 cards
+      reporting `stale_considered = 40`). Each side now counts what only it can
+      see: the discards here, the survivors there.
 * **A backpressure guard forces a global sync if the pipeline stalls** (evidence
   arriving, nothing committing). Without it a mismatched `async_ratio > alpha`
   livelocks under Guarded: workers propose against a snapshot too old to accept,

--- a/docs/execution.md
+++ b/docs/execution.md
@@ -99,6 +99,16 @@ resolved* and says why. So:
 | omitted | a `ThreadExecutor` sized from `eval_concurrency` |
 | a `ThreadExecutor` you built | accepted; `evolve()`'s `run`/`reward` are attached to it and **win** over any passed to its constructor |
 | anything without `attach_actors` (e.g. `ProcessExecutor`) | **refused at build time**, naming the fix |
+| any of the above under `async_evolve()` / `asynchronous=True` | **refused**: the barrier-free loop has no executor seam |
+
+!!! warning "`async_evolve()` does not take an executor"
+    Its worker calls `eng.run` directly — there is no seam to route through yet.
+    Both engines shared one list of honoured `Policies` fields, so `executor` was
+    declared supported for a loop that never read it: accepted, then dropped. That
+    is the single outcome [`require_supported`](evolution.md) exists to prevent,
+    and it got sharper once a supplied executor started working under `evolve()`,
+    because flipping `asynchronous=True` would silently stop honouring it. It now
+    raises `NotImplementedError` naming the field.
 
 !!! warning "Why the refusal, rather than a best effort"
     It used to be a best effort, and the spec named `agents:echo` /

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -117,6 +117,28 @@ were measured) → [Results](results.md).
 [algorithm ports](self-evolution-examples.md), each of which replaces a different
 piece.
 
+## Provided, tested, and not in any engine path
+
+Some of what `import agentdescent` gives you is a **primitive for a
+configuration that does not ship yet** — the design calls for it, it is
+implemented and tested in isolation, and no loop reaches it today. Each one says
+so in its own docstring, which meant finding out cost a read of the source, one
+class at a time. They are all in one table instead:
+
+| name | why it exists | what would reach it |
+|---|---|---|
+| [`Ledger.commit_atomic`](ledger.md) | 2PC across several artifacts, for a contract-breaking diff that must land with its adapters | a multi-artifact library; `evolve()` registers exactly one |
+| [`L1SerialGate`](governance.md) | "at most one L1 diff in evaluation anywhere" | concurrent merging; every shipped runtime merges on one thread, so the guarantee already holds by construction |
+| [`ResumeQueue`](duration-scheduling.md) | turn-level checkpoints of a timed-out rollout | a rollout that exposes its turns; `run(rendered, task) -> output` is opaque, which is what lets any agent be plugged in |
+| [`AuditScheduler.pop`](duration-scheduling.md) | draining the Ĝ-ordered audit queue out of band | `AuditScheduler(collect=True)`; the default computes priorities without queuing, because nothing drains it |
+| [`EvidenceBuffer.settled`](aggregator.md) | discarded evidence stays addressable — the structural advantage of artifacts over gradients | re-filing settled cards into the trajectory pool; today it is a bounded diagnostic ring |
+| `TaskScheduler` × artifact axis | the design's L-task is `(task cluster × artifact)` | more than one artifact; `TaskCluster` has no artifact dimension |
+| [`PipelineParallel`](parallelism.md) | one artifact per stage, with upstream blame | a multi-artifact run; `evolve()` **refuses** it rather than degrading to DP in silence |
+
+The rule they share: a primitive that is implemented and unreachable is honest;
+one that is *reachable and silently does nothing* is not, which is why
+`PipelineParallel` raises and `Policies` refuses a field it cannot honour.
+
 ## Dependency shape
 
 Nothing in the framework imports a provider SDK at module level, and the core

--- a/docs/verifier.md
+++ b/docs/verifier.md
@@ -139,13 +139,32 @@ money it was told not to spend. Note that this only saves anything when
 `cheap_eval_tasks` makes the cheap layer genuinely cheaper — the two knobs go
 together, and setting `oracle_budget` alone does nothing.
 
-!!! tip "The oracle gate is usually free"
-    For an [L1 artifact](governance.md) every merge is forced through the oracle
-    — and it costs no extra agent calls. `oracle_eval` and `eval_counts` call the
-    same `eval_fn` over the same held-out set, and the engine's evaluation cache
-    is keyed on `(rendered artifact, task id)`, so the second call is served from
-    the first. L1 spends the *counter*, not the model. Evolving a harness is not
-    more expensive than evolving a skill.
+!!! tip "The oracle gate is free, because it is not a second measurement"
+    For an [L1 artifact](governance.md) every merge is forced through the oracle,
+    and `ThreeLayerVerifier`'s oracle scores **exactly** the set `eval_counts`
+    scores — same `eval_fn`, same held-out set. So the aggregator reuses the
+    full-set rates it has already measured for the acceptance test instead of
+    asking for them again. `ThreeLayerVerifier.oracle_shares_full_set` is what
+    says so; a substitute whose oracle is a genuinely independent measurement
+    leaves it undefined and keeps being called.
+
+    The verdict is identical either way. Evolving a harness is not more expensive
+    than evolving a skill, and with the shipped verifier an L1 run now reports
+    `oracle_calls_used == 0` — the audit ran, nothing had to be bought. Use
+    `AuditScheduler.audits` to ask whether the gate opened.
+
+!!! danger "Why reuse, and not just a saving"
+    `oracle_eval` degrades to `rule_eval` when the budget runs out, and
+    `rule_eval` is the **sub-sample**. So an exhausted budget silently turned the
+    audit gate into a sub-sample veto — measured, a candidate that took the
+    full-set rate from 0.5 to 1.0 was reported `oracle-rejected` because a
+    two-task sample scored both sides at 0.5.
+
+    That contradicted the two promises above it on this page: sub-sampling trades
+    ranking precision and never decides a commit. The merge path no longer
+    reaches the fallback. If you bring your own verifier, either keep
+    `oracle_eval` exact or set `oracle_shares_full_set` — an oracle that quietly
+    gets cheaper must not hold a veto.
 
 ## Trust, and why it has to be measurable for free
 
@@ -186,6 +205,18 @@ learned_eval(artifact) -> (score, uncertainty) # the audit priority's uncertaint
 eval_counts(artifact) -> (successes, failures) # the acceptance test, full set
 oracle_eval(artifact) -> float                 # ground truth, spends budget
 ```
+
+There is also one **optional** attribute, read with a default so a substitute
+that omits it is unaffected:
+
+```python
+oracle_shares_full_set = True    # oracle_eval scores the same set eval_counts does
+```
+
+Set it when both are the same measurement, and the aggregator will reuse the
+rates it already has rather than asking twice. Leave it out when your oracle is
+genuinely independent — then it is called, and it must stay exact: an
+`oracle_eval` that gets cheaper under budget pressure holds a veto over commits.
 
 An [`aggregator_factory`](aggregator.md#replacing-aggregator_factory-aggregatorprotocol)
 receives the verifier, so a custom optimizer that does not want an audit gate can

--- a/tests/test_async_semantics.py
+++ b/tests/test_async_semantics.py
@@ -91,3 +91,100 @@ def test_pending_intake_is_bounded_by_the_lag_budget():
     r = async_evolve(_tasks(), REWARD, agent=_Composer(), strategy=AppendRules(),
                      n_workers=4, async_ratio=2, max_seconds=2.0, held_out_frac=0.5)
     assert r.error is None
+
+
+# ---------------------------------------------------------------------------
+# What the async path measures about itself
+# ---------------------------------------------------------------------------
+
+
+def _counting_run(**kw):
+    """Run the async path with the cards and the ledger reads counted."""
+    import tempfile
+    import warnings
+
+    from agentdescent import Policies
+    from agentdescent.aggregator import Aggregator
+    from agentdescent.evolution import EvolvingArtifact
+    from agentdescent.ledger import Ledger
+
+    seen = {"cards": 0, "reads": 0}
+
+    class _Ledger(Ledger):
+        def head_version(self, branch=Ledger.DEV):
+            seen["reads"] += 1
+            return super().head_version(branch)
+
+        def snapshot(self, branch=Ledger.DEV):
+            seen["reads"] += 1
+            return super().snapshot(branch)
+
+    class _Agg(Aggregator):
+        def ingest(self, card):
+            seen["cards"] += 1
+            return super().ingest(card)
+
+    ledger = _Ledger(
+        tempfile.mkdtemp() + "/repo",
+        lambda a: {"state": a.state, "blast_radius": a.blast_radius},
+        lambda aid, v, d: EvolvingArtifact(aid, d.get("state", {}), v,
+                                           d.get("blast_radius", 0.2)))
+    n = [0]
+
+    def propose(rendered, task, output, score):
+        n[0] += 1
+        return f"rule {n[0]}"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = async_evolve(
+            _tasks(n=12), lambda t, o: 0.0, run=lambda rendered, t: "x",
+            propose=propose, strategy=AppendRules(), n_workers=2,
+            max_iters=20, max_seconds=10.0, self_verify=False,
+            aggregator_factory=lambda l, v, a, c, p: _Agg(
+                l, v, a, c, staleness_policy=p),
+            policies=Policies(ledger=ledger), **kw)
+    return result, seen
+
+
+def test_the_stale_denominator_counts_each_card_once():
+    """`async_evolve` runs a staleness gate and so does `Aggregator`.
+
+    Both wrote to the same meter, so every card that *survived* the first gate
+    was counted as "considered" twice: measured, 20 cards reported
+    `stale_considered = 40`. A true 50% stale rate then read as 33%, and the
+    "you are discarding most of your evidence" warning -- which fires at
+    `discarded/considered > 0.5` -- needed a true rate of 67% to trip.
+
+    Each side now counts only what the other cannot see: this gate's discards,
+    the aggregator's survivors.
+    """
+    result, seen = _counting_run()
+    assert seen["cards"] > 0, "premise: cards reached the aggregator"
+    assert result.stale_considered == seen["cards"] + result.stale_discarded, (
+        f"stale_considered={result.stale_considered} but "
+        f"{seen['cards']} card(s) survived the gate and "
+        f"{result.stale_discarded} were discarded")
+    assert 0.0 <= result.stale_rate() <= 1.0
+
+
+def test_a_worker_does_not_read_the_ledger_once_per_rollout():
+    """Drift is measured against a head the merger publishes, not against git.
+
+    Every ledger read is a `git checkout` behind a process-wide file lock and an
+    RLock the whole run queues on, so asking "am I far enough behind to resync?"
+    got more expensive with exactly the concurrency it exists to support.
+
+    The property is that reads scale with **merger sweeps**, not with rollouts:
+    each sweep costs two here plus one inside `Aggregator._process`, and startup
+    and shutdown cost a handful. A worker reading per rollout adds a term this
+    bound has no room for -- measured on this workload, 46 reads before and 22
+    after, against a budget of 27.
+    """
+    result, seen = _counting_run()
+    assert result.rollouts > 0 and result.history, "premise: the run did something"
+    budget = 3 * len(result.history) + 12
+    assert seen["reads"] <= budget, (
+        f"{seen['reads']} ledger reads for {len(result.history)} sweeps and "
+        f"{result.rollouts} rollouts (budget {budget}) -- a worker is asking git "
+        "for the head on every loop again")

--- a/tests/test_audit_and_cheap_layer.py
+++ b/tests/test_audit_and_cheap_layer.py
@@ -91,9 +91,78 @@ def test_a_distrusted_artifact_opens_the_gate_below_the_blast_radius_threshold()
 
 
 def test_a_high_blast_radius_artifact_is_still_audited_unconditionally():
-    """The other half of the condition must keep working."""
+    """The other half of the condition must keep working.
+
+    This used to assert `oracle_calls_used > 0`, which stopped being the same
+    question once the audit began reusing the full-set measurement the
+    acceptance test had already taken: the gate opens, the audit runs, and no
+    budget moves. `AuditScheduler.audits` counts the thing being asserted.
+    """
     _, agg = _run(blast_radius=0.6)
-    assert agg.verifier.budget.oracle_calls_used > 0
+    assert agg.audit.audits > 0
+
+
+def test_an_l1_audit_reuses_the_measurement_instead_of_re_buying_it():
+    """`oracle_eval` and `eval_counts` are the same sweep over the same set.
+
+    Buying it twice was never free of consequence -- see the sub-sample veto
+    below -- and the budget it consumed made `oracle_budget` look like a cost cap
+    that was doing something.
+    """
+    _, agg = _run(blast_radius=0.6)
+    assert agg.audit.audits > 0, "premise: an L1 artifact is audited every merge"
+    assert agg.verifier.budget.oracle_calls_used == 0, (
+        "the audit re-bought a full held-out sweep the acceptance test had "
+        "already paid for")
+
+
+def test_the_audit_gate_never_vetoes_on_the_cheap_sub_sample():
+    """The hole that reuse closes, stated as the invariant it broke.
+
+    Past `oracle_budget`, `oracle_eval` degrades to `rule_eval` -- a sub-sample.
+    The gate then vetoed on it: measured, a candidate that took the full-set rate
+    from 0.5 to 1.0 came back `oracle-rejected` because a two-task sample scored
+    both sides at 0.5. Two sections of the verifier page promise sub-sampling can
+    never decide a commit.
+    """
+    from agentdescent.aggregator import Aggregator, AggregatorConfig
+    from agentdescent.evolvable import Diff
+    from agentdescent.ledger import Ledger
+    from agentdescent.stats import BetaPosterior
+
+    held_out = list(range(10))
+
+    class _Art:
+        id, blast_radius, version, state = "a", 0.6, 1, {}
+
+        def __init__(self, name):
+            self.name = name
+
+    base, cand = _Art("base"), _Art("cand")
+
+    def eval_fn(artifact, tasks):
+        if len(tasks) < len(held_out):
+            return 0.5                       # the sub-sample cannot see it
+        return 1.0 if artifact.name == "cand" else 0.5
+
+    verifier = ThreeLayerVerifier(
+        eval_fn=eval_fn, held_out=held_out, rule_subset=2, learned_noise=0.0,
+        budget=VerifierBudget(oracle_calls_remaining=0))     # already exhausted
+
+    import tempfile
+
+    ledger = Ledger(tempfile.mkdtemp() + "/repo", lambda a: {},
+                    lambda i, v, s: _Art("base"))
+    agg = Aggregator(ledger, verifier, AuditScheduler(), AggregatorConfig())
+
+    rejected = agg._audit(base, "a", cand, Diff("d", "a", {"k": "v"}),
+                          base_full=0.5, cand_full=1.0,
+                          base_score=verifier.cheap_eval(base),
+                          cand_score=verifier.cheap_eval(cand),
+                          prior=BetaPosterior())
+    assert not rejected, (
+        "the audit vetoed a candidate that doubled the full held-out rate, "
+        "because an exhausted budget turned the oracle into a 2-task sample")
 
 
 # -- the cheap layer is actually cheap ------------------------------------------

--- a/tests/test_policy_contract.py
+++ b/tests/test_policy_contract.py
@@ -341,6 +341,47 @@ def test_the_async_path_honours_the_same_bundle():
                      policies=Policies(sandbox_provider=object()))
 
 
+def test_the_async_path_refuses_an_executor_it_would_otherwise_ignore():
+    """The barrier-free loop has no executor seam: its worker calls `eng.run`.
+
+    Both engines shared one `_WIRED_POLICIES` tuple, so `executor` was declared
+    supported for a loop that never reads it -- accepted and dropped, which is the
+    single outcome `require_supported` exists to prevent. It matters more since a
+    supplied executor started working under `evolve()`: flipping
+    `asynchronous=True` would silently stop honouring it.
+    """
+    from agentdescent import async_evolve
+    from agentdescent.executor import ThreadExecutor
+
+    ex = ThreadExecutor(2, run=lambda r, t: "x", reward=lambda t, o: 0.0)
+    try:
+        with pytest.raises(NotImplementedError, match="executor"):
+            async_evolve(_tasks(), lambda t, o: 0.0, run=lambda r, t: "x",
+                         propose=lambda r, t, o, s: None, max_iters=1,
+                         policies=Policies(executor=ex))
+    finally:
+        ex.shutdown()
+
+
+def test_the_sync_path_still_honours_an_executor():
+    """The other half: narrowing the async set must not narrow evolve()'s."""
+    from agentdescent.executor import ThreadExecutor
+
+    seen = []
+
+    class Counting(ThreadExecutor):
+        def rollout(self, spec):
+            seen.append(spec.task.id)
+            return super().rollout(spec)
+
+    ex = Counting(2)
+    try:
+        _run_evolve(policies=Policies(executor=ex))
+    finally:
+        ex.shutdown()
+    assert seen, "evolve() stopped routing rollouts through a supplied executor"
+
+
 def test_a_multi_proposal_policy_is_refused_rather_than_truncated():
     """Keeping the first of k would make a sampling algorithm look like it ran
     when only a fraction of it did."""

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -44,3 +44,58 @@ def test_unknown_policy_raises():
         assert "unknown staleness policy" in str(e)
     else:
         assert False, "expected ValueError"
+
+
+# ---------------------------------------------------------------------------
+# The REBASE branch's re-verification has to actually verify something
+# ---------------------------------------------------------------------------
+
+
+def test_an_evidence_card_with_nothing_to_score_says_so():
+    """`REBASE` keeps a diff iff `before <= after`, and an empty task list scores
+    0.0 on both sides -- so the check passes for every diff and the "cheap
+    re-verification" the policy is named for becomes a no-op.
+
+    `trajectory_refs` was annotated `List[str]`, so a domain that followed the
+    annotation and stored ids arrives here with a non-empty list and nothing in
+    it the engine can score. The annotation is fixed; this is the part that makes
+    it visible while it is happening.
+    """
+    import warnings
+
+    from agentdescent.evalcache import MemoryCache
+    from agentdescent.evolution import EvolvingArtifact, _Runtime
+    from agentdescent.evolvable import Diff, EvidenceCard
+
+    runtime = _Runtime(run=lambda rendered, t: "x", reward=lambda t, o: 1.0,
+                       cache=MemoryCache())
+    art = EvolvingArtifact("a", {}, runtime=runtime)
+    card = EvidenceCard(diff=Diff("d", "a", {"k": "v"}), base_version={"a": 1},
+                        touched=["a"], trajectory_refs=["t0", "t1"])   # ids, not Tasks
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert art.evidence_eval(card) == 0.0
+        art.evidence_eval(card)                      # ...and it is not repeated
+    assert len(caught) == 1, f"expected exactly one warning, got {len(caught)}"
+    assert "nothing to score" in str(caught[0].message)
+
+
+def test_a_card_carrying_real_tasks_is_silent():
+    """The warning must not fire on the ordinary path."""
+    import warnings
+
+    from agentdescent.evalcache import MemoryCache
+    from agentdescent.evolution import EvolvingArtifact, Task, _Runtime
+    from agentdescent.evolvable import Diff, EvidenceCard
+
+    runtime = _Runtime(run=lambda rendered, t: "x", reward=lambda t, o: 1.0,
+                       cache=MemoryCache())
+    art = EvolvingArtifact("a", {}, runtime=runtime)
+    card = EvidenceCard(diff=Diff("d", "a", {"k": "v"}), base_version={"a": 1},
+                        touched=["a"], trajectory_refs=[Task(id="t0", prompt="q")])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert art.evidence_eval(card) == 1.0
+    assert not caught, [str(w.message) for w in caught]


### PR DESCRIPTION
Six defects from one read-through of the merge path. Five share a shape —
**a check that looks like it ran, on evidence that was not there** — and each is
reproduced by a test that fails on `main`. The sixth is a dead field.

| # | defect | measured |
|---|---|---|
| 1 | an exhausted `oracle_budget` let a 2-task sample veto a commit | candidate 0.5 → 1.0 on the full set, reported `oracle-rejected` |
| 2 | `async_evolve()` accepted `Policies(executor=)` and dropped it | silent |
| 3 | a "cheap re-verification" with nothing to score kept every diff | silent |
| 4 | the async path counted every surviving card twice | 20 cards → `stale_considered = 40` |
| 5 | an async worker asked git for the head on every rollout | 46 ledger reads for 21 rollouts |
| 6 | `EvidenceCard.version_annotations` had no writer and no reader | — |

---

## 1. An exhausted `oracle_budget` turned the audit gate into a sub-sample veto

`oracle_eval` degrades to `rule_eval` once the budget is gone — deliberately, so
a run cannot spend money it was told not to spend. But `rule_eval` is the
`cheap_eval_tasks` **sub-sample**, and `Aggregator._audit` vetoed on its verdict:

```
full set:    base=0.5  cand=1.0   -> the candidate doubled the held-out rate
cheap layer: base=0.5  cand=0.5   -> a 2-task sample cannot see it
oracle budget remaining: 0
AUDIT VETOED THE CANDIDATE: True
```

`docs/verifier.md` promises in two separate sections that sub-sampling trades
ranking precision and never decides a commit. This was the path that made it
false — the same hole the acceptance step's regression guard was fixed for.

**Fix:** the audit stops re-buying a measurement it already has.
`ThreeLayerVerifier.oracle_shares_full_set` records what that class has always
done — `oracle_eval` and `eval_counts` are one `eval_fn` over one held-out set —
and the aggregator reuses the rates the acceptance test just computed.
**Numerically identical** while budget remains, and no degraded path to fall onto
when it does not. A verifier whose oracle is genuinely independent leaves the
attribute undefined and keeps being called. `AuditScheduler.audits` is added
because an L1 run now correctly reports `oracle_calls_used == 0`, and that number
was being used as the proxy for "did the gate open".

## 2. `async_evolve()` accepted `Policies(executor=...)` and ignored it

One `_WIRED_POLICIES` tuple served both engines, and the barrier-free loop has no
executor seam — its worker calls `eng.run` directly. Accepted, then dropped:
precisely what `Policies.require_supported` exists to prevent, arriving through a
shared constant rather than a missing check. It got sharper with #90, since
flipping `asynchronous=True` would silently stop honouring a working executor.
The async path now has its own set and raises, naming the field.

## 3. A "cheap re-verification" that verified nothing did so in silence

The `REBASE` branch keeps a diff iff `before <= after`, and
`EvolvingArtifact.score` returns `0.0` for an empty task list — so a card the
engine cannot score makes the branch compare `0.0 <= 0.0` and keep **every**
diff. `trajectory_refs` was annotated `List[str]` for a while, so a domain that
followed the annotation and stored ids landed exactly there. `evidence_eval` now
warns once per run. No merge outcome changes: flipping accept/discard under
existing callers would be a worse trade than making the condition visible.

## 4. The async path counted every surviving card twice

`async_evolve` runs its own staleness gate — it has to, because a custom
`aggregator_factory` is promised only already-rebased cards — and then
`Aggregator` runs its own over the survivors, **on the same `Meter`**. A true 50%
stale rate read as 33%, and the end-of-run "you are discarding most of your
evidence" warning, which fires at `discarded/considered > 0.5`, needed a **67%**
true rate to trip. Each side now counts what only it can see: the gate's
discards, the aggregator's survivors.

## 5. An async worker asked git for the head on every rollout

It only wanted to know whether it had drifted past the lag budget. A ledger read
is a `git checkout` behind a process-wide file lock plus an RLock every worker
and the merger queue on, so the cost of asking *"am I far enough behind?"* grew
with the concurrency it exists to support. The merger is the only writer, so it
publishes the head after each sweep — which is what
`AsyncAgentDescent._publish_head` has always done. **46 ledger reads → 22.** The
published head can lag by one sweep, delaying a refresh by at most one rollout;
the refresh still takes a real snapshot.

## 6. `EvidenceCard.version_annotations` never existed in any meaningful sense

"Per-turn version annotations, used when the ledger hot-updates mid-rollout" —
no producer, no consumer, no test, no doc page. A field on the object every
worker constructs reads as a capability, and the hot-update it names does not
exist, because a worker holds one snapshot for a whole rollout by construction.
**Removed.**

---

## Tests

Full suite green. Every fix has a test that fails on `main`:

`test_the_audit_gate_never_vetoes_on_the_cheap_sub_sample` ·
`test_an_l1_audit_reuses_the_measurement_instead_of_re_buying_it` ·
`test_the_async_path_refuses_an_executor_it_would_otherwise_ignore` ·
`test_the_sync_path_still_honours_an_executor` ·
`test_an_evidence_card_with_nothing_to_score_says_so` (+ silent-path twin) ·
`test_the_stale_denominator_counts_each_card_once` ·
`test_a_worker_does_not_read_the_ledger_once_per_rollout` (a budget in *sweeps*,
so it cannot be satisfied by a rollout term)

Updated: `test_a_high_blast_radius_artifact_is_still_audited_unconditionally`
asserted `oracle_calls_used > 0`, which stopped being the same question once the
audit reuses the measurement; it asserts `audit.audits > 0` instead.

## Docs

`verifier.md` (both promises, plus the new optional attribute) · `execution.md`
(the async refusal) · `async.md` (published head, split denominator) ·
`staleness.md` + `evolution.md` (a policy needs staleness to exist before it can
decide) · `api.md` regenerated · **`modules.md` gains one table of everything
provided, tested and not in any engine path** — `Ledger.commit_atomic`,
`L1SerialGate`, `ResumeQueue`, `AuditScheduler.pop`, `EvidenceBuffer.settled`,
`TaskScheduler`'s missing artifact axis, `PipelineParallel` — each of which
already said so in its own docstring, so finding out cost a read of the source
one class at a time.

## Docs

`verifier.md` (both promises, plus the new optional attribute) · `execution.md`
(the async refusal) · `async.md` (published head, split denominator) · `api.md`
regenerated · **`modules.md` gains one table of everything provided, tested and
not in any engine path** — `Ledger.commit_atomic`, `L1SerialGate`,
`ResumeQueue`, `AuditScheduler.pop`, `EvidenceBuffer.settled`, `TaskScheduler`'s
missing artifact axis, `PipelineParallel` — each of which already said so in its
own docstring, so finding out cost a read of the source one class at a time.

## Follow-up

§4 and §5 are both direct costs of the two duplicated engine stacks, tracked in
#93. The three general-engine gaps that blocked merging them are closed in a
follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
