### PR TITLE
refactor: legacy ports' optimizer rules as policies at the standard seams

### DIFF
--- a/docs/acceptance-policies.md
+++ b/docs/acceptance-policies.md
@@ -17,6 +17,7 @@ says it doesn't help" and "it never reached the gate" need opposite fixes.
 | `AdvantageAcceptance(inner, strength)` | shifts the prior by the candidate group's standardised advantage (`GroupAdvantage`), then defers to `inner` — wraps, never replaces, so the Beta test and regression guard survive | GRPO-shaped methods (R-Zero here); group evidence should nudge, not override |
 | `StableDistanceAcceptance` | penalises candidates that drift far from the `stable` branch — the KL-to-reference analogy with `stable` as the reference | long runs where dev can wander; distance as regularisation |
 | `AcceptAnyCompiling` (examples/godel_agent) | accepts everything the validator let through | faithfulness ablations of gateless methods; measuring what the gate is worth |
+| `StrictImprovement` (examples/skillopt) | commit only a strict full-held-out improvement — no Beta draw, no annealing | SkillOpt's deliberately harsher gate; small clean val sets where strictness is the algorithm |
 
 Related knobs that are *not* policies: `TrustRegion` / `AdaptiveTrustRegion`
 cap diff size before cards ever reach the gate.

--- a/docs/algo-ace.md
+++ b/docs/algo-ace.md
@@ -132,3 +132,12 @@ python -m examples.ace.ace_context_evolution --top-k 40 --pool 400 --rounds 8   
 ```
 
 Offline tests: `tests/test_ace_example.py`.
+
+## Where the mechanism lives (decision-plane note)
+
+ACE is the port that needed no optimizer surgery: its distinctive mechanism --
+incremental delta updates curated into a playbook -- is entirely an **artifact
+shape**, so it lives at the [strategy layer](strategies.md) (`ACEPlaybook`),
+and the shipped merge pipeline runs unchanged underneath. Of the three
+insertion layers in [choosing policies](policies.md), ACE uses the first alone;
+there is deliberately no custom aggregator and no local policy class here.

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -112,3 +112,17 @@ through the [population aggregator](aggregator-factory.md): committed heads
 enter an archive, the policy picks the next parent from it, and the pick is a
 ledger commit. Declare `Policies(selection=…)` as usual — the candidate runner
 routes it there automatically.
+
+## Legacy-port policies
+
+The mechanism-heavy ports express their parent rules as policy classes at this
+seam (local where the upstream rule differs from a shipped policy — the
+difference is always documented on the class):
+
+| Policy | Rule | Port |
+|---|---|---|
+| `DGMParentSelection` | `sigmoid(10·(s−0.5)) × 1/(1+children)` sampling | [DGM](algo-dgm.md) |
+| `ParetoWinFrequency` | per-instance Pareto frontier, sampled by unique wins | [GEPA](algo-gepa.md) |
+| `FrontierBest` | best member of the bounded top-K frontier | [EvoSkill](algo-evoskill.md) |
+| shipped `Beam(1)` | best of the keep-all archive (exact match, no subclass) | [ADAS](algo-adas.md) |
+| `EpsilonGreedy` | exploit best with probability ε, else uniform | [OpenEvolve](algo-openevolve.md) |

--- a/examples/adas/adas_meta_agent_search.py
+++ b/examples/adas/adas_meta_agent_search.py
@@ -780,10 +780,17 @@ class MetaSearchAggregator(AggregatorProtocol):
     """ADAS's optimizer: a keep-all archive with bootstrap-CI fitness."""
 
     def __init__(self, ledger: Ledger, verifier, ctx: AdasContext,
-                 artifact_id: str = "agentic_system", boot_seed: int = 0):
+                 artifact_id: str = "agentic_system", boot_seed: int = 0,
+                 selection=None):
+        from agentdescent.selection import Beam
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
+        # ADAS keeps the archive's best design as head. That rule is exactly
+        # the shipped Beam(1): stable sort, first maximal wins -- the same
+        # tie-break as the incremental strictly-greater tracking it replaces.
+        # The first legacy port whose rule needed no local subclass.
+        self.selection = selection or Beam(1)
         self.aid = artifact_id
         self.boot_seed = boot_seed
         self.cards: List[EvidenceCard] = []
@@ -857,11 +864,22 @@ class MetaSearchAggregator(AggregatorProtocol):
                          card.diff.ops.get("thought", ""),
                          json.loads(design), mean, ci)
 
-        best_design = canonical(self.ctx.best_agent["program"])
+        # Best-of-archive at the standard seam (version = archive index).
+        from agentdescent.selection import Candidate, SelectionContext
+        rows = [Candidate(artifact_id=self.aid, version=i,
+                          score=a["fitness"])
+                for i, a in enumerate(self.ctx.archive)]
+        best_agent = self.ctx.best_agent
+        if rows:
+            sel = SelectionContext(head=rows[0], candidates=tuple(rows),
+                                   n_workers=1)
+            best_agent = self.ctx.archive[
+                self.selection.select(sel, 1)[0].version]
+        best_design = canonical(best_agent["program"])
         diff = Diff(diff_id="best", target=self.aid,
                     ops={"design": best_design,
-                         "name": self.ctx.best_agent["name"],
-                         "thought": self.ctx.best_agent.get("thought", "")},
+                         "name": best_agent["name"],
+                         "thought": best_agent.get("thought", "")},
                     author="adas")
         committed, category = None, ALREADY_BEST
         if not cards:

--- a/examples/dgm/dgm_self_improve.py
+++ b/examples/dgm/dgm_self_improve.py
@@ -110,6 +110,34 @@ def choose_selfimproves(archive: List["Agent"], k: int,
     return rng.choices(range(len(archive)), weights=weights, k=k)
 
 
+class DGMParentSelection:
+    """`choose_selfimproves` at the standard selection seam.
+
+    A :class:`~agentdescent.selection.SelectionPolicy` over `Candidate` records:
+    ``score`` carries the staged-eval score and ``selected`` carries DGM's
+    children-explored count, so `dgm_parent_weights` reads them unchanged and
+    the single ``rng.choices`` call keeps the exact random-consumption order of
+    the inline rule it replaces -- a seeded run picks identical parents.
+
+    Local rather than shipped on purpose: `Archive('novelty')` divides by
+    ``1+selected`` but scores with a temperature softmax, not DGM's
+    ``sigmoid(10*(s-0.5))`` -- close enough to look right and wrong enough to
+    change a measured run.
+    """
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+
+    def select(self, ctx, n: int):
+        candidates = list(ctx.candidates)
+        if len(candidates) <= 1:
+            return [ctx.head] * n
+        weights = dgm_parent_weights(
+            [c.score or 0.0 for c in candidates],
+            [c.selected for c in candidates])
+        return self.rng.choices(candidates, weights=weights, k=n)
+
+
 # ===========================================================================
 # The self-improving coding agent (its harness = its editable "codebase")
 # ===========================================================================
@@ -288,10 +316,12 @@ class DGMArchiveAggregator(AggregatorProtocol):
     """DGM's optimizer: keep-all archive + staged eval + sigmoid×novelty selection."""
 
     def __init__(self, ledger: Ledger, verifier, ctx: DGMContext,
-                 artifact_id: str = "coding_agent"):
+                 artifact_id: str = "coding_agent",
+                 selection: Optional[DGMParentSelection] = None):
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
+        self.selection = selection or DGMParentSelection(ctx.rng)
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread
@@ -343,8 +373,16 @@ class DGMArchiveAggregator(AggregatorProtocol):
             self.ctx.best_score = max(self.ctx.best_score, child.score)
         parent.children += 1                               # this parent was explored
 
-        # DGM parent selection: sample the next head ~ sigmoid(perf) x 1/(1+children).
-        self.head_index = choose_selfimproves(self.ctx.archive, 1, self.ctx.rng)[0]
+        # DGM parent selection at the standard seam: sample the next head
+        # ~ sigmoid(perf) x 1/(1+children). Candidate.version carries the
+        # archive index so the pick maps straight back.
+        from agentdescent.selection import Candidate, SelectionContext
+        rows = [Candidate(artifact_id=self.aid, version=i,
+                          score=a.score, selected=a.children)
+                for i, a in enumerate(self.ctx.archive)]
+        ctx = SelectionContext(head=rows[self.head_index],
+                               candidates=tuple(rows), n_workers=1)
+        self.head_index = self.selection.select(ctx, 1)[0].version
         target = ",".join(sorted(self.ctx.archive[self.head_index].capabilities))
         committed = None
         if target != head.state.get("capabilities"):

--- a/examples/evoskill/evoskill_skill_discovery.py
+++ b/examples/evoskill/evoskill_skill_discovery.py
@@ -259,6 +259,23 @@ class Frontier:
         return max(self.members, key=lambda m: m[1])       # strategy="best"
 
 
+class FrontierBest:
+    """EvoSkill's parent rule at the standard selection seam.
+
+    A :class:`~agentdescent.selection.SelectionPolicy`: pick the frontier's
+    best-scoring member (upstream ``strategy="best"``). Local rather than the
+    shipped ``Beam(1)`` so the tie-break stays byte-identical to the inline
+    ``max`` it replaces (first maximal member wins, in admission order).
+    """
+
+    def select(self, ctx, n: int):
+        candidates = list(ctx.candidates)
+        if not candidates:
+            return [ctx.head] * n
+        best = max(candidates, key=lambda c: c.score or 0.0)
+        return [best] * n
+
+
 # ===========================================================================
 # Dataset: OfficeQA (real, HF-gated) with a bundled-sample fallback
 # ===========================================================================
@@ -461,10 +478,12 @@ class TopKFrontierAggregator(AggregatorProtocol):
     """EvoSkill's optimizer: the bounded top-K aggregate frontier."""
 
     def __init__(self, ledger: Ledger, verifier, ctx: EvoSkillContext,
-                 artifact_id: str = "skill_library"):
+                 artifact_id: str = "skill_library",
+                 selection: Optional[FrontierBest] = None):
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
+        self.selection = selection or FrontierBest()
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread
@@ -511,7 +530,15 @@ class TopKFrontierAggregator(AggregatorProtocol):
                 f"{skill_name(list(card.diff.ops)[0])}: "
                 f"{'admitted' if admitted else 'discarded'} (val {score:.3f})")
 
-        parent_state, _ = self.ctx.frontier.select_parent()   # strategy="best"
+        # strategy="best" at the standard seam: frontier members become
+        # Candidates (version = member index) and FrontierBest picks the parent.
+        from agentdescent.selection import Candidate, SelectionContext
+        rows = [Candidate(artifact_id=self.aid, version=i, state=dict(state),
+                          score=score)
+                for i, (state, score) in enumerate(self.ctx.frontier.members)]
+        sel_ctx = SelectionContext(head=rows[0] if rows else None,
+                                   candidates=tuple(rows), n_workers=1)
+        parent_state = dict(self.selection.select(sel_ctx, 1)[0].state)
         report_diff = committed = None
         if parent_state != head.state:
             try:

--- a/examples/gepa/gepa_prompt_evolution.py
+++ b/examples/gepa/gepa_prompt_evolution.py
@@ -170,6 +170,34 @@ def pareto_select(scores: List[List[float]], rng: random.Random) -> int:
     return rng.choices(cands, weights=weights, k=1)[0]
 
 
+class ParetoWinFrequency:
+    """GEPA's Algorithm-2 sampling at the standard selection seam.
+
+    A :class:`~agentdescent.selection.SelectionPolicy` whose candidates carry
+    their per-instance rows in ``Candidate.per_task``; ``select`` rebuilds the
+    aligned score matrix and defers to :func:`pareto_select`, so the rng call
+    order -- and therefore every seeded run -- is identical to the inline rule
+    it replaces.
+
+    Local rather than the shipped ``ParetoFrontier`` on purpose: the shipped
+    policy walks the frontier round-robin, GEPA samples it weighted by how many
+    instances a candidate *uniquely* wins. Same frontier, different draw --
+    close enough to look right and wrong enough to change a measured run.
+    """
+
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+
+    def select(self, ctx, n: int):
+        candidates = list(ctx.candidates)
+        if len(candidates) <= 1:
+            return [ctx.head] * n
+        tasks = sorted({t for c in candidates for t in c.per_task})
+        scores = [[c.per_task.get(t, 0.0) for t in tasks] for c in candidates]
+        k = pareto_select(scores, self.rng)
+        return [candidates[k]] * n
+
+
 # ===========================================================================
 # The optimizer: swap evolve()'s greedy aggregator for Pareto illumination
 # ===========================================================================
@@ -194,11 +222,13 @@ class ParetoAggregator(AggregatorProtocol):
     ``D_pareto`` row and is unaffected."""
 
     def __init__(self, ledger: Ledger, verifier, audit, config, policy,
-                 artifact_id: str = "gepa_prompt", seed: int = 0):
+                 artifact_id: str = "gepa_prompt", seed: int = 0,
+                 selection: Optional[ParetoWinFrequency] = None):
         self.ledger = ledger
         self.verifier = verifier
         self.artifact_id = artifact_id
         self.rng = random.Random(seed)
+        self.selection = selection or ParetoWinFrequency(self.rng)
         self._cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread
         # pool: list of (state_dict, per_instance_scores, avg). Parallel lists so
@@ -275,8 +305,17 @@ class ParetoAggregator(AggregatorProtocol):
             self._admit(candidate)
             admitted += len(self.states) - before
 
-        # Algorithm 2: sample the next parent from the Pareto frontier.
-        k = pareto_select(self.scores, self.rng)
+        # Algorithm 2 at the standard seam: candidates carry their per-instance
+        # rows in Candidate.per_task; version carries the pool index.
+        from agentdescent.selection import Candidate, SelectionContext
+        task_ids = [t.id for t in self.verifier.held_out]
+        rows = [Candidate(artifact_id=self.artifact_id, version=i,
+                          state=dict(state),
+                          score=sum(row) / len(row) if row else 0.0,
+                          per_task=dict(zip(task_ids, row)))
+                for i, (state, row) in enumerate(zip(self.states, self.scores))]
+        ctx = SelectionContext(head=rows[0], candidates=tuple(rows), n_workers=1)
+        k = self.selection.select(ctx, 1)[0].version
         target_state = self.states[k]
         report_diff = None
         committed_version = None

--- a/examples/openevolve/openevolve_program_evolution.py
+++ b/examples/openevolve/openevolve_program_evolution.py
@@ -191,6 +191,33 @@ def _program_summary(program: Program) -> Dict[str, Any]:
     }
 
 
+class EpsilonGreedy:
+    """OpenEvolve's in-pool parent rule at the standard selection seam.
+
+    A :class:`~agentdescent.selection.SelectionPolicy`: with probability
+    ``exploitation_ratio`` take the pool's best-fitness member (first maximal
+    wins, as the inline ``max`` did), otherwise draw uniformly. It shares the
+    archive's rng, and consumes it in the same order as the inline rule --
+    one ``random()`` then at most one ``choice`` -- so seeded runs pick
+    identical parents. Islands, MAP-Elites cells, and ring migration are the
+    upstream mechanism itself and stay on the archive.
+    """
+
+    def __init__(self, rng, exploitation_ratio: float) -> None:
+        self.rng = rng
+        self.exploitation_ratio = exploitation_ratio
+
+    def select(self, ctx, n: int):
+        candidates = list(ctx.candidates)
+        if not candidates:
+            return [ctx.head] * n
+        if self.rng.random() < self.exploitation_ratio:
+            pick = max(candidates, key=lambda c: c.score or 0.0)
+        else:
+            pick = self.rng.choice(candidates)
+        return [pick] * n
+
+
 @dataclass
 class OpenEvolveArchive:
     """Thread-safe MAP-Elites and island state shared by proposers and merger."""
@@ -308,10 +335,16 @@ class OpenEvolveArchive:
             pool_ids = island_ids or archive_ids
             if not pool_ids:
                 raise RuntimeError("OpenEvolve archive has no parent candidates")
-            if self._rng.random() < self.exploitation_ratio:
-                parent_id = max(pool_ids, key=lambda pid: self._fitness(self.programs[pid]))
-            else:
-                parent_id = self._rng.choice(pool_ids)
+            # The epsilon-greedy pick at the standard seam (version = pool index).
+            from agentdescent.selection import Candidate, SelectionContext
+            if not hasattr(self, "_selection") or self._selection is None:
+                self._selection = EpsilonGreedy(self._rng, self.exploitation_ratio)
+            rows = [Candidate(artifact_id="openevolve", version=i,
+                              score=self._fitness(self.programs[pid]))
+                    for i, pid in enumerate(pool_ids)]
+            sel_ctx = SelectionContext(head=rows[0], candidates=tuple(rows),
+                                       n_workers=1)
+            parent_id = pool_ids[self._selection.select(sel_ctx, 1)[0].version]
             parent = self.programs[parent_id]
             best = self.programs[self.best_id]
             inspiration_id = max(

--- a/examples/skillopt/skillopt_skill_training.py
+++ b/examples/skillopt/skillopt_skill_training.py
@@ -329,14 +329,39 @@ def make_propose(ctx: SkillOptContext, complete: Completion):
     return propose
 
 
+class StrictImprovement:
+    """SkillOpt's gate at the standard acceptance seam.
+
+    An :class:`~agentdescent.policies.AcceptancePolicy` over genuine
+    ``MergeContext`` records: commit only a candidate whose **full held-out**
+    EM strictly beats the current document's. No Beta draw, no annealing --
+    SkillOpt's rule is deliberately harsher than the shipped statistical gate,
+    and naming it at the seam records that as a decision rather than a loop
+    detail.
+    """
+
+    def accept(self, ctx):
+        from agentdescent.policies import AcceptDecision, MergeContext
+        base = MergeContext.rate(ctx.base_counts)
+        cand = MergeContext.rate(ctx.cand_counts)
+        improved = cand > base
+        return AcceptDecision(
+            accept=improved,
+            category="" if improved else "strict-gate",
+            detail=f"val EM {base:.3f} -> {cand:.3f}",
+            observed_delta=cand - base)
+
+
 class StrictGateAggregator(AggregatorProtocol):
     """SkillOpt's optimizer: strict held-out EM gate + rejected-edit buffer + LR."""
 
     def __init__(self, ledger: Ledger, verifier, ctx: SkillOptContext,
-                 artifact_id: str = "skill_document"):
+                 artifact_id: str = "skill_document",
+                 acceptance: Optional[StrictImprovement] = None):
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
+        self.acceptance = acceptance or StrictImprovement()
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread
@@ -358,9 +383,16 @@ class StrictGateAggregator(AggregatorProtocol):
         with self._lock:
             cards, self.cards = self.cards, []
         best = None
+        n = max(1, len(self.verifier.held_out))
         for card in cards:                                 # pick the best strict improver
-            em = head.apply(card.diff).score(self.verifier.held_out)
-            if em > self.current_em and (best is None or em > best[1]):
+            from agentdescent.policies import MergeContext
+            candidate = head.apply(card.diff)
+            em = candidate.score(self.verifier.held_out)
+            decision = self.acceptance.accept(MergeContext(
+                artifact=head, candidate=candidate, cards=[card],
+                base_counts=(self.current_em * n, (1 - self.current_em) * n),
+                cand_counts=(em * n, (1 - em) * n), diff=card.diff))
+            if decision.accept and (best is None or em > best[1]):
                 best = (card, em)
 
         report_diff = committed = None


### PR DESCRIPTION
Follow-up to #109 (merged): the seven legacy ports, migrated one commit each so every step is reviewable and bisectable.

**Discipline: uniform shape, unchanged behaviour.** Each port's inline parent/gate rule becomes a named policy class consumed by its aggregator through the standard seam contract (`SelectionPolicy` / `AcceptancePolicy`). Where the upstream rule matches a shipped policy byte-for-byte, the shipped one is used; where it differs, a local subclass documents the difference — close-enough-to-look-right is exactly what a measured run cannot afford.

| Port | Extracted rule | Policy | Equivalence argument |
|---|---|---|---|
| DGM | `sigmoid(10·(s−0.5)) × 1/(1+children)` sampling | local `DGMParentSelection` | same single `rng.choices` call → identical seeded picks |
| GEPA | per-instance Pareto, win-frequency sampling | local `ParetoWinFrequency` (rows in `Candidate.per_task`) | defers to `pareto_select`; rng order unchanged; spot-check inline==policy |
| SkillOpt | strict full-held-out EM gate | local `StrictImprovement` on genuine `MergeContext` | rate reconstruction exact (em·n/n) |
| ACE | — (mechanism is the `ACEPlaybook` strategy) | docs note only | no optimizer existed to migrate |
| EvoSkill | best-of-frontier parent | local `FrontierBest` | inline `max` tie-break preserved |
| ADAS | best-of-archive head | **shipped `Beam(1)`** | stable sort ≡ strictly-greater tracking — the one exact match |
| OpenEvolve | ε-greedy in-pool pick | local `EpsilonGreedy` | shares the archive rng, same consumption order |

Archive/frontier/island structures stay on the aggregators — they are the upstream mechanisms themselves, and `aggregator_factory` remains their sanctioned home (see `docs/aggregator-factory.md`). Every port's offline tests pass unchanged; `mkdocs build --strict` green; the seam docs pages list the new classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)