### PR TITLE
fix: the OpenEvolve port skipped the entrypoint contract, so main went red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+- **The OpenEvolve port joined the examples tree without joining the entrypoint
+  contract, and `main` went red on the guard test written for exactly that.**
+  `test_ports_table_covers_every_standardised_entrypoint` globs the examples
+  directory for anything calling `add_standard_args` and demands it appear in
+  `PORTS`; the port called the helper and never appeared, so the seventh entry
+  was missing and the assertion failed on every push.
+
+  The table was the smaller half of it. The port had also grown its own copies
+  of two things `examples/_common.py` already owns: a `_make_completion` that
+  branched on `provider in ("openai", "glm")` itself, and an inline
+  `input("Proceed with paid model calls? [y/N] ")`. Both are what
+  `test_no_port_reimplements_the_shared_behaviour` exists to catch — it just
+  never ran on this module, because the module was not in the table. Adding the
+  row without the cleanup would have traded a red gate for a silent exemption.
+
+  `_make_completion` now dispatches through `completion_for()` and assembles
+  only the genuinely one-sided option (GLM `thinking`), the prompt is
+  `confirm(args)`, and `PORTS` became a `NamedTuple` whose `provider` and
+  `async_ratio` carry the shared defaults. That last part is what keeps the
+  entry honest: OpenEvolve really is measured on an OpenAI-compatible GLM
+  endpoint with a lag budget of 1, so the deviation is now written down in the
+  row rather than expressed by staying out of the table.
+
 ### Added
 - **A test that runs the container execution chain end to end**, and the first
   time `sandbox_container.py` has been exercised against a real engine at all.

--- a/examples/openevolve_program_evolution.py
+++ b/examples/openevolve_program_evolution.py
@@ -41,7 +41,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
-from agentdescent.agents import Completion, Usage, claude, openai_compatible
+from agentdescent.agents import Completion, Usage
 from agentdescent.aggregator import (
     AggregatorConfig,
     AggregatorProtocol,
@@ -55,7 +55,12 @@ from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 from agentdescent.staleness import StaleAction, get_policy
 
-from examples._common import add_standard_args
+from examples._common import (
+    add_standard_args,
+    completion_for,
+    confirm,
+    is_openai_compatible,
+)
 from examples._openevolve_support import (
     INITIAL_PROGRAM,
     UPSTREAM_COMMIT,
@@ -87,27 +92,26 @@ def _require_api_environment(provider: str) -> None:
 
 
 def _make_completion(args: argparse.Namespace, usage: Usage) -> Completion:
-    if args.provider in ("openai", "glm"):
-        options: Dict[str, Any] = {}
-        if (
-            args.thinking != "default"
-            and (args.provider == "glm" or args.model.lower().startswith("glm"))
-        ):
-            options["thinking"] = {"type": args.thinking}
-        return openai_compatible(
-            model=args.model,
-            usage=usage,
-            max_tokens=args.max_tokens,
-            timeout=args.api_timeout,
-            temperature=args.temperature,
-            **options,
-        )
-    return claude(
-        model=args.model,
+    """Dispatch through the shared helper, branching only for the GLM extra.
+
+    ``thinking`` is one-sided -- it reaches an OpenAI-compatible GLM endpoint and
+    nothing else -- so it is the one option assembled here rather than passed to
+    both factories, exactly as ADAS does for its OpenAI-only ``--timeout``.
+    """
+    options: Dict[str, Any] = {}
+    if (
+        is_openai_compatible(args)
+        and args.thinking != "default"
+        and (args.provider == "glm" or args.model.lower().startswith("glm"))
+    ):
+        options["thinking"] = {"type": args.thinking}
+    return completion_for(
+        args,
         usage=usage,
         max_tokens=args.max_tokens,
         timeout=args.api_timeout,
         temperature=args.temperature,
+        **options,
     )
 
 
@@ -928,11 +932,8 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         return 0
 
     _require_api_environment(args.provider)
-    if not args.yes and sys.stdin.isatty():
-        answer = input("Proceed with paid model calls? [y/N] ").strip().lower()
-        if answer not in ("y", "yes"):
-            print("aborted.")
-            return 0
+    if not confirm(args):
+        return 0
 
     model_usage = Usage()
     actor_usage = Usage()

--- a/tests/test_example_entrypoints.py
+++ b/tests/test_example_entrypoints.py
@@ -1,4 +1,4 @@
-"""The command-line contract shared by the six faithful algorithm ports."""
+"""The command-line contract shared by the seven faithful algorithm ports."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import inspect
 import pathlib
 import socket
 import urllib.request
+from typing import Any, NamedTuple, Optional
 
 import pytest
 
@@ -15,20 +16,44 @@ from examples import adas_meta_agent_search as adas
 from examples import dgm_self_improve as dgm
 from examples import evoskill_skill_discovery as evoskill
 from examples import gepa_prompt_evolution as gepa
+from examples import openevolve_program_evolution as openevolve
 from examples import skillopt_skill_training as skillopt
 from examples import _TEMPLATE as port_template
 from examples import _common as common
 from examples._common import add_standard_args
 
 
+class Port(NamedTuple):
+    """One port's entry in the contract.
+
+    ``provider`` and ``async_ratio`` carry defaults because six of the seven
+    ports take the shared ones; a port that names them is declaring a deliberate
+    deviation, which is the only way one gets past this file.
+    """
+
+    module: Any
+    iteration: str
+    model: Optional[str]
+    seconds: float
+    loader: str
+    provider: str = "claude"
+    async_ratio: int = 3
+
+
 PORTS = (
-    (ace, "rounds", "claude-haiku-4-5", 30.0, "load_dataset"),
-    (gepa, "rounds", "claude-haiku-4-5", 45.0, "load_dataset"),
-    (evoskill, "iterations", "claude-haiku-4-5", 40.0, "load_dataset"),
-    (skillopt, "steps", "claude-haiku-4-5", 40.0, "load_dataset"),
-    (adas, "generations", "claude-haiku-4-5", 60.0, "build_examples"),
-    (dgm, "generations", None, 15.0, "load_dataset"),
+    Port(ace, "rounds", "claude-haiku-4-5", 30.0, "load_dataset"),
+    Port(gepa, "rounds", "claude-haiku-4-5", 45.0, "load_dataset"),
+    Port(evoskill, "iterations", "claude-haiku-4-5", 40.0, "load_dataset"),
+    Port(skillopt, "steps", "claude-haiku-4-5", 40.0, "load_dataset"),
+    Port(adas, "generations", "claude-haiku-4-5", 60.0, "build_examples"),
+    Port(dgm, "generations", None, 15.0, "load_dataset"),
+    # OpenEvolve is measured against an OpenAI-compatible GLM endpoint, and its
+    # sandboxed candidate evaluation makes a lag budget of 3 versions too loose.
+    Port(openevolve, "iterations", "glm-5.2", 300.0, "build_tasks",
+         provider="openai", async_ratio=1),
 )
+
+PORT_IDS = tuple(port.module.__name__.rsplit(".", 1)[-1] for port in PORTS)
 
 
 def test_standard_args_have_one_definition():
@@ -53,50 +78,49 @@ def test_standard_args_have_one_definition():
     assert args.yes is True
 
 
-@pytest.mark.parametrize("module,iteration,model,seconds,_loader", PORTS)
-def test_every_port_uses_the_standard_contract(module, iteration, model, seconds,
-                                                _loader):
-    parser = module.build_parser()
+@pytest.mark.parametrize("port", PORTS, ids=PORT_IDS)
+def test_every_port_uses_the_standard_contract(port):
+    parser = port.module.build_parser()
     args = parser.parse_args([])
-    assert args.provider == "claude"
-    assert args.model == model
+    assert args.provider == port.provider
+    assert args.model == port.model
     assert args.seed == 0
     assert args.asynchronous is False
-    assert args.async_ratio == 3
-    assert args.max_seconds == seconds
+    assert args.async_ratio == port.async_ratio
+    assert args.max_seconds == port.seconds
     assert args.dry_run is False
     assert args.yes is False
-    assert hasattr(args, iteration)
+    assert hasattr(args, port.iteration)
 
     option_strings = [opt for action in parser._actions for opt in action.option_strings]
     for option in ("--provider", "--model", "--seed", "--async", "--async-ratio",
                    "--max-seconds", "--dry-run", "--yes"):
-        assert option_strings.count(option) == 1, f"{module.__name__}: {option}"
+        assert option_strings.count(option) == 1, f"{port.module.__name__}: {option}"
     iteration_options = {"--rounds", "--generations", "--iterations", "--steps"}
-    assert iteration_options.intersection(option_strings) == {f"--{iteration}"}
+    assert iteration_options.intersection(option_strings) == {f"--{port.iteration}"}
 
 
-@pytest.mark.parametrize("module,_iteration,_model,_seconds,_loader", PORTS)
-def test_every_port_calls_the_shared_helper_once(
-        module, _iteration, _model, _seconds, _loader, monkeypatch):
+@pytest.mark.parametrize("port", PORTS, ids=PORT_IDS)
+def test_every_port_calls_the_shared_helper_once(port, monkeypatch):
     calls = []
 
     def recording_helper(parser, **kwargs):
         calls.append(kwargs)
         return common.add_standard_args(parser, **kwargs)
 
-    monkeypatch.setattr(module, "add_standard_args", recording_helper)
-    module.build_parser()
+    monkeypatch.setattr(port.module, "add_standard_args", recording_helper)
+    port.module.build_parser()
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("module,_iteration,_model,_seconds,loader", PORTS)
-def test_dry_run_never_touches_data_network_or_models(
-        module, _iteration, _model, _seconds, loader, monkeypatch, capsys):
+@pytest.mark.parametrize("port", PORTS, ids=PORT_IDS)
+def test_dry_run_never_touches_data_network_or_models(port, monkeypatch, capsys):
+    module = port.module
+
     def forbidden(*_args, **_kwargs):
         raise AssertionError("dry-run crossed an external boundary")
 
-    monkeypatch.setattr(module, loader, forbidden)
+    monkeypatch.setattr(module, port.loader, forbidden)
     monkeypatch.setattr(module, "completion_for", forbidden)
     monkeypatch.setattr(common, "claude", forbidden)
     monkeypatch.setattr(common, "openai_compatible", forbidden)
@@ -166,8 +190,12 @@ def test_completion_for_dispatches_on_provider(provider, factory, monkeypatch):
     assert seen == {factory: {"model": "test-model", "usage": None, "max_tokens": 99}}
 
 
-@pytest.mark.parametrize("module,_i,_m,_s,_l", PORTS + ((port_template, "", "", 0.0, ""),))
-def test_no_port_reimplements_the_shared_behaviour(module, _i, _m, _s, _l):
+@pytest.mark.parametrize(
+    "module",
+    [port.module for port in PORTS] + [port_template],
+    ids=list(PORT_IDS) + ["_TEMPLATE"],
+)
+def test_no_port_reimplements_the_shared_behaviour(module):
     source = inspect.getsource(module)
     assert "Proceed with real API calls?" not in source, (
         f"{module.__name__}: use examples._common.confirm(args)")


### PR DESCRIPTION
## What broke

`tests/test_example_entrypoints.py::test_ports_table_covers_every_standardised_entrypoint` has been failing on every push since #97 merged. It globs the examples directory for modules that call `add_standard_args` and asserts each one appears in `PORTS`:

```
Extra items in the left set:
'openevolve_program_evolution'
```

The test's own docstring predicted this: *"A seventh port must join PORTS, or it escapes the whole contract."*

## Why the one-line fix was the wrong one

Being absent from `PORTS` did not just skip one assertion — it exempted the module from `test_no_port_reimplements_the_shared_behaviour`. And it was reimplementing two things `examples/_common.py` owns:

- `_make_completion` branched on `provider in ("openai", "glm")` and called `claude` / `openai_compatible` directly, instead of `completion_for()`
- the paid-call confirmation was an inline `input("Proceed with paid model calls? [y/N] ")` instead of `confirm(args)`

Adding the row without that cleanup would have traded a red gate for a silent exemption.

## Changes

- `_make_completion` dispatches through `completion_for()`, assembling only the genuinely one-sided option (GLM `thinking`) — the shape the helper's docstring prescribes and ADAS already uses for its OpenAI-only `--timeout`.
- The confirmation prompt is `confirm(args)`.
- `PORTS` becomes a `NamedTuple` whose `provider` and `async_ratio` default to the shared values. OpenEvolve is genuinely measured against an OpenAI-compatible GLM endpoint with a lag budget of 1, so those deviations are now stated in its row rather than expressed by staying out of the table.
- The five `PORTS`-driven tests take the record instead of a positional 5-tuple, and get readable parametrize ids.

## Verification

- `pytest -q` — full suite passes locally
- `mkdocs build --strict` — clean
- `CHANGELOG.md` updated under **[Unreleased]**

🤖 Generated with [Claude Code](https://claude.com/claude-code)