### PR TITLE
feat(adas): a domain with headroom, five fixes, and why the row still has no lift (#73)

### DIFF
--- a/bench/matrix_run.py
+++ b/bench/matrix_run.py
@@ -222,6 +222,17 @@ SEMANTICS = {
     "adas": {
         "serial": "upstream Meta Agent Search over the DSL substrate "
                   "(the substrate is this port's standing departure), one worker",
+        # `--reflective-merge` is deliberately NOT passed to this row, and the
+        # reason is the archive. ADAS is keep-all: every proposed design is
+        # appended, and the meta-agent's entire conditioning signal is that
+        # archive (designs plus fitness). Fusing a round's N designs into one
+        # would remove N-1 archive entries per round, which shrinks what the next
+        # generation is designed against -- the algorithm's central mechanism,
+        # not its merge timing. The usual justification does not apply either: the
+        # aggregator here drops nothing, so there is no "all but one discarded"
+        # for fusion to recover. And a proposal is a whole agent *program*, not a
+        # delta, so "merge these two designs" is itself an ADAS-shaped design
+        # operation smuggled in below the archive.
         "parallel": SCHEDULING_ONLY,
         "async": SCHEDULING_ONLY,
     },

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -58,46 +58,106 @@ In [`examples/adas/adas_meta_agent_search.py`](https://github.com/Birfy/agentdes
 | **`Interpreter`** + **`seed_archive`** | (agent substrate) | the safe control-flow DSL (`cot`/`cot_sc`/`reflexion`/`debate`/`step_back`/`role_assignment`/`ensemble`) and the seven MGSM seeds |
 | **`dgm_parent_weights`** | `--select dgm` | DGM's sigmoid×novelty rule as an alternative archive-conditioning strategy |
 
-## Measured — MGSM with DeepSeek
+## Measured — the cost, and why there is no lift number
 
-MGSM is saturated for a strong model, so the search has no gradient without
-`--hard`. Measured with `deepseek-v4-flash` over the **whole benchmark** — all 11
-languages, 250 items each:
+**This row is not measurable with `deepseek-v4-flash`.** Not "not measured yet":
+the two constraints that would make it measurable point in opposite directions,
+and the middle is empty. What follows is the evidence, because a page that leaves
+a lift row blank without saying why invites someone to spend the two hours again.
+
+### MGSM is saturated, in every language
+
+The port's own dataset is a 2022 grade-school benchmark, and a current model has
+finished with it. Measured, Chain-of-Thought alone:
+
+| languages | CoT accuracy |
+|---|---|
+| `en` | **1.000** |
+| `sw`, `te` | **1.000** |
+| `th`, `bn` | **1.000** |
+
+The hard-language escape does not exist. And saturation here is worse than a
+missing lift: ADAS conditions its meta-agent on **the whole archive with its
+fitness values**, so when all seven hand-designed seeds score 1.000 the archive
+carries no signal about which control flow is better. The search is not merely
+unable to improve — it is unable to *learn*, because everything it is shown is
+tied.
+
+### GPQA has the headroom, and costs ten times as much per call
+
+Switching domain is not a fidelity break: ADAS searches four upstream (`_mgsm`,
+`_gpqa`, `_drop`, `_arc`), and **GPQA Diamond's 198 rows ship inside the ADAS
+repo** (`dataset/gpqa_diamond.csv`, no HuggingFace gate). `--dataset gpqa` selects
+it. Chain-of-Thought measures **0.625** there — above the 0.250 floor of a
+four-way choice and well under the ceiling.
+
+The bill arrives with it. From a completed run:
 
 | | |
 |---|---|
-| pool | 2750 items |
-| direct, structure-free single call | **0.919** |
-| items it answers incorrectly | **222** (8.1%) |
+| model calls | 28 |
+| completion tokens | **143,246** — 5,116 per call |
+| time in the model | 1,385 s — **49 s per call** |
 
-Those 222 are what the search runs on, split 15 / 50 / 35:
+A graduate-level science question makes this model generate five thousand tokens
+of reasoning before it answers, and the reasoning is not optional: at
+`max_tokens=512` and `4096` the reply comes back **empty**, the budget spent
+before any visible text. `MAX_TOKENS` is 16384 for exactly this reason.
 
-```
-Split    : 34 trigger / 110 val (fitness) / 78 test
-```
+### Why that is fatal *here* specifically
 
-The train share only *triggers* proposals — the meta-agent conditions on the
-archive, not on the task `evolve()` hands it, so a generation consumes `--workers`
-items and ignores the rest. Everything else measures. Splits are stratified by
-language, because MGSM's languages differ by 8 points of baseline accuracy (`en`
-0.964, `ja` 0.880) and an unstratified draw hands validation one mixture and test
-another.
+Every port on this page's sibling pages pays per rollout. ADAS pays
+`|val| x program_cost` per **candidate**, where a candidate is itself a
+multi-call program — the seed archive alone is 19 calls per question:
 
-On a `--hard` subset the structure-free baseline is 0.000 by construction, so the
-searched agent's test accuracy on its own says nothing. The run scores the best
-hand-designed seed on the same split and reports both:
+| seed design | calls/question |
+|---|---|
+| Chain-of-Thought | 1 |
+| Self-Refine (Reflexion) | 2 |
+| Step-back Abstraction | 2 |
+| Dynamic Assignment of Roles | 2 |
+| Self-Consistency (CoT-SC) | 3 |
+| LLM Debate | 4 |
+| Quality-Diversity | 5 |
+| **total, before round 0** | **19** |
 
-```
-                                  val (search)   test (held out)
-  best hand-designed seed              ?.???           ?.???
-  best searched design                 ?.???           ?.???
-  lift                                +?.???          +?.???
-```
+At 49 s a call that is 19 x |val| x 49 s of seeding before the search starts.
+And the calls inside one design are **serial** — Debate's second round waits on
+its first — so concurrency parallelises across questions, never within a design.
+Raising `--eval-concurrency` past `len(val)` buys nothing, which is why the seed
+archive is now scored across designs concurrently as well, with the nested
+fan-out bounded so `inner x outer` stays inside the budget.
 
-!!! note "The lift row is not filled in yet"
-    A run over the split above is ~2 hours and 6k–17k model calls. One has not
-    been completed against the current code, so this page does not claim a
-    demonstrated lift — the table is the shape of the answer, not the answer.
+**The two constraints are opposed.** Shrink `|val|` to afford the run and the
+validation split returns to a ceiling — measured at `|val| = 7`, CoT scores
+1.000 again and the strict comparison has nothing to rank. Keep `|val|` large
+enough to separate designs and a single run is hours. There is no size that is
+both affordable and readable on this model.
+
+### What was tried
+
+| configuration | outcome |
+|---|---|
+| MGSM, all languages | saturated, 1.000 |
+| GPQA, `\|val\| = 45`, 16 rollouts | stopped at 40 min, still seeding |
+| GPQA, `\|val\| = 29`, 12 rollouts | stopped at 40 min, still seeding |
+| GPQA, `\|val\| = 7`, 8 rollouts, `--no-thinking` | completed; 7 seeds + 2 searched; val back to 1.000 |
+| GPQA, `\|val\| = 7`, 4 rollouts | completed; 7 seeds + **0** searched; val 1.000, test 0.667, lift +0.000 |
+
+`--no-thinking` deserves its own line, because it looks like the answer and is
+not. It cuts a GPQA call from 52.6 s to 5.8 s for six items with 5/6 still
+correct — a ninefold saving at no visible accuracy cost. But what ADAS searches
+over is *reasoning orchestration*: Debate, Step-back and Self-Consistency are
+ways of spending reasoning. Switch reasoning off and they collapse into
+"answer directly", the seven seeds tie again, and the flag has deleted the thing
+under measurement rather than accelerated it.
+
+!!! danger "What would make this row measurable"
+    A cheaper actor with genuine headroom on a reasoning benchmark — the two
+    properties this model has one of at a time. Failing that, an actor whose
+    per-call latency is small enough that `|val| >= 30` is affordable, since the
+    ceiling problem is entirely a small-sample problem. Neither is a change to
+    this port.
 
 ### Give a reasoning model a real token budget
 
@@ -123,9 +183,19 @@ empty. You are billed for tokens generated, not for the cap.
 
     | chain | length |
     |---|---|
-    | seed archive | 19 sequential calls per item (7 seeds) |
+    | seed archive | 19 calls per item across the 7 seeds; the designs are scored **concurrently**, the calls inside one design are not |
     | `propose` | 3 Reflexion rounds, ~84 s |
-    | candidate evaluation | `program_cost` calls per item, candidates run one after another |
+    | candidate evaluation | `program_cost` calls per item, and Debate's second round waits on its first |
+
+    Measured on GPQA with `deepseek-v4-flash`: **49 s and 5,116 completion tokens
+    per call**. Multiply that by 19 x `|val|` and the seed archive alone is the
+    length of an entire run of any other port on this site.
+
+    The nested fan-out is bounded rather than multiplied: `_fitness` opens
+    `min(--eval-concurrency, |val|)` threads, so the outer pool over designs is
+    sized `--eval-concurrency // inner`. Without that the two levels multiply,
+    which is the squared fan-out this repo was bitten by once already on GEPA's
+    D_pareto sweep.
 
     A proposed design may cost up to `MAX_PROGRAM_CALLS` (10) calls per question
     against a seed average of 2.7, which is what dominates a generation. The
@@ -158,16 +228,22 @@ python -m examples.adas.adas_meta_agent_search --dry-run
 python -m examples.adas.adas_meta_agent_search --select dgm --langs en,es
 ```
 
-The settings the numbers above come from — the whole benchmark, hard subset, a
-split that leaves something to measure. The baseline pass is cached per
-(model, question), so only the first run pays for it:
+GPQA instead of MGSM, since MGSM is saturated (see above). `--generations 9999`
+lets `--budget-rollouts` be what stops the run; `--eval-cache` memoises held-out
+scores across processes, which is worth setting for a sweep whose cells share a
+split and worth nothing for a single run:
 
 ```bash
-python -m examples.adas.adas_meta_agent_search \
-    --provider openai --model deepseek-v4-flash \
-    --hard --langs bn,de,en,es,fr,ja,ru,sw,te,th,zh --per-lang 250 \
-    --generations 4 --workers 3 --eval-concurrency 128 \
-    --train-frac 0.15 --test-frac 0.35 --yes
+python -m examples.adas.adas_meta_agent_search --yes \
+    --dataset gpqa --langs en --per-lang 56 \
+    --budget-rollouts 12 --generations 9999 --workers 4 \
+    --async --staleness full --eval-concurrency 32 \
+    --eval-cache ~/.cache/agentdescent/adas-gpqa \
+    --model deepseek-v4-flash
 ```
+
+That configuration did **not** finish inside 40 minutes on the endpoint measured
+here — it was still scoring the seed archive. The section above is the honest
+account of why, and of what would have to change for a lift number to exist.
 
 Offline tests: `tests/test_adas_example.py`.

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -188,6 +188,18 @@ column of each section below says exactly where to look.
   one: running model-written Python through `exec` is arbitrary code execution.
   It bounds what the port demonstrates — the *search* is faithful, the space it
   searches is smaller than upstream's.
+* **Checked against upstream, and clean otherwise.** Keep-all archive, the
+  meta-agent conditioned on the entire archive *with* fitness, exactly two
+  Reflexion refinement rounds, bootstrap-CI fitness, and the seven hand-designed
+  seeds by name (`_mgsm/search.py`, `_mgsm/mgsm_prompt.py`) all match. `--dataset
+  gpqa` is a *domain* change within ADAS's own four, not a dataset swap: GPQA
+  Diamond ships in the ADAS repo.
+* **Not measurable on `deepseek-v4-flash`, and the page says why.** MGSM is
+  saturated in every language (CoT 1.000), which does not merely remove the lift
+  — it ties all seven seeds and so removes the meta-agent's conditioning signal.
+  GPQA has headroom but costs 49 s and 5,116 completion tokens per call, and a
+  candidate is `|val| x program_cost` of those. Shrinking `|val|` to afford it
+  returns the split to a ceiling. The two constraints are opposed.
 * **Selection rule lives in**: the shipped [`Beam(1)`](selection.md) over the
   keep-all archive — best-of-archive, byte-identical to the inline
   strictly-greater tracking it replaced.
@@ -280,7 +292,7 @@ be speedups over.
 | GEPA | HotpotQA | 1424 s / 97 calls | sync 1022 s / 70 · async 742 s / 95 | 1.39× / **1.92×** | 0.75 → 0.60 / 0.65 (1–3 tasks of 20; noise-range) | round's diffs merged into one pool candidate (`--reflective-merge`); empty seed instruction; 1 seed — [full setup](results.md#merging-as-a-cost-lever-serial-vs-8-wide-sync-and-async-gepahotpotqa) |
 | EvoSkill | FinQA (OfficeQA is HF-gated) | — | async N=4: 0.527 → 0.707 val over 120 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--reflective-merge` offers the frontier one fused candidate per sweep instead of one per worker (`update_frontier` and the parent draw unchanged). The async arm used to swap in `SgdSkillAggregator` — no frontier, per-batch validation — which is now removed rather than optional |
 | SkillOpt | SearchQA (`--hard` subset) | — | async N=4: 0.053 → 0.211 val over 60 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--minibatch` is this port's name for the worker count, not upstream's minibatch of tasks. `--reflective-merge` scores one fused patch per step, which is *upstream's* shape (a ReflACT step emits one patch of up to `lr` edits) rather than a departure from it |
-| ADAS | MGSM | — | — | — | — | scheduling and merge timing; budget must be pinned |
+| ADAS | GPQA Diamond (MGSM is saturated) | — | **not measurable on this model** — see [algo-adas.md](algo-adas.md#measured-the-cost-and-why-there-is-no-lift-number) | — | — | scheduling and merge timing; budget must be pinned. `--reflective-merge` is deliberately *not* passed: the archive is keep-all and is the meta-agent's whole conditioning signal, so fusing a round's designs would remove archive entries rather than change merge timing |
 | DGM | surrogate | — | — | — | — | scheduling and merge timing; budget must be pinned. `--serial` sets `selfimprove_size=1`, which is a population of one, so this row's control is the degenerate archive rather than upstream's default |
 | OpenEvolve | function minimization | — | — | — | — | **none** — `rounds = iterations // workers` already fixes total work, so this row's speedup is the only one that was equal-budget before the flag existed |
 

--- a/docs/results.md
+++ b/docs/results.md
@@ -84,7 +84,7 @@ comes from a knob calibrated against that model. Those rows do not transfer.
     a reasoning model. At the library default the meta-agent returns empty content
     on every call and no design reaches the archive — and an empty completion
     scores as a wrong answer rather than raising.
-    [Details](algo-adas.md#measured-mgsm-with-deepseek).
+    [Details](algo-adas.md#give-a-reasoning-model-a-real-token-budget).
 
 Each learned something specific to the failure it was shown:
 

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -111,6 +111,14 @@ def add_standard_args(
               "the cheap layer (see agentdescent.fusion.reflective_merge)"),
     )
     parser.add_argument(
+        "--eval-cache",
+        default="",
+        metavar="DIR",
+        help=("memoise held-out evaluations to this directory, shared across "
+              "processes (see eval_cache_kwargs). Off by default: a cache that "
+              "outlives the run changes what a rerun measures"),
+    )
+    parser.add_argument(
         "--no-thinking",
         action="store_true",
         help=("ask the backend not to emit reasoning tokens (Anthropic-shaped "
@@ -232,6 +240,34 @@ def report_engine(result) -> None:
           f"stale_considered={result.stale_considered}  "
           f"stale_discarded={result.stale_discarded}  "
           f"redispatched={result.redispatched}", flush=True)
+
+
+def eval_cache_kwargs(args: argparse.Namespace) -> dict:
+    """``policies=Policies(eval_cache=...)`` for ``--eval-cache``, or nothing.
+
+    The engine has shipped :class:`~agentdescent.evalcache.FileCache` -- "two
+    processes on one machine stop paying twice for the same gate" -- and every
+    port used the in-process default, so every gate was re-paid on every run.
+
+    ADAS is the clearest case: its seed archive is seven *hand-designed* programs
+    scored over the whole validation split before round 0, and each program is
+    itself several model calls, so a run begins by spending several hundred calls
+    on an evaluation whose inputs never change. A three-arm, three-seed sweep pays
+    that nine times, and a calibration session pays it once per attempt.
+
+    Off by default, and that is not timidity: a persistent cache makes a rerun
+    return the first run's numbers. That is exactly what you want while sizing a
+    configuration and exactly what you do not want when the question is run-to-run
+    variance -- which, on these workloads, is often the question. Turn it on for
+    a sweep whose cells share a dataset and a seed; leave it off when measuring
+    spread.
+    """
+    directory = getattr(args, "eval_cache", "")
+    if not directory:
+        return {}
+    from agentdescent import Policies
+    from agentdescent.evalcache import FileCache
+    return {"policies": Policies(eval_cache=FileCache(directory))}
 
 
 def is_openai_compatible(args: argparse.Namespace) -> bool:

--- a/examples/adas/adas_meta_agent_search.py
+++ b/examples/adas/adas_meta_agent_search.py
@@ -60,9 +60,10 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from agentdescent.staleness import get_policy
 from examples._common import (add_standard_args, completion_for, confirm,
                               is_openai_compatible, worker_count,
-                              budget_kwargs, report_engine)
+                              budget_kwargs, eval_cache_kwargs, report_engine)
 
 MGSM_URL = "https://raw.githubusercontent.com/ShengranHu/ADAS/main/dataset/mgsm/mgsm_{lang}.tsv"
 # ADAS's MGSM language set (utils.ALL_LANGUAGES).
@@ -89,6 +90,20 @@ def _extract_int(text: str) -> Optional[str]:
     else:
         m_val = m.group(1)
     return m_val.replace(",", "")
+
+
+def _extract_choice(text: str) -> Optional[str]:
+    """Pull the final A-D choice out of free-form model output.
+
+    The DSL's blocks are answer-format agnostic -- they compose calls -- but the
+    thing they return has to be comparable to a gold answer, and MGSM's is an
+    integer while GPQA's is a option label. So the extractor travels with the
+    dataset rather than being wired into the blocks.
+    """
+    m = re.findall(r"Answer:\s*\(?([A-D])\)?", text, re.IGNORECASE)
+    if not m:
+        m = re.findall(r"\b([A-D])\b", text)
+    return m[-1].upper() if m else None
 
 
 def _majority(answers: List[Optional[str]]) -> Optional[str]:
@@ -164,10 +179,20 @@ def program_cost(program: dict, depth: int = 0) -> int:
 
 @dataclass
 class Interpreter:
-    """Runs a DSL agent program over one MGSM question via LLM calls."""
+    """Runs a DSL agent program over one question via LLM calls.
+
+    ``extract`` and ``verb`` are the only things that differ between the domains
+    ADAS searches on: MGSM wants an integer out of "solve the math problem",
+    GPQA a choice letter out of "answer the multiple-choice question". The
+    control-flow blocks -- which are what Meta Agent Search actually searches
+    over -- are identical either way.
+    """
 
     complete: Completion
     max_samples: int = 5
+    extract: Callable[[str], Optional[str]] = _extract_int
+    verb: str = "Solve the math problem."
+    tail: str = "the line `Answer: <integer>`"
 
     def run(self, program: dict, question: str) -> Optional[str]:
         block = program["block"]
@@ -195,26 +220,26 @@ class Interpreter:
         return self.complete(prompt)
 
     def _cot(self, q: str) -> Optional[str]:
-        return _extract_int(self._ask(
-            f"Solve the math problem. Think step by step, then end with "
-            f"`Answer: <integer>`.\n\nProblem: {q}"))
+        return self.extract(self._ask(
+            f"{self.verb} Think step by step, then end with "
+            f"{self.tail}.\n\nProblem: {q}"))
 
     def _step_back(self, q: str) -> Optional[str]:
         principles = self._ask(f"What general principles/steps solve this kind of "
                                f"problem? Be brief.\n\nProblem: {q}")
-        return _extract_int(self._ask(
+        return self.extract(self._ask(
             f"Using these principles:\n{principles}\n\nNow solve step by step and "
-            f"end with `Answer: <integer>`.\n\nProblem: {q}"))
+            f"end with {self.tail}.\n\nProblem: {q}"))
 
     def _reflexion(self, q: str, n: int) -> Optional[str]:
-        answer = self._ask(f"Solve step by step, end with `Answer: <integer>`.\n\n"
-                           f"Problem: {q}")
+        answer = self._ask(f"{self.verb} Think step by step, end with {self.tail}."
+                           f"\n\nProblem: {q}")
         for _ in range(max(0, n)):
             answer = self._ask(
                 f"Problem: {q}\n\nYour previous attempt:\n{answer}\n\nCritique it "
                 f"for errors, then give a corrected solution ending with "
-                f"`Answer: <integer>`.")
-        return _extract_int(answer)
+                f"{self.tail}.")
+        return self.extract(answer)
 
     def _debate(self, q: str, roles: List[str], rounds: int) -> Optional[str]:
         transcript = ""
@@ -222,18 +247,18 @@ class Interpreter:
             for role in roles:
                 reply = self._ask(
                     f"You are a {role}. Problem: {q}\n\nDebate so far:\n{transcript}\n\n"
-                    f"Give your reasoning and a tentative `Answer: <integer>`.")
+                    f"Give your reasoning and a tentative {self.tail}.")
                 transcript += f"\n[{role}] {reply}\n"
-        return _extract_int(self._ask(
+        return self.extract(self._ask(
             f"Given this debate, state the final consensus ending with "
-            f"`Answer: <integer>`.\n\n{transcript}"))
+            f"{self.tail}.\n\n{transcript}"))
 
     def _role_assignment(self, q: str, roles: List[str]) -> Optional[str]:
         choice = self._ask(f"Which single expert is best for this problem? "
                            f"Choose one of {roles}. Reply with just the name.\n\n{q}")
         role = next((r for r in roles if r.lower() in choice.lower()), roles[0])
-        return _extract_int(self._ask(
-            f"You are a {role}. Solve step by step, end with `Answer: <integer>`."
+        return self.extract(self._ask(
+            f"You are a {role}. {self.verb} Step by step, end with {self.tail}."
             f"\n\nProblem: {q}"))
 
 
@@ -526,15 +551,87 @@ def evaluate_agent(interp: Interpreter, program: dict, examples: List[Tuple[str,
 
     def one(ex):
         q, a = ex
-        return 1.0 if score_mgsm(a, interp.run(program, q)) else 0.0
+        return 1.0 if score_answer(a, interp.run(program, q)) else 0.0
 
     with ThreadPoolExecutor(max(1, min(concurrency, len(examples)))) as pool:
         return list(pool.map(one, examples))
 
 
+GPQA_URL = "https://raw.githubusercontent.com/ShengranHu/ADAS/main/dataset/gpqa_diamond.csv"
+
+#: The domain's answer contract, in one place. ADAS searches four domains
+#: upstream (`_mgsm`, `_gpqa`, `_drop`, `_arc`); what differs between them is the
+#: question source, how an answer is pulled out of free text, and how it is
+#: compared to gold. The control-flow blocks Meta Agent Search actually searches
+#: over are identical, which is why swapping the domain is a *configuration*
+#: change here and not a fidelity one.
+DOMAINS = {
+    "mgsm": dict(name="MGSM", extract=_extract_int,
+                 verb="Solve the math problem.",
+                 tail="the line `Answer: <integer>`"),
+    "gpqa": dict(name="GPQA Diamond", extract=_extract_choice,
+                 verb="Answer the multiple-choice question.",
+                 tail="the line `Answer: <letter>`"),
+}
+
+
+def build_gpqa_examples(limit: int, seed: int = 0) -> List[Tuple[str, str]]:
+    """GPQA Diamond as (question-with-choices, gold-label) pairs.
+
+    The 198 rows ship with ADAS itself (`dataset/gpqa_diamond.csv`), so this
+    needs no HuggingFace gate. **The options are shuffled per item**: the CSV
+    stores the correct answer in its own column and the three distractors in
+    theirs, so presenting them in file order would put the answer at A every
+    time and the search would discover "always say A".
+    """
+    import csv
+    import io
+    rows = list(csv.DictReader(io.StringIO(fetch_text(GPQA_URL))))
+    rng = random.Random(seed)
+    rng.shuffle(rows)
+    out: List[Tuple[str, str]] = []
+    for i, r in enumerate(rows[:limit]):
+        options = [r["Correct Answer"], r["Incorrect Answer 1"],
+                   r["Incorrect Answer 2"], r["Incorrect Answer 3"]]
+        order = list(range(4))
+        random.Random(seed * 1000 + i).shuffle(order)
+        body = "\n".join(f"{'ABCD'[pos]}. {options[o].strip()}"
+                          for pos, o in enumerate(order))
+        out.append((f"{r['Question'].strip()}\n\nChoices:\n{body}",
+                    "ABCD"[order.index(0)]))
+    return out
+
+
+#: The active domain, set once by ``main`` from ``--dataset``. A module global
+#: because the scorer and the interpreter are constructed in four places that do
+#: not otherwise share state, and threading a config object through all of them
+#: would be a bigger change than the domain swap itself.
+DOMAIN = "mgsm"
+
+
+def interpreter(complete: Completion) -> "Interpreter":
+    """An `Interpreter` wired to the active domain's answer contract."""
+    d = DOMAINS[DOMAIN]
+    return Interpreter(complete, extract=d["extract"], verb=d["verb"], tail=d["tail"])
+
+
+def score_answer(target: str, prediction: Optional[str]) -> bool:
+    """Compare a prediction to gold under the active domain's rule."""
+    return (score_choice(target, prediction) if DOMAIN == "gpqa"
+            else score_mgsm(target, prediction))
+
+
+def score_choice(target: str, prediction: Optional[str]) -> bool:
+    """Label equality -- GPQA's scoring, and the whole of it."""
+    return prediction is not None and target.strip().upper() == prediction.strip().upper()
+
+
 def load_dataset(langs: List[str], per_lang: int, seed: int = 0,
-                 ratios=(0.5, 0.25, 0.25)) -> Dataset:
-    """MGSM (q, a) examples split into train / val (search) / test."""
+                 ratios=(0.5, 0.25, 0.25), dataset: str = "mgsm") -> Dataset:
+    """(q, a) examples split into train / val (search) / test."""
+    if dataset == "gpqa":
+        return split_dataset(build_gpqa_examples(per_lang * max(1, len(langs)), seed=seed),
+                             ratios=ratios, seed=seed, name="GPQA Diamond")
     return split_dataset(build_examples(langs, per_lang, seed=seed),
                          ratios=ratios, seed=seed, name="MGSM")
 
@@ -598,7 +695,8 @@ def fmt_score(x: Optional[float]) -> str:
 
 
 def estimate_calls(generations: int, n_train: int, n_val: int, n_test: int,
-                   n_workers: int = 2) -> Tuple[int, int]:
+                   n_workers: int = 2,
+                   budget_rollouts: Optional[int] = None) -> Tuple[int, int]:
     """``(typical, ceiling)`` model calls for a run of this shape.
 
     The old estimate was ``(7 + generations) * (n_val + n_test) * 3`` computed
@@ -613,6 +711,14 @@ def estimate_calls(generations: int, n_train: int, n_val: int, n_test: int,
     a candidate at the mean seed cost, the ceiling at the cap. Not every
     generation yields a candidate either (a proposal is only requested when the
     trigger rollout fails), so even the low end is an over-estimate."""
+    # `--budget-rollouts` is what stops a run whenever it is set, and the idiom
+    # for using it is `--generations 9999` so the iteration knob cannot bind
+    # first. Pricing the run at 9999 generations then reports a ceiling of ten
+    # million calls for a twelve-rollout run -- the estimate is the number a
+    # caller uses to decide whether they can afford this at all, so it has to
+    # price what will actually happen.
+    if budget_rollouts:
+        generations = max(1, -(-budget_rollouts // max(1, n_workers)))
     seeds = seed_archive()
     costs = [program_cost(s["program"]) for s in seeds]
     seed_calls = sum(costs) * n_val
@@ -683,7 +789,7 @@ def evaluate(complete: Completion, program: dict,
     """Mean MGSM accuracy of an agent program on a held-out split."""
     if not examples:
         return 0.0
-    return sum(evaluate_agent(Interpreter(complete), program, examples,
+    return sum(evaluate_agent(interpreter(complete), program, examples,
                               concurrency=EVAL_CONCURRENCY)) / len(examples)
 
 
@@ -829,8 +935,30 @@ class MetaSearchAggregator(AggregatorProtocol):
             return
         self._seeded = True
         head = self.ledger.snapshot(Ledger.DEV).get(self.aid)
-        for a in seed_archive():
-            mean, ci = self._fitness(head, canonical(a["program"]))
+        # The seven designs are scored **concurrently**, not one after another.
+        # `_fitness` already fans out over the held-out items, but its width is
+        # `min(EVAL_CONCURRENCY, len(held_out))` -- so at a 7-item validation
+        # split it runs 7 calls at a time no matter what `--eval-concurrency`
+        # says, and the seven designs queue behind each other. Measured on
+        # GPQA at 44 s a call: 19 calls per question serialised across designs is
+        # a quarter-hour before round 0 begins.
+        #
+        # Nothing here depends on anything else: the designs are fixed, the
+        # split is fixed, and a design's score is independent of the others'.
+        # `_record` is the one shared write, so it stays on this thread.
+        seeds = seed_archive()
+        # Outer width divides rather than multiplies: `_fitness` already opens
+        # `min(EVAL_CONCURRENCY, len(held_out))` threads of its own, so an outer
+        # pool of `EVAL_CONCURRENCY` would put `EVAL_CONCURRENCY x len(held_out)`
+        # calls in flight -- the squared fan-out this repo has already been bitten
+        # by once, on GEPA's D_pareto sweep.
+        inner = max(1, min(EVAL_CONCURRENCY, len(self.verifier.held_out) or 1))
+        outer = max(1, min(len(seeds), EVAL_CONCURRENCY // inner))
+        from concurrent.futures import ThreadPoolExecutor
+        with ThreadPoolExecutor(outer) as pool:
+            scored = list(pool.map(
+                lambda a: self._fitness(head, canonical(a["program"])), seeds))
+        for a, (mean, ci) in zip(seeds, scored):
             self._record(a["name"], a["thought"], a["program"], mean, ci, seed=True)
         self.ctx.seed_fitness = self.ctx.best_fitness
         self.ctx.best_seed = dict(self.ctx.best_agent)
@@ -936,13 +1064,15 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
                           generations: int, select: str = "adas", seed: int = 0,
                           asynchronous: bool = False, async_ratio: int = 3,
                           max_seconds: float = 45.0, held_out_frac: float = 0.5,
+                          staleness: str = "guarded",
+                          policy_kwargs: Optional[dict] = None,
                           n_workers: int = 2, max_rollouts: Optional[int] = None,
                           verbose: bool = False) -> SearchResult:
     """Drive Meta Agent Search through `evolve()` (val split into trigger/held-out)."""
     tasks = [Task(id=f"mgsm{i}", prompt=q, meta={"answer": a})
              for i, (q, a) in enumerate(val)]
     ctx = AdasContext(select=select, rng_seed=seed)
-    interp = Interpreter(complete)
+    interp = interpreter(complete)
 
     def run(rendered, task):
         try:
@@ -952,7 +1082,7 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
         return interp.run(program, task.prompt) or ""
 
     def reward(task, output):
-        return 1.0 if score_mgsm(task.meta["answer"], output) else 0.0
+        return 1.0 if score_answer(task.meta["answer"], output) else 0.0
 
     def factory(ledger, verifier, audit, config, policy):
         agg = MetaSearchAggregator(ledger, verifier, ctx,
@@ -973,6 +1103,13 @@ def run_meta_agent_search(complete: Completion, val: List[Tuple[str, str]],
            # example in the repo.
            self_verify=False,
            eval_concurrency=EVAL_CONCURRENCY,
+           # A discarded card is a whole meta-agent proposal plus its two
+           # Reflexion refinement rounds -- the most expensive unit of work in
+           # this port -- and the archive is keep-all, so a design that arrives
+           # late still belongs in it. `full` rebases onto the current head and
+           # lets the archive record it, which is the only "gate" ADAS has.
+           staleness_policy=get_policy(staleness),
+           **(policy_kwargs or {}),
            held_out_frac=held_out_frac, aggregator_factory=factory, verbose=verbose,
            max_rollouts=max_rollouts)
     if verbose:
@@ -991,6 +1128,16 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(description=__doc__)
     add_standard_args(p, max_seconds_default=60.0, eval_concurrency_default=16)
     p.add_argument("--generations", type=int, default=6)
+    p.add_argument("--dataset", default="mgsm", choices=["mgsm", "gpqa"],
+                   help=("which of ADAS's own domains to search on. MGSM is "
+                         "saturated for a strong model -- measured, "
+                         "deepseek-v4-flash scores 1.000 on Chain-of-Thought in "
+                         "every language including sw/te/th/bn, so all seven "
+                         "seed designs tie and the meta-agent has no signal to "
+                         "condition on. GPQA Diamond ships with ADAS too "
+                         "(`dataset/gpqa_diamond.csv`, no HF gate) and measures "
+                         "0.625 there: above random (0.250) and well below the "
+                         "ceiling"))
     p.add_argument("--langs", default="en,es,fr",
                    help=f"comma-separated MGSM languages (of {','.join(ALL_LANGUAGES)})")
     p.add_argument("--per-lang", type=int, default=8, help="validation examples per language")
@@ -1005,6 +1152,10 @@ def build_parser() -> argparse.ArgumentParser:
                         "budget is spent on hidden reasoning first, so too small a "
                         "cap returns EMPTY content -- which scores as a wrong "
                         "answer and silently understates every agent")
+    p.add_argument("--staleness", default="guarded",
+                   choices=["guarded", "reflective", "full"],
+                   help=("what to do with a design proposed against an archive "
+                         "the merger has since moved (agentdescent.staleness)"))
     p.add_argument("--workers", type=int, default=2,
                    help="meta-agents proposing per generation. A proposal is only "
                         "requested when the generation's trigger rollout FAILS, so "
@@ -1036,6 +1187,7 @@ def main(argv=None) -> None:
     # the cost estimate and the run cannot disagree about what ran.
     args.workers = worker_count(args, args.workers)
 
+    globals()["DOMAIN"] = args.dataset
     langs = [l.strip() for l in args.langs.split(",") if l.strip() in ALL_LANGUAGES]
     # `not` binds tighter than `and`, so the guard needs its own parentheses --
     # without them `--train-frac 0.9 --test-frac 0.5` passed and produced a
@@ -1056,19 +1208,30 @@ def main(argv=None) -> None:
         print(f"Parallel : {args.workers} meta-agents propose concurrently each "
               "generation (synchronous DP; the archive merge is the barrier)")
     if args.dry_run:
-        print(f"Data     : langs={langs}, per-lang={args.per_lang}; deferred "
+        print(f"Data     : {DOMAINS[DOMAIN]['name']}, "
+              + (f"langs={langs}, " if args.dataset == "mgsm" else "")
+              + f"per-lang={args.per_lang}; deferred "
               "(dry-run performs no network access)")
         print("\n[dry-run] plan only; no dataset or model API was accessed.")
         return
 
-    langmap = language_of(langs, args.per_lang, seed=args.seed)
-    pool = build_examples(langs, args.per_lang, seed=args.seed)
-    ds = split_dataset(pool, ratios=ratios, seed=args.seed, name="MGSM",
-                       stratify_key=lambda ex: langmap.get(ex[0], "?"))
+    if args.dataset == "gpqa":
+        pool = build_gpqa_examples(args.per_lang * max(1, len(langs)), seed=args.seed)
+        # Stratify on the gold label so val and test get the same mix of correct
+        # positions -- an unstratified split can hand one arm a label the model
+        # happens to favour, and that difference reads as a lift.
+        ds = split_dataset(pool, ratios=ratios, seed=args.seed, name="GPQA Diamond",
+                           stratify_key=lambda ex: ex[1])
+    else:
+        langmap = language_of(langs, args.per_lang, seed=args.seed)
+        pool = build_examples(langs, args.per_lang, seed=args.seed)
+        ds = split_dataset(pool, ratios=ratios, seed=args.seed, name="MGSM",
+                           stratify_key=lambda ex: langmap.get(ex[0], "?"))
     harness = EvolvingArtifact("agentic_system", blast_radius=0.6)
     print(f"Governance: harness artifact blast_radius={harness.blast_radius} "
           f"-> {classify(harness).name} (harness changes are high-blast-radius)")
-    print(f"Loaded   : langs={langs}; {len(pool)} items")
+    print(f"Loaded   : {DOMAINS[DOMAIN]['name']}; {len(pool)} items"
+          + (f"; langs={langs}" if args.dataset == "mgsm" else ""))
     print(f"Seeds    : {', '.join(a['name'] for a in seed_archive())}")
     print("\nExample problem:")
     print("  Q:", ds.train[0][0][:150])
@@ -1124,7 +1287,7 @@ def main(argv=None) -> None:
             # and the run then measures the agents against items they were never
             # actually wrong about. One extractor for both sides, so the subset
             # means what it says.
-            score = 1.0 if score_mgsm(a, _extract_int(out or "")) else 0.0
+            score = 1.0 if score_answer(a, DOMAINS[DOMAIN]["extract"](out or "")) else 0.0
             cache.put(q, score)
             verdicts[q] = score
             return score
@@ -1153,7 +1316,8 @@ def main(argv=None) -> None:
 
     ntr, nva, nte = ds.sizes()
     print(f"Split    : {ntr} trigger / {nva} val (fitness) / {nte} test")
-    lo, hi = estimate_calls(args.generations, ntr, nva, nte, args.workers)
+    lo, hi = estimate_calls(args.generations, ntr, nva, nte, args.workers,
+                            budget_rollouts=args.budget_rollouts)
     print(f"Budget   : ~{lo}-{hi} model calls (each candidate is a multi-step "
           f"program, run on every val item)")
     if nva < 20 or nte < 20:
@@ -1167,7 +1331,10 @@ def main(argv=None) -> None:
                                    asynchronous=args.asynchronous, async_ratio=args.async_ratio,
                                    max_seconds=args.max_seconds, n_workers=args.workers,
                                    # the engine's held-out split IS ds.val
-                                   held_out_frac=ds.val_frac, verbose=True,
+                                   held_out_frac=ds.val_frac,
+                                   staleness=args.staleness,
+                                   policy_kwargs=eval_cache_kwargs(args),
+                                   verbose=True,
                                    **budget_kwargs(args))
 
     # Both numbers on the SAME held-out split. Reporting only the searched agent's


### PR DESCRIPTION
Fourth algorithm of the #73 matrix. **This one does not produce a lift number, and the page now explains why instead of leaving the row blank.**

## Fidelity: clean

Checked against `ShengranHu/ADAS` before running. Keep-all archive, meta-agent conditioned on the entire archive *with* fitness, exactly two Reflexion rounds, bootstrap-CI fitness, and the seven hand-designed seeds by name all match `_mgsm/search.py` and `_mgsm/mgsm_prompt.py`. The DSL substitution for `exec`'d Python remains the one declared departure.

## MGSM is saturated — and for ADAS that's worse than a missing lift

Chain-of-Thought alone scores **1.000** on `en`, and also on `sw`, `te`, `th`, `bn`. The hard-language escape doesn't exist.

ADAS conditions its meta-agent on the archive's *fitness values*. Seven seeds all at 1.000 leaves it nothing to **learn** from, not merely nothing to beat.

## `--dataset gpqa`

A *domain* change within ADAS's own four (`_mgsm`, `_gpqa`, `_drop`, `_arc`), not a dataset swap — GPQA Diamond's 198 rows ship inside the ADAS repo, no HF gate. CoT measures **0.625** there.

Options are shuffled per item and the split stratified on the gold label: the CSV keeps the correct answer in its own column, so file order would put it at A every time and the search would discover "always answer A".

## Four things found while trying to run it

- **The budget estimate priced a run that could not happen.** `--generations 9999` is the idiom for letting `--budget-rollouts` stop a run; `estimate_calls` took the 9999 literally and reported **2.8M–10M calls** for a twelve-rollout run that costs ~1,400.
- **`--staleness` was unavailable.** A discarded card here is a whole meta-agent proposal plus its two Reflexion rounds, and the archive is keep-all — a design arriving late still belongs in it.
- **`--eval-cache`** (shared, in `_common`). The engine has shipped `FileCache` all along and every port used the in-process default. Off by default, and **worth nothing for a single run** — it pays across cells sharing a split.
- **The seed archive was scored one design at a time**, while `_fitness`'s own width is `min(--eval-concurrency, |val|)` — so at a 7-item split it ran 7 calls at a time whatever `--eval-concurrency 32` said. Designs are independent, so they now run concurrently, with the outer pool sized `--eval-concurrency // inner` rather than multiplied against it.

## `--reflective-merge` is deliberately not wired here

`SEMANTICS` records why: the archive is keep-all and *is* the meta-agent's conditioning signal, so fusing a round's N designs would delete N−1 archive entries per round — the algorithm's central mechanism, not its merge timing. The usual justification is absent too (this aggregator drops nothing), and a proposal is a whole agent *program* rather than a delta.

## Why there is still no lift number

Measured on GPQA: **49 s and 5,116 completion tokens per call** — and the reasoning isn't optional, since at `max_tokens` 512 and 4096 the reply comes back empty. A candidate costs `|val| × program_cost` of those; the seed archive alone is 19 calls per question.

Shrink `|val|` to afford the run and the split returns to a ceiling (measured: CoT 1.000 again at `|val| = 7`). **The two constraints are opposed and the middle is empty.**

| configuration | outcome |
|---|---|
| MGSM, all languages | saturated, 1.000 |
| GPQA, \|val\|=45, 16 rollouts | stopped at 40 min, still seeding |
| GPQA, \|val\|=29, 12 rollouts | stopped at 40 min, still seeding |
| GPQA, \|val\|=7, `--no-thinking` | completed; val back to 1.000 |
| GPQA, \|val\|=7, 4 rollouts | completed; 0 searched designs; lift +0.000 |

`--no-thinking` looks like the answer and isn't: it cuts a call 52.6s → 5.8s with 5/6 still correct, but ADAS searches over *reasoning orchestration* — with reasoning off, Debate, Step-back and Self-Consistency all collapse into "answer directly", the seeds tie again, and the flag has deleted the object of measurement. Recorded on the page for the next person who reaches for it.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)