### PR TITLE
fix: CI-breaking doc anchor + knife-edge acceptance test

### DIFF
--- a/docs/algo-evoskill.md
+++ b/docs/algo-evoskill.md
@@ -141,7 +141,7 @@ where it pays — the held-out eval runs concurrently (`eval_concurrency`) and a
 round's workers run concurrently (`max_concurrency`). Wall-clock was ~3 h,
 essentially `15 candidates × 30-item val`. The OpenHands backend's setup, the
 DeepSeek structured-output shim, and the Python ≥ 3.12 requirement are documented
-in [Connecting agents & LLMs → Tool-using agent backends](agents.md#running-the-openhands-backend).
+in [Backends → `openhands`](backends.md#openhands-a-real-openhands-agent).
 
 ## Dataset caveat
 

--- a/tests/test_merge_diagnostics.py
+++ b/tests/test_merge_diagnostics.py
@@ -10,7 +10,15 @@ TASKS = [Task(id=str(i), prompt="p", meta={"gold": "g"}) for i in range(6)]
 
 
 def _run(**kw):
-    return evolve(TASKS, lambda t, o: 0.5, run=lambda a, t: "x",
+    # The proposal must be *decisively* unhelpful: with candidate and baseline
+    # held-out rewards exactly equal, P(delta>0) sits on the annealed threshold
+    # and the accept draw is a near coin flip -- ~3% of seeded runs committed
+    # the no-op diff in round 1, after which SingleSlot deduped every later
+    # proposal and `below-threshold` never appeared. A strictly worse candidate
+    # keeps the test's point (proposals reach the gate and fail) without the
+    # knife edge; defaults.py labels the measured drop `below-threshold` too.
+    return evolve(TASKS, lambda t, o: 0.5 if o == "x" else 0.2,
+                  run=lambda a, t: "x" if a == "v" else "y",
                   propose=lambda *a: "does not help",
                   strategy=SingleSlot(initial_value="v"),
                   rounds=4, held_out_frac=0.5, **kw)


### PR DESCRIPTION
Two test failures, one hotfix:

1. **CI red since #112**: `test_docs_links.py::test_every_internal_anchor_exists` — algo-evoskill.md linked `agents.md#running-the-openhands-backend`, an anchor the freshness pass removed when collapsing that section into a pointer at backends.md. `mkdocs --strict` doesn't check anchors; the repo's own link test does. Repointed at backends.md's real heading.

2. **The ~3% flake in `test_rejections_name_a_category`**, reproduced and measured (2/60 trials): candidate and baseline held-out rewards were *exactly equal*, so `P(Δ>0)` sat on the annealed acceptance threshold — a near coin flip. When the no-op diff committed in round 1, `SingleSlot` deduped every later identical proposal and `below-threshold` never appeared (`outcomes == {'committed': 1}`). The proposal is now decisively unhelpful (strictly worse on held-out), which keeps the test's point — proposals reach the gate and fail — without the knife edge; `defaults.py` labels the measured-drop path `below-threshold` too. 30/30 consecutive runs green.

Link + diagnostics tests green locally; full suite green; `mkdocs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)