### PR TITLE
test: run the container execution chain against a real engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+- **A test that runs the container execution chain end to end**, and the first
+  time `sandbox_container.py` has been exercised against a real engine at all.
+  Ten of its tests carry `skipif engine_available(...)`, and every machine that
+  has run this suite skipped all ten -- the provider shipped, and stayed shipped,
+  without an engine ever seeing it.
+
+  What that hid is not in any one component. It is that `runners._sh` has to
+  notice `sandbox.exec_prefix()`, that the workspace has to appear at
+  `CONTAINER_WORKDIR`, and that a missing tool has to come back as a *scored*
+  failure rather than an exception. The new test materialises a candidate, runs
+  its frozen test suite inside the container, runs the entrypoint there, and
+  asserts a broken gate returns `TEST_FAILURE_MARKER` in-band.
+
+  It puts the workspace under `$HOME` rather than `$TMPDIR`, which is the fix the
+  provider's own error message gives: on macOS and Windows the engine runs in a
+  VM that shares only part of the host filesystem, and the system temp directory
+  is usually outside it. Reaching that message was the first thing a live run
+  found.
+
 ### Documentation
 - **The algorithm-port results table now says which rows survive a change of
   model, because two of them do not.** Every row was measured with

--- a/tests/test_sandbox_container.py
+++ b/tests/test_sandbox_container.py
@@ -534,3 +534,69 @@ def test_an_unmounted_workspace_says_so_instead_of_looking_like_a_missing_file(
         assert "workspace_root" in str(e), "the error must say what to do"
         return
     p.release(sb)          # this host shares the whole filesystem; nothing to test
+
+
+# ---------------------------------------------------------------------------
+# The whole chain, against a real engine
+# ---------------------------------------------------------------------------
+
+
+@needs_engine
+def test_candidate_code_is_judged_by_real_tests_inside_a_container():
+    """The execution plane, end to end: materialise a candidate, run its frozen
+    test suite **inside the container**, then run the entrypoint there.
+
+    Every piece of this was unit-tested and the chain never was -- the ten live
+    tests above were `skipif`-ed on every machine that has run this suite, so
+    `sandbox_container.py` shipped without once being exercised against an
+    engine. What that hid is not in any one component: it is that
+    `runners._sh` has to notice `sandbox.exec_prefix()`, the workspace has to
+    appear at `CONTAINER_WORKDIR`, and a missing tool has to come back as a
+    scored failure rather than an exception.
+
+    The workspace goes under `$HOME` rather than `$TMPDIR` on purpose. On macOS
+    and Windows the engine runs in a VM that shares only part of the host
+    filesystem, and the system temp directory is usually outside it -- the
+    provider says so, with the fix, and this is the fix.
+    """
+    import os
+    import tempfile
+
+    from agentdescent.evolution import Task
+    from agentdescent.filetree import canonical, load_tree
+    from agentdescent.runners import TEST_FAILURE_MARKER, code_runner
+    from agentdescent.sandbox import SandboxPool
+
+    source = tempfile.mkdtemp(dir=os.path.expanduser("~"))
+    workspaces = tempfile.mkdtemp(dir=os.path.expanduser("~"))
+    with open(os.path.join(source, "solver.py"), "w") as fh:
+        fh.write("import sys\n\n"
+                 "def solve(expr):\n"
+                 "    return sum(int(x) for x in expr.split('+'))\n\n"
+                 "if __name__ == '__main__':\n"
+                 "    print(solve(sys.argv[1]))\n")
+    rendered = canonical(load_tree(source))
+
+    pool = SandboxPool(ContainerProvider("python:3.11-slim"), max_sandboxes=1)
+    try:
+        # No pytest in the base image, so the gate is a plain interpreter check --
+        # the point is that it runs *there*, not what runs it.
+        run = code_runner(
+            ["python", "solver.py"], layout="root", name="solver",
+            test_cmd=["python", "-c", "from solver import solve; assert solve('2+3') == 5"],
+            sandbox_pool=pool, workspace_root=workspaces)
+        out = run(rendered, Task(id="t0", prompt="2+3", meta={"gold": "5"}))
+        assert out == "5", f"the entrypoint did not run in the container: {out!r}"
+
+        # ...and a gate that fails comes back in-band, scored, not raised: "you
+        # broke the tests" is a learning signal, not a crashed run.
+        broken = code_runner(
+            ["python", "solver.py"], layout="root", name="solver",
+            test_cmd=["python", "-c", "raise SystemExit(1)"],
+            sandbox_pool=pool, workspace_root=workspaces)
+        assert broken(rendered, Task(id="t1", prompt="2+3")).startswith(
+            TEST_FAILURE_MARKER)
+    finally:
+        pool.close()
+        shutil.rmtree(source, ignore_errors=True)
+        shutil.rmtree(workspaces, ignore_errors=True)


### PR DESCRIPTION
`sandbox_container.py` has ten tests marked `skipif engine_available(...)`, and
**every machine that has run this suite skipped all ten.** 439 lines of provider
shipped, and stayed shipped, whose only evidence was that the command strings it
builds are the ones it says it builds.

That arrangement is deliberate and good — it lets the flag order be asserted
exactly, on a machine with no engine at all. What it cannot catch is everything
*between* the components:

* `runners._sh` has to notice `sandbox.exec_prefix()` and hand the command over
* the workspace has to actually appear at `CONTAINER_WORKDIR`
* a tool the image lacks has to come back as a **scored** failure, not an exception

Each is fine in isolation, and none is what a unit test of either side asserts.

## What the test does

Materialises a candidate tree → runs its frozen test suite **inside the
container** → runs the entrypoint there → asserts a deliberately broken gate
returns `TEST_FAILURE_MARKER` in-band rather than raising.

No pytest needed in the image: the gate is a plain interpreter check, because the
point is *where* it runs, not what runs it. So it works on stock
`python:3.11-slim`.

## The first thing a live run found

```
EngineError: the workspace /var/folders/…/agentdescent-ws-yuld9ryf did not appear
inside the container. On macOS and Windows the engine runs in a VM that shares
only part of the host filesystem, and the system temporary directory is usually
outside it. Point the run at a shared location — `SandboxSpec(workspace_root=…)`
under your home directory is the usual answer — or add the path to the VM's
mounts (`colima start --mount <path>:w`, or Docker Desktop's File Sharing).
```

Cause named, two ways out given. The test takes the first one — workspace under
`$HOME` — and says why in a comment. This message is the reason the run took
minutes instead of an afternoon, and it is worth recording that the standard held
up the first time anything actually leaned on it.

## Verified both ways

```
live docker          27 passed
engine unreachable   16 passed, 11 skipped
```

So CI without a daemon is unaffected — the new test skips with the other ten.

## Context

Found while checking whether DGM could be run against a real sandbox rather than
its capability-cover surrogate. The execution plane turned out to be ready and
untested; DGM itself is blocked elsewhere (its evolved artifact is a set of
twelve capability strings, so there is no patch for a real harness to evaluate —
a separate finding, and one its docs do not currently state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
