### PR TITLE
the semantics column, generated beside the rows — and the one row it caught (#73)

### DIFF
--- a/bench/matrix_report.py
+++ b/bench/matrix_report.py
@@ -1,0 +1,254 @@
+"""Render the parallelisation matrix as the table issue #73 asks for.
+
+Reads the cells `bench/matrix_run.py` wrote and emits one row per algorithm:
+serial against the parallel and async arms, the speedup between them, the
+held-out quality delta, and **what each arm changed about the published
+algorithm**. That last column is not written here and not written by hand --
+it is :data:`bench.matrix_run.SEMANTICS`, and a row with no entry there is
+refused rather than rendered blank. A speedup table whose semantics column is
+empty is a claim that nothing changed, made by omission.
+
+    python -m bench.matrix_report --json bench/results/matrix.json
+
+Three things this refuses to do quietly, because each of them turns a number
+into a different number wearing the same name:
+
+* **Report a speedup across unequal budgets.** The arms are only comparable
+  because `--budget-rollouts` pinned them; where the cells recorded what they
+  actually spent (`engine_rollouts`) and the arms disagree by more than the
+  synchronous path's `N-1` barrier overshoot, the row says so instead of
+  dividing.
+* **Report a speedup off raw wall-clock when an arm hit bad endpoint weather.**
+  `wall_seconds - failure_seconds` is the basis where the port reported the
+  failure time; a retry storm in one arm is not a property of its scheduler.
+* **Print a single seed as a result.** Fewer than three seeds renders the
+  number with the count attached, so a pilot cannot be read as a measurement.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import statistics
+import sys
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from bench.matrix_run import ROWS, SEMANTICS
+
+ARMS = ("serial", "parallel", "async")
+#: Seeds below this cannot support a spread; the same bar as everywhere else.
+MIN_SEEDS = 3
+
+
+def _cells_by_arm(cells: Sequence[dict], row: str) -> Dict[str, List[dict]]:
+    out: Dict[str, List[dict]] = {arm: [] for arm in ARMS}
+    for cell in cells:
+        if cell.get("row") == row and cell.get("arm") in out and "error" not in cell:
+            out[cell["arm"]].append(cell)
+    return out
+
+
+def _net_wall(cell: dict) -> Optional[float]:
+    """Wall-clock net of time lost inside failed calls, when the port reported it.
+
+    A cell whose endpoint spent ten minutes in retry backoff did not take that
+    long to *evolve* anything, and the arm that was unlucky is not the arm with
+    the worse scheduler.
+    """
+    wall = cell.get("wall_seconds")
+    if wall is None:
+        return None
+    return max(0.0, wall - float(cell.get("failure_seconds", 0.0)))
+
+
+def _median(values: Iterable[Optional[float]]) -> Optional[float]:
+    rows = [v for v in values if v is not None]
+    return statistics.median(rows) if rows else None
+
+
+def _spread(values: Iterable[Optional[float]], digits: int = 2) -> str:
+    """Median with the min-max range beside it -- never a bare point estimate.
+
+    A single seed has no range to show, so it shows none; the row carries a
+    dagger and a caveat line instead, which says the same thing once rather
+    than in every cell.
+    """
+    rows = sorted(v for v in values if v is not None)
+    if not rows:
+        return "—"
+    med = statistics.median(rows)
+    if len(rows) == 1:
+        return f"{med:.{digits}f}"
+    return f"{med:.{digits}f} [{rows[0]:.{digits}f}–{rows[-1]:.{digits}f}]"
+
+
+def _budget_note(arms: Dict[str, List[dict]], width: int) -> str:
+    """Empty when the arms really did spend the same budget, a warning when not.
+
+    The pin is the whole comparison, so it is checked against what the cells
+    measured rather than trusted because a flag was passed. The synchronous path
+    checks at the round barrier, so a `width`-worker arm may legitimately
+    overshoot by up to `width - 1`.
+    """
+    spent = {arm: _median(c.get("engine_rollouts") for c in cells)
+             for arm, cells in arms.items() if cells}
+    known = {arm: v for arm, v in spent.items() if v is not None}
+    if len(known) < 2:
+        return ""
+    low, high = min(known.values()), max(known.values())
+    if high - low <= max(0, width - 1):
+        return ""
+    return (f"**unequal budget**: rollouts actually spent differ across arms "
+            f"({', '.join(f'{a}={v:.0f}' for a, v in sorted(known.items()))}) "
+            f"by more than the barrier overshoot — speedup withheld")
+
+
+def _speedup(arms: Dict[str, List[dict]], arm: str, blocked: bool) -> str:
+    if blocked:
+        return "withheld"
+    base = _median(_net_wall(c) for c in arms["serial"])
+    other = _median(_net_wall(c) for c in arms[arm])
+    if not base or not other:
+        return "—"
+    return f"{base / other:.2f}×"
+
+
+def _stale(arms: Dict[str, List[dict]]) -> str:
+    """The async arm's stale rate, numerator with denominator or not at all."""
+    considered = [c.get("stale_considered") for c in arms["async"]]
+    discarded = [c.get("stale_discarded") for c in arms["async"]]
+    total_c = sum(v for v in considered if v is not None)
+    total_d = sum(v for v in discarded if v is not None)
+    if not any(v is not None for v in considered):
+        return "not recorded"
+    if not total_c:
+        return "0 considered"
+    return f"{total_d}/{total_c} ({total_d / total_c:.0%})"
+
+
+def _quality(arms: Dict[str, List[dict]], arm: str) -> str:
+    """Held-out score for an arm, and its delta against the serial control."""
+    base = _median(c.get("test") for c in arms["serial"])
+    here = _median(c.get("test") for c in arms[arm])
+    if here is None:
+        return "—"
+    shown = _spread((c.get("test") for c in arms[arm]), digits=3)
+    if base is None:
+        return shown
+    return f"{shown} (Δ {here - base:+.3f})"
+
+
+def _seed_note(arms: Dict[str, List[dict]]) -> str:
+    counts = {arm: len(cells) for arm, cells in arms.items() if cells}
+    if not counts:
+        return ""
+    fewest = min(counts.values())
+    if fewest >= MIN_SEEDS:
+        return ""
+    return (f"{fewest} seed{'s' if fewest != 1 else ''} — below the {MIN_SEEDS} "
+            f"this repository requires before a number is a result")
+
+
+def render(payload: dict) -> str:
+    """The issue-73 table, plus the notes that keep each row readable."""
+    cells = payload.get("cells", [])
+    width = int(payload.get("width", 8) or 8)
+    budget = payload.get("budget_rollouts")
+    measured = {c.get("row") for c in cells}
+
+    out: List[str] = []
+    out.append("# The parallelisation matrix — measured")
+    out.append("")
+    out.append(f"Generated by `bench/matrix_report.py` from "
+               f"`{payload.get('_source', 'the cells file')}`. "
+               f"Budget: **{budget} rollouts pinned on every arm**; "
+               f"parallel and async width {width}; "
+               f"async lag budget {payload.get('async_ratio', '?')}; "
+               f"model `{payload.get('model')}` via `{payload.get('provider')}`.")
+    out.append("")
+    out.append("Speedup is computed from wall-clock **net of time lost inside "
+               "failed calls**, so one arm's retry storm is not reported as the "
+               "other arm's scheduler. Quality is the held-out test score: "
+               "median across seeds, with the range, and the delta against the "
+               "serial control.")
+    out.append("")
+    out.append("| Algorithm | Dataset | Serial | Parallel N=" + str(width)
+               + " | Async N=" + str(width) + " | Speedup sync / async "
+               "| Held-out Δ sync / async | Stale (async) |")
+    out.append("|---|---|---|---|---|---|---|---|")
+
+    notes: List[str] = []
+    for row in ROWS:
+        name = row["name"]
+        if name not in SEMANTICS:
+            raise SystemExit(
+                f"row {name!r} has no entry in bench.matrix_run.SEMANTICS. The "
+                f"semantics column is not optional: a speedup published beside a "
+                f"blank one claims by omission that the algorithm was untouched.")
+        arms = _cells_by_arm(cells, name)
+        if name not in measured:
+            out.append(f"| {name} | {row['dataset']} | — | — | — | — | — | — |")
+            continue
+        blocked = bool(_budget_note(arms, width))
+        walls = {arm: _spread((_net_wall(c) for c in arms[arm]), digits=0)
+                 for arm in ARMS}
+        # The dagger travels with the row so a reader scanning only the table
+        # cannot mistake a pilot for a measurement.
+        label = name + (" †" if _seed_note(arms) else "")
+        out.append(
+            f"| {label} | {row['dataset']} "
+            f"| {walls['serial']} s | {walls['parallel']} s | {walls['async']} s "
+            f"| {_speedup(arms, 'parallel', blocked)} / "
+            f"{_speedup(arms, 'async', blocked)} "
+            f"| {_quality(arms, 'parallel')} / {_quality(arms, 'async')} "
+            f"| {_stale(arms)} |")
+        for marker, text in (("", _budget_note(arms, width)),
+                             ("† ", _seed_note(arms))):
+            if text:
+                notes.append(f"* {marker}**{name}** — {text}")
+
+    if notes:
+        out += ["", "## Caveats the cells themselves raised", ""] + notes
+
+    out += ["", "## What each arm changed about the published algorithm", "",
+            "The column issue #73 says the table is worthless without. Source: "
+            "`bench.matrix_run.SEMANTICS`, declared beside the rows themselves "
+            "rather than written up afterwards.", "",
+            "| Algorithm | Serial (the control) | Parallel | Async |",
+            "|---|---|---|---|"]
+    for row in ROWS:
+        sem = SEMANTICS[row["name"]]
+        out.append(f"| {row['name']} | {sem['serial']} | {sem['parallel']} "
+                   f"| {sem['async']} |")
+
+    out += ["", "A row reading anything other than *rollout scheduling and merge "
+            "timing only* is either a bug or a finding, and either way its "
+            "speedup and quality numbers have to be read through it. "
+            "**The quality column is allowed to go down** — a table of all-green "
+            "more likely means the control arm was not really the control than "
+            "that asynchrony is free.", ""]
+    return "\n".join(out)
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--json", default="bench/results/matrix.json")
+    p.add_argument("--out", default="", help="write here instead of stdout")
+    args = p.parse_args(argv)
+
+    path = pathlib.Path(args.json)
+    if not path.exists():
+        raise SystemExit(f"no cells at {path} -- run `python -m bench.matrix_run` first")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["_source"] = str(path)
+    text = render(payload)
+    if args.out:
+        pathlib.Path(args.out).write_text(text, encoding="utf-8")
+        print(f"wrote {args.out}")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/matrix_run.py
+++ b/bench/matrix_run.py
@@ -86,6 +86,91 @@ ROWS = [
          size=["--tasks", "8"], needs="bwrap"),
 ]
 
+#: The expected answer in the "semantics changed" column, for every row and every
+#: arm: parallelising is allowed to change *when* work is scheduled and *when*
+#: diffs are merged, and nothing else (`docs/port-fidelity.md`).
+SCHEDULING_ONLY = "rollout scheduling and merge timing only"
+
+#: What each arm of each row changed about the published algorithm, keyed
+#: `row -> arm`. This lives beside :data:`ROWS` rather than in a doc because a
+#: column filled in after the fact is filled in by whoever is writing the
+#: results, from memory, once the numbers are already on the page -- and a blank
+#: or optimistic entry there makes the whole table unreadable rather than
+#: slightly incomplete. `bench/matrix_report.py` refuses to render a row that has
+#: no entry here, and `tests/test_matrix_semantics.py` refuses a row added to
+#: `ROWS` without one.
+#:
+#: The `serial` arm's entry describes the control itself: it is the upstream loop
+#: for six of the seven, and where it is *not* -- DGM -- saying so is the point,
+#: because a speedup is measured against whatever is written here.
+SEMANTICS = {
+    "ace": {
+        "serial": "upstream ACE: one worker, no merge",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "gepa": {
+        "serial": "upstream GEPA (single instruction module), one worker",
+        # `--reflective-merge` is in this row's `size`, so it is on in every arm
+        # including the control -- which is what keeps the arms comparable. On
+        # one worker there is nothing to merge and it is inert; from two workers
+        # up it changes what the Pareto pool *contains* (one merged candidate per
+        # round instead of one per worker) while leaving the selection rule
+        # itself untouched. That is a merge-timing change by the letter of the
+        # rule and a pool-contents change in effect, so it is named rather than
+        # folded into SCHEDULING_ONLY.
+        "parallel": SCHEDULING_ONLY + "; `--reflective-merge` admits one merged "
+                    "candidate per round instead of one per worker (Pareto "
+                    "selection unchanged, its input is not)",
+        "async": SCHEDULING_ONLY + "; `--reflective-merge` as above",
+    },
+    "evoskill": {
+        "serial": "upstream EvoSkill: bounded top-K aggregate frontier "
+                  "(`manager.py:update_frontier`), one worker",
+        "parallel": SCHEDULING_ONLY,
+        # Found by auditing the arms rather than by running them: the port swaps
+        # the aggregator on `asynchronous=True`. This is the admission rule, which
+        # `docs/port-fidelity.md` lists under "must not change" -- so this row's
+        # async cell measures a different algorithm from its serial cell, and its
+        # quality delta cannot be read as a cost of asynchrony.
+        "async": "**admission rule changed**: `SgdSkillAggregator` replaces the "
+                 "strict per-candidate top-K frontier -- every update is applied "
+                 "cheaply and held-out validation is amortised over `val_every` "
+                 "steps with rollback on regression. Not upstream's rule, and not "
+                 "the sync arm's either",
+    },
+    "skillopt": {
+        "serial": "upstream ReflACT: one edit batch per step, strict gate",
+        "parallel": SCHEDULING_ONLY + "; `--minibatch` is this port's name for "
+                    "the worker count, not upstream's minibatch of tasks",
+        "async": SCHEDULING_ONLY + "; `--minibatch` as above",
+    },
+    "adas": {
+        "serial": "upstream Meta Agent Search over the DSL substrate "
+                  "(the substrate is this port's standing departure), one worker",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "dgm": {
+        # Not a clean control, and the matrix has to say so before any speedup is
+        # read off this row: `--serial` reaches n_workers through
+        # `--selfimprove-size`, and for DGM that is the population, so the control
+        # arm is a population of one rather than upstream's default.
+        "serial": "**degenerate control**: `--serial` sets `selfimprove_size=1`, "
+                  "a population of one -- upstream's archive search with a "
+                  "single child per generation, not its default configuration",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "openevolve": {
+        "serial": "upstream OpenEvolve; `rounds = iterations // workers` already "
+                  "fixed total work, so this row was equal-budget before "
+                  "`--budget-rollouts` existed",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+}
+
 #: Pulled out of each port's own stdout rather than re-derived, so a row reports
 #: what the port reported. `rollouts` is the measured count, not the budget: the
 #: synchronous path checks at the round barrier and a wide arm can overshoot.

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -46,6 +46,18 @@ The "semantics changed" column of the matrix below is expected to read *"rollout
 scheduling and merge timing only"* on every row. A row saying anything else is
 either a bug or a finding, and either way it has to be written down.
 
+!!! note "That column is generated, not typed"
+    It is [`bench.matrix_run.SEMANTICS`](https://github.com/Birfy/agentdescent/blob/main/bench/matrix_run.py)
+    — one entry per row **per arm**, declared beside the rows the sweep runs, and
+    `bench/matrix_report.py` refuses to render a row that has no entry. A column
+    filled in afterwards is filled in from memory by whoever is writing up the
+    results, with the numbers already on the page; a blank one reads as "nothing
+    changed" rather than as "nobody checked".
+
+    Auditing the arms that way has already found one: **EvoSkill's async arm runs
+    a different admission rule from its own serial arm** (below). Six of the
+    seven ports use the same aggregator on all three arms; that one does not.
+
 Until [#75](selection.md)'s selection seam is wired to a multi-head ledger, each
 port's candidate-selection rule still lives in its own example file — so for now
 "we did not change it" is a claim a reader verifies by reading, and the last
@@ -96,6 +108,19 @@ column of each section below says exactly where to look.
 * **Why this one matters most**: it is the clearest case of the rule. A port
   faithful to the paper here would be a *better-sounding* algorithm that the
   authors' own code does not implement.
+* **Departure, and the only one of its kind here — the async arm changes the
+  admission rule.** `run_evoskill` picks its aggregator off the `asynchronous`
+  flag: the serial and synchronous arms run `TopKFrontierAggregator`, which is
+  upstream's rule, and the asynchronous arm runs `SgdSkillAggregator`, which is
+  not. That one applies every proposed skill to the head immediately and
+  amortises held-out validation over `val_every` steps, rolling back to the last
+  validated checkpoint when the batch fails to improve — cheaper by roughly
+  `val_every`×, and a different algorithm. It sits in the *must not change*
+  column of the table above, so this row's async cell is not a measurement of
+  what asynchrony costs EvoSkill; it is a measurement of a different optimizer
+  that happens to run asynchronously. Pinned by
+  `tests/test_matrix_report.py::test_the_evoskill_async_arm_is_recorded_as_an_algorithm_change`,
+  so it cannot quietly become "scheduling only" in the results table.
 * **Selection rule lives in**: `FrontierBest` — the frontier's best member as a named `SelectionPolicy`; the bounded top-K admission stays on `Frontier`
   `SgdSkillAggregator` (async) in
   `examples/evoskill/evoskill_skill_discovery.py` — the `topk_aggregate` mode of
@@ -219,7 +244,7 @@ be speedups over.
 |---|---|---|---|---|---|---|
 | ACE | FiNER-139 | — | — | — | — | scheduling and merge timing; budget must be pinned |
 | GEPA | HotpotQA | 1424 s / 97 calls | sync 1022 s / 70 · async 742 s / 95 | 1.39× / **1.92×** | 0.75 → 0.60 / 0.65 (1–3 tasks of 20; noise-range) | round's diffs merged into one pool candidate (`--reflective-merge`); empty seed instruction; 1 seed — [full setup](results.md#merging-as-a-cost-lever-serial-vs-8-wide-sync-and-async-gepahotpotqa) |
-| EvoSkill | OfficeQA | — | — | — | — | scheduling and merge timing; budget must be pinned |
+| EvoSkill | OfficeQA | — | — | — | — | sync: scheduling and merge timing. **async: the admission rule changes** — `SgdSkillAggregator` (amortised validation, rollback) replaces upstream's strict top-K frontier, so the async cell is a different optimizer rather than a cost of asynchrony |
 | SkillOpt | SearchQA | — | — | — | — | scheduling and merge timing; budget must be pinned. `--minibatch` is this port's name for the worker count, not upstream's minibatch of tasks |
 | ADAS | MGSM | — | — | — | — | scheduling and merge timing; budget must be pinned |
 | DGM | surrogate | — | — | — | — | scheduling and merge timing; budget must be pinned. `--serial` sets `selfimprove_size=1`, which is a population of one, so this row's control is the degenerate archive rather than upstream's default |
@@ -239,5 +264,13 @@ two runs of itself.
 
 The cells are empty because they have not been measured. Filling them in with a
 one-seed run would be worse than leaving them.
+
+Once they are, `python -m bench.matrix_report --json bench/results/matrix.json`
+renders them — speedup off wall-clock net of time lost in failed calls, quality
+as a median with its range, the async arm's stale rate with its denominator, and
+a row daggered whenever it rests on fewer than three seeds. It withholds a
+speedup outright where the cells show the arms did not spend the same budget,
+which is the one check that cannot be done by reading the flags that were
+passed.
 
 The eleven MethodPolicy ports *are* measured under all three schedulers — see the [runtime matrix](matrix-report.md).

--- a/tests/test_matrix_report.py
+++ b/tests/test_matrix_report.py
@@ -1,0 +1,125 @@
+"""The matrix report's refusals, which are the only reason to have one.
+
+Rendering a markdown table is not worth a test. Refusing to render a speedup
+that is not one is, and each test here pins a way the table could otherwise
+publish a number that means something other than what it says.
+"""
+from __future__ import annotations
+
+import pytest
+
+from bench import matrix_report
+from bench.matrix_run import ROWS, SCHEDULING_ONLY, SEMANTICS
+
+
+ARMS = ("serial", "parallel", "async")
+
+
+def _cell(row="gepa", arm="serial", seed=0, wall=100.0, test=0.5, **extra):
+    return dict(row=row, dataset="HotpotQA", arm=arm, seed=seed, width=8,
+                budget=16, wall_seconds=wall, test=test, **extra)
+
+
+def _payload(cells, **head):
+    return dict(budget_rollouts=16, width=8, async_ratio=3, model="m",
+                provider="p", cells=list(cells), **head)
+
+
+def test_every_row_declares_what_each_arm_changed():
+    """A row in ROWS without a SEMANTICS entry is a blank column, and a blank
+    column is a claim that nothing changed made by omission."""
+    for row in ROWS:
+        assert row["name"] in SEMANTICS, row["name"]
+        for arm in ARMS:
+            assert SEMANTICS[row["name"]].get(arm), (row["name"], arm)
+
+
+def test_a_row_missing_from_semantics_is_refused_not_rendered_blank():
+    saved = SEMANTICS.pop("gepa")
+    try:
+        with pytest.raises(SystemExit, match="SEMANTICS"):
+            matrix_report.render(_payload([_cell()]))
+    finally:
+        SEMANTICS["gepa"] = saved
+
+
+def test_the_evoskill_async_arm_is_recorded_as_an_algorithm_change():
+    """The audit's one finding. If this ever reverts to the clean string, either
+    the port stopped swapping its aggregator or somebody papered over it."""
+    assert SEMANTICS["evoskill"]["async"] != SCHEDULING_ONLY
+    assert "admission rule changed" in SEMANTICS["evoskill"]["async"]
+    assert SEMANTICS["evoskill"]["parallel"] == SCHEDULING_ONLY
+
+
+def test_speedup_is_withheld_when_the_arms_did_not_spend_the_same_budget():
+    """The pin is the comparison. Checked against what the cells measured, not
+    trusted because a flag was passed."""
+    cells = [_cell(arm="serial", wall=200.0, engine_rollouts=16),
+             _cell(arm="parallel", wall=50.0, engine_rollouts=64)]
+    text = matrix_report.render(_payload(cells))
+    assert "withheld" in text
+    assert "unequal budget" in text
+    assert "4.00×" not in text
+
+
+def test_the_barrier_overshoot_is_not_treated_as_an_unequal_budget():
+    """The synchronous path checks at the round barrier, so an N-worker arm may
+    legitimately overshoot by up to N-1 -- refusing that would refuse every
+    honest sync cell."""
+    cells = [_cell(arm="serial", wall=200.0, engine_rollouts=16),
+             _cell(arm="parallel", wall=100.0, engine_rollouts=23)]
+    text = matrix_report.render(_payload(cells))
+    assert "unequal budget" not in text
+    assert "2.00×" in text
+
+
+def test_speedup_is_net_of_time_lost_in_failed_calls():
+    """A retry storm in one arm is endpoint weather, not the other arm's
+    scheduler. 300-100 against 100 is 2x, not 3x."""
+    cells = [_cell(arm="serial", wall=300.0, failure_seconds=100.0),
+             _cell(arm="parallel", wall=100.0)]
+    assert "2.00×" in matrix_report.render(_payload(cells))
+
+
+def test_a_single_seed_row_is_daggered_and_called_out():
+    text = matrix_report.render(_payload([_cell(), _cell(arm="parallel")]))
+    assert "gepa †" in text
+    assert "below the 3" in text
+
+
+def test_three_seeds_report_a_range_and_lose_the_dagger():
+    cells = [_cell(arm=arm, seed=s, wall=100.0 + 10 * s, test=0.5 + 0.1 * s)
+             for arm in ("serial", "parallel") for s in range(3)]
+    text = matrix_report.render(_payload(cells))
+    assert "gepa †" not in text
+    assert "[100–120]" in text
+
+
+def test_the_async_stale_rate_never_appears_without_its_denominator():
+    """A bare discard count cannot be read at all -- the mistake this codebase
+    already made once on the async path."""
+    no_data = matrix_report.render(_payload([_cell(), _cell(arm="async")]))
+    assert "not recorded" in no_data
+
+    cells = [_cell(), _cell(arm="async", stale_considered=40, stale_discarded=10)]
+    assert "10/40 (25%)" in matrix_report.render(_payload(cells))
+
+
+def test_failed_cells_do_not_become_measurements():
+    """A cell with an error has no wall-clock worth reporting; it must not be
+    averaged into the arm that failed."""
+    cells = [_cell(arm="serial", wall=200.0),
+             _cell(arm="parallel", wall=100.0),
+             dict(row="gepa", arm="parallel", seed=1, error="boom")]
+    text = matrix_report.render(_payload(cells))
+    assert "2.00×" in text
+
+
+def test_an_unmeasured_row_renders_empty_rather_than_inventing_a_dash_speedup():
+    text = matrix_report.render(_payload([_cell()]))
+    for line in text.splitlines():
+        if line.startswith("| ace "):
+            assert line.count("—") == 6
+            break
+    else:                                     # pragma: no cover - guard
+        pytest.fail("the ace row was not rendered")


### PR DESCRIPTION
Step 2 of the #73 matrix. Follows #115, which added the async arm.

The issue is explicit that the table is untrustworthy without a "what did parallelising change" column, and that its expected value is *rollout scheduling and merge timing only* on every row. A column like that, written up after the sweep, gets filled in from memory by whoever is typing the results with the numbers already in front of them — and a blank cell reads as "nothing changed" rather than as "nobody checked".

So it is `SEMANTICS` in [`bench/matrix_run.py`](bench/matrix_run.py), one entry per row **per arm**, sitting beside the rows the sweep runs. `bench/matrix_report.py` refuses to render a row with no entry; a test refuses a row added to `ROWS` without one.

## The finding

Auditing the arms in order to write the column found what writing it afterwards would have missed:

**EvoSkill's async arm runs a different admission rule from its own serial arm.** `run_evoskill` picks the aggregator off the `asynchronous` flag — `TopKFrontierAggregator` (upstream's strict top-K frontier, `manager.py:update_frontier`) on serial and sync, `SgdSkillAggregator` on async, which applies every proposed skill to the head immediately and amortises held-out validation over `val_every` steps with rollback on regression.

That is the acceptance/admission rule, which `docs/port-fidelity.md` lists under *must not change*. The async cell of that row would have been read as the cost of asynchrony; it is a different optimizer that happens to run asynchronously. Six of the seven ports use one aggregator across all three arms — that one does not. Pinned by a test so it cannot quietly revert to the clean string.

## The report is mostly refusals

Which is the only reason to generate the table rather than write it:

- **a speedup is withheld** where the cells show the arms did not actually spend the same rollouts — the equal-budget pin checked against measured `engine_rollouts` rather than trusted because a flag was passed, with the sync path's `N-1` barrier overshoot allowed
- **speedup is net of time lost inside failed calls**, so one arm's retry storm is not published as the other arm's scheduler
- **the async stale rate never prints without its denominator**
- **a row resting on fewer than three seeds is daggered in the table**, not only footnoted

Rendered against the existing GEPA pilot cells to check the output shape.

## Verification

Full suite: 1148 passed, 2 skipped.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)