### PR TITLE
feat: the matrix is eighteen rows, and the budget flag the eleven never read (#73)

### DIFF
--- a/bench/matrix_run.py
+++ b/bench/matrix_run.py
@@ -123,6 +123,36 @@ ROWS = [
          # task_count and the flag never was, so this row crashed argparse on
          # its first live cell.
          size=["--tasks", "8"], needs="bwrap"),
+
+    # The eleven declarative MethodPolicy ports. They reach the same three
+    # arms through `examples._method_runner.standard_main`, and their budget
+    # is already equal by construction: `rounds = candidates // workers` on
+    # the synchronous path and `max_iters = candidates` on the async one, so
+    # width divides the work rather than multiplying it. `--budget-rollouts`
+    # is mapped onto `--candidates` in the runner -- one quantity, two
+    # vocabularies -- and must be divisible by `--width`.
+    dict(name="promptbreeder", module="examples.promptbreeder.promptbreeder_genetic_prompts",
+         dataset="compact QA (mechanism microport)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="aflow", module="examples.aflow.aflow_workflow_search",
+         dataset="compact QA (mechanism microport)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="reflexion", module="examples.reflexion.reflexion_episodic_memory",
+         dataset="compact QA (mechanism microport)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="self_refine", module="examples.self_refine.self_refine_feedback_loop",
+         dataset="compact QA (mechanism microport)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="voyager", module="examples.voyager.voyager_skill_library",
+         dataset="skill library (environment analogue)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="skillweaver", module="examples.skillweaver.skillweaver_web_apis",
+         dataset="web APIs (environment analogue)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="absolute_zero", module="examples.absolute_zero.absolute_zero_selfplay",
+         dataset="self-play (inference analogue)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="r_zero", module="examples.r_zero.r_zero_challenger_solver",
+         dataset="challenger/solver (inference analogue)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="agent0", module="examples.agent0.agent0_tool_curriculum",
+         dataset="calculator tasks (inference analogue)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="sica", module="examples.sica.sica_self_edit",
+         dataset="self-edit (analogue)", width_flag="--workers", size=[], method_policy=True),
+    dict(name="godel_agent", module="examples.godel_agent.godel_agent_self_modify",
+         dataset="self-edit (analogue)", width_flag="--workers", size=[], method_policy=True),
 ]
 
 #: The expected answer in the "semantics changed" column, for every row and every
@@ -213,6 +243,122 @@ SEMANTICS = {
         "parallel": SCHEDULING_ONLY,
         "async": SCHEDULING_ONLY,
     },
+
+    # The eleven MethodPolicy ports. Their merge behaviour is not a matrix
+    # knob: `MethodPolicy.reflective` is declared by each method, because
+    # for these the merger is part of the definition rather than an
+    # execution choice -- so `--reflective-merge` is deliberately not passed
+    # to them and their rows carry the clean string.
+    "promptbreeder": {
+        "serial": "PromptBreeder as a declared `mechanism_microport` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "aflow": {
+        "serial": "AFlow as a declared `mechanism_microport` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "reflexion": {
+        "serial": "Reflexion as a declared `mechanism_microport` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "self_refine": {
+        "serial": "Self-Refine as a declared `mechanism_microport` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "voyager": {
+        "serial": "Voyager as a declared `environment_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "skillweaver": {
+        "serial": "SkillWeaver as a declared `environment_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "absolute_zero": {
+        "serial": "Absolute Zero as a declared `inference_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "r_zero": {
+        "serial": "R-Zero as a declared `inference_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "agent0": {
+        "serial": "Agent0 as a declared `inference_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "sica": {
+        "serial": "SICA as a declared `self_edit_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
+    "godel_agent": {
+        "serial": "Godel Agent as a declared `self_edit_analogue` -- see "
+                  "docs/port-fidelity.md for what that class claims and does "
+                  "not. **Serial here is not a one-worker loop**: these express "
+                  "it as `max_concurrency=1` over the same `candidates // "
+                  "workers` rounds, so the arm runs identical work without "
+                  "concurrency rather than a narrower algorithm",
+        "parallel": SCHEDULING_ONLY,
+        "async": SCHEDULING_ONLY,
+    },
 }
 
 #: Pulled out of each port's own stdout rather than re-derived, so a row reports
@@ -292,6 +438,16 @@ def _cell(row: dict, arm: str, seed: int, args) -> Dict:
         cmd += ["--serial"]
     else:
         cmd += [row["width_flag"], str(args.width)]
+    if row.get("method_policy"):
+        # These size their work as `candidates // workers` rounds, so the worker
+        # count is part of the budget arithmetic rather than only of the
+        # schedule -- and their `--serial` sets `max_concurrency=1` without
+        # touching it. Passing the width on every arm is therefore what keeps
+        # the budget equal: leave it off the serial arm and that arm silently
+        # runs the 2-worker default, i.e. a different number of rounds over the
+        # same candidate budget.
+        if arm == "serial":
+            cmd += [row["width_flag"], str(args.width)]
     if arm == "async":
         # The cell timeout as the wall-clock budget: the async runtime refuses to
         # run unbounded, and the ports' own --max-seconds defaults (15-45s) would
@@ -403,6 +559,16 @@ def main(argv=None) -> None:
         raise SystemExit(f"unknown arm(s) {bad}; choose from {known}")
     todo = [(r, a, s) for r in rows for s in seeds for a in arms
             if (r["name"], a, s) not in done]
+
+    # `run_port` refuses a candidate budget that is not a multiple of the worker
+    # count, and it refuses it *after* the sweep has started paying for earlier
+    # cells. Checked here instead, before anything runs.
+    mp = [r["name"] for r in rows if r.get("method_policy")]
+    if mp and (args.budget % args.width or args.budget < args.width):
+        raise SystemExit(
+            f"--budget {args.budget} must be a positive multiple of --width "
+            f"{args.width} for the MethodPolicy rows ({', '.join(mp[:3])}...), "
+            f"which size their work as `candidates // workers` rounds")
 
     print(f"matrix: {len(rows)} rows x {len(arms)} arms x {len(seeds)} seeds "
           f"= {len(rows) * len(arms) * len(seeds)} cells, {len(done)} already done, "

--- a/examples/_method_runner.py
+++ b/examples/_method_runner.py
@@ -22,6 +22,7 @@ from typing import Callable, Dict, List, Optional, Sequence
 from agentdescent.aggregator import AggregatorConfig
 from agentdescent.agents import Usage
 from agentdescent.async_evolve import async_evolve
+from agentdescent.staleness import get_policy
 from agentdescent.evolution import EvolutionResult, Task, evolve
 from agentdescent.fusion import reflective_merge
 
@@ -160,6 +161,7 @@ def run_port(
     async_ratio: int = 1,
     max_seconds: float = 300.0,
     shutdown_grace: float = 120.0,
+    staleness: str = "guarded",
 ) -> MethodRunResult:
     """Run one method through AgentDescent with an equal candidate budget."""
     if mode not in MODES:
@@ -226,6 +228,11 @@ def run_port(
         "verbose": False,
         "policies": engine,
         "aggregator_factory": aggregator_factory,
+        # A discarded card is a candidate from the budget spent on nothing, and
+        # the budget is what makes these rows comparable. `full` rebases onto the
+        # current head and leaves the acceptance gate as the verification, which
+        # it already is.
+        "staleness_policy": get_policy(staleness),
     }
     if mode == "async_pipeline":
         result = async_evolve(
@@ -352,11 +359,23 @@ def standard_main(build: Callable[[int], MethodPolicy],
     add_standard_args(parser, model_default="glm-5.2")
     parser.add_argument("--workers", type=int, default=2)
     parser.add_argument("--candidates", type=int, default=2)
+    parser.add_argument("--staleness", default="guarded",
+                        choices=["guarded", "reflective", "full"],
+                        help="what to do with a diff proposed against a head the "
+                             "merger has since moved (agentdescent.staleness)")
     parser.add_argument("--max-tokens", type=int, default=1024)
     parser.add_argument("--timeout", type=float, default=180.0)
     args = parser.parse_args(argv)
 
     policy = build(args.seed)
+    # `--budget-rollouts` is `add_standard_args`' name for the quantity these
+    # methods call `--candidates`: the total number of proposals the run may
+    # spend. It was declared for every port and read by none of them here, so a
+    # sweep pinning the budget got the 2-candidate default and a row that
+    # measured nothing it asked for. One quantity, two vocabularies -- mapped
+    # rather than duplicated, the way OpenEvolve maps it onto `iterations`.
+    if getattr(args, "budget_rollouts", None):
+        args.candidates = args.budget_rollouts
     mode = ("serial" if args.serial
             else "async_pipeline" if args.asynchronous
             else "sync_parallel")
@@ -381,6 +400,7 @@ def standard_main(build: Callable[[int], MethodPolicy],
     outcome = run_port(
         policy, recorder, mode=mode, seed=args.seed, workers=args.workers,
         candidate_budget=args.candidates, max_seconds=args.max_seconds,
+        staleness=args.staleness,
     )
     print(f"{policy.name}/{mode}: quality {outcome.baseline_quality:.3f} -> "
           f"{outcome.final_quality:.3f}, validation "


### PR DESCRIPTION
`ROWS` carried the seven benchmark-faithful ports and stopped there, while `docs/port-fidelity.md` has said "eighteen published algorithms" for some time. The other eleven ran only through `bench/candidate_methods.py`, on its own vocabulary, so the parallelisation table could never cover them.

## They already reach the same three arms

Every one goes through `examples._method_runner.standard_main`, which is `add_standard_args` — so `--serial` / `--async` / `--workers` were there all along. Their budget is also **already equal by construction**: `rounds = candidates // workers` synchronously, `max_iters = candidates` asynchronously. That's the property six of the original seven needed `--budget-rollouts` bolted on to get.

## `--budget-rollouts` was declared for them and read by none of them

`standard_main` reads its own `--candidates` and ignored the shared flag, so a sweep pinning the budget got the **2-candidate default** and produced a row that measured nothing it asked for.

That's the fourth flag in this series declared and dropped, after ACE's `--val-cap` and EvoSkill's and SkillOpt's `--reflective-merge`. It's one quantity in two vocabularies, so it's *mapped* onto `--candidates` rather than duplicated — the way OpenEvolve maps it onto `iterations`.

`--staleness` joins them too, passed through `run_port`. On these rows a discarded card is a candidate from the pinned budget spent on nothing, which is exactly what the budget exists to prevent.

## Two things the matrix has to handle rather than assume

**Their `--serial` is not a one-worker loop.** It sets `max_concurrency=1` and leaves the worker count alone, so the arm runs identical work without concurrency rather than a narrower algorithm. `_cell` therefore passes the width on *every* arm for them — leave it off the serial arm and that arm quietly runs the 2-worker default, i.e. a different number of rounds over the same candidate budget, which is the confound the pin exists to remove. Their `SEMANTICS` serial entry says so outright.

**Their merge behaviour is not a matrix knob.** `MethodPolicy.reflective` is declared per method, because for these the merger is part of the definition rather than an execution choice — so `--reflective-merge` is deliberately not passed to them, and their rows carry the clean scheduling-only string.

## Fail fast, not mid-sweep

`run_port` refuses a candidate budget that is not a multiple of the worker count, and refuses it *after* the sweep has paid for earlier cells. Now checked in `main()` before anything runs.

## Verified

- all **eighteen** rows dry-run clean through the exact async-arm command shape `_cell` builds
- `SEMANTICS` covers all eighteen (the report refuses to render a row without an entry)
- `--budget-rollouts 12 --workers 4` reaches `candidates=12`, where it previously reached the default 2

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)