### PR TITLE
release: 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-08-05
+
+One engine. 0.3.0 made the numbers readable; this release removes the second
+implementation they were being measured against.
+
+`AgentDescent` and `AsyncAgentDescent` each had their own round barrier, worker
+dispatch, snapshot staggering, merger thread, published head and backpressure.
+`docs/architecture.md` called that "a known wart rather than a design intent",
+and it kept costing: two measured fixes that had to be hand-ported between the
+loops, two early-stop epsilons nobody chose, and three mechanisms the general
+engine re-derived — and got wrong — because the reference stack already had
+them. Both are adapters over `evolve()` now, the public surface is unchanged,
+and the reference table still reads first 0.604, final 1.000, against a fork
+baseline of 0.379.
+
+Underneath that, the decisions a loop used to hard-code became replaceable
+contracts, and the resources a rollout consumes got a plane of their own:
+sandbox leases with an owner, a ceiling and a way to be reclaimed; a container
+boundary verified against both podman and docker; a ledger and an evaluation
+cache that survive more than one writing process; and an executor seam the
+round's rollout actually goes through, which it did not before — a supplied
+executor ran nothing and the run reported that it had gone fine.
+
+**Breaking.** `agentdescent.worker.Worker`, `AsyncConfig.aggregator_interval`,
+`AsyncConfig.worker_pause`, `EvidenceCard.version_annotations` and the
+`domains.router.Task` alias are removed, and `full_eval` is no longer part of
+the `Evolvable` protocol. Each entry below says what replaced it.
+`Evolvable.cheap_eval` was renamed to `evidence_eval` but remains an alias, and
+the three moved strategy import paths still work.
+
 ### Changed
 - **Each faithful algorithm port now owns a directory.** `examples/` had grown to
   seven ports flat alongside six framework demos, and nothing in the name said
@@ -1823,6 +1853,8 @@ First public release on PyPI as **`agentdescent`**.
   discrete-space `Aggregator`, staleness policies, DP/TP/PP parallelism, layered
   governance, and the provider-agnostic `agentdescent.agents` completion layer.
 
-[Unreleased]: https://github.com/Birfy/agentdescent/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/Birfy/agentdescent/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Birfy/agentdescent/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/Birfy/agentdescent/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Birfy/agentdescent/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Birfy/agentdescent/releases/tag/v0.1.0

--- a/agentdescent/__init__.py
+++ b/agentdescent/__init__.py
@@ -156,7 +156,7 @@ from .parallel import (
     shard_round_robin,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "Contract",


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.4.0]` and bumps the single-sourced version in `agentdescent/__init__.py`.

**Not 0.3.1.** The ~60 commits since `v0.3.0` remove four pieces of public API (`agentdescent.worker.Worker`, `AsyncConfig.aggregator_interval` / `worker_pause`, `EvidenceCard.version_annotations`, the `domains.router.Task` alias), drop `full_eval` from the `Evolvable` protocol, and add `ClusterParallel`, directory evolution, the container sandbox and the executor seam. Under the SemVer this changelog says the project follows, that is a minor bump — and a PyPI version number cannot be reused if we get it wrong.

The link definitions at the bottom of the changelog were also stale: `[Unreleased]` still compared against `v0.2.0`, and `0.3.0` had no entry at all.

## Verified

| Check | Result |
| --- | --- |
| `pytest` | 915 passed, 2 skipped |
| `python -m build` | `agentdescent-0.4.0-py3-none-any.whl` + `.tar.gz` |
| `twine check dist/*` | both PASSED |
| `mkdocs build --clean --strict` (what `docs.yml` runs) | green |

## After merge

1. Tag `v0.4.0` on main.
2. Publish the GitHub Release — this triggers `publish.yml`, which builds and uploads to PyPI via Trusted Publishing.
3. Run `docs.yml` manually (`workflow_dispatch`) to deploy the site to Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)