### PR TITLE
refactor: share the port CLI behaviour, not just its flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,9 +109,13 @@ All notable changes to AgentDescent are documented here. The format follows
   model, seed, async, dry-run and confirmation flags come from
   `examples._common`; upstream iteration vocabulary and per-port defaults remain
   local. A copyable code/test template and a short porting checklist make the
-  same contract the starting point for future ports. All six `--dry-run` paths
-  now return before dataset/model setup, so they are genuinely zero-network on a
-  cold machine, and the candidate backlog records mechanism gaps and owners.
+  same contract the starting point for future ports. The behaviour behind the
+  flags is shared too, not just their declaration: `confirm` reads `--yes` and
+  `completion_for` dispatches `--provider`, so a port cannot declare a flag it
+  never honours — which is the drift that lost DGM its `--yes`. All six
+  `--dry-run` paths now return before dataset/model setup, so they are genuinely
+  zero-network on a cold machine, and the candidate backlog records mechanism
+  gaps and owners.
 - **The two barrier-free runtimes share their policies.** `async_evolve` and
   `AsyncAgentDescent` implemented the same shape independently; a previous
   release had to hand-port two measured fixes between them. The parts that are

--- a/docs/porting-checklist.md
+++ b/docs/porting-checklist.md
@@ -5,6 +5,7 @@ Use this before calling an algorithm example a faithful port.
 - [ ] Start from **released code**, not only the paper; follow code on conflicts and document each conflict in `docs/algo-<name>.md`.
 - [ ] Use the original repository's dataset rather than substituting an easier benchmark.
 - [ ] Build the CLI with `examples._common.add_standard_args`; keep the upstream iteration term (`rounds`, `generations`, `iterations`, or `steps`).
+- [ ] Honour the shared flags through `_common.confirm` (`--yes`) and `_common.completion_for` (`--provider`/`--model`), and add the module to `PORTS` in `tests/test_example_entrypoints.py`.
 - [ ] Load data through `agentdescent.dataloader`, never port-specific HTTP.
 - [ ] Choose an explicit `Strategy` (`AppendRules`, `KeyedRules`, `SingleSlot`, `FileTree`, or a justified custom strategy).
 - [ ] Prefer an existing scorer from `agentdescent.rewards` when it matches the benchmark.

--- a/examples/_TEMPLATE.py
+++ b/examples/_TEMPLATE.py
@@ -12,13 +12,12 @@ the dataset loader and model adapter, so it is safe on a cold, offline machine.
 from __future__ import annotations
 
 import argparse
-import sys
 
-from agentdescent.agents import Usage, claude, openai_compatible
+from agentdescent.agents import Usage
 from agentdescent.dataloader import hf_rows
 from agentdescent.evolution import AppendRules, LLMAgent, Task, evolve
 from agentdescent.rewards import exact_match
-from examples._common import add_standard_args
+from examples._common import add_standard_args, completion_for, confirm
 
 
 PORT_NAME = "replace-with-algorithm-name"
@@ -72,17 +71,11 @@ def main(argv=None) -> None:
     tasks = load_tasks(args.limit)
     if len(tasks) < 4:
         raise ValueError("a port needs at least four tasks for train/held-out splitting")
-    if not args.yes and sys.stdin.isatty():
-        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-            print("aborted.")
-            return
+    if not confirm(args):
+        return
 
     usage = Usage()
-    completion = (
-        openai_compatible(model=args.model, usage=usage)
-        if args.provider in ("openai", "glm")
-        else claude(model=args.model, usage=usage)
-    )
+    completion = completion_for(args, usage=usage)
     result = evolve(
         tasks,
         REWARD,

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,23 +1,37 @@
-"""Shared command-line arguments for the faithful algorithm ports.
+"""The command-line contract shared by the faithful algorithm ports.
 
 Algorithm-specific vocabulary stays in each port. In particular, iteration
 flags such as ``--rounds``, ``--generations``, ``--iterations``, and ``--steps``
 must not be normalised here: they are part of the upstream algorithm's language.
+
+Declaring a flag in one place is only half of a contract -- the code that
+*honours* it has to live here too, or a port can grow a ``--yes`` it never reads
+and every test still passes. So the three behaviours behind the shared flags are
+functions, not prose: ``confirm`` for ``--yes``, ``completion_for`` for
+``--provider``/``--model``, and the early ``--dry-run`` return that each port's
+``main`` performs before touching data.
 """
 
 from __future__ import annotations
 
 import argparse
+import sys
+from typing import Optional
+
+from agentdescent.agents import Usage, claude, openai_compatible
 
 
 PROVIDER_CHOICES = ("claude", "openai", "glm")
+# Providers served by the OpenAI-compatible adapter; 'glm' is a legacy alias.
+OPENAI_COMPATIBLE = ("openai", "glm")
 DEFAULT_MODEL = "claude-haiku-4-5"
 
 
 def add_standard_args(
     parser: argparse.ArgumentParser,
     *,
-    model_default=DEFAULT_MODEL,
+    model_default: Optional[str] = DEFAULT_MODEL,
+    model_help: str = "model id",
     max_seconds_default: float = 30.0,
 ) -> argparse.ArgumentParser:
     """Add the provider/runtime flags shared by every algorithm port.
@@ -35,9 +49,7 @@ def add_standard_args(
               "vLLM, ...) via OPENAI_BASE_URL + OPENAI_API_KEY; 'glm' is a "
               "legacy alias"),
     )
-    parser.add_argument(
-        "--model", default=model_default,
-        help="model id (DGM may omit it for deterministic proposals)")
+    parser.add_argument("--model", default=model_default, help=model_help)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument(
         "--async",
@@ -64,3 +76,36 @@ def add_standard_args(
         help="skip confirmation before real model API calls",
     )
     return parser
+
+
+def is_openai_compatible(args: argparse.Namespace) -> bool:
+    """Whether ``--provider`` selects the OpenAI-compatible adapter."""
+    return args.provider in OPENAI_COMPATIBLE
+
+
+def confirm(args: argparse.Namespace) -> bool:
+    """Whether the run may proceed to real model API calls.
+
+    Honours ``--yes``, and treats a non-interactive stdin as consent so a port
+    stays scriptable in CI. Prints ``aborted.`` when the answer is no, so the
+    caller only has to ``return``.
+    """
+    if args.yes or not sys.stdin.isatty():
+        return True
+    if input("\nProceed with real API calls? [y/N] ").strip().lower() in ("y", "yes"):
+        return True
+    print("aborted.")
+    return False
+
+
+def completion_for(args: argparse.Namespace, *, usage: Optional[Usage] = None,
+                   **kwargs):
+    """Build the ``Completion`` that ``--provider`` and ``--model`` select.
+
+    Extra keyword arguments reach whichever factory is chosen, so pass only
+    options both accept; branch in the caller for genuinely one-sided ones (ADAS
+    does this for the OpenAI-only ``--timeout``).
+    """
+    if is_openai_compatible(args):
+        return openai_compatible(model=args.model, usage=usage, **kwargs)
+    return claude(model=args.model, usage=usage, **kwargs)

--- a/examples/ace_context_evolution.py
+++ b/examples/ace_context_evolution.py
@@ -48,18 +48,17 @@ import threading
 
 import argparse
 import re
-import sys
 from collections import Counter
 from typing import Dict, List, Optional, Tuple
 
-from agentdescent.agents import Usage, claude, openai_compatible
+from agentdescent.agents import Usage
 from agentdescent.dataloader import Dataset, hf_feature_names, hf_rows, split_dataset
 from agentdescent.evolvable import Diff
 from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.parallel import DataParallel
 from agentdescent.sampling import DifficultyWeighted, RoundRobin
-from examples._common import add_standard_args
+from examples._common import add_standard_args, completion_for, confirm
 
 FINER = ("nlpaueb/finer-139", "validation", "finer-139")   # (dataset, split, config)
 
@@ -341,14 +340,11 @@ def main(argv=None) -> None:
     est = estimate_calls(args.rounds, args.workers, nva) + nte
     print(f"Budget   : up to ~{est} model calls (cached repeats are free)")
 
-    if not args.yes and sys.stdin.isatty():
-        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-            print("aborted.")
-            return
+    if not confirm(args):
+        return
 
     usage = Usage()                       # what the run actually costs
-    completion = (openai_compatible(model=args.model, usage=usage) if args.provider in ("openai", "glm")
-                  else claude(model=args.model, usage=usage))
+    completion = completion_for(args, usage=usage)
     agent = ace_agent(completion)
     try:
         agent.solve("", Task(id="probe", prompt="Reply with the single word: ok"))

--- a/examples/adas_meta_agent_search.py
+++ b/examples/adas_meta_agent_search.py
@@ -48,20 +48,20 @@ import json
 import math
 import random
 import re
-import sys
 import threading
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Tuple
 
-from agentdescent.agents import Usage, claude, openai_compatible
+from agentdescent.agents import Usage
 from agentdescent.aggregator import AggregatorProtocol, MergeOutcome, MergeReport
 from agentdescent.dataloader import Dataset, fetch_text, split_dataset
 from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
-from examples._common import add_standard_args
+from examples._common import (add_standard_args, completion_for, confirm,
+                              is_openai_compatible)
 
 MGSM_URL = "https://raw.githubusercontent.com/ShengranHu/ADAS/main/dataset/mgsm/mgsm_{lang}.tsv"
 # ADAS's MGSM language set (utils.ALL_LANGUAGES).
@@ -1017,7 +1017,11 @@ def main(argv=None) -> None:
     args = p.parse_args(argv)
 
     langs = [l.strip() for l in args.langs.split(",") if l.strip() in ALL_LANGUAGES]
-    if not 0.0 < args.train_frac and 0.0 < args.test_frac and args.train_frac + args.test_frac < 1.0:
+    # `not` binds tighter than `and`, so the guard needs its own parentheses --
+    # without them `--train-frac 0.9 --test-frac 0.5` passed and produced a
+    # negative validation ratio.
+    if not (0.0 < args.train_frac and 0.0 < args.test_frac
+            and args.train_frac + args.test_frac < 1.0):
         p.error("--train-frac and --test-frac must be positive and sum to < 1")
     ratios = (args.train_frac, 1.0 - args.train_frac - args.test_frac, args.test_frac)
     print("Algorithm: ADAS Meta Agent Search -- harness (agentic-system) self-evolution")
@@ -1049,16 +1053,14 @@ def main(argv=None) -> None:
     print("\nExample problem:")
     print("  Q:", ds.train[0][0][:150])
     print("  A:", ds.train[0][1])
-    if not args.yes and sys.stdin.isatty():
-        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-            print("aborted.")
-            return
+    if not confirm(args):
+        return
 
     usage = Usage()                       # what the run actually costs
-    raw = (openai_compatible(model=args.model, usage=usage,
-                             max_tokens=args.max_tokens, timeout=args.timeout)
-           if args.provider in ("openai", "glm")
-           else claude(model=args.model, usage=usage, max_tokens=args.max_tokens))
+    # --timeout is an openai_compatible-only knob; claude() takes no such
+    # parameter, so it stays a caller-side branch rather than a shared default.
+    extra = {"timeout": args.timeout} if is_openai_compatible(args) else {}
+    raw = completion_for(args, usage=usage, max_tokens=args.max_tokens, **extra)
     guard = EmptyCompletionGuard(raw)
     completion = guard
     globals()["EVAL_CONCURRENCY"] = args.eval_concurrency

--- a/examples/dgm_self_improve.py
+++ b/examples/dgm_self_improve.py
@@ -58,18 +58,16 @@ import argparse
 import hashlib
 import math
 import random
-import sys
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Tuple
 
-from agentdescent.agents import claude, openai_compatible
 from agentdescent.aggregator import AggregatorProtocol, MergeReport
 from agentdescent.dataloader import Dataset, hf_rows, split_dataset
 from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
-from examples._common import add_standard_args
+from examples._common import add_standard_args, completion_for, confirm
 
 SWEBENCH = ("princeton-nlp/SWE-bench_Verified", "test", "default")   # (dataset, split, config)
 
@@ -432,7 +430,9 @@ def load_dataset(limit: int, seed: int = 0, ratios=(0.5, 0.25, 0.25)) -> Dataset
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
-    add_standard_args(p, model_default=None, max_seconds_default=15.0)
+    add_standard_args(
+        p, model_default=None, max_seconds_default=15.0,
+        model_help="optional: let an LLM propose self-modifications (else deterministic)")
     p.add_argument("--generations", type=int, default=12)
     p.add_argument("--selfimprove-size", type=int, default=2)
     p.add_argument("--archive", default="keep_all", choices=["keep_all", "keep_better"])
@@ -470,12 +470,9 @@ def main(argv=None) -> None:
     print(f"Example  : {ds.train[0]['instance_id']} ({ds.train[0]['repo']})")
     complete = None
     if args.model:
-        if not args.yes and sys.stdin.isatty():
-            if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-                print("aborted.")
-                return
-        complete = (openai_compatible(model=args.model) if args.provider in ("openai", "glm")
-                    else claude(model=args.model))
+        if not confirm(args):
+            return
+        complete = completion_for(args)
         try:
             complete("Reply with the single word: ok")
         except Exception as e:  # noqa: BLE001

--- a/examples/evoskill_skill_discovery.py
+++ b/examples/evoskill_skill_discovery.py
@@ -45,12 +45,10 @@ import argparse
 import csv
 import os
 import re
-import sys
 import threading
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
 
-from agentdescent.agents import claude, openai_compatible
 from agentdescent.aggregator import AggregatorProtocol, MergeReport
 from agentdescent.dataloader import (Dataset, fetch_text, hf_rows,
                                      load_gated_hf, split_dataset)
@@ -60,7 +58,8 @@ from agentdescent.filetree import parse_tree
 from agentdescent.treestrategy import FileTree
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
-from examples._common import add_standard_args
+from examples._common import (add_standard_args, completion_for, confirm,
+                              is_openai_compatible)
 
 RAW = "https://raw.githubusercontent.com/sentient-agi/EvoSkill/main/examples/officeqa/data"
 Completion = Callable[[str], str]
@@ -839,13 +838,10 @@ def main(argv=None) -> None:
     print(f"Workers  : dataset provides {min(3, ntr)} active workers")
     print(f"Budget   : up to ~{calls} model calls")
 
-    if not args.yes and sys.stdin.isatty():
-        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-            print("aborted.")
-            return
+    if not confirm(args):
+        return
 
-    completion = (openai_compatible(model=args.model) if args.provider in ("openai", "glm")
-                  else claude(model=args.model))
+    completion = completion_for(args)
     try:
         completion("Reply with the single word: ok")
     except Exception as e:  # noqa: BLE001
@@ -857,7 +853,7 @@ def main(argv=None) -> None:
     if args.backend == "openhands":
         from agentdescent.backends import openhands_backend
         oh_model = args.model if args.model.startswith("openai/") else f"openai/{args.model}"
-        base = ("https://api.deepseek.com" if args.provider in ("openai", "glm")
+        base = ("https://api.deepseek.com" if is_openai_compatible(args)
                 else os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1"))
         backend = openhands_backend(model=oh_model, base_url=base)
         print(f"Backend  : real OpenHands agent (terminal + file_editor) on {oh_model}")

--- a/examples/gepa_prompt_evolution.py
+++ b/examples/gepa_prompt_evolution.py
@@ -46,17 +46,16 @@ import argparse
 import random
 import re
 import string
-import sys
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
-from agentdescent.agents import Usage, claude, openai_compatible
+from agentdescent.agents import Usage
 from agentdescent.aggregator import AggregatorProtocol, MergeReport
 from agentdescent.dataloader import Dataset, hf_rows, split_dataset
 from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
-from examples._common import add_standard_args
+from examples._common import add_standard_args, completion_for, confirm
 
 HOTPOTQA = ("hotpotqa/hotpot_qa", "validation", "distractor")   # (dataset, split, config)
 
@@ -429,14 +428,11 @@ def main(argv=None) -> None:
     est = estimate_calls(args.rounds, args.workers, nva) + nte
     print(f"Budget   : up to ~{est} model calls (cached repeats are free)")
 
-    if not args.yes and sys.stdin.isatty():
-        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-            print("aborted.")
-            return
+    if not confirm(args):
+        return
 
     usage = Usage()                       # what the run actually costs
-    completion = (openai_compatible(model=args.model, usage=usage) if args.provider in ("openai", "glm")
-                  else claude(model=args.model, usage=usage))
+    completion = completion_for(args, usage=usage)
     agent = gepa_agent(completion)
     try:
         agent.solve("", Task(id="probe", prompt="Reply with the single word: ok"))

--- a/examples/skillopt_skill_training.py
+++ b/examples/skillopt_skill_training.py
@@ -46,19 +46,18 @@ import collections
 import json
 import re
 import string
-import sys
 import threading
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Tuple
 
-from agentdescent.agents import Usage, claude, openai_compatible
+from agentdescent.agents import Usage
 from agentdescent.aggregator import AggregatorProtocol, MergeReport
 from agentdescent.dataloader import Dataset, hf_rows, split_dataset
 from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
-from examples._common import add_standard_args
+from examples._common import add_standard_args, completion_for, confirm
 
 SEARCHQA = ("lucadiliello/searchqa", "default")   # (dataset, config)
 Completion = Callable[[str], str]
@@ -541,14 +540,11 @@ def main(argv=None) -> None:
     calls = args.steps * (args.minibatch + 1 + nva) + nte
     print(f"Budget   : up to ~{calls} model calls (rollouts dominate)")
 
-    if not args.yes and sys.stdin.isatty():
-        if input("\nProceed with real API calls? [y/N] ").strip().lower() not in ("y", "yes"):
-            print("aborted.")
-            return
+    if not confirm(args):
+        return
 
     usage = Usage()                       # what the run actually costs
-    completion = (openai_compatible(model=args.model, usage=usage) if args.provider in ("openai", "glm")
-                  else claude(model=args.model, usage=usage))
+    completion = completion_for(args, usage=usage)
     if args.hard:
         # Needs the model, which is built above, so the dataset is re-selected here
         # rather than at load time.

--- a/tests/test_example_entrypoints.py
+++ b/tests/test_example_entrypoints.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import pathlib
 import socket
 import urllib.request
@@ -96,8 +97,9 @@ def test_dry_run_never_touches_data_network_or_models(
         raise AssertionError("dry-run crossed an external boundary")
 
     monkeypatch.setattr(module, loader, forbidden)
-    monkeypatch.setattr(module, "claude", forbidden)
-    monkeypatch.setattr(module, "openai_compatible", forbidden)
+    monkeypatch.setattr(module, "completion_for", forbidden)
+    monkeypatch.setattr(common, "claude", forbidden)
+    monkeypatch.setattr(common, "openai_compatible", forbidden)
     monkeypatch.setattr(urllib.request, "urlopen", forbidden)
     monkeypatch.setattr(socket, "create_connection", forbidden)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -105,6 +107,85 @@ def test_dry_run_never_touches_data_network_or_models(
 
     module.main(["--dry-run"])
     assert "dry-run" in capsys.readouterr().out.lower()
+
+
+# ---------------------------------------------------------------------------
+# The flags have to be *honoured*, not only declared. A port that grows a
+# `--yes` it never reads is exactly the drift #74 was filed about, and a shape
+# test over the parser cannot see it -- so these exercise the behaviour and
+# then check no port reimplements it locally.
+# ---------------------------------------------------------------------------
+
+
+class _Stdin:
+    def __init__(self, tty: bool):
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+def _never_asks(*_args, **_kwargs):
+    raise AssertionError("confirm() prompted when it should not have")
+
+
+@pytest.mark.parametrize("yes,tty", [(True, True), (True, False), (False, False)])
+def test_confirm_does_not_prompt_when_yes_or_non_interactive(yes, tty, monkeypatch):
+    monkeypatch.setattr(common.sys, "stdin", _Stdin(tty))
+    monkeypatch.setattr("builtins.input", _never_asks)
+    assert common.confirm(argparse.Namespace(yes=yes)) is True
+
+
+@pytest.mark.parametrize("answer,expected", [
+    ("y", True), ("YES", True), ("n", False), ("", False),
+])
+def test_confirm_honours_an_interactive_answer(answer, expected, monkeypatch, capsys):
+    monkeypatch.setattr(common.sys, "stdin", _Stdin(True))
+    monkeypatch.setattr("builtins.input", lambda *_args: answer)
+    assert common.confirm(argparse.Namespace(yes=False)) is expected
+    assert ("aborted." in capsys.readouterr().out) is not expected
+
+
+@pytest.mark.parametrize("provider,factory", [
+    ("claude", "claude"), ("openai", "openai_compatible"), ("glm", "openai_compatible"),
+])
+def test_completion_for_dispatches_on_provider(provider, factory, monkeypatch):
+    seen = {}
+
+    def record(name):
+        def factory_stub(**kwargs):
+            seen[name] = kwargs
+            return name
+        return factory_stub
+
+    monkeypatch.setattr(common, "claude", record("claude"))
+    monkeypatch.setattr(common, "openai_compatible", record("openai_compatible"))
+    args = argparse.Namespace(provider=provider, model="test-model")
+
+    assert common.completion_for(args, max_tokens=99) == factory
+    assert seen == {factory: {"model": "test-model", "usage": None, "max_tokens": 99}}
+
+
+@pytest.mark.parametrize("module,_i,_m,_s,_l", PORTS + ((port_template, "", "", 0.0, ""),))
+def test_no_port_reimplements_the_shared_behaviour(module, _i, _m, _s, _l):
+    source = inspect.getsource(module)
+    assert "Proceed with real API calls?" not in source, (
+        f"{module.__name__}: use examples._common.confirm(args)")
+    assert 'provider in ("openai", "glm")' not in source, (
+        f"{module.__name__}: use examples._common.completion_for/is_openai_compatible")
+    assert "confirm(args)" in source, f"{module.__name__}: --yes is declared but never read"
+    assert "completion_for(" in source, f"{module.__name__}: --provider is never dispatched"
+
+
+def test_ports_table_covers_every_standardised_entrypoint():
+    """A seventh port must join PORTS, or it escapes the whole contract."""
+    examples_dir = pathlib.Path(common.__file__).resolve().parent
+    on_disk = {
+        path.stem for path in examples_dir.glob("*.py")
+        if path.stem != "_common" and "add_standard_args" in path.read_text()
+    }
+    listed = {module.__name__.rsplit(".", 1)[-1] for module, *_ in PORTS}
+    assert on_disk == listed | {"_TEMPLATE"}
 
 
 def test_porting_checklist_stays_short():

--- a/tests/test_template_example.py
+++ b/tests/test_template_example.py
@@ -2,6 +2,9 @@
 
 Copy to ``tests/test_<algorithm>_example.py`` and change the import. Keep the
 tests offline: patch dataset rows and completions instead of using real services.
+
+The name is ``test_``-prefixed on purpose: a template pytest never collects is a
+template that rots, so this file runs on every ``pytest -q`` like any other.
 """
 
 from examples import _TEMPLATE as port
@@ -35,7 +38,6 @@ def test_dry_run_stops_before_loading_data(monkeypatch, capsys):
         raise AssertionError("dry-run must be offline")
 
     monkeypatch.setattr(port, "load_tasks", forbidden)
-    monkeypatch.setattr(port, "claude", forbidden)
-    monkeypatch.setattr(port, "openai_compatible", forbidden)
+    monkeypatch.setattr(port, "completion_for", forbidden)
     port.main(["--dry-run"])
     assert "dry-run" in capsys.readouterr().out.lower()


### PR DESCRIPTION
Follow-up to #85 (now merged), from reviewing it. #85 is good; these are the findings.

## What this changes

**1. The contract now covers behaviour, not only declaration.** `add_standard_args` gave the six ports one place to *declare* `--provider`/`--yes`, but the code that *honours* them stayed copy-pasted: the `if not args.yes and sys.stdin.isatty()` block appeared 8 times and the `openai_compatible(...) if args.provider in ("openai", "glm") else claude(...)` ternary 9 times. Nothing tested that `--yes` actually skips the prompt or that `--provider openai` actually dispatches — so a port could declare a `--yes` it never reads and the suite would stay green. That is the exact drift #74 was filed about.

`examples/_common` now owns `confirm(args)`, `completion_for(args, ...)` and `is_openai_compatible(args)`. New tests exercise the behaviour (`--yes` and non-tty suppress the prompt; `y`/`n` answers; each provider picks the right adapter), and `test_no_port_reimplements_the_shared_behaviour` fails if any port grows a local copy again.

ADAS keeps one caller-side branch, with a comment: `--timeout` is an `openai_compatible`-only knob and `claude()` has no such parameter.

**2. `tests/_TEMPLATE_example.py` was never collected.** `testpaths = ["tests"]` plus pytest's default `test_*.py` pattern means `pytest --collect-only tests/` finds it 0 times; it only ran because #85's verification list named it explicitly. It had *already* gone stale against the template it tests. Renamed to `tests/test_template_example.py` — which caught the staleness on the first collected run.

**3. `PORTS` was hand-maintained.** A seventh port that forgot to register would escape the zero-network dry-run guarantee entirely. `test_ports_table_covers_every_standardised_entrypoint` now derives the expected set from disk.

**4. `--model`'s help text named DGM in all six ports** — `ace_context_evolution --help` read `model id (DGM may omit it for deterministic proposals)`. It is a `model_help=` parameter now, and DGM passes its own wording back.

**5. Drive-by, pre-existing.** `examples/adas_meta_agent_search.py` validated the split with `if not 0.0 < train_frac and 0.0 < test_frac and ... < 1.0:`. `not` binds tighter than `and`, so `--train-frac 0.9 --test-frac 0.5` passed validation and produced a negative validation ratio. It sits in a hunk #85 touched, so it is fixed here rather than left behind.

## Deliberately not changed

`--dry-run` no longer prints a budget estimate. #74 mandates the zero-network return, #85's docs say so honestly, and restoring the estimate would require the dataset — so this is a trade-off, not a defect. If the cheap pre-flight is still wanted, a later `--dry-run --with-data` tier can bring it back without touching the offline default.

## Verification

- `pytest -q` — full suite, exit 0
- all six ports plus the template: `--dry-run` offline, no dataset, no API key
- `python -m mkdocs build --strict`
- `python -m compileall -q examples tests`
- `--train-frac 0.9 --test-frac 0.5` now rejected; defaults unaffected
- `ace --help` shows the generic model text, `dgm --help` keeps its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)
