### PR TITLE
docs: re-measure the efficiency numbers — and script the four that had none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,20 @@ All notable changes to AgentDescent are documented here. The format follows
   rejected as `oversized`, which surfaces five rounds later as "my reflector
   emits junk" rather than "that file was never editable".
 
+### Added
+- **`examples/efficiency.py` now produces every number `docs/efficiency.md`
+  publishes.** Four of them had **no entry point in the repository at all** --
+  the latency-distribution table, the `eval_concurrency` table, and the
+  threads-and-the-GIL table were measured by hand and could not be re-run. Three
+  new experiments, selectable with `--only`:
+
+      --only distribution   overlap against four shapes of latency
+      --only gate           wall-clock against eval_concurrency 1/4/8/16
+      --only gil --model X  a real API round trip vs pure-Python arithmetic
+
+  The GIL one needs a model (`ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY`, or any
+  id `agentdescent.agents.claude` can reach); the other two need nothing.
+
 ### Documentation
 - **The offline measurements were re-taken on the ported runtimes, and two of
   them were being measured wrongly.** Both flattered the result, and both were
@@ -530,14 +544,43 @@ All notable changes to AgentDescent are documented here. The format follows
     `AgentDescent(self_verify=)` expose the knob; the throughput experiment turns
     it off, because dispatch rate is what it measures.
 
+  Three more tables were re-measured, and two moved for reasons worth knowing
+  rather than drift:
+
+  * **the latency-distribution table** read 5.9x / 4.8x / 3.3x / 2.4x and now
+    reads 1.8x / 2.4x / 2.2x / 1.7x. The old one isolated the rollout stage under
+    a setup nobody could reproduce; the new one is end-to-end `evolve()` at
+    default settings. Subtract the columns and the rollout saving is exactly what
+    eight workers should buy -- the speedup is smaller because the ceiling is
+    whatever in a round is *not* a rollout, which at default settings is the
+    gate;
+  * **the threads-and-the-GIL row** was 7.1x on `deepseek-v4-flash` and is 5.8x
+    on `glm-5.2` (5.8 / 6.3 / 6.5 across three runs). The gap is the
+    latency-distribution table restated: eight threads finish when the slowest
+    finishes, and a reasoning model has a long tail. Its CPU row was 1.0x from a
+    25 ms unit of work -- too small to measure -- and is 1.1x from a unit sized
+    to take seconds;
+  * **the `eval_concurrency` table** keeps its shape (serial, then linear, then
+    flat past the held-out size) on a workload small enough to re-run.
+
   The stated variance band is honest about the machine now: across five runs the
   8-worker speedup landed between 7.83x and 9.15x, dominated by a single-worker
   baseline that itself varied 15%.
 
-- **`docs/results.md`'s five efficiency figures are marked "needs an API key"**
-  rather than silently left in place. They come through `evolve()` against a real
-  model, `evolve()`'s default behaviour did not change, and there is no way to
-  confirm that without spending on the API.
+- **`docs/results.md`'s efficiency table is re-measured and says how.** Every row
+  now names the command that produces it. Only one of the five needed a model at
+  all -- the other four were stub-backend measurements that had simply never been
+  scripted.
+
+### Removed
+- **Six resilience tests that had become duplicates.** `AsyncAgentDescent` was a
+  separate implementation of the barrier-free loop when they were written, so
+  driving failures through it tested something of its own. It is an adapter now,
+  and they were asserting `async_evolve`'s behaviour through a wrapper --
+  `tests/test_fault_matrix.py` asserts the same invariants directly against both
+  engines, and `tests/test_worker_resilience.py` in more detail. One survives, as
+  the only test of the adapter's `rollout=` seam: a broken seam would otherwise
+  make every reference example quietly stop exercising failures.
 
 ### Changed
 - **The two reference runtimes are adapters, not a second implementation of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,38 @@ All notable changes to AgentDescent are documented here. The format follows
   rejected as `oversized`, which surfaces five rounds later as "my reflector
   emits junk" rather than "that file was never editable".
 
+### Documentation
+- **The offline measurements were re-taken on the ported runtimes, and two of
+  them were being measured wrongly.** Both flattered the result, and both were
+  found by re-measuring rather than by reading:
+
+  * **`docs/efficiency.md`'s `stale%` column was understated by roughly a factor
+    of two** — 86% and 10% for the two async rows, against a corrected 93% and
+    25%. The async path ran its own staleness gate and `Aggregator` ran another
+    over the survivors, both writing to the same meter, so every surviving card
+    was counted twice in the denominator. Nothing about the runs changed; the
+    numerator was always right.
+  * **The throughput experiment's denominator included setup and the shutdown
+    grace**, which are fixed costs and therefore fall hardest on the low-worker
+    rows — which reads as superlinear speedup (8.2–9.4x for 8 workers against
+    ~8.1x). It says "a fixed wall-clock window", so it now divides by the window
+    it asked for.
+  * **`self_verify` doubled what a counted rollout cost** in that experiment: the
+    engine re-runs a proposal's own rollout for a before/after delta and counts
+    only the first, so an injected 6 ms latency became 12 ms per counted rollout.
+    The reference loop got that delta free. `AsyncConfig.self_verify` and
+    `AgentDescent(self_verify=)` expose the knob; the throughput experiment turns
+    it off, because dispatch rate is what it measures.
+
+  The stated variance band is honest about the machine now: across five runs the
+  8-worker speedup landed between 7.83x and 9.15x, dominated by a single-worker
+  baseline that itself varied 15%.
+
+- **`docs/results.md`'s five efficiency figures are marked "needs an API key"**
+  rather than silently left in place. They come through `evolve()` against a real
+  model, `evolve()`'s default behaviour did not change, and there is no way to
+  confirm that without spending on the API.
+
 ### Changed
 - **The two reference runtimes are adapters, not a second implementation of the
   loop.** `AgentDescent` and `AsyncAgentDescent` had their own round barrier,

--- a/agentdescent/async_runtime.py
+++ b/agentdescent/async_runtime.py
@@ -55,6 +55,14 @@ class AsyncConfig:
     # duration_timeout_factor x its *estimated* cost is counted as a straggler.
     duration_timeout_factor: float = 3.0
     seed: int = 0
+    #: Re-run a proposal's own rollout with the diff applied, to record a local
+    #: before/after delta. The reference loop got that delta **free** -- it
+    #: measured accuracy directly, with no second rollout -- so a port that
+    #: leaves this on doubles what a counted rollout costs. It stays on by
+    #: default because the delta is real evidence and feeds acceptance; the
+    #: throughput experiment turns it off, because a second sleep per rollout is
+    #: not the dispatch rate it is trying to measure.
+    self_verify: bool = True
 
     # `aggregator_interval` and `worker_pause` used to live here. They paced a
     # loop that no longer exists -- `async_evolve` owns its own sleeps -- and a
@@ -150,7 +158,6 @@ class AsyncAgentDescent:
     # -- the run --------------------------------------------------------------
 
     def run(self) -> AsyncStats:
-        start = time.time()
         timeline: List[Tuple[int, float]] = []
 
         def factory(ledger, verifier, audit, config, policy):
@@ -188,6 +195,7 @@ class AsyncAgentDescent:
             stall_patience=self.cfg.stall_patience,
             duration_estimator=self.estimator,
             straggler_factor=self.cfg.duration_timeout_factor,
+            self_verify=self.cfg.self_verify,
             solved_threshold=0.999,
             seed=self.cfg.seed,
             on_round=on_round,
@@ -211,7 +219,13 @@ class AsyncAgentDescent:
                          if self.verifier is not None else 0),
             final_dev_accuracy=self._accuracy_on(Ledger.DEV),
             final_stable_accuracy=self._accuracy_on(Ledger.STABLE),
-            wallclock=time.time() - start,
+            # The engine's own clock, which starts after the ledger, verifier
+            # and aggregator are built. Timing from the top of this method
+            # instead put that setup inside the window, and since it is a fixed
+            # cost it depressed the low-worker rows hardest -- which reads as
+            # superlinear speedup. Measured: 8 workers came out at 8.5-9.4x
+            # against a true ~8.1x.
+            wallclock=r.wallclock,
             error=r.error,
             timeline=timeline,
         )

--- a/agentdescent/orchestrator.py
+++ b/agentdescent/orchestrator.py
@@ -89,6 +89,7 @@ class AgentDescent:
         oracle_budget: int = 300,
         seed: int = 0,
         staleness_policy=None,
+        self_verify: bool = True,
     ) -> None:
         self.universe = universe
         self.skill_id = skill_id
@@ -99,6 +100,11 @@ class AgentDescent:
         self.oracle_budget = oracle_budget
         self.config = config or AggregatorConfig()
         self.staleness_policy = staleness_policy
+        #: See `AsyncConfig.self_verify`: the reference loop measured its
+        #: before/after delta for free, so leaving this on doubles what a
+        #: rollout costs. On by default -- the delta is evidence acceptance
+        #: reads -- and off for anything measuring throughput.
+        self.self_verify = self_verify
         self.train, self.held_out = universe.split()
 
         self.strategy = RouterStrategy()
@@ -188,6 +194,7 @@ class AgentDescent:
             staleness_policy=self.staleness_policy,
             aggregator_factory=factory,
             oracle_budget=self.oracle_budget,
+            self_verify=self.self_verify,
             solved_threshold=0.999,
             seed=self.seed,
             on_round=on_round,

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -76,25 +76,37 @@ configuration. Quality is scored on a split `evolve()`'s gate never saw.
 
 | config | seeds | reached | time-to-quality (min/med/max) | cost-to-quality | test quality | stale% |
 |---|---|---|---|---|---|---|
-| sync-1 | 3 | 2/3 | 1.06 / 1.10 / 1.13 | 21 / 22 / 22 | 0.793 / 0.862 / 0.897 | 0% |
-| sync-4 | 3 | 3/3 | 0.41 / 0.50 / 0.71 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
-| sync-8 | 3 | 3/3 | 0.25 / 0.26 / 0.42 | 24 / 24 / 40 | 0.931 / 1.000 / 1.000 | 0% |
-| async-4 (lag 3, the default) | 3 | **0/3** | — | — | 0.345 / 0.379 / 0.448 | **86%** |
-| async-4 (lag 1) | 3 | 3/3 | 0.49 / 0.56 / 0.59 | 35 / 38 / 76 | 0.931 / 1.000 / 1.000 | 10% |
-| async-4 (lag 0) | 3 | 3/3 | 0.59 / 0.66 / 0.83 | 21 / 23 / 35 | 0.897 / 0.931 / 1.000 | 0% |
+| sync-1 | 3 | 2/3 | 1.22 / 1.26 / 1.29 | 21 / 22 / 22 | 0.793 / 0.862 / 0.897 | 0% |
+| sync-4 | 3 | 3/3 | 0.46 / 0.52 / 0.71 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
+| sync-8 | 3 | 3/3 | 0.25 / 0.25 / 0.41 | 24 / 24 / 40 | 0.931 / 1.000 / 1.000 | 0% |
+| async-4 (lag 3, the default) | 3 | **0/3** | — | — | 0.310 / 0.345 / 0.379 | **93%** |
+| async-4 (lag 1) | 3 | 3/3 | 0.56 / 0.74 / 0.93 | 31 / 35 / 123 | 0.897 / 0.931 / 1.000 | 25% |
+| async-4 (lag 0) | 3 | 3/3 | 0.59 / 0.66 / 0.75 | 25 / 28 / 46 | 0.828 / 0.897 / 0.931 | 0% |
+
+!!! warning "The `stale%` column was understated, and this is the corrected run"
+    It read **86%** and **10%** for the two async rows. The async path ran its own
+    staleness gate and `Aggregator` ran another over the survivors, both writing
+    to the same meter, so every card that survived the first gate was counted as
+    "considered" twice — a true 50% rate read as 33%. With the denominator fixed
+    the same configurations report **93%** and **25%**.
+
+    Nothing about the runs changed; the numerator was always right. This is why
+    the row that never reaches the bar is the one whose figure moved least: at
+    93% there is not much room for a factor of two.
 
 ### What it says
 
-**Parallelism buys time, not rollouts.** Time-to-quality falls 1.10 → 0.50 → 0.26
+**Parallelism buys time, not rollouts.** Time-to-quality falls 1.26 → 0.52 → 0.25
 from 1 to 4 to 8 workers, while cost-to-quality *rises* slightly (22 → 24). More
 workers reach the bar sooner and more reliably (2/3 → 3/3), and spend marginally
 more rollouts doing it. Anyone hoping parallelism reduces total work should read
 the second column.
 
 **The barrier-free path's default lag budget is wrong for this domain, and the
-first version of this table blamed the path.** At `async_ratio=3` it discards 86%
-of its evidence and never reaches the bar. At 1 it matches the synchronous path
-on quality; at 0 it is the cheapest configuration in the table.
+first version of this table blamed the path.** At `async_ratio=3` it discards 93%
+of its evidence and never reaches the bar. At 1 it comes within a point of the
+synchronous path on quality; at 0 it is the steadiest configuration in the table,
+reaching the bar on every seed.
 
 `async_ratio` is a lag budget in **artifact versions**, and how much wall-clock a
 version represents depends entirely on how long a rollout takes. Three is
@@ -107,12 +119,12 @@ for, not for the one that is cheap to measure. Instead, a run that discards more
 than half its evidence now says so:
 
 ```
-RuntimeWarning: async_evolve discarded 110/130 (85%) of its evidence as stale.
+RuntimeWarning: async_evolve discarded 121/130 (93%) of its evidence as stale.
 async_ratio=3 is a lag budget in artifact versions, so it is too high whenever a
 worker finishes several rollouts in the time the merger takes one sweep.
 ```
 
-**Even correctly tuned, async does not beat sync here** — 0.56 against 0.50. Its
+**Even correctly tuned, async does not beat sync here** — 0.74 against 0.52. Its
 advantage is that workers never wait for the merge, and on a domain with no
 rollout latency there is no waiting to avoid. That is the caveat below, arrived
 at from the other direction.
@@ -184,10 +196,10 @@ and count rollouts. Throughput (rollouts/sec) should scale with N; **efficiency
 
 ```
  workers  rollouts  rollouts/s  speedup  efficiency
-       1       230         115     1.00        1.00
-       2       465         231     2.02        1.01
-       4       940         466     4.07        1.02
-       8      1880         935     8.09        1.01
+       1       271         136     1.00        1.00
+       2       467         234     1.72        0.86
+       4      1082         541     3.99        1.00
+       8      2172        1086     8.01        1.00
 ```
 
 **Near-linear scaling through 8 workers.** The rollout stage holds no global lock,
@@ -197,13 +209,35 @@ forking a `git checkout`). This is the `O(N / T_iter)` throughput the design
 targets versus serial RSI's `O(1 / T_iter)`.
 
 !!! note "Read efficiency as ≈1.0, not as a precise constant"
-    Across repeated runs the 8-worker figure lands between **8.05x and 8.16x**
-    (efficiency 1.01–1.02), and the 4-worker one between 3.96x and 4.13x. Values
-    slightly *above* 1.0 are not a superlinear effect: the single-worker baseline
-    absorbs the same fixed start-up inside its timed window, which depresses the
-    denominator by a percent or two. The honest reading is "linear to within
-    measurement noise at this scale", and the absolute rollout counts depend on the
-    machine — rerun it rather than quoting these.
+    Across five repeated runs the 8-worker figure landed between **7.83x and
+    9.15x** (efficiency 0.98–1.14) and the 4-worker one between 3.99x and 4.46x.
+    The spread is dominated by the **single-worker baseline**, which varied 15%
+    run to run (120–136 rollouts/s) and sits in the denominator of every other
+    row. The 2-worker row is consistently the weakest (0.86–1.01), which is where
+    a fixed per-run cost still shows.
+
+    The honest reading is "linear to within measurement noise at this scale", and
+    the absolute rollout counts depend on the machine — **rerun it rather than
+    quoting these**.
+
+!!! warning "Two measurement definitions were wrong here, and both flattered it"
+    Found while re-measuring on the ported runtime, and worth stating because
+    each inflated the headline:
+
+    * **The denominator included setup and the shutdown grace.** The rate was
+      `rollouts / measured wallclock`, and the measured clock covered building the
+      ledger, verifier and aggregator plus up to `shutdown_grace` seconds after
+      the window. Those are *fixed* costs, so they fall hardest on the low-worker
+      rows — which reads as superlinear speedup. Measured both ways: 8 workers
+      came out at **8.2–9.4x** against ~8.1x. The experiment says "a fixed
+      wall-clock window", so it now divides by the window it asked for.
+    * **`self_verify` doubled what a counted rollout cost.** The engine re-runs a
+      proposal's own rollout to record a before/after delta, and only the first
+      is counted — so with a 6 ms latency injected, every counted rollout paid
+      12 ms. The reference loop got that delta free. Throughput halved (935 →
+      466 rollouts/s) with the speedup unchanged, which is the signature of a
+      cost-model change rather than a scaling one. This experiment measures
+      dispatch, so it now passes `self_verify=False`.
 
 ---
 
@@ -220,10 +254,10 @@ ways:
 
 ```
             mode  wall-clock  rollouts/s  utilization
-    sync barrier       1.41s         114         36%
-async (no barrier)       0.51s         316        100%
+    sync barrier       1.41s         113         38%
+async (no barrier)       0.53s         300        100%
 
-async speedup: 2.78x  (the barrier idles fast workers waiting for the tail every round)
+async speedup: 2.65x  (the barrier idles fast workers waiting for the tail every round)
 ```
 
 The barrier runs at **~36–40% utilization** — most worker-time is spent idling for

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -21,12 +21,32 @@ Overlap depends almost entirely on your latency *distribution*, not on your work
 count. Measured with a fixed-latency stub backend, so the only variable is the
 framework:
 
-| what changes | overlap with `n_workers=8` |
-|---|---|
-| uniform latency | **5.9×** |
-| moderate latency spread | 4.8× |
-| high spread | 3.3× |
-| heavy tail (a reasoning model) | **2.4×** |
+```bash
+python -m examples.efficiency --only distribution
+```
+
+| latency shape | sequential | 8 workers | overlap |
+|---|---|---|---|
+| uniform | 9.9 s | 5.5 s | **1.8×** |
+| moderate spread | 15.1 s | 6.3 s | 2.4× |
+| high spread | 33.3 s | 14.9 s | 2.2× |
+| heavy tail (a reasoning model) | 35.4 s | 20.6 s | **1.7×** |
+
+!!! warning "This table replaces one that had no script behind it"
+    The previous version read 5.9× / 4.8× / 3.3× / 2.4× and there was **no entry
+    point in the repository that produced it** — it isolated the rollout stage
+    under a setup nobody could re-run, and did not say what latency it used. What
+    is above is end-to-end `evolve()` at default settings, and the difference is
+    the point: subtract the columns and the *rollout* saving is exactly what eight
+    workers should buy (9.9 − 5.5 ≈ the 4.2 s of sleeping that got overlapped).
+    The speedup is smaller than that because **the ceiling is whatever in a round
+    is not a rollout** — and at default settings that is the gate, which scores
+    every candidate the aggregator ranks on the whole held-out set.
+
+    At a 20 ms latency the same table reads 1.9× / 2.1× / 2.0× / 1.3×: a fixed
+    ~1.2 s per configuration swamps 0.6 s of sleeping. Neither reading is wrong;
+    they answer different questions, and the old table did not say which one it
+    was answering.
 
 **Latency variance is the cost, and the round barrier is where you pay it.** The
 aggregator is a synchronisation point, so a round lasts as long as its *slowest*
@@ -45,12 +65,21 @@ Every gate goes through one held-out evaluation: each round's measurement and, f
 more often, the aggregator's per-candidate comparisons. That is a second pool,
 independent of `n_workers`. Same work, varying only `eval_concurrency`:
 
+```bash
+python -m examples.efficiency --only gate
+```
+
 | `eval_concurrency` | wall-clock | |
 |---|---|---|
-| 1 (serial) | 193.6 s | — |
-| 4 | 96.7 s | **2.0× faster** |
-| 8 (default) | 90.0 s | **2.2× faster** |
-| 16 | 89.0 s | saturated — the held-out set is only 12 tasks |
+| 1 (serial) | 3.6 s | — |
+| 4 | 2.2 s | **1.7× faster** |
+| 8 (default) | 1.2 s | **2.9× faster** |
+| 16 | 1.6 s | saturated — the held-out set is only 8 tasks |
+
+Also re-measured with a script rather than by hand; the previous row set (193.6 s
+→ 90.0 s → 89.0 s) came from a larger workload with no reproducible entry point.
+The shape is what carries: **serial gate, then linear, then flat past the size of
+the held-out set.**
 
 It saturates once `eval_concurrency` reaches the size of your held-out set, so
 raise it if yours is large and your provider allows the concurrency.
@@ -170,10 +199,25 @@ Yes, for this workload, and no amount of arguing about the GIL settles it — so
 here it is measured. Eight threads, one pool, two workloads: a real API round
 trip, and pure-Python arithmetic.
 
+```bash
+python -m examples.efficiency --only gil --model glm-5.2
+```
+
 | workload | sequential | 8 threads | speedup |
 |---|---|---|---|
-| **I/O** — a real `deepseek-v4-flash` call | 14.9 s | **2.1 s** | **7.1×** |
-| **CPU** — pure Python arithmetic | 1.0 s | 1.0 s | 1.0× |
+| **I/O** — a real `glm-5.2` call | 48.6 s | **8.3 s** | **5.8×** |
+| **CPU** — pure Python arithmetic | 2.3 s | 2.1 s | 1.1× |
+
+!!! note "Measured on `glm-5.2`, not on the model the old row named"
+    The previous row read **7.1×** against `deepseek-v4-flash`. This one is a
+    *reasoning* model, and the gap is the table two sections up restated: eight
+    threads finish when the slowest finishes, so a long-tailed latency costs
+    overlap. Across three runs it landed at 5.8× / 6.3× / 6.5×.
+
+    The CPU row is 1.1× rather than 1.0× because the work was too small to
+    measure at first — 25 ms a unit, where the answer is whatever the scheduler
+    did that second. It is sized to take seconds now, and 1.1× is what is left:
+    noise around "threads buy nothing here".
 
 Near-linear on I/O, exactly nothing on CPU. CPython releases the GIL around
 socket I/O and holds it around bytecode, and a rollout is almost entirely spent

--- a/docs/results.md
+++ b/docs/results.md
@@ -97,25 +97,26 @@ integers representing cents, without dollar signs or decimal points."*
 
 Full breakdown in [Efficiency](efficiency.md).
 
-| | result | re-measured? |
+| | result | how |
 |---|---|---|
-| Thread parallelism, 8 threads, real API calls | **7.1×** (pure-Python CPU work: 1.0×) | needs an API key |
-| Whole `evolve()` run, uniform latency | **5.9×** of 8 workers | needs an API key |
-| ...heavy-tailed latency (a reasoning model) | **2.4×** — the round barrier waits on the slowest worker | needs an API key |
-| ...same, barrier-free `asynchronous=True` | **3.0×** | needs an API key |
-| Gate concurrency (`eval_concurrency` 1 → 8) | **193.6 s → 90.0 s** on identical work | needs an API key |
+| Thread parallelism, 8 threads, real API calls | **5.8×** on `glm-5.2` (pure-Python CPU work: 1.1×) | `examples.efficiency --only gil --model <id>` |
+| Whole `evolve()` run, uniform latency | **1.8×** of 8 workers, end-to-end | `--only distribution` |
+| ...heavy-tailed latency (a reasoning model) | **1.7×** — the round barrier waits on the slowest worker | `--only distribution` |
+| ...same, barrier-free | **2.65×** on the dispatch microbenchmark | `--only async` |
+| Gate concurrency (`eval_concurrency` 1 → 8) | **3.6 s → 1.2 s**, saturating past the held-out size | `--only gate` |
 
-!!! note "These five were not re-measured when the reference runtimes became adapters"
-    They all come through [`evolve()`](evolution.md) against a real model, and
-    `evolve()`'s default behaviour did not change — `refresh_interval` defaults to
-    `1`, which is exactly the old snapshot discipline, and the new `RoundInfo`
-    fields are reported rather than acted on. So there is no reason to expect
-    them to have moved, and no way to confirm it without spending on the API.
+!!! warning "Every row here was re-measured, and four of them had no script"
+    The previous version of this table (7.1× / 5.9× / 2.4× / 3.0× / 193.6 s →
+    90.0 s) was produced by hand and could not be re-run: nothing in the
+    repository generated it. `examples/efficiency.py` now does, and the commands
+    above are the whole of it.
 
-    The [offline table](efficiency.md#the-configuration-matrix-bench) *was*
-    re-measured, and one column there moved for a reason worth knowing: `stale%`
-    was understated by roughly a factor of two, because two staleness gates were
-    both counting into one denominator.
+    Two of the numbers moved for reasons worth knowing rather than drift. The
+    thread-parallelism row is a *reasoning* model now, whose long-tailed latency
+    costs overlap — which is the row below it, restated. The whole-run rows are
+    **end-to-end at default settings** rather than the rollout stage in
+    isolation, and the ceiling there is the gate; see
+    [Efficiency](efficiency.md#where-the-parallelism-actually-goes).
 
 `n_workers` buys rollout parallelism and `eval_concurrency` buys gate parallelism;
 they are independent, and a run slower than its worker count suggests usually

--- a/docs/results.md
+++ b/docs/results.md
@@ -97,13 +97,25 @@ integers representing cents, without dollar signs or decimal points."*
 
 Full breakdown in [Efficiency](efficiency.md).
 
-| | result |
-|---|---|
-| Thread parallelism, 8 threads, real API calls | **7.1×** (pure-Python CPU work: 1.0×) |
-| Whole `evolve()` run, uniform latency | **5.9×** of 8 workers |
-| ...heavy-tailed latency (a reasoning model) | **2.4×** — the round barrier waits on the slowest worker |
-| ...same, barrier-free `asynchronous=True` | **3.0×** |
-| Gate concurrency (`eval_concurrency` 1 → 8) | **193.6 s → 90.0 s** on identical work |
+| | result | re-measured? |
+|---|---|---|
+| Thread parallelism, 8 threads, real API calls | **7.1×** (pure-Python CPU work: 1.0×) | needs an API key |
+| Whole `evolve()` run, uniform latency | **5.9×** of 8 workers | needs an API key |
+| ...heavy-tailed latency (a reasoning model) | **2.4×** — the round barrier waits on the slowest worker | needs an API key |
+| ...same, barrier-free `asynchronous=True` | **3.0×** | needs an API key |
+| Gate concurrency (`eval_concurrency` 1 → 8) | **193.6 s → 90.0 s** on identical work | needs an API key |
+
+!!! note "These five were not re-measured when the reference runtimes became adapters"
+    They all come through [`evolve()`](evolution.md) against a real model, and
+    `evolve()`'s default behaviour did not change — `refresh_interval` defaults to
+    `1`, which is exactly the old snapshot discipline, and the new `RoundInfo`
+    fields are reported rather than acted on. So there is no reason to expect
+    them to have moved, and no way to confirm it without spending on the API.
+
+    The [offline table](efficiency.md#the-configuration-matrix-bench) *was*
+    re-measured, and one column there moved for a reason worth knowing: `stale%`
+    was understated by roughly a factor of two, because two staleness gates were
+    both counting into one denominator.
 
 `n_workers` buys rollout parallelism and `eval_concurrency` buys gate parallelism;
 they are independent, and a run slower than its worker count suggests usually

--- a/examples/efficiency.py
+++ b/examples/efficiency.py
@@ -81,11 +81,21 @@ def experiment_parallel(universe, seconds=2.0):
     for n in (1, 2, 4, 8):
         # target unreachable -> run the full window; huge async_ratio + stall
         # patience keep workers off the ledger so we measure pure rollout rate.
+        # `self_verify=False`: this counts dispatch, and a self-verify rollout
+        # is a second sleep the counter does not see. The reference loop got its
+        # before/after delta free, so leaving it on would halve a number that is
+        # supposed to be comparable with the published table.
         sys = _build(universe, n, constant_latency(0.006), seed=1,
-                     async_ratio=10_000, stall_patience=10_000,
+                     async_ratio=10_000, stall_patience=10_000, self_verify=False,
                      target_accuracy=2.0, max_seconds=seconds)
         stats = sys.run()
-        rate = stats.rollouts / stats.wallclock
+        # The window the experiment asked for, not a measured wall-clock. This
+        # is what the description says ("a fixed wall-clock window"), and a
+        # measured one also counts setup and the shutdown grace -- fixed costs
+        # that fall hardest on the low-worker rows and read as superlinear
+        # speedup. Measured both ways: 8 workers came out at 8.2-9.4x against
+        # ~8.1x here.
+        rate = stats.rollouts / seconds
         if base_rate is None:
             base_rate = rate
         speedup = rate / base_rate

--- a/examples/efficiency.py
+++ b/examples/efficiency.py
@@ -159,10 +159,182 @@ def experiment_async(universe, n_workers=4, rounds=40):
     print()
 
 
+# -- Experiment 3: where the overlap goes (latency distribution) ---------------
+
+
+def _stub_workload(latency, n_tasks=20):
+    """A minimal `evolve()` workload whose only cost is waiting.
+
+    Deterministic, no model, no ledger contention worth speaking of: the rollout
+    sleeps and returns. That is the point -- the *only* variable across the rows
+    below is the shape of the latency distribution, so what the table measures is
+    the framework rather than a provider.
+    """
+    from agentdescent import Task
+
+    tasks = [Task(id=f"t{i}", prompt=f"q{i}", meta={"gold": str(i)})
+             for i in range(n_tasks)]
+
+    def run(rendered, task):
+        time.sleep(latency())
+        return task.meta["gold"] if task.id in rendered else "?"
+
+    return tasks, run
+
+
+def _timed_evolve(tasks, run, *, concurrency, rounds=6, workers=8, eval_conc=8):
+    import warnings as _w
+
+    from agentdescent import AppendRules, evolve
+
+    start = time.time()
+    with _w.catch_warnings():
+        _w.simplefilter("ignore")
+        evolve(tasks, lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+               run=run, propose=lambda r, t, o, s: t.id, strategy=AppendRules(),
+               rounds=rounds, n_workers=workers, max_concurrency=concurrency,
+               eval_concurrency=eval_conc, held_out_frac=0.4, self_verify=False,
+               seed=0)
+    return time.time() - start
+
+
+def experiment_distribution(rounds: int = 4) -> None:
+    """Overlap depends on the latency *distribution*, not on the worker count.
+
+    Same eight workers, same rollout budget, four shapes of latency. A round is a
+    barrier, so it lasts as long as its slowest worker -- which is why a heavy
+    tail costs more than a high mean.
+    """
+    print("=== Experiment 3: where the overlap goes ===")
+    print(f"n_workers=8, {rounds} rounds, sequential vs concurrent")
+    print("rollout latency ~150ms, chosen so the rollout dominates the round --")
+    print("see the note below the table for what happens when it does not.\n")
+    print(f"{'latency shape':>26} {'sequential':>11} {'8 workers':>10} {'overlap':>8}")
+    shapes = (
+        ("uniform", constant_latency(0.15)),
+        ("moderate spread", heavy_tailed_latency(0.15, 2.0, 0.30, seed=1)),
+        ("high spread", heavy_tailed_latency(0.15, 5.0, 0.30, seed=2)),
+        ("heavy tail (reasoning)", heavy_tailed_latency(0.075, 20.0, 0.15, seed=3)),
+    )
+    for name, latency in shapes:
+        tasks, run = _stub_workload(latency)
+        seq = _timed_evolve(tasks, run, concurrency=1, rounds=rounds)
+        par = _timed_evolve(tasks, run, concurrency=8, rounds=rounds)
+        print(f"{name:>26} {seq:>10.1f}s {par:>9.1f}s {seq / par:>7.1f}x")
+    print("\nThe ceiling is set by whatever in a round is *not* a rollout -- the")
+    print("ledger, and the gate. At a 20ms latency the same table reads 1.9x /")
+    print("2.1x / 2.0x / 1.3x, because a fixed ~1.2s per configuration swamps")
+    print("0.6s of sleeping. That is experiment 4's subject, not a smaller")
+    print("speedup.\n")
+
+
+# -- Experiment 4: the other axis, eval_concurrency ---------------------------
+
+
+def experiment_gate(rounds: int = 4) -> None:
+    """The gate is a second pool, and it is often the one that is too small.
+
+    Every round measures held-out, and the aggregator scores every candidate it
+    ranks. Same work in each row; only `eval_concurrency` moves.
+    """
+    print("=== Experiment 4: gate concurrency (eval_concurrency) ===")
+    print(f"identical work, {rounds} rounds, n_workers=8 throughout\n")
+    print(f"{'eval_concurrency':>18} {'wall-clock':>11} {'vs serial':>10}")
+    tasks, run = _stub_workload(constant_latency(0.02), n_tasks=20)
+    base = None
+    for conc in (1, 4, 8, 16):
+        secs = _timed_evolve(tasks, run, concurrency=8, rounds=rounds, eval_conc=conc)
+        base = base or secs
+        print(f"{conc:>18} {secs:>10.1f}s {base / secs:>9.1f}x")
+    print("\nIt saturates once eval_concurrency reaches the size of the held-out")
+    print("set -- raise it if yours is large and your provider allows it.\n")
+
+
+# -- Experiment 5: the GIL question, measured ---------------------------------
+
+
+def _time_pool(work, n: int, threads: int) -> float:
+    """Run `work` n times, `threads` at a time, and return the wall-clock."""
+    start = time.time()
+    if threads <= 1:
+        for i in range(n):
+            work(i)
+    else:
+        with ThreadPoolExecutor(max_workers=threads) as ex:
+            list(ex.map(work, range(n)))
+    return time.time() - start
+
+
+def _cpu_work(_i: int) -> int:
+    """Pure-Python arithmetic: the GIL is held throughout, so threads cannot help."""
+    # Sized so the sequential pass takes seconds. At 400k it took 25 ms a unit,
+    # and a 0.2s measurement against a 0.2s measurement reports whatever the
+    # scheduler did that second -- it came out at "1.2x", which reads as threads
+    # helping and is noise.
+    total = 0
+    for k in range(4_000_000):
+        total += k * k % 7
+    return total
+
+
+def experiment_gil(model: str, calls: int = 8, threads: int = 8) -> None:
+    """Is thread parallelism real here? Measured, on both kinds of work.
+
+    The answer depends entirely on whether the work *waits*. A model call spends
+    almost all of its time on a socket, and CPython releases the GIL there; pure
+    Python arithmetic never lets go of it. One pool, two workloads, same shape.
+
+    Needs a model: set `ANTHROPIC_BASE_URL` + `ANTHROPIC_API_KEY` (or run with
+    `--no-api` to see only the CPU row, which is the one that needs nothing).
+    """
+    print("=== Experiment 3: threads and the GIL ===")
+    print(f"{calls} units of work, sequential vs {threads} threads\n")
+    print(f"{'workload':>34} {'sequential':>11} {'threads':>9} {'speedup':>8}")
+
+    if model:
+        from agentdescent.agents import claude
+
+        complete = claude(model=model, max_tokens=64, retries=1)
+
+        def io_work(i: int) -> str:
+            return complete(f"Reply with exactly the number {i}.")
+
+        seq = _time_pool(io_work, calls, 1)
+        par = _time_pool(io_work, calls, threads)
+        print(f"{'I/O — a real ' + model + ' call':>34} {seq:>10.1f}s {par:>8.1f}s "
+              f"{seq / par:>7.1f}x")
+
+    seq = _time_pool(_cpu_work, calls, 1)
+    par = _time_pool(_cpu_work, calls, threads)
+    print(f"{'CPU — pure-Python arithmetic':>34} {seq:>10.1f}s {par:>8.1f}s "
+          f"{seq / par:>7.1f}x")
+    print("\nThe speedup tracks how much of the work is *waiting*. Threads buy")
+    print("nothing for an agent that burns CPU locally.\n")
+
+
 def main() -> None:
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=os.environ.get("AGENTDESCENT_MODEL", ""),
+                        help="model id for experiment 3; omitted skips the I/O row")
+    parser.add_argument("--only",
+                        choices=("parallel", "async", "distribution", "gate", "gil"),
+                        help="run one experiment instead of all of them")
+    args = parser.parse_args()
+
     universe = make_task_universe(seed=7)
-    experiment_parallel(universe)
-    experiment_async(universe)
+    if args.only in (None, "parallel"):
+        experiment_parallel(universe)
+    if args.only in (None, "async"):
+        experiment_async(universe)
+    if args.only in (None, "distribution"):
+        experiment_distribution()
+    if args.only in (None, "gate"):
+        experiment_gate()
+    if args.only == "gil":
+        experiment_gil(args.model)
 
 
 if __name__ == "__main__":

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -72,57 +72,13 @@ def test_stable_branch_promotes_under_async():
     assert s.final_stable_accuracy > 0.0
 
 
-def _failing_run(policy_name="full", n_fail=None, seconds=20.0):
-    """Run the reference stack with a rollout that raises.
-
-    This used to patch `system.workers[i].run`. There are no `Worker` objects any
-    more -- the runtime is an adapter over `async_evolve` -- so it replaces the
-    rollout itself, which is the same seam under its new name.
-    """
-    import tempfile
-
-    from agentdescent.async_runtime import AsyncAgentDescent, AsyncConfig
-    from agentdescent.domains.router import router_run
-
-    universe = make_task_universe(seed=7)
-    cfg = AsyncConfig(n_workers=4, async_ratio=4, target_accuracy=0.95,
-                      max_seconds=seconds, seed=1)
-    state = {"n": 0}
-
-    def flaky(rendered, task):
-        state["n"] += 1
-        if n_fail is None or state["n"] <= n_fail:
-            raise RuntimeError("backend down")
-        return router_run(rendered, task)
-
-    with tempfile.TemporaryDirectory() as repo:
-        system = AsyncAgentDescent(repo, universe, config=cfg,
-                                   staleness_policy=get_policy(policy_name),
-                                   rollout=flaky)
-        return system.run()
-
-
-def test_dead_backend_is_reported_not_silent():
-    """Every worker raising used to print tracebacks, burn the whole budget, and
-    return normal-looking zeros with no way for the caller to tell."""
-    s = _failing_run()
-    assert s.error is not None
-    assert "backend down" in s.error
-
-
-def test_dead_backend_ends_the_run_early():
-    import time as _t
-
-    t0 = _t.time()
-    _failing_run(seconds=20.0)
-    assert _t.time() - t0 < 15.0, "should retire the workers, not spin out the budget"
-
-
-def test_transient_failures_are_survived():
-    """A few failures must not end the run -- they are retried."""
-    s = _failing_run(n_fail=2, seconds=15.0)
-    assert s.rollouts > 0, "the workers should have recovered and produced"
-
+# Failure injection used to live here, driving `AsyncAgentDescent` with a
+# rollout that raises. It was worth having when that class was a *separate*
+# implementation of the barrier-free loop; it is an adapter over `async_evolve`
+# now, so those three tests asserted `async_evolve`'s resilience through a
+# wrapper -- which `tests/test_fault_matrix.py` already asserts directly, against
+# both engines, and `tests/test_worker_resilience.py` asserts in more detail.
+# One test of the adapter's own seam survives, in `test_async_parity.py`.
 
 def test_a_healthy_run_reports_no_error():
     s = _run("full")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -52,7 +52,21 @@ def test_guarded_discards_more_than_reflective():
     r = _run("reflective", async_ratio=4, seconds=12.0, seed=3)
 
     assert g.discarded_stale > r.discarded_stale   # the claim under test
-    assert r.rollouts < g.rollouts                 # Reflective wastes far less work
+    # ...and as a *rate*, which is what "wastes less work" actually means.
+    #
+    # This used to read `r.rollouts < g.rollouts`, which is not an invariant: both
+    # runs are bounded by wall-clock *and* stop at the first sweep past
+    # `target_accuracy`, so total rollouts mixes "how much did it waste" with "how
+    # long did it take to get there" -- whichever policy converges first has fewer.
+    # It is a coin flip, and it flipped: CI failed with reflective at 12094
+    # rollouts against guarded's 1657 on 3.12 and 40182 against 6587 on 3.11,
+    # while 3.9 passed. Measured locally the rate never comes close: guarded
+    # discards 97-98% of its evidence, reflective 13-26%.
+    assert (g.discarded_stale / max(1, g.proposals)
+            > r.discarded_stale / max(1, r.proposals)), (
+        f"guarded wasted {g.discarded_stale}/{g.proposals} of its evidence and "
+        f"reflective {r.discarded_stale}/{r.proposals}; rebasing is supposed to "
+        "recover what the budget would otherwise throw away")
     # Recovering that work cannot leave Reflective *materially* behind, and both
     # must progress. Not `r >= g`: both runs stop at the first sweep that crosses
     # `target_accuracy` (0.95 here), so the value each one *lands* on is a

--- a/tests/test_async_parity.py
+++ b/tests/test_async_parity.py
@@ -1,22 +1,24 @@
-"""The two async pipelines must not diverge in behaviour.
+"""Capabilities the general engine was missing, and one seam the adapter keeps.
 
-`AsyncAgentDescent` (reference stack, synthetic router domain) and `async_evolve`
-(general, and the only one a real workload reaches) implement the same
-barrier-free shape independently and share no code. The cost was that fixes and
-capabilities lived in whichever one they were written for:
+This file used to guard **two independent barrier-free implementations** against
+drifting apart: `AsyncAgentDescent` had its own worker threads, merger thread,
+published head and backpressure, and shared no code with `async_evolve`. The cost
+was that fixes and capabilities lived in whichever one they were written for --
+the worker-retirement heuristic was measured wrong and fixed in one, backpressure
+and duration-aware straggler detection existed only in the other.
 
-* the worker-retirement heuristic was **measured wrong** and fixed in
-  `async_evolve` -- "at a 1-in-3 call failure rate the old blanket rule retired
-  all three workers in 22s with nothing learned" -- while `AsyncAgentDescent` kept
-  the rule that paragraph describes, along with a merger that ended the run on its
-  first exception (the other pattern that measurement removed);
-* backpressure and duration-aware straggler detection existed only in
-  `AsyncAgentDescent`, which accepts nothing but `TaskUniverse` -- so the guard
-  `concepts.md` says prevents a livelock, and the whole L-traj mechanism, were
-  unreachable from the API every real workload uses.
+`AsyncAgentDescent` is an adapter now (#93), so most of what was here tested
+`async_evolve` through a wrapper -- which `test_fault_matrix.py` asserts directly
+against both engines, and `test_worker_resilience.py` asserts in more detail.
+Those went. What is left is what only this file says:
 
-These pin the behaviour on *both* sides rather than the implementation, so they
-keep holding if the two are ever merged into one.
+* the capabilities that were reference-only are reachable from the general API
+  and actually fire -- backpressure, straggler detection, and the diagnostics
+  that report them;
+* one test of the **adapter's own seam** (`rollout=`), because a broken seam
+  would otherwise make every reference example silently stop exercising failures;
+* one that the retirement rule has a single implementation, by name -- the two
+  loops are `evolve` and `async_evolve` now, and that is still two.
 """
 
 import tempfile
@@ -49,37 +51,14 @@ def _async_evolve(**kw):
 # -- the retirement heuristic, on both sides ------------------------------------
 
 
-def test_the_reference_runtime_no_longer_sheds_workers_over_a_transient():
-    """Every worker shares one backend, so shedding workers cannot relieve
-    throttling -- it only guarantees the run dies."""
-    universe = make_task_universe(seed=7)
-    cfg = AsyncConfig(n_workers=4, max_seconds=3.0, seed=1)
-    with tempfile.TemporaryDirectory() as repo:
-        calls = {"n": 0}
-
-        def flaky(rendered, task):
-            calls["n"] += 1
-            if calls["n"] > 2 and calls["n"] % 3:   # ~2 in 3, once it has worked
-                raise RuntimeError("429 rate limited")
-            return router_run(rendered, task)
-
-        # This used to patch `system.workers[i].run`. The runtime is an adapter
-        # over `async_evolve` now, so the seam is the rollout itself -- and the
-        # merger's held-out scoring goes through it too, which the old seam
-        # bypassed. Hence the two guaranteed successes: the invariant under test
-        # is "once the backend has demonstrably worked, do not shed workers", so
-        # the run has to reach that state before the failures start.
-        system = AsyncAgentDescent(repo, universe, config=cfg, rollout=flaky)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            stats = system.run()
-    assert stats.retired_workers == 0, (
-        f"{stats.retired_workers} worker(s) retired over a transient the backend "
-        "recovers from; shedding them cannot relieve a shared throttle")
-
-
 def test_a_misconfigured_backend_still_retires_every_worker_fast():
-    """The other half: while nothing has ever succeeded, give up loudly."""
+    """While nothing has ever succeeded, give up loudly rather than spin.
+
+    Kept out of a larger group that all asserted this through the adapter,
+    because it is also the only test of the adapter's `rollout=` seam: if that
+    stopped reaching the engine, every reference example would quietly stop
+    exercising failures and nothing else would notice.
+    """
     universe = make_task_universe(seed=7)
     cfg = AsyncConfig(n_workers=3, max_seconds=20.0, seed=1)
     with tempfile.TemporaryDirectory() as repo:
@@ -93,44 +72,6 @@ def test_a_misconfigured_backend_still_retires_every_worker_fast():
             stats = system.run()
     assert stats.error is not None and "401" in stats.error, "ended silently"
     assert time.time() - t0 < 15.0, "burned the whole budget on a dead backend"
-
-
-def test_the_reference_merger_survives_a_transient():
-    """It scores held-out every sweep, so it is a backend caller like any other.
-
-    Ending the run on its first exception made the merger a single point of
-    failure -- measured in `async_evolve` as 0 sweeps while the workers were fine.
-    """
-    universe = make_task_universe(seed=7)
-    # Generous budget on purpose: the retry backs off 2s after one failure, which
-    # would be half of a short run and would test the clock, not the tolerance.
-    cfg = AsyncConfig(n_workers=2, max_seconds=12.0, target_accuracy=2.0, seed=1)
-    with tempfile.TemporaryDirectory() as repo:
-        calls = {"n": 0}
-
-        def factory(ledger, verifier, audit, config, policy):
-            # The aggregator is built by the run now, so the injection point is
-            # the factory rather than an attribute patched before it starts.
-            agg = Aggregator(ledger, verifier, audit, config,
-                             staleness_policy=policy)
-            original = agg.step
-
-            def flaky_step():
-                calls["n"] += 1
-                if calls["n"] == 2:
-                    raise RuntimeError("503 transient")
-                return original()
-
-            agg.step = flaky_step
-            return agg
-
-        system = AsyncAgentDescent(repo, universe, config=cfg,
-                                   aggregator_factory=factory)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            stats = system.run()
-    assert stats.sweeps > 2, \
-        f"the merger stopped at the first transient ({stats.sweeps} sweeps)"
 
 
 # -- capabilities the general path was missing ----------------------------------
@@ -205,11 +146,12 @@ def test_the_new_diagnostics_survive_save_and_load(tmp_path):
 def test_both_loops_retire_workers_through_the_same_object():
     """The rule that was hand-ported once must not be re-implemented again.
 
-    `pipeline.py`'s module docstring records that these two runtimes implemented
-    the same shape independently, and that a measured fix had to be carried
-    across by hand. The synchronous loop had re-grown its own copy
-    (`any_success` + `dead_rounds >= max_worker_errors`); this asserts there is
-    one implementation, by name, in both.
+    `pipeline.py`'s module docstring records that a measured fix had to be
+    carried across by hand between two implementations of the same shape. The
+    reference runtimes are adapters now, but `evolve` and `async_evolve` are
+    still two loops, and the synchronous one had re-grown its own copy once
+    already (`any_success` + `dead_rounds >= max_worker_errors`). This asserts
+    there is one implementation, by name, in both.
     """
     import re
     from pathlib import Path


### PR DESCRIPTION
The half of #93 deliberately deferred while the port landed — plus four published tables that turned out to have no script behind them at all. Both corrections
**flatter the published result**, and both were found by re-measuring rather than
by reading.

## 1. `stale%` was understated by roughly a factor of two

| config | published | corrected |
|---|---|---|
| async-4 (lag 3, the default) | 86% | **93%** |
| async-4 (lag 1) | 10% | **25%** |

`async_evolve` runs its own staleness gate — it has to, because a custom
`aggregator_factory` is promised only already-rebased cards — and `Aggregator`
then runs another over the survivors, both writing to the same `Meter`. Every
surviving card was counted twice in the denominator (fixed in #92; this is the
first re-measurement since).

Nothing about the runs changed and the numerator was always right, which is why
the row that never reaches the bar moved least: at 93% there is not much room
for a factor of two left.

## 2. The throughput experiment's denominator included setup and shutdown

The rate was `rollouts / measured wallclock`, and the measured clock covered
building the ledger, verifier and aggregator, plus up to `shutdown_grace` seconds
after the window closed. Those are **fixed** costs, so they fall hardest on the
low-worker rows — which reads as superlinear speedup.

Measured both ways: 8 workers came out at **8.2–9.4×** against ~8.1×. The
experiment's own description says *"a fixed wall-clock window"*, so it now
divides by the window it asked for.

## 3. `self_verify` doubled what a counted rollout cost

The engine re-runs a proposal's own rollout to record a before/after delta, and
only the first is counted — so with a 6 ms latency injected, every counted
rollout paid 12 ms. Throughput halved (935 → 466 rollouts/s) with the speedup
unchanged, which is the signature of a cost-model change rather than a scaling
one. The reference loop got that delta free, because it measured accuracy
directly.

`AsyncConfig.self_verify` and `AgentDescent(self_verify=)` expose the knob,
defaulting to `True` — the delta is real evidence and acceptance reads it. The
throughput experiment turns it off, because dispatch rate is what it measures.

## What the numbers are now

```
 workers  rollouts  rollouts/s  speedup  efficiency
       1       271         136     1.00        1.00
       2       467         234     1.72        0.86
       4      1082         541     3.99        1.00
       8      2172        1086     8.01        1.00
```

Across five runs the 8-worker figure landed between **7.83× and 9.15×**
(efficiency 0.98–1.14), dominated by a single-worker baseline that itself varied
15% and sits in the denominator of every other row. The 2-worker row is
consistently the weakest (0.86–1.01). The band in the doc says so now instead of
claiming 8.05–8.16.

RQ1 is unchanged and re-measured: **merge 1.000 against best-fork 0.379**.
Experiment 2 (barrier vs barrier-free) came out at 2.65× against a published
2.78×, inside its own stated 2.6–2.9× band.

## The four numbers that had no script

While re-measuring I found that **four of the published tables had no entry point
in the repository at all** — the latency-distribution sweep, the
`eval_concurrency` sweep and the threads-and-the-GIL comparison were measured by
hand. A number nobody can re-run is a claim, not a measurement, which is awkward
two sections after correcting two others that were measured wrongly.

`examples/efficiency.py` gains three experiments:

```bash
python -m examples.efficiency --only distribution   # overlap vs latency shape
python -m examples.efficiency --only gate           # eval_concurrency 1/4/8/16
python -m examples.efficiency --only gil --model X  # a real call vs pure Python
```

Only the last needs a model. Two of the numbers moved, both for reasons worth
knowing:

**The latency-distribution table** read 5.9× / 4.8× / 3.3× / 2.4× and now reads
**1.8× / 2.4× / 2.2× / 1.7×**. The old one isolated the rollout stage under a
setup that was never written down; this is end-to-end `evolve()` at default
settings. Subtract the columns and the rollout saving is exactly what eight
workers should buy — 9.9 s sequential against 5.5 s *is* the 4.2 s of sleeping
getting overlapped. The speedup is smaller because **the ceiling is whatever in a
round is not a rollout**, and at default settings that is the gate. At a 20 ms
latency the same table reads 1.9× / 2.1× / 2.0× / 1.3×. Neither reading is wrong;
the old table did not say which question it was answering.

**The threads-and-the-GIL row** was 7.1× on `deepseek-v4-flash` and is **5.8× on
`glm-5.2`** (5.8 / 6.3 / 6.5 across three runs, measured against a live
endpoint). That gap is the latency-distribution table restated: eight threads
finish when the slowest finishes, and a reasoning model has a long tail. Its CPU
row was 1.0× measured over a 25 ms unit of work — which reports whatever the
scheduler did that second — and is 1.1× over a unit sized to take seconds.

The `eval_concurrency` table keeps its shape (serial, then linear, then flat past
the held-out size) on a workload small enough to re-run: 3.6 s → 2.2 s → 1.2 s →
1.6 s.

## Tests removed

Six resilience tests. `AsyncAgentDescent` was a *separate implementation* of the
barrier-free loop when they were written, so driving failures through it tested
something of its own. It is an adapter now, and they were asserting
`async_evolve`'s behaviour through a wrapper — which `test_fault_matrix.py`
asserts directly against both engines and `test_worker_resilience.py` asserts in
more detail. One survives, as the only test of the adapter's `rollout=` seam: a
broken seam would otherwise make every reference example quietly stop exercising
failures.

Suite is green and ~37 s shorter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
