### PR TITLE
fix(skillopt): the hard filter selected unlucky answers, and two seams were unwired (#73)

### DIFF
--- a/agentdescent/dataloader.py
+++ b/agentdescent/dataloader.py
@@ -282,7 +282,8 @@ def load_gated_hf(dataset: str, split: str, *,
 
 def select_hard(items: Sequence[Any], score: Callable[[Any], float],
                 keep: Optional[int] = None, threshold: float = 0.999,
-                concurrency: int = 8, min_items: int = 12) -> List[Any]:
+                concurrency: int = 8, min_items: int = 12,
+                passes: int = 1) -> List[Any]:
     """Keep the items a baseline gets **wrong** -- headroom, from a saturated set.
 
     A benchmark a model already solves cannot demonstrate a skill: there is
@@ -301,6 +302,17 @@ def select_hard(items: Sequence[Any], score: Callable[[Any], float],
     numbers from the full set -- say which you used. ``keep`` caps the result
     (the hardest are kept in their original order); if nothing fails, everything
     is returned rather than an empty set.
+
+    ``passes`` is how many independent baseline measurements an item has to fail
+    before it counts as hard, and 1 is not enough for a non-deterministic model.
+    Selecting on a single noisy measurement selects the *unlucky* answers, and
+    re-measuring them regresses to the mean -- measured on SkillOpt/SearchQA with
+    ``deepseek-v4-flash``: the filter kept only items the seed skill got wrong,
+    and the gate then scored that same split at **1.000**. Every one of them was
+    answered correctly the second time. A run set up that way cannot show
+    anything: the strict gate needs `candidate > current` and there is nothing
+    above 1.000. Raise this to 2 or 3 where the actor is a sampled model; the
+    filter costs `passes` times as much and stops selecting for luck.
     """
     from concurrent.futures import ThreadPoolExecutor
 
@@ -308,7 +320,12 @@ def select_hard(items: Sequence[Any], score: Callable[[Any], float],
     if not items:
         return items
     with ThreadPoolExecutor(max(1, min(concurrency, len(items)))) as pool:
+        # An item is hard only if it fails *every* pass; `scores` keeps the best
+        # one it ever achieved, so the top-up below still orders by difficulty.
         scores = list(pool.map(score, items))
+        for _ in range(max(0, passes - 1)):
+            scores = [max(prev, new) for prev, new
+                      in zip(scores, pool.map(score, items))]
     hard = [it for it, sc in zip(items, scores) if sc < threshold]
     if not hard:
         return items                      # nothing failed: caller keeps the full set

--- a/bench/matrix_run.py
+++ b/bench/matrix_run.py
@@ -182,8 +182,12 @@ SEMANTICS = {
     "skillopt": {
         "serial": "upstream ReflACT: one edit batch per step, strict gate",
         "parallel": SCHEDULING_ONLY + "; `--minibatch` is this port's name for "
-                    "the worker count, not upstream's minibatch of tasks",
-        "async": SCHEDULING_ONLY + "; `--minibatch` as above",
+                    "the worker count, not upstream's minibatch of tasks. "
+                    "`--reflective-merge` scores one fused patch per step, which "
+                    "is upstream's shape -- a ReflACT step emits one patch of up "
+                    "to `lr` edits and evaluates it once -- rather than a "
+                    "departure from it",
+        "async": SCHEDULING_ONLY + "; `--minibatch` and `--reflective-merge` as above",
     },
     "adas": {
         "serial": "upstream Meta Agent Search over the DSL substrate "

--- a/bench/results/skillopt-hard-async.json
+++ b/bench/results/skillopt-hard-async.json
@@ -1,0 +1,30 @@
+{
+  "model": "deepseek-v4-flash",
+  "provider": "claude",
+  "budget_rollouts": 60,
+  "width": 4,
+  "cells": [
+    {
+      "row": "skillopt",
+      "dataset": "SearchQA (--hard subset)",
+      "arm": "async",
+      "seed": 0,
+      "width": 4,
+      "budget": 60,
+      "staleness": "full",
+      "reflective_merge": true,
+      "hard_passes": 2,
+      "hard_kept": 93,
+      "hard_pool": 500,
+      "engine_rollouts": 63,
+      "stale_considered": 0,
+      "stale_discarded": 0,
+      "val_seed": 0.053,
+      "val_end": 0.211,
+      "test": 0.316,
+      "edits_accepted": 3,
+      "edits_rejected": 40,
+      "sweeps": 10
+    }
+  ]
+}

--- a/docs/algo-skillopt.md
+++ b/docs/algo-skillopt.md
@@ -57,37 +57,79 @@ In [`examples/skillopt/skillopt_skill_training.py`](https://github.com/Birfy/age
 
 ## Measured — SearchQA with DeepSeek
 
-`--steps 5 --provider openai --model deepseek-v4-flash`:
+Barrier-free (`--async`), 4 workers, **60 rollouts pinned**, `--reflective-merge`,
+`--staleness full`, `deepseek-v4-flash`, one seed. `--hard --hard-passes 2` over
+a 500-item pool keeps the 93 the seed skill answers wrong twice running, split
+55 train / 19 val / 19 test.
 
-| | full split | `--hard` subset |
-|---|---|---|
-| items | 120 train / 80 val / 80 test | 29 / 20 / 20 (69 of 280 kept) |
-| val hard-EM, before → after | 0.900 → 0.900 | **0.250 → 0.500** |
-| test hard-EM | 0.900 | **0.450** |
-| edits accepted / rejected | 0 / 1 | 3 / 3 |
+| | value |
+|---|---|
+| val hard-EM, before → after | **0.053 → 0.211** |
+| test hard-EM | 0.316 |
+| edits accepted / rejected | **3 / 40** |
+| stale discarded | 0 / 0 |
+| sweeps | 10 (commits at 1, 5, 9) |
 
-On the full split the seed skill already answers 9 of 10, so a skill document has
-nothing to add and the strict gate accepts no edit.
+**The gate rejecting 93% is the algorithm, not a failure.** Upstream's rule is
+`candidate > current` on the full held-out split with no tolerance and no
+tie-break (`evaluation/gate.py`), so an edit has to fix at least one whole val
+question to survive. At 19 val items one question is 5.3 points, which is also
+the step size visible in the sweep log: every commit moves val by exactly one
+item. Edits that make three answers *closer* without making any of them match are
+invisible to it and are correctly dropped.
 
-`--hard` keeps the 69 questions of 280 that the seed skill gets **wrong**, and on
-those the skill document **doubles** hard-EM. The gate stays strict there too:
-3 of 6 proposed edits are still rejected.
+**What it learned, and why the gains stop.** The three accepted edits say one
+thing three ways:
 
-!!! warning "The two columns are different benchmarks"
-    0.250 is not "worse than 0.900" — it is the score on a subset selected for
-    being unsolved. Report which one you used.
+```
+For final answers, output the target's conventional name as a single noun
+phrase... Do not add parenthetical explanations, synonyms, full official names,
+or extra qualifiers unless the question explicitly asks for them.
+
+When a target can be named by a common/vernacular name and also by a longer
+formal/descriptive name, prefer the common name that would be used in a
+reference answer.
+
+If the model is tempted to include extra information for safety, it should
+instead leave the answer minimal: a direct identification question is answered
+by the identifier, not by a definition or parenthetical gloss.
+```
+
+Under hard-EM against a gold like `(Lou) Gehrig`, answering *"Lou Gehrig, the
+Yankees first baseman"* scores zero. Most of what `--hard` selects is therefore
+not a knowledge gap but a **formatting** one, and formatting is what the
+optimizer generalises. That pays once — the first "stop adding qualifiers" edit
+fixes several questions at once — and the restatements after it add nothing,
+which is why sweeps 2–4 and 6–8 commit nothing at all.
+
+The same shape appears in [EvoSkill](algo-evoskill.md#empirical-results-claude-code-as-the-base-agent-on-finqa),
+where a tolerance-based numeric scorer produces skills about rounding. Two ports,
+two datasets, two scorers, and in both the induced skill targets the metric's
+surface. It is worth knowing before reading a lift as evidence about capability.
 
 ## Making it measurable — `--hard`
 
-SearchQA is saturated for a strong model, so the run above proves the gate works
-and nothing else. `--hard` keeps the dataset and drops the questions carrying no
-signal: one pass of the seed skill over a wider pool, keeping only what it gets
-**wrong**.
+SearchQA is saturated for a strong model — the seed skill answers 9 of 10 out of
+the box, so the strict gate correctly accepts nothing and the run proves only
+that the gate works. `--hard` keeps the dataset and drops the questions carrying
+no signal: run the seed skill over a wider pool and keep what it gets **wrong**.
 
-```bash
-python -m examples.skillopt.skillopt_skill_training --hard \
-    --provider openai --model deepseek-v4-flash --steps 5 --yes
-```
+!!! danger "One pass selects unlucky answers, not hard ones"
+    `--hard-passes` defaults to **3** because a single baseline measurement does
+    not survive a sampled model. Measured here at `passes=1`: the filter kept
+    only questions the seed skill got wrong, and the gate then scored that same
+    val split at **1.000** — every one of them answered correctly the second
+    time. That is a ceiling, and a strict `candidate > current` gate can accept
+    nothing above it, so the run rejected all five proposals and looked like a
+    broken optimizer.
+
+    Selecting on one noisy measurement selects the tail of the noise, and
+    re-measuring regresses to the mean. At `passes=2` the same pool yields a
+    0.053 baseline — real headroom. Survival was 18.6% at 2 passes against 17% at
+    3, so most of the luck is already gone after the second.
+
+    The filter is not free: it costs `pool × passes` calls, which here was 1,000
+    — more than the training run it enables. Budget for it.
 
 That makes the *benchmark* harder, so its numbers are not comparable with numbers
 from the full split — say which you used. The underlying helper,
@@ -98,6 +140,21 @@ from the full split — say which you used. The underlying helper,
 ```bash
 python -m examples.skillopt.skillopt_skill_training --dry-run
 python -m examples.skillopt.skillopt_skill_training --model claude-haiku-4-5 --lr 4
+
+# the run measured above
+python -m examples.skillopt.skillopt_skill_training --yes --seed 0 \
+    --minibatch 4 --hard --hard-passes 2 --train 300 --val 200 --steps 9999 \
+    --budget-rollouts 60 --reflective-merge --staleness full \
+    --async --async-ratio 3 --max-seconds 3600 --eval-concurrency 8 \
+    --model deepseek-v4-flash
 ```
+
+`--reflective-merge` scores **one fused patch per step** instead of one candidate
+per worker, which is upstream's shape rather than a departure from it: a ReflACT
+step emits a single patch of up to `lr` edits and evaluates it once. The strict
+gate is untouched; what it scores is. `--staleness full` rebases a patch onto the
+current document instead of discarding it when the merger has moved on — the
+gate is already the verification, so re-verifying each patch before it gets there
+buys nothing.
 
 Offline tests: `tests/test_skillopt_example.py`.

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -159,7 +159,18 @@ column of each section below says exactly where to look.
   wrong. This is a *measurement* decision, not an algorithm one — plain SearchQA
   scores ~0.900 for a strong model, leaving no headroom to detect a change — and
   it is stated because a reported lift on a filtered set is not a lift on the
-  benchmark.
+  benchmark. It takes `--hard-passes` measurements per item (default 3) because
+  filtering on one selects the model's unlucky answers rather than hard
+  questions: at one pass the filtered val split scored **1.000** on re-measurement
+  and the strict gate could accept nothing above it.
+* **Checked against upstream, and clean.** All four load-bearing invariants match
+  the released code line for line: the op set `{append, insert_after, replace,
+  delete}` (`optimizer/skill.py`), the strict `candidate > current` gate with no
+  tolerance or tie-break and `gate_metric=hard` by default
+  (`evaluation/gate.py`), the textual learning rate as an integer cap on edits
+  per step (`optimizer/scheduler.py`), and the per-epoch rejected-edit buffer fed
+  back to the optimizer (`engine/trainer.py`'s `_format_step_buffer`). Unlike ACE
+  and EvoSkill, nothing here had to be put back.
 * **Selection rule lives in**: best-of-batch in the strict-gate aggregator;
   the gate itself is `StrictImprovement`, a named `AcceptancePolicy`
   ([acceptance](acceptance-policies.md)).
@@ -268,7 +279,7 @@ be speedups over.
 | ACE | FiNER-139 | — | — | — | — | scheduling and merge timing; budget must be pinned |
 | GEPA | HotpotQA | 1424 s / 97 calls | sync 1022 s / 70 · async 742 s / 95 | 1.39× / **1.92×** | 0.75 → 0.60 / 0.65 (1–3 tasks of 20; noise-range) | round's diffs merged into one pool candidate (`--reflective-merge`); empty seed instruction; 1 seed — [full setup](results.md#merging-as-a-cost-lever-serial-vs-8-wide-sync-and-async-gepahotpotqa) |
 | EvoSkill | FinQA (OfficeQA is HF-gated) | — | async N=4: 0.527 → 0.707 val over 120 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--reflective-merge` offers the frontier one fused candidate per sweep instead of one per worker (`update_frontier` and the parent draw unchanged). The async arm used to swap in `SgdSkillAggregator` — no frontier, per-batch validation — which is now removed rather than optional |
-| SkillOpt | SearchQA | — | — | — | — | scheduling and merge timing; budget must be pinned. `--minibatch` is this port's name for the worker count, not upstream's minibatch of tasks |
+| SkillOpt | SearchQA (`--hard` subset) | — | async N=4: 0.053 → 0.211 val over 60 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--minibatch` is this port's name for the worker count, not upstream's minibatch of tasks. `--reflective-merge` scores one fused patch per step, which is *upstream's* shape (a ReflACT step emits one patch of up to `lr` edits) rather than a departure from it |
 | ADAS | MGSM | — | — | — | — | scheduling and merge timing; budget must be pinned |
 | DGM | surrogate | — | — | — | — | scheduling and merge timing; budget must be pinned. `--serial` sets `selfimprove_size=1`, which is a population of one, so this row's control is the degenerate archive rather than upstream's default |
 | OpenEvolve | function minimization | — | — | — | — | **none** — `rounds = iterations // workers` already fixes total work, so this row's speedup is the only one that was equal-budget before the flag existed |

--- a/examples/skillopt/skillopt_skill_training.py
+++ b/examples/skillopt/skillopt_skill_training.py
@@ -57,6 +57,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from agentdescent.staleness import get_policy
 from examples._common import (add_standard_args, completion_for, confirm,
                               worker_count,
                               budget_kwargs, report_engine)
@@ -286,8 +287,13 @@ class SkillOptContext:
     budget: int
     rejected_buffer: List[dict] = field(default_factory=list)
     edits_by_diff: dict = field(default_factory=dict)
-    seed_em: float = 0.0
-    best_em: float = 0.0
+    #: ``None`` until the gate has measured the seed document, which happens
+    #: inside ``step()`` -- and ``step()`` only runs when a card reaches the
+    #: merger. A run that proposes nothing therefore never measures its own
+    #: baseline, and a 0.0 default printed ``val hard-EM : 0.000 -> 0.000`` for
+    #: that case: indistinguishable from a seed document that answers nothing.
+    seed_em: Optional[float] = None
+    best_em: Optional[float] = None
     accepted: int = 0
     rejected: int = 0
     lock: threading.Lock = field(default_factory=threading.Lock)   # workers run concurrently
@@ -358,7 +364,8 @@ class StrictGateAggregator(AggregatorProtocol):
 
     def __init__(self, ledger: Ledger, verifier, ctx: SkillOptContext,
                  artifact_id: str = "skill_document",
-                 acceptance: Optional[StrictImprovement] = None):
+                 acceptance: Optional[StrictImprovement] = None,
+                 merge_round=None):
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
@@ -367,6 +374,18 @@ class StrictGateAggregator(AggregatorProtocol):
         self.cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread
         self.current_em = None
+        #: Fuse the sweep's edit patches into ONE before the gate scores them
+        #: (`--reflective-merge`). Closer to upstream than the default, not
+        #: further from it: ReflACT's step emits **one patch of up to `lr`
+        #: edits** and evaluates it once (`engine/trainer.py`'s `ranked_patch`),
+        #: where this loop scores one candidate per worker and takes the best.
+        #: The gate is untouched either way -- still `cand > current` on the
+        #: full held-out split -- but N held-out sweeps become one, and the
+        #: surviving edits go forward together instead of all but one being
+        #: dropped.
+        self.merge_round = merge_round
+        if merge_round is not None and hasattr(merge_round, "bind"):
+            merge_round.bind(verifier)
 
     def ingest(self, card: EvidenceCard) -> None:
         # ingest runs on worker threads, step on one: see AggregatorProtocol.
@@ -385,36 +404,54 @@ class StrictGateAggregator(AggregatorProtocol):
             cards, self.cards = self.cards, []
         best = None
         n = max(1, len(self.verifier.held_out))
-        for card in cards:                                 # pick the best strict improver
+        # One fused patch per sweep instead of one candidate per worker. The
+        # strict gate is unchanged; what it scores is.
+        diffs = [card.diff for card in cards]
+        if self.merge_round is not None and len(diffs) > 1:
+            merged, _, _ = self.merge_round.select(head, diffs)
+            if merged is not None:
+                diffs = [merged]
+        for diff in diffs:                                 # pick the best strict improver
             from agentdescent.policies import MergeContext
-            candidate = head.apply(card.diff)
+            candidate = head.apply(diff)
             em = candidate.score(self.verifier.held_out)
             decision = self.acceptance.accept(MergeContext(
-                artifact=head, candidate=candidate, cards=[card],
+                artifact=head, candidate=candidate, cards=list(cards),
                 base_counts=(self.current_em * n, (1 - self.current_em) * n),
-                cand_counts=(em * n, (1 - em) * n), diff=card.diff))
+                cand_counts=(em * n, (1 - em) * n), diff=diff))
             if decision.accept and (best is None or em > best[1]):
-                best = (card, em)
+                best = (diff, em)
 
         report_diff = committed = None
         if best is not None:
-            card, em = best
+            diff, em = best
             try:
                 _, committed = self.ledger.commit(
-                    head.apply(card.diff), base_vv, branch=Ledger.DEV,
-                    message=f"skillopt accept {card.diff.diff_id}")
+                    head.apply(diff), base_vv, branch=Ledger.DEV,
+                    message=f"skillopt accept {diff.diff_id}")
                 self.current_em = em
-                self.ctx.best_em = max(self.ctx.best_em, em)
+                self.ctx.best_em = em if self.ctx.best_em is None else max(self.ctx.best_em, em)
                 self.ctx.accepted += 1
                 self.ctx.rejected_buffer.clear()           # accepted -> reset buffer
-                report_diff = card.diff
+                report_diff = diff
             except CASConflict:
                 committed = None
-        # every non-accepted candidate's edits are remembered in-epoch.
+        # Every non-accepted candidate's edits are remembered in-epoch, which is
+        # upstream's `step_buffer`: "use it to avoid repeating ineffective edits".
+        # Compared by diff id, not object identity: under `--reflective-merge`
+        # the accepted candidate is a *fused* diff that is none of the cards, so
+        # an identity test would file every contributing edit as rejected -- and
+        # then feed the optimizer a list telling it not to re-propose the edits
+        # it had just accepted.
+        accepted_ids = ({best[0].diff_id} if best is not None else set())
+        contributing = ({c.diff.diff_id for c in cards}
+                        if best is not None and best[0].diff_id not in
+                        {c.diff.diff_id for c in cards} else set())
         for card in cards:
-            if best is None or card is not best[0]:
-                self.ctx.rejected += 1
-                self.ctx.rejected_buffer.extend(self.ctx.edits_by_diff.get(card.diff.diff_id, []))
+            if card.diff.diff_id in accepted_ids or card.diff.diff_id in contributing:
+                continue
+            self.ctx.rejected += 1
+            self.ctx.rejected_buffer.extend(self.ctx.edits_by_diff.get(card.diff.diff_id, []))
 
         self.ctx.budget = self.ctx.scheduler.step()        # advance the LR schedule
         return [MergeReport(self.aid, report_diff, False, len(cards), len(cards), 0, 0,
@@ -425,8 +462,8 @@ class StrictGateAggregator(AggregatorProtocol):
 @dataclass
 class SkillOptResult:
     skill: str
-    seed_em: float
-    best_em: float
+    seed_em: Optional[float]
+    best_em: Optional[float]
     accepted: int
     rejected: int
     history: List[float]
@@ -442,7 +479,8 @@ def run_skillopt(complete: Completion, train: List[dict], val: List[dict],
                  steps: int = 8, lr: int = 4, minibatch: int = 4,
                  lr_mode: str = "cosine", seed: int = 0, asynchronous: bool = False,
                  async_ratio: int = 3, max_seconds: float = 30.0,
-                 max_rollouts: Optional[int] = None,
+                 max_rollouts: Optional[int] = None, staleness: str = "guarded",
+                 merge_round=None, eval_concurrency: int = 8,
                  verbose: bool = False) -> SkillOptResult:
     """Drive SkillOpt through `evolve()` (`val` becomes the held-out gate set)."""
     def to_task(i, ex):
@@ -463,7 +501,9 @@ def run_skillopt(complete: Completion, train: List[dict], val: List[dict],
         return em_score(output, task.meta["answers"])
 
     def factory(ledger, verifier, audit, config, policy):
-        return StrictGateAggregator(ledger, verifier, ctx, artifact_id="skill_document")
+        return StrictGateAggregator(ledger, verifier, ctx,
+                                    artifact_id="skill_document",
+                                    merge_round=merge_round)
 
     result = evolve(tasks, reward, run=run, propose=make_propose(ctx, complete),
                     strategy=SkillDocStrategy(ctx), initial_state={"skill": SEED_SKILL},
@@ -473,6 +513,13 @@ def run_skillopt(complete: Completion, train: List[dict], val: List[dict],
                     asynchronous=asynchronous, async_ratio=async_ratio,
                     max_seconds=max_seconds if asynchronous else None,
                     held_out_frac=len(val) / max(1, len(tasks)),
+                    eval_concurrency=eval_concurrency,
+                    # A discarded card is a whole optimizer step thrown away.
+                    # `full` rebases onto the current head and leaves the strict
+                    # gate as the only verification -- which it already is: the
+                    # candidate is scored on the full held-out split before it
+                    # can commit, so nothing unverified reaches the document.
+                    staleness_policy=get_policy(staleness),
                     aggregator_factory=factory, verbose=verbose,
                     max_rollouts=max_rollouts)
     if verbose:
@@ -499,7 +546,7 @@ def download_searchqa(split: str, limit: int) -> List[dict]:
 
 
 def load_dataset(n_train: int, n_val: int, seed: int = 0, hard: bool = False,
-                 rollout: "Rollout" = None) -> Dataset:
+                 rollout: "Rollout" = None, hard_passes: int = 3) -> Dataset:
     """SearchQA using its native `train` split, and splitting `validation` into
     the val (gate) and test halves.
 
@@ -516,8 +563,13 @@ def load_dataset(n_train: int, n_val: int, seed: int = 0, hard: bool = False,
         from agentdescent.dataloader import select_hard
         scorer = lambda ex: em_score(rollout.answer(SEED_SKILL, ex), ex["answers"])
         before = len(train) + len(pool_rows)
-        train = select_hard(train, scorer)
-        pool_rows = select_hard(pool_rows, scorer)
+        # `hard_passes` measurements, and an item has to fail all of them. One
+        # pass selects the answers the model got unlucky on, and the gate then
+        # re-measures them back to correct: at `passes=1` this filter produced a
+        # val split the seed skill scored **1.000** on -- a ceiling, where a
+        # strict `candidate > current` gate can accept nothing by construction.
+        train = select_hard(train, scorer, passes=hard_passes)
+        pool_rows = select_hard(pool_rows, scorer, passes=hard_passes)
         print(f"Hard mode: kept {len(train) + len(pool_rows)} of {before} items the "
               f"seed skill answers incorrectly")
     pool = split_dataset(pool_rows, ratios=(0.0, 0.5, 0.5), seed=seed, name="SearchQA")
@@ -535,6 +587,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--steps", type=int, default=8)
     p.add_argument("--lr", type=int, default=4, help="max edits/step (learning rate)")
     p.add_argument("--lr-mode", default="cosine", choices=["constant", "linear", "cosine"])
+    p.add_argument("--staleness", default="guarded",
+                   choices=["guarded", "reflective", "full"],
+                   help=("what to do with an edit patch proposed against a doc "
+                         "the merger has since moved: `guarded` rebases inside "
+                         "the --async-ratio band and discards beyond it, `full` "
+                         "rebases regardless and leaves the strict gate as the "
+                         "only verification"))
     p.add_argument("--minibatch", type=int, default=4)
     p.add_argument("--train", type=int, default=40)
     p.add_argument("--val", type=int, default=20)
@@ -542,6 +601,9 @@ def build_parser() -> argparse.ArgumentParser:
                    help="keep only questions the seed skill answers wrong -- plain "
                         "SearchQA is already ~0.900 for a strong model, so there is "
                         "nothing for a skill document to add")
+    p.add_argument("--hard-passes", type=int, default=3,
+                   help="baseline measurements an item must fail before --hard "
+                        "keeps it; 1 selects unlucky answers rather than hard ones")
     return p
 
 
@@ -591,6 +653,7 @@ def main(argv=None) -> None:
         # Needs the model, which is built above, so the dataset is re-selected here
         # rather than at load time.
         ds = load_dataset(args.train, args.val, seed=args.seed, hard=True,
+                          hard_passes=args.hard_passes,
                           rollout=Rollout(completion))
         ntr, nva, nte = ds.sizes()
         print(f"Splits   : {ntr} train / {nva} val / {nte} test  (hard subset)")
@@ -602,17 +665,35 @@ def main(argv=None) -> None:
               "for claude set ANTHROPIC_API_KEY (or `ant auth login`).")
         return
 
+    # `--reflective-merge` was declared by `add_standard_args` and never read.
+    # `StrictGateAggregator` implements `AggregatorProtocol` itself, so the
+    # engine's fusion policy never reaches it -- GEPA hands its aggregator the
+    # merger explicitly, and so does this one now.
+    merge_round = None
+    if args.reflective_merge:
+        from agentdescent.fusion import ReflectiveFusion
+        merge_round = ReflectiveFusion(completion)
+        print("NOTE: --reflective-merge scores ONE fused patch per step instead "
+              "of one candidate per worker -- which is upstream's shape (a step "
+              "emits one patch of up to `lr` edits). The strict gate is "
+              "unchanged; what it scores is.")
+
     print("\nTraining skill document (ReflACT: edits + strict gate + LR + buffer, L2)...\n")
     result = run_skillopt(completion, ds.train, ds.val, steps=args.steps, lr=args.lr,
                           minibatch=args.minibatch, lr_mode=args.lr_mode, seed=args.seed,
                           asynchronous=args.asynchronous, async_ratio=args.async_ratio,
-                          max_seconds=args.max_seconds, verbose=True,
+                          max_seconds=args.max_seconds, staleness=args.staleness,
+                          merge_round=merge_round,
+                          eval_concurrency=args.eval_concurrency, verbose=True,
                           **budget_kwargs(args))
 
     test_em = eval_hard_em(Rollout(completion), result.skill, ds.test)
     print("\n=== trained skill document ===")
     print(result.skill)
-    print(f"\nval hard-EM : {result.seed_em:.3f} -> {result.best_em:.3f}")
+    seed = ("not measured (no patch reached the gate)"
+            if result.seed_em is None else f"{result.seed_em:.3f}")
+    best = "—" if result.best_em is None else f"{result.best_em:.3f}"
+    print(f"\nval hard-EM : {seed} -> {best}")
     print(f"test hard-EM: {test_em:.3f}  (held out, never seen by the gate)")
     print(f"edits accepted / rejected: {result.accepted} / {result.rejected}")
     print(f"stopped     : {result.stop_reason}")


### PR DESCRIPTION
Third algorithm of the #73 matrix.

## Fidelity: clean

Checked against `microsoft/SkillOpt` before running it, and unlike ACE and EvoSkill **nothing had to be put back**. All four load-bearing invariants match the released code line for line:

| invariant | upstream | port |
|---|---|---|
| edit ops | `{append, insert_after, replace, delete}` (`optimizer/skill.py`) | identical |
| accept gate | `candidate > current`, no tolerance, no tie-break, `gate_metric=hard` (`evaluation/gate.py`) | `StrictImprovement` |
| textual LR | integer cap on edits per step (`optimizer/scheduler.py`) | `--lr-mode` |
| rejected-edit buffer | per-epoch, fed back to the optimizer (`engine/trainer.py`) | `_format_buffer` |

## `--hard` selected the model's unlucky answers, not hard questions

`select_hard` took **one** baseline pass and kept whatever fell below threshold. With a sampled actor that selects the tail of the noise, and re-measuring regresses to the mean.

Measured: the filter kept only questions the seed skill got wrong, and the gate then scored that same val split at **1.000** — every one answered correctly the second time. A strict `candidate > current` gate can accept nothing above a ceiling, so the run rejected all five proposals and read as a broken optimizer.

`select_hard(passes=)` now requires an item to fail **every** pass; SkillOpt defaults to 3 and exposes `--hard-passes`. At 2 the same pool gives a 0.053 baseline. Survival was 18.6% at two passes against 17% at three — most of the luck is gone after the second. The filter costs `pool × passes` calls (1,000 here), more than the training run it enables; that's documented.

## Two flags declared and never read

- **`--reflective-merge`** could not have worked by the usual route — `StrictGateAggregator` implements `AggregatorProtocol` itself, so the engine's fusion policy never reaches it. Worth having twice over: admission costs a full held-out sweep per candidate, and fusing is **upstream's shape** rather than a departure — a ReflACT step emits one patch of up to `lr` edits and evaluates it once.
- **`--staleness`** joins ACE's and EvoSkill's. `full` rebases onto the current document instead of discarding; the strict gate is already the verification, so re-verifying each patch before it gets there buys nothing.

Plus `seed_em` defaulting to `0.0`, which printed `val hard-EM : 0.000 -> 0.000` for a run that never measured its baseline (the gate seeds inside `step()`, which only runs when a patch reaches the merger).

## Measured

60 rollouts pinned, `--hard --hard-passes 2` over a 500-item pool (93 kept → 55 train / 19 val / 19 test), `--reflective-merge --staleness full`:

| | |
|---|---|
| val hard-EM | **0.053 → 0.211** |
| test hard-EM | 0.316 |
| edits accepted / rejected | **3 / 40** |
| stale discarded | 0 / 0 |

**The gate rejecting 93% is the algorithm.** At 19 val items one question is 5.3 points, and that's exactly the step size in the sweep log: every commit moves val by one item, because an edit has to fix a whole question to clear `candidate > current`.

## What the docs now say that they didn't

`docs/algo-skillopt.md`'s results are **replaced** — the old ones were a `--steps 5` synchronous run under the single-pass filter this PR removes.

What replaces them records the part that isn't a win: the three accepted edits say one thing three ways ("do not add parenthetical explanations", "prefer the common name", "leave the answer minimal"). Under hard-EM against a gold like `(Lou) Gehrig`, most of what `--hard` selects is a **formatting** failure rather than a knowledge gap, so formatting is what the optimizer generalises. EvoSkill's rounding skills are the same shape under a tolerance scorer — two ports, two datasets, two scorers, both learning the metric's surface. Worth knowing before reading a lift as evidence about capability.

Full suite: 1149 passed, 2 skipped.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)