### PR TITLE
the win rate is a diagnostic to run, not a figure to publish (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,15 +449,19 @@ Read `negative` before believing a high win rate: an empty losing tail usually
 means the held-out set is too small to separate the candidates, and `ties` is the
 tell.
 
-Three outcomes, all worth having. Well above 50% means merging recovers the N−1
-proposals best-of-N discards. Near 50% means fusion is noise, and ranking it was
-never worth the sweep. Below 50% *with the tournament catching it* means ranking
-is doing real work on this workload — which is a reason to turn it on there, and
-the reason the measurement is per-workload rather than a fact about the
-mechanism. Measured numbers go in
-[Measured results](https://github.com/Birfy/agentdescent/blob/main/docs/results.md);
-the synthetic router domain is not where they can come from, because its diffs
-are additive by construction and fusion there wins by definition.
+Three outcomes, all worth having on **your** workload. Well above 50% means
+merging recovers the N−1 proposals best-of-N discards. Near 50% means fusion is
+noise there, and ranking it is not worth the sweep. Below 50% *with the
+tournament catching it* means ranking is doing real work — a reason to leave it
+on for that artifact.
+
+**No number is published here, and that is deliberate.** The win rate is a
+property of the artifact's key space and of how much the workers' proposals
+overlap, not of the mechanism — so a figure measured on one dataset would be read
+as a fact about merging and would not transfer to the next one. It is a
+diagnostic to run on the workload you care about, which is why it is one keyword
+argument and not a benchmark. The synthetic router domain is the clearest case of
+why: its diffs are additive by construction, so fusion there wins by definition.
 
 ## Parallelism & asynchrony
 

--- a/docs/aggregator.md
+++ b/docs/aggregator.md
@@ -110,9 +110,12 @@ it, because `best_single_score` exists only where a single was actually scored.
 `RoundStat.fused` counted **committed** fusions, which cannot answer it: a tally
 of successes with the denominator missing.
 
-The win rate is a property of the workload, not of the mechanism — one dataset's
-number does not transfer to the next — so this is a measurement to run
-deliberately per workload rather than a tax on every run:
+The win rate is a property of the workload, not of the mechanism — it depends on
+how coarse the artifact's key space is and on how much the workers' proposals
+overlap, so one dataset's number does not transfer to the next. That is why this
+project publishes no figure for it: a number measured on one benchmark would be
+read as a fact about merging. It is a diagnostic to run on the workload in front
+of you, rather than a tax on every run:
 
 ```python
 result = evolve(tasks, reward, agent=agent, n_workers=4,


### PR DESCRIPTION
Refs #72. This commit was on the #107 branch but landed after the merge took the
one before it, so it missed the train.

The README pointed at `docs/results.md` for "measured numbers", which is a promise
to publish a win rate. It should not be kept: the rate depends on how coarse the
artifact's key space is and on how much the workers' proposals overlap — both
properties of the workload — so a figure taken on one benchmark would be read as a
fact about merging and would not transfer to the next one. The synthetic router
domain is the clearest case of why: its diffs are additive by construction, so
fusion there wins by definition.

Both places now say that instead: it is a diagnostic to run on the workload in
front of you, which is why it is one keyword argument and not a benchmark.

Docs only. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)