### PR TITLE
docs: say which port results survive a change of model, because two do not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Documentation
+- **The algorithm-port results table now says which rows survive a change of
+  model, because two of them do not.** Every row was measured with
+  `deepseek-v4-flash` -- stated in the page's opening line and nowhere in the
+  table, so a table copied out of context carried none of it.
+
+  Re-running all five ports against `glm-5.2` (real API, original datasets, the
+  published settings) reproduced three and flattened two:
+
+      DGM        0.000 -> 0.300, test 0.200   identical to the digit
+      GEPA       Pareto 0.500 -> 0.600        reproduced; test 0.800
+      EvoSkill   val 0.500 -> 0.577           against a published 0.487 -> 0.573
+      ACE        val 0.867 -> 0.867           against a published 0.844 -> 0.889
+      SkillOpt   val 1.000 -> 1.000           0 edits accepted, 6 rounds
+
+  The mechanism ran correctly in all five -- ACE spent 413 calls against a
+  published 403, so it did the same work. What differs is that the two that
+  flattened take their difficulty from a **knob calibrated against the published
+  model**: `--hard` keeps the items the seed answers wrong, and `glm-5.2` answers
+  95% of SearchQA correctly, so `select_hard` found 2 hard items in 40 and padded
+  to its floor with items the model already solves. `--top-k 120` sets how many
+  XBRL concepts compete, and `glm-5.2` starts above where the published run
+  finished.
+
+  The three that reproduce are the three whose difficulty is model-independent: a
+  deterministic surrogate, multi-hop retrieval, and a decimal-place *convention*
+  no capability can guess. The table marks the knob-dependent rows with ⚠︎ and
+  the published numbers are unchanged -- they were measured, and nothing here
+  falsifies them for the model they were measured on.
+
 ### Fixed
 - **`claude()` was the one blocking boundary in the package with no timeout.**
   `_git` bounds a command at 120s, `_CliAgent` at 600s, `runners._sh` takes one

--- a/docs/results.md
+++ b/docs/results.md
@@ -6,14 +6,54 @@ so you can reproduce it.
 
 ## The algorithm ports
 
-| Algorithm | Dataset | Settings | Held-out, before → after | Cost |
-|---|---|---|---|---|
-| **[GEPA](algo-gepa.md)** | HotpotQA | `--rounds 5 --fetch 40` | Pareto EM **0.500 → 0.600**; test EM **0.700** | 80 calls, 10 min |
-| **[ACE](algo-ace.md)** | FiNER-139 | `--top-k 120 --rounds 8 --workers 4` | val **0.844 → 0.889**; test **0.884**, 2 bullets | 403 calls, 20 min |
-| **[SkillOpt](algo-skillopt.md)** | SearchQA | `--hard --steps 6` | val hard-EM **0.250 → 0.500**; test **0.450** | 6 steps |
-| **[EvoSkill](algo-evoskill.md)** | FinQA | `--dataset finqa --iterations 5` | val **0.487 → 0.573**; test **0.617**, 1 skill | 115 calls, 4 min |
-| **[DGM](algo-dgm.md)** | surrogate | `--generations 4` | resolve-rate **0.000 → 0.300**; test 0.200 | offline |
-| **[ADAS](algo-adas.md)** | MGSM | `--hard`, all 11 languages | direct **0.919** → 222-item hard subset; lift **not yet measured** | ~2 h, 6k–17k calls |
+| Algorithm | Dataset | Settings | Held-out, before → after | Cost | Difficulty knob |
+|---|---|---|---|---|---|
+| **[GEPA](algo-gepa.md)** | HotpotQA | `--rounds 5 --fetch 40` | Pareto EM **0.500 → 0.600**; test EM **0.700** | 80 calls, 10 min | none |
+| **[ACE](algo-ace.md)** | FiNER-139 | `--top-k 120 --rounds 8 --workers 4` | val **0.844 → 0.889**; test **0.884**, 2 bullets | 403 calls, 20 min | ⚠︎ `--top-k` |
+| **[SkillOpt](algo-skillopt.md)** | SearchQA | `--hard --steps 6` | val hard-EM **0.250 → 0.500**; test **0.450** | 6 steps | ⚠︎ `--hard` |
+| **[EvoSkill](algo-evoskill.md)** | FinQA | `--dataset finqa --iterations 5` | val **0.487 → 0.573**; test **0.617**, 1 skill | 115 calls, 4 min | none |
+| **[DGM](algo-dgm.md)** | surrogate | `--generations 4` | resolve-rate **0.000 → 0.300**; test 0.200 | offline | none |
+| **[ADAS](algo-adas.md)** | MGSM | `--hard`, all 11 languages | direct **0.919** → 222-item hard subset; lift **not yet measured** | ~2 h, 6k–17k calls | ⚠︎ `--hard` |
+
+**Every row above was measured with `deepseek-v4-flash`.** That is stated at the
+top of this page, and it is not decoration: ⚠︎ marks a row whose *difficulty*
+comes from a knob calibrated against that model. Those rows do not transfer.
+
+!!! danger "Re-run on `glm-5.2`: the two ⚠︎ rows lost their lift entirely"
+    Not a contradiction of the numbers above — a different model, so a different
+    measurement. What it shows is which rows are portable:
+
+    | | `deepseek-v4-flash` (published) | `glm-5.2` (re-run) |
+    |---|---|---|
+    | DGM | `0.000 → 0.300`, test 0.200 | identical, to the digit |
+    | GEPA | Pareto `0.500 → 0.600` | `0.500 → 0.600`, test 0.800 |
+    | EvoSkill | val `0.487 → 0.573`, 1 skill | val `0.500 → 0.577`, test 0.613, 1 skill |
+    | **ACE** ⚠︎ | val `0.844 → 0.889`, 2 bullets | val **`0.867 → 0.867`**, 1 bullet, 8 rounds, 413 calls |
+    | **SkillOpt** ⚠︎ | val hard-EM `0.250 → 0.500` | val **`1.000 → 1.000`**, **0 edits accepted** |
+
+    The mechanism ran correctly in all five — ACE spent 413 calls against a
+    published 403, so it did the same work. What changed is that there was
+    nothing left to learn:
+
+    * **SkillOpt.** `--hard` keeps the items the seed gets wrong. `glm-5.2`
+      answers 95% of SearchQA correctly, so `select_hard` found **2 hard items in
+      40** and **1 in 20**, then padded to its 12-item floor with items the model
+      already solves. Validation was 1.000 from the first round; six rounds of
+      edits were all correctly rejected.
+    * **ACE.** `--top-k 120` sets how many XBRL concepts compete. `glm-5.2`
+      starts at 0.867 where `deepseek-v4-flash` starts at 0.844, and the residual
+      errors are not the kind one playbook bullet fixes.
+
+    The three unmarked rows reproduce because their difficulty does not depend on
+    the model: DGM's objective is a deterministic surrogate, HotpotQA's multi-hop
+    structure is hard regardless, and FinQA's decimal-place convention is a
+    *convention* — no amount of model capability guesses how many places the table
+    used.
+
+    **Re-calibrate the knob before comparing across models.** For SkillOpt that
+    means a pool large enough that `select_hard` finds genuinely hard items
+    without padding — at a 5% hard rate, roughly 240 items per split rather than
+    40.
 
 !!! note "What the *before* number is, per row"
     GEPA, EvoSkill and SkillOpt score the **seed** artifact explicitly before


### PR DESCRIPTION
Every row of the algorithm-port table was measured with `deepseek-v4-flash`. That
is stated in the page's opening line and **nowhere in the table** — so a table
read or copied out of context carries none of it. It turns out to be load-bearing
for two of the six rows.

## What was run

All five runnable ports, against `glm-5.2`: real API, the original datasets, the
published settings. No simulation, no substituted benchmark.

| | published (`deepseek-v4-flash`) | re-run (`glm-5.2`) | |
|---|---|---|---|
| DGM | `0.000 → 0.300`, test 0.200 | identical, to the digit | ✅ |
| GEPA | Pareto EM `0.500 → 0.600` | `0.500 → 0.600`, test 0.800 | ✅ |
| EvoSkill | val `0.487 → 0.573`, 1 skill | val `0.500 → 0.577`, test 0.613, 1 skill | ✅ |
| **ACE** | val `0.844 → 0.889`, 2 bullets | val **`0.867 → 0.867`**, 1 bullet, 413 calls | ⚠︎ |
| **SkillOpt** | val hard-EM `0.250 → 0.500` | val **`1.000 → 1.000`**, **0 edits accepted** | ⚠︎ |

**The mechanism ran correctly in all five.** ACE spent 413 calls against a
published 403 — it did the same work. It simply had nothing left to learn.

## Why the two flattened

Both take their difficulty from a knob calibrated against the published model.

**SkillOpt / `--hard`** keeps the items the seed answers wrong. `glm-5.2` answers
95% of SearchQA correctly, so `select_hard` found **2 hard items in 40** and **1
in 20**, then padded to its 12-item floor with items the model already solves:

```
RuntimeWarning: select_hard kept only 2 of 40 items (95% of the pool is already solved).
                Topping up to 12; pass a larger pool for a subset that is entirely hard.

round 0..5   reward=1.000 on 6   +0/-3
val hard-EM : 1.000 -> 1.000     edits accepted / rejected: 0 / 3
```

Validation was 1.000 from the first round and every edit was correctly rejected —
the framework doing exactly the right thing with no signal.

**ACE / `--top-k 120`** sets how many XBRL concepts compete. `glm-5.2` starts at
0.867 where the published run *started* at 0.844 and *finished* at 0.889. The one
bullet it did learn is sound — *"anchor the tag to the noun phrase directly
modifying the amount"* — there is just little left that a playbook rule fixes.

## Why the other three reproduce

Their difficulty does not depend on the model:

* **DGM** — a deterministic capability-cover surrogate
* **GEPA** — HotpotQA multi-hop is hard structurally, not by calibration
* **EvoSkill** — FinQA's decimal-place rule is a **convention**; no amount of
  capability guesses how many places the source table used

That distinction is the finding, and it was not written down anywhere.

## What this PR changes

**No published number.** They were measured, and a run on a different model does
not falsify them — it establishes which of them transfer. The table gains a
`Difficulty knob` column, ⚠︎ on the two rows that need re-calibration before any
cross-model comparison, and a collapsed section with the re-run figures and the
mechanism above.

## Not in this PR

Re-running SkillOpt against a pool large enough for `select_hard` to find hard
items without padding (~240 per split at the observed 5% rate). That would
confirm the port is correct when its precondition holds, but it is validation
rather than a number for the table, and it costs ~640 baseline calls.

Also worth a separate look: when the top-up fires, the result line still reads
`val hard-EM` for a subset that is 11/12 easy items. The warning goes to stderr;
the mislabelled number goes to stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
