### PR TITLE
the matrix's third arm: async, with the counters that make its quality column readable (#73)

### DIFF
--- a/bench/matrix_run.py
+++ b/bench/matrix_run.py
@@ -1,12 +1,22 @@
-"""The parallelisation matrix: every port, serial against N workers, equal budget.
+"""The parallelisation matrix: every port, serial / parallel / async, equal budget.
 
-One row per algorithm, two arms per row, `--budget-rollouts` pinned to the same
-value on both. That pin is the whole point. Six of the seven ports pass a fixed
+One row per algorithm, three arms per row, `--budget-rollouts` pinned to the
+same value on all of them. That pin is the whole point. Six of the seven ports
+pass a fixed
 iteration count and let `n_workers` multiply it, so an unbudgeted `N=8` arm runs
 eight times the rollouts of the `--serial` arm -- measured on the engine at
 `rounds=24`: 192 rollouts against 24. A wall-clock read across that gap is eight
 times the model spend reported as parallel efficiency, and the quality column
 beside it credits the extra spend to parallelism.
+
+The `async` arm is the same width barrier-free (`--async`), where a diff can be
+proposed against a head the merger has since moved. Its `--max-seconds` is set
+to the cell timeout so the wall-clock never binds before the rollout budget --
+the async runtime has no unbounded mode, and its own defaults (tens of seconds)
+would otherwise silently become the stop condition, reporting a wall-clock cap
+as a converged run. Read `stale_discarded`/`stale_considered` on every async
+cell: a quality drop with a high stale rate is the lag budget, not the
+algorithm, and those need opposite fixes.
 
 **Results are written after every cell**, because a full sweep is many hours of
 real model time and a sweep that only reports at the end reports nothing when it
@@ -70,7 +80,10 @@ ROWS = [
          width_flag="--selfimprove-size", size=[]),
     dict(name="openevolve", module="examples.openevolve.openevolve_program_evolution",
          dataset="function minimization", width_flag="--workers",
-         size=["--task-count", "8"], needs="bwrap"),
+         # `--tasks`, not `--task-count`: the run function's parameter is named
+         # task_count and the flag never was, so this row crashed argparse on
+         # its first live cell.
+         size=["--tasks", "8"], needs="bwrap"),
 ]
 
 #: Pulled out of each port's own stdout rather than re-derived, so a row reports
@@ -92,6 +105,14 @@ PATTERNS = {
     # which is what a speedup between two arms should be computed from when one
     # arm was unlucky. Only printed by ports once Usage carries it.
     "failure_seconds": r"failed \(([\d.]+)s lost\)",
+    # The engine's own counters, printed by `examples._common.report_engine` in
+    # one shared format. `engine_rollouts` is measured spend where `rollouts`
+    # above is what the port's stdout happened to say; the stale pair is the
+    # async arm's quality-drop diagnosis, numerator WITH denominator.
+    "engine_rollouts": r"engine counters: rollouts=([\d,]+)",
+    "stale_considered": r"stale_considered=([\d,]+)",
+    "stale_discarded": r"stale_discarded=([\d,]+)",
+    "redispatched": r"redispatched=([\d,]+)",
 }
 
 
@@ -127,6 +148,13 @@ def _cell(row: dict, arm: str, seed: int, args) -> Dict:
         cmd += ["--serial"]
     else:
         cmd += [row["width_flag"], str(args.width)]
+    if arm == "async":
+        # The cell timeout as the wall-clock budget: the async runtime refuses to
+        # run unbounded, and the ports' own --max-seconds defaults (15-45s) would
+        # otherwise stop the arm long before `--budget-rollouts` binds -- the one
+        # comparison this matrix exists to make.
+        cmd += ["--async", "--async-ratio", str(args.async_ratio),
+                "--max-seconds", str(args.timeout)]
     if not row.get("offline"):
         cmd += ["--provider", args.provider, "--model", args.model]
 
@@ -175,6 +203,7 @@ def _save(path: Optional[str], cells: List[Dict], args) -> None:
     os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
     with open(path, "w", encoding="utf-8") as handle:
         json.dump({"budget_rollouts": args.budget, "width": args.width,
+                   "async_ratio": args.async_ratio,
                    "model": args.model, "provider": args.provider,
                    "cells": cells}, handle, indent=2)
 
@@ -186,6 +215,10 @@ def main(argv=None) -> None:
     p.add_argument("--width", type=int, default=8, help="workers in the parallel arm")
     p.add_argument("--seeds", default="0,1,2")
     p.add_argument("--rows", default="", help="comma-separated subset of row names")
+    p.add_argument("--arms", default="serial,parallel,async",
+                   help="comma-separated subset of arms to run")
+    p.add_argument("--async-ratio", type=int, default=3,
+                   help="staleness lag budget for the async arm")
     p.add_argument("--provider", default="claude")
     p.add_argument("--model", default="GLM-5.2")
     p.add_argument("--eval-concurrency", type=int, default=16,
@@ -203,15 +236,18 @@ def main(argv=None) -> None:
 
     cells = _load(args.json)
     done = {(c["row"], c["arm"], c["seed"]) for c in cells}
-    arms = ("serial", "parallel")
+    known = ("serial", "parallel", "async")
+    arms = tuple(a.strip() for a in args.arms.split(",") if a.strip())
+    if bad := [a for a in arms if a not in known]:
+        raise SystemExit(f"unknown arm(s) {bad}; choose from {known}")
     todo = [(r, a, s) for r in rows for s in seeds for a in arms
             if (r["name"], a, s) not in done]
 
     print(f"matrix: {len(rows)} rows x {len(arms)} arms x {len(seeds)} seeds "
           f"= {len(rows) * len(arms) * len(seeds)} cells, {len(done)} already done, "
           f"{len(todo)} to run")
-    print(f"budget: {args.budget} rollouts on BOTH arms; parallel arm width "
-          f"{args.width}\n")
+    print(f"budget: {args.budget} rollouts on EVERY arm; parallel/async width "
+          f"{args.width}, async lag budget {args.async_ratio}\n")
     if not args.yes:
         print("pass --yes to run (this spends real model time)")
         return

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -209,6 +209,24 @@ def budget_kwargs(args: argparse.Namespace) -> dict:
             if getattr(args, "budget_rollouts", None) else {})
 
 
+def report_engine(result) -> None:
+    """Print the engine's own counters in the one format the matrix parses.
+
+    ``bench/matrix_run.py`` reads a port through its stdout, and until this line
+    existed the ports printed *their* numbers (test score, usage) but never the
+    engine's: measured rollouts rather than the budget, and staleness with its
+    denominator. The async arm's quality column is unreadable without the
+    latter -- "the score dropped" with no ``stale_discarded`` beside it cannot
+    distinguish a lag-budget problem from a reflector problem, which need
+    opposite fixes. One shared implementation, because seven hand-rolled copies
+    of a parsed format is how the ACE ``model usage  :`` two-space bug happened.
+    """
+    print(f"engine counters: rollouts={result.rollouts}  "
+          f"stale_considered={result.stale_considered}  "
+          f"stale_discarded={result.stale_discarded}  "
+          f"redispatched={result.redispatched}", flush=True)
+
+
 def is_openai_compatible(args: argparse.Namespace) -> bool:
     """Whether ``--provider`` selects the OpenAI-compatible adapter."""
     return args.provider in OPENAI_COMPATIBLE

--- a/examples/ace/ace_context_evolution.py
+++ b/examples/ace/ace_context_evolution.py
@@ -60,7 +60,7 @@ from agentdescent.parallel import DataParallel
 from agentdescent.sampling import DifficultyWeighted, RoundRobin
 from examples._common import (add_standard_args, completion_for, confirm,
                               score_tasks, worker_count,
-                              budget_kwargs)
+                              budget_kwargs, report_engine)
 
 FINER = ("nlpaueb/finer-139", "validation", "finer-139")   # (dataset, split, config)
 
@@ -388,6 +388,7 @@ def main(argv=None) -> None:
     print(f"test accuracy: {test_acc:.3f}  (held out, never seen by the Curator)")
     print(f"bullets curated: {len(result.state)}")
     print(f"stop reason  : {result.stop_reason}")
+    report_engine(result)
     if result.error:
         print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print(f"model usage  : {usage.summary()}")

--- a/examples/adas/adas_meta_agent_search.py
+++ b/examples/adas/adas_meta_agent_search.py
@@ -62,7 +62,7 @@ from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 from examples._common import (add_standard_args, completion_for, confirm,
                               is_openai_compatible, worker_count,
-                              budget_kwargs)
+                              budget_kwargs, report_engine)
 
 MGSM_URL = "https://raw.githubusercontent.com/ShengranHu/ADAS/main/dataset/mgsm/mgsm_{lang}.tsv"
 # ADAS's MGSM language set (utils.ALL_LANGUAGES).
@@ -975,6 +975,8 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
            eval_concurrency=EVAL_CONCURRENCY,
            held_out_frac=held_out_frac, aggregator_factory=factory, verbose=verbose,
            max_rollouts=max_rollouts)
+    if verbose:
+        report_engine(out)
     return SearchResult(ctx.archive, ctx.best_agent or {}, ctx.seed_fitness,
                         ctx.best_fitness, ctx.best_seed or {},
                         out.outcomes(), out.stop_reason, out.error)

--- a/examples/dgm/dgm_self_improve.py
+++ b/examples/dgm/dgm_self_improve.py
@@ -69,7 +69,7 @@ from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 from examples._common import (add_standard_args, completion_for, confirm,
                               worker_count,
-                              budget_kwargs)
+                              budget_kwargs, report_engine)
 
 SWEBENCH = ("princeton-nlp/SWE-bench_Verified", "test", "default")   # (dataset, split, config)
 
@@ -436,14 +436,16 @@ def run_dgm(instances: List[dict], generations: int = 12,
     def factory(ledger, verifier, audit, config, policy):
         return DGMArchiveAggregator(ledger, verifier, ctx, artifact_id="coding_agent")
 
-    evolve(tasks, reward, run=run, propose=propose, strategy=HarnessStrategy(),
-           blast_radius=0.6, artifact_id="coding_agent", rounds=generations,
-           n_workers=selfimprove_size,
-           max_concurrency=1 if asynchronous else selfimprove_size,
-           asynchronous=asynchronous, async_ratio=async_ratio,
-           max_seconds=max_seconds if asynchronous else None,
-           held_out_frac=0.5, aggregator_factory=factory, verbose=verbose,
-           max_rollouts=max_rollouts)
+    result = evolve(tasks, reward, run=run, propose=propose, strategy=HarnessStrategy(),
+                    blast_radius=0.6, artifact_id="coding_agent", rounds=generations,
+                    n_workers=selfimprove_size,
+                    max_concurrency=1 if asynchronous else selfimprove_size,
+                    asynchronous=asynchronous, async_ratio=async_ratio,
+                    max_seconds=max_seconds if asynchronous else None,
+                    held_out_frac=0.5, aggregator_factory=factory, verbose=verbose,
+                    max_rollouts=max_rollouts)
+    if verbose:
+        report_engine(result)
     best = max(ctx.archive, key=lambda a: a.score)
     return DGMResult(ctx.archive, best, ctx.seed_score, best.score)
 

--- a/examples/evoskill/evoskill_skill_discovery.py
+++ b/examples/evoskill/evoskill_skill_discovery.py
@@ -60,7 +60,7 @@ from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 from examples._common import (add_standard_args, completion_for, confirm,
                               is_openai_compatible, worker_count,
-                              budget_kwargs)
+                              budget_kwargs, report_engine)
 
 RAW = "https://raw.githubusercontent.com/sentient-agi/EvoSkill/main/examples/officeqa/data"
 Completion = Callable[[str], str]
@@ -744,6 +744,8 @@ def run_evoskill(complete: Completion, docs: Dict[str, str],
                     self_verify=False,   # repo evaluates the child on val only -- no per-trajectory re-run
                     aggregator_factory=factory, verbose=verbose,
                     max_rollouts=max_rollouts)
+    if verbose:
+        report_engine(result)
 
     best = ctx.best_score
     if eval_at_end and val:
@@ -823,6 +825,9 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
     add_standard_args(p, max_seconds_default=40.0)
     p.add_argument("--iterations", type=int, default=6)
+    p.add_argument("--workers", type=int, default=3,
+                   help="failure-analysis workers per round; the upstream loop "
+                        "is serial, so this is the AgentDescent-added width")
     p.add_argument("--frontier", type=int, default=5,
                    help="bounded top-K frontier size "
                         "(src/registry/manager.py:update_frontier uses 5)")
@@ -844,7 +849,7 @@ def main(argv=None) -> None:
     # --serial collapses this to the upstream algorithm's own semantics:
     # one worker, nothing to merge. Applied to args so the printed plan,
     # the cost estimate and the run cannot disagree about what ran.
-    args.workers = worker_count(args, 3)
+    args.workers = worker_count(args, args.workers)
 
     print("Algorithm: EvoSkill -- failure-driven skill discovery (top-K frontier)")
     print(f"Dataset  : selection={args.dataset} (OfficeQA preferred; FinQA fallback)")

--- a/examples/gepa/gepa_prompt_evolution.py
+++ b/examples/gepa/gepa_prompt_evolution.py
@@ -57,7 +57,7 @@ from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 from examples._common import (add_standard_args, completion_for, confirm,
                               score_tasks, worker_count,
-                              budget_kwargs, capped_val)
+                              budget_kwargs, capped_val, report_engine)
 
 HOTPOTQA = ("hotpotqa/hotpot_qa", "validation", "distractor")   # (dataset, split, config)
 
@@ -648,6 +648,7 @@ def main(argv=None) -> None:
     print(f"best D_pareto EM   : {agg.best_avg:.3f}")
     print(f"test EM            : {test_em:.3f}  (held out, never seen by the optimizer)")
     print(f"stopped            : {result.stop_reason}")
+    report_engine(result)
     if result.error:
         print(f"WARNING: the run did not finish cleanly -- {result.error}")
     print(f"model usage: {usage.summary()}")

--- a/examples/openevolve/openevolve_program_evolution.py
+++ b/examples/openevolve/openevolve_program_evolution.py
@@ -61,6 +61,7 @@ from examples._common import (
     confirm,
     worker_count,
     is_openai_compatible,
+    report_engine,
 )
 from examples.openevolve._openevolve_support import (
     INITIAL_PROGRAM,
@@ -878,6 +879,8 @@ def run_agentdescent_openevolve(
             max_concurrency=1 if mode == "serial" else workers,
             **common,
         )
+    if verbose:
+        report_engine(result)
     wall_seconds = time.monotonic() - started
     test_seed = seed + task_count
     _, baseline_test, _ = evaluate_program_metrics(

--- a/examples/skillopt/skillopt_skill_training.py
+++ b/examples/skillopt/skillopt_skill_training.py
@@ -59,7 +59,7 @@ from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
 from examples._common import (add_standard_args, completion_for, confirm,
                               worker_count,
-                              budget_kwargs)
+                              budget_kwargs, report_engine)
 
 SEARCHQA = ("lucadiliello/searchqa", "default")   # (dataset, config)
 Completion = Callable[[str], str]
@@ -475,6 +475,8 @@ def run_skillopt(complete: Completion, train: List[dict], val: List[dict],
                     held_out_frac=len(val) / max(1, len(tasks)),
                     aggregator_factory=factory, verbose=verbose,
                     max_rollouts=max_rollouts)
+    if verbose:
+        report_engine(result)
     return SkillOptResult(result.rendered, ctx.seed_em, ctx.best_em,
                           ctx.accepted, ctx.rejected,
                           [h.held_out_reward for h in result.history],


### PR DESCRIPTION
Step 1 of the #73 parallelisation matrix: the harness could compare serial against N workers and stop there. The claim the issue asks that table to carry — that AgentDescent is an acceleration layer you can wrap around a published serial algorithm — needs the barrier-free arm too, because that is where the cost shows up.

## What is here

**`bench/matrix_run.py` grows a third arm.** `--arms serial,parallel,async`, with `--async-ratio` as the lag budget. The async arm runs at the same width as the parallel arm, so the only difference between them is the barrier.

**The async arm passes `--max-seconds` explicitly.** The async runtime has no unbounded mode and the ports' own defaults are 15–45 seconds — small enough that the wall-clock would stop every async cell long before `--budget-rollouts` bound. The arm would then report a truncated run as a converged one. The cell timeout goes in instead, so the rollout budget is the only stop condition that can fire. (Budget mapping confirmed: `evolve(asynchronous=True, max_rollouts=B)` becomes `async_evolve(max_iters=B)`, so all three arms are equal-budget.)

**`examples._common.report_engine()` puts the engine's counters on stdout,** in one shared parsed format across all seven ports: measured `rollouts`, `stale_considered`/`stale_discarded` (numerator *with* denominator), `redispatched`. Without the stale pair an async cell that scores lower is unreadable — "the lag budget is too high" and "the reflector is weak" look identical and need opposite fixes. One implementation rather than seven, because a parsed format copied seven times is how the ACE two-space `model usage  :` bug happened.

## Two bugs the dry-run found

Both would have crashed on their first live cell, hours into a sweep:

- the OpenEvolve row passed `--task-count` to a port whose flag is `--tasks`
- EvoSkill had no `--workers` flag at all — the worker count was the literal `3` inside `main`, so every parallel and async cell of that row was an argparse error waiting for the sweep to reach it

## Verification

- all 7 rows × 3 arms dry-run clean through the exact command shape `_cell()` builds
- DGM's offline path run live on the serial and async arms; the `engine counters:` line prints and all four fields parse back out
- 82 example tests pass, 1 skipped

## Not here

The sweep itself. This is the harness; running it is real model time and a separate decision. The existing `bench/results/matrix-gepa-b16-w8-seed0-clean.json` already holds a hand-run GEPA async cell (742s / test 0.65, against serial 2148s / 0.75 and parallel 1022s / 0.60) — useful as a pilot reference, though it predates the counters and would be worth re-running.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)