### PR TITLE
feat(dgm): an objective the agent can actually fail at (#73)

### DIFF
--- a/bench/results/dgm-real-objective.json
+++ b/bench/results/dgm-real-objective.json
@@ -1,0 +1,31 @@
+{
+  "model": "deepseek-v4-flash",
+  "provider": "claude",
+  "eval_concurrency": 16,
+  "cells": [
+    {
+      "row": "dgm",
+      "dataset": "vendored bugs w/ pytest",
+      "arm": "async",
+      "seed": 0,
+      "objective": "real",
+      "width": 2,
+      "budget": 16,
+      "staleness": "full",
+      "tasks": 64,
+      "held_out": 32,
+      "engine_rollouts": 17,
+      "stale_considered": 0,
+      "stale_discarded": 0,
+      "seed_score": 0.844,
+      "final_reward": 0.844,
+      "archive_scores": [
+        0.906,
+        0.906,
+        0.844
+      ],
+      "kept_below_seed": 0,
+      "solve_py_lines": 79
+    }
+  ]
+}

--- a/docs/algo-dgm.md
+++ b/docs/algo-dgm.md
@@ -58,31 +58,90 @@ In [`examples/dgm/dgm_self_improve.py`](https://github.com/Birfy/agentdescent/bl
 | **`dgm_parent_weights` / `choose_selfimproves`** | (selection) | the exact DGM rule `p_i ∝ sigmoid(10·(score−0.5)) · 1/(1+children_i)` |
 | `propose` + `make_surrogate_evaluator` | `propose=` / objective | add the most-needed capability; the transparent surrogate objective (swap in a real Docker harness via `evaluate_fn`) |
 
-## Measured — surrogate objective
+## Measured — the real objective
 
-`--generations 4 --provider openai --model deepseek-v4-flash`:
+`--objective real` evolves the agent's own Python source and scores it by running
+pytest. 64 vendored bugs in `examples/dgm/tasks/` (32 train / 32 held-out),
+16 rollouts, `--staleness full`, `deepseek-v4-flash`, one seed:
 
 | | resolve rate |
 |---|---|
-| val, before → after | 0.000 → **0.300** |
-| test (held out, never seen by selection) | 0.200 |
+| seed agent, held out | **0.844** (27 of 32) |
+| best archived child | **0.906** (29 of 32) |
+| archive | 3 agents: 0.906, 0.906, 0.844 |
+| the agent's own `solve.py` | 18 lines → **79 lines** |
 
-Archive: 4 agents (keep-all). The best lineage reached generation 3 with
-capabilities `context-retrieval`, `dependency-resolver`, `diff-minimization`,
-`regression-test-runner`.
+**What it wrote for itself.** The seed agent sends `lib.py` and the pytest output
+to a model and writes the reply straight back. Its own diagnosis produced three
+changes, all of them aimed at failures that actually occurred:
 
-!!! warning "This is the surrogate, not SWE-bench"
-    The objective is a capability-cover stand-in; real DGM evaluates on SWE-bench
-    Verified inside Docker, which this example does not run. What is faithful is
-    the **archive, the selection rule and the staged escalation** — the numbers
-    above measure those mechanics, not coding ability.
+```python
+def _strip_code_fences(reply):     # replies arrived wrapped in ``` and broke the import
+    if text.startswith("```"): ...
+    match = re.search(r"```[a-zA-Z0-9_+-]*\s*\n(.*?)```", text, re.DOTALL)
+
+def _is_success(out):              # "passed" alone is not success
+    return " passed" in out and " failed" not in out and " error" not in out
+
+test_source = (task_path / "test_lib.py").read_text()   # read the tests too
+```
+
+The fence stripper is the one that mattered: measured before the run, six of the
+sixteen tasks the seed failed came back as `1 error` rather than `1 failed` --
+the reply had been written into `lib.py` complete with its Markdown fence, so the
+module would not import. Reading the test file is not a fix for anything that
+failed; it is the agent giving itself an input the seed never had.
+
+!!! warning "This is not SWE-bench"
+    64 hand-written bugs are not 500 repository issues, and a number here cannot
+    be compared with the paper. What this reproduces is the *shape*: real source,
+    real execution, real pass/fail, and self-edits that can leave the agent worse
+    -- or unable to run at all.
+
+    The [surrogate objective](#honesty-boundary) remains the default, and its
+    limitation is worth stating precisely: it is **monotone**. Adding a
+    capability can never un-resolve a task, so a self-modification can never
+    regress -- which removes the reason to keep an archive. Open-ended search
+    retains stepping stones because a worse intermediate can lead somewhere
+    better, and under a monotone objective there are no worse intermediates.
+    Under the real objective there are: an earlier run archived children at
+    **0.875 and 0.500**, the worse one kept, which is the behaviour `keep-all`
+    exists for and which the surrogate cannot produce.
+
+!!! danger "Two numbers on this page were wrong before they were right"
+    An earlier version of this run reported **0.000 → 0.844**. The final figure
+    was correct and the baseline was invented: the archive seeded itself inside
+    `step()`, which only runs once a card reaches the merger, so a run whose
+    self-modifications all failed never measured its own seed and printed
+    `DGMContext.seed_score`'s 0.0 default. A wrong denominator under a right
+    numerator reads as a large success. Seeding now happens when the archive is
+    built, and a test pins it with an actor that proposes nothing at all.
+
+    Before that, a self-edit that added a **retry loop** scored 0.875 → 0.500 and
+    looked like a regression. It was not: the harness pre-fetched a single model
+    reply and served it to every call, so the second and third attempts received
+    the first answer again. "One model call per task" was a property of the
+    harness, and the first improvement the agent ever proposed was the one thing
+    that made impossible. The bridge is now a real request/reply channel with a
+    call budget.
 
 ## Run it
 
 ```bash
-python -m examples.dgm.dgm_self_improve                      # runs offline (surrogate)
+python -m examples.dgm.dgm_self_improve                      # offline (surrogate)
 python -m examples.dgm.dgm_self_improve --generations 12 --archive keep_all
 python -m examples.dgm.dgm_self_improve --model claude-haiku-4-5   # LLM proposes modifications
+
+# the real objective, as measured above
+python -m examples.dgm.dgm_self_improve --yes --seed 0 --objective real \
+    --selfimprove-size 2 --generations 9999 --budget-rollouts 16 \
+    --staleness full --async --async-ratio 3 --max-seconds 2700 \
+    --eval-concurrency 16 --model deepseek-v4-flash \
+    --write-agent /tmp/evolved-agent
 ```
 
-Offline tests: `tests/test_dgm_example.py`.
+`--write-agent` is not optional if you want to see what the run produced: the
+ledger is a scratch git repo that `evolve` reaps on exit, and for a self-editing
+agent that source *is* the result.
+
+Offline tests: `tests/test_dgm_example.py`, `tests/test_dgm_real_objective.py`.

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -222,6 +222,16 @@ column of each section below says exactly where to look.
 * **A past departure, now fixed**: the port once had a third staged-eval rung
   upstream's self-improve loop does not use. It passes exactly two subsets, and
   the test above pins that it stops at medium.
+* **The surrogate objective is monotone, and `--objective real` is the way out.**
+  Hashing an instance id into a capability set means adding a capability can
+  never un-resolve a task, so a self-modification can never regress -- which
+  removes the reason DGM keeps an archive at all. `--objective real` evolves the
+  agent's own Python source against vendored bugs with real pytest runs: not
+  SWE-bench, but real execution, real regressions, and self-edits that can leave
+  the agent unable to run. Measured there, the seed scores 0.844 and the best
+  archived child 0.906, and an earlier run archived children at 0.875 and 0.500
+  -- the worse one kept, which is what `keep-all` is for and what the surrogate
+  cannot produce. See [algo-dgm.md](algo-dgm.md#measured-the-real-objective).
 * **Selection rule lives in**: `DGMParentSelection` — `sigmoid(10·(s−0.5)) × 1/(1+children)` as a named `SelectionPolicy` over the archive
   `examples/dgm/dgm_self_improve.py` — [`Archive`](selection.md) with
   `sampling="novelty"`.
@@ -293,7 +303,7 @@ be speedups over.
 | EvoSkill | FinQA (OfficeQA is HF-gated) | — | async N=4: 0.527 → 0.707 val over 120 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--reflective-merge` offers the frontier one fused candidate per sweep instead of one per worker (`update_frontier` and the parent draw unchanged). The async arm used to swap in `SgdSkillAggregator` — no frontier, per-batch validation — which is now removed rather than optional |
 | SkillOpt | SearchQA (`--hard` subset) | — | async N=4: 0.053 → 0.211 val over 60 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--minibatch` is this port's name for the worker count, not upstream's minibatch of tasks. `--reflective-merge` scores one fused patch per step, which is *upstream's* shape (a ReflACT step emits one patch of up to `lr` edits) rather than a departure from it |
 | ADAS | GPQA Diamond (MGSM is saturated) | — | **not measurable on this model** — see [algo-adas.md](algo-adas.md#measured-the-cost-and-why-there-is-no-lift-number) | — | — | scheduling and merge timing; budget must be pinned. `--reflective-merge` is deliberately *not* passed: the archive is keep-all and is the meta-agent's whole conditioning signal, so fusing a round's designs would remove archive entries rather than change merge timing |
-| DGM | surrogate | — | — | — | — | scheduling and merge timing; budget must be pinned. `--serial` sets `selfimprove_size=1`, which is a population of one, so this row's control is the degenerate archive rather than upstream's default |
+| DGM | vendored bugs w/ pytest (`--objective real`) | — | async N=2: seed 0.844, best archived child **0.906** over 16 rollouts | — | — | scheduling and merge timing; budget must be pinned. `--serial` sets `selfimprove_size=1`, which is a population of one, so this row's control is the degenerate archive rather than upstream's default |
 | OpenEvolve | function minimization | — | — | — | — | **none** — `rounds = iterations // workers` already fixes total work, so this row's speedup is the only one that was equal-budget before the flag existed |
 
 **The quality column is allowed to go down, and a table of all-green is probably

--- a/examples/dgm/dgm_self_improve.py
+++ b/examples/dgm/dgm_self_improve.py
@@ -67,6 +67,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from agentdescent.staleness import get_policy
 from examples._common import (add_standard_args, completion_for, confirm,
                               worker_count,
                               budget_kwargs, report_engine)
@@ -412,7 +413,7 @@ def run_dgm(instances: List[dict], generations: int = 12,
             evaluate_fn: Optional[Callable[[Agent, List[dict]], float]] = None,
             complete: Optional[Callable[[str], str]] = None, seed: int = 0,
             asynchronous: bool = False, async_ratio: int = 3, max_seconds: float = 20.0,
-            max_rollouts: Optional[int] = None,
+            max_rollouts: Optional[int] = None, staleness: str = "guarded",
             verbose: bool = False) -> DGMResult:
     """Drive DGM through `evolve()` (SWE instances split into trigger/held-out)."""
     evaluate_fn = evaluate_fn or make_surrogate_evaluator()
@@ -443,6 +444,14 @@ def run_dgm(instances: List[dict], generations: int = 12,
                     asynchronous=asynchronous, async_ratio=async_ratio,
                     max_seconds=max_seconds if asynchronous else None,
                     held_out_frac=0.5, aggregator_factory=factory, verbose=verbose,
+                    # A discarded card is a whole self-improvement -- the parent
+                    # reads its own evaluation log, diagnoses a weakness and
+                    # rewrites a file. And a child branches from its *parent*
+                    # rather than deltas onto a moving head, so arriving late
+                    # costs it nothing: the archive is keep-all and still wants
+                    # it. Under the real objective the rebase is also self-
+                    # checking, since a child that no longer runs scores zero.
+                    staleness_policy=get_policy(staleness),
                     max_rollouts=max_rollouts)
     if verbose:
         report_engine(result)
@@ -478,9 +487,75 @@ def build_parser() -> argparse.ArgumentParser:
         p, model_default=None, max_seconds_default=15.0,
         model_help="optional: let an LLM propose self-modifications (else deterministic)")
     p.add_argument("--generations", type=int, default=12)
+    p.add_argument("--objective", default="surrogate",
+                   choices=["surrogate", "real"],
+                   help=("`surrogate` hashes each SWE instance id into a latent "
+                         "capability set -- offline, deterministic, and MONOTONE, "
+                         "so a self-edit can never regress and the keep-all "
+                         "archive has no stepping stones to keep. `real` evolves "
+                         "the agent's own Python source against vendored bugs "
+                         "with real pytest runs: not SWE-bench, but real code, "
+                         "real execution, and self-edits that can break the "
+                         "agent (see examples/dgm/real_objective.py)"))
+    p.add_argument("--staleness", default="guarded",
+                   choices=["guarded", "reflective", "full"],
+                   help="what to do with a self-edit proposed against a head the "
+                        "merger has since moved (agentdescent.staleness)")
     p.add_argument("--selfimprove-size", type=int, default=2)
     p.add_argument("--archive", default="keep_all", choices=["keep_all", "keep_better"])
     return p
+
+
+def _main_real(args) -> None:
+    """The `--objective real` path: self-editing source, scored by pytest.
+
+    Kept apart from the surrogate `main` rather than threaded through it,
+    because almost nothing is shared below the algorithm: a different artifact,
+    a different actor, a different scorer. What *is* shared is the part that
+    matters -- `run_dgm_real` builds the same `DGMArchiveAggregator`.
+    """
+    from examples.dgm.real_objective import load_tasks, run_dgm_real
+    from agentdescent.filetree import parse_tree
+
+    art = EvolvingArtifact("coding_agent", blast_radius=0.6)
+    cases = load_tasks()
+    print(f"Governance: coding-agent source blast_radius={art.blast_radius} "
+          f"-> {classify(art).name} (the agent edits its own code)")
+    print(f"Loaded   : {len(cases)} vendored bugs -- "
+          + ", ".join(c.id for c in cases))
+    if not args.model:
+        print("\nThis objective needs a model: the agent's own `solve` calls one, "
+              "and so does the self-modification. Pass --model.")
+        return
+    if not confirm(args):
+        return
+    from examples.dgm.real_objective import MAX_TOKENS
+    complete = completion_for(args, max_tokens=MAX_TOKENS)
+    try:
+        complete("Reply with the single word: ok")
+    except Exception as e:  # noqa: BLE001
+        print(f"\nLLM unreachable ({type(e).__name__}: {e}).")
+        return
+
+    print(f"\nRunning DGM (real objective, selfimprove_size="
+          f"{args.selfimprove_size}, L1 harness)...\n")
+    result = run_dgm_real(
+        complete, cases=cases, generations=args.generations,
+        selfimprove_size=args.selfimprove_size, seed=args.seed,
+        asynchronous=args.asynchronous, async_ratio=args.async_ratio,
+        max_seconds=args.max_seconds, staleness=args.staleness,
+        eval_concurrency=args.eval_concurrency, verbose=True,
+        **budget_kwargs(args))
+    report_engine(result)
+
+    files = parse_tree(result.rendered)
+    print("\n=== best self-improved agent ===")
+    for path in sorted(files):
+        print(f"--- {path} ({len(files[path].splitlines())} lines) ---")
+    print(f"\nheld-out resolve-rate: {result.final_reward:.3f}")
+    print(f"stopped   : {result.stop_reason}")
+    if result.error:
+        print(f"WARNING: the run did not finish cleanly -- {result.error}")
 
 
 def main(argv=None) -> None:
@@ -491,7 +566,11 @@ def main(argv=None) -> None:
     args.selfimprove_size = worker_count(args, args.selfimprove_size)
 
     print("Algorithm: Darwin Godel Machine (DGM) -- harness self-evolution")
-    print("Dataset  : SWE-bench Verified (real instance ids; surrogate objective)")
+    if args.objective == "real":
+        print("Dataset  : vendored Python bugs with real pytest suites "
+              "(examples/dgm/tasks) -- NOT SWE-bench")
+    else:
+        print("Dataset  : SWE-bench Verified (real instance ids; surrogate objective)")
     print(f"Plan     : model={args.model or 'deterministic'}, "
           f"generations={args.generations}, archive={args.archive}")
     if args.asynchronous:
@@ -501,12 +580,20 @@ def main(argv=None) -> None:
     else:
         print(f"Parallel : {args.selfimprove_size} agents self-modify concurrently each "
               "generation (synchronous DP; the archive merge is the barrier)")
-    print("\nObjective: SURROGATE (capability-cover) -- real DGM runs SWE-bench in "
-          "Docker.\n           The archive + selection + staged escalation are faithful.")
+    if args.objective == "real":
+        print("\nObjective: REAL -- the agent edits its own Python source and is "
+              "scored by pytest.\n           Not SWE-bench: six vendored bugs, so "
+              "these numbers are not comparable with the paper.")
+    else:
+        print("\nObjective: SURROGATE (capability-cover) -- real DGM runs SWE-bench in "
+              "Docker.\n           The archive + selection + staged escalation are faithful.")
     if args.dry_run:
         print("Data     : deferred (dry-run performs no network access)")
         print("\n[dry-run] plan only; no dataset or model API was accessed.")
         return
+
+    if args.objective == "real":
+        return _main_real(args)
 
     ds = load_dataset(STAGE_BIG, seed=args.seed)
     art = EvolvingArtifact("coding_agent", blast_radius=0.6)

--- a/examples/dgm/dgm_self_improve.py
+++ b/examples/dgm/dgm_self_improve.py
@@ -487,6 +487,10 @@ def build_parser() -> argparse.ArgumentParser:
         p, model_default=None, max_seconds_default=15.0,
         model_help="optional: let an LLM propose self-modifications (else deterministic)")
     p.add_argument("--generations", type=int, default=12)
+    p.add_argument("--write-agent", default="", metavar="DIR",
+                   help=("write the evolved agent's source here (--objective "
+                         "real). The ledger is scratch and is reaped on exit, so "
+                         "without this the thing the run produced is not kept"))
     p.add_argument("--objective", default="surrogate",
                    choices=["surrogate", "real"],
                    help=("`surrogate` hashes each SWE instance id into a latent "
@@ -552,7 +556,26 @@ def _main_real(args) -> None:
     print("\n=== best self-improved agent ===")
     for path in sorted(files):
         print(f"--- {path} ({len(files[path].splitlines())} lines) ---")
-    print(f"\nheld-out resolve-rate: {result.final_reward:.3f}")
+    if args.write_agent:
+        # The ledger is a scratch git repo that `evolve` reaps on exit, so the
+        # evolved source is gone the moment the run ends unless it is asked for.
+        # For a self-editing agent that source *is* the result -- a line count is
+        # not a finding.
+        plan = result.write_to(args.write_agent)
+        print(f"\nwrote {len(plan['written'])} file(s) to {args.write_agent}")
+    seed = getattr(result, "dgm_seed_score", None)
+    archive = getattr(result, "dgm_archive", []) or []
+    base = "not measured" if seed is None else f"{seed:.3f}"
+    print(f"\nheld-out resolve-rate: {base} -> {result.final_reward:.3f}")
+    if archive:
+        scores = sorted((a.score for a in archive), reverse=True)
+        worse = sum(1 for a in archive[1:] if a.score < archive[0].score)
+        print(f"archive  : {len(archive)} agent(s), scores "
+              + ", ".join(f"{s:.3f}" for s in scores[:6])
+              + (" ..." if len(scores) > 6 else ""))
+        # The point of keep-all, and the thing the surrogate objective cannot
+        # produce: children that scored *below* the seed and were kept anyway.
+        print(f"           {worse} kept below the seed (stepping stones)")
     print(f"stopped   : {result.stop_reason}")
     if result.error:
         print(f"WARNING: the run did not finish cleanly -- {result.error}")
@@ -582,7 +605,7 @@ def main(argv=None) -> None:
               "generation (synchronous DP; the archive merge is the barrier)")
     if args.objective == "real":
         print("\nObjective: REAL -- the agent edits its own Python source and is "
-              "scored by pytest.\n           Not SWE-bench: six vendored bugs, so "
+              "scored by pytest.\n           Not SWE-bench: a vendored bug set, so "
               "these numbers are not comparable with the paper.")
     else:
         print("\nObjective: SURROGATE (capability-cover) -- real DGM runs SWE-bench in "

--- a/examples/dgm/evolved/README.md
+++ b/examples/dgm/evolved/README.md
@@ -1,0 +1,11 @@
+# What the agent wrote for itself
+
+The best archived child from the run recorded in
+[`docs/algo-dgm.md`](../../../docs/algo-dgm.md#measured-the-real-objective) --
+seed 0.844, this agent 0.906 on 32 held-out bugs.
+
+Not hand-written and not edited afterwards: `solve.py` is what
+`--objective real` produced from the 18-line seed in
+`examples/dgm/real_objective.py`, kept here because the ledger is a scratch git
+repo that `evolve` reaps on exit and for a self-editing agent the source *is*
+the result.

--- a/examples/dgm/evolved/solve.py
+++ b/examples/dgm/evolved/solve.py
@@ -1,0 +1,79 @@
+"""The agent: read a failing task, edit `lib.py` to fix it."""
+import pathlib
+import re
+from tools import read_source, run_tests, write_source
+
+
+def _strip_code_fences(reply):
+    text = reply.strip()
+    if not text:
+        return ""
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        out = []
+        for line in lines:
+            if line.strip().startswith("```"):
+                break
+            out.append(line)
+        if out:
+            return "\n".join(out).strip() + "\n"
+    match = re.search(r"```[a-zA-Z0-9_+-]*\s*\n(.*?)```", text, re.DOTALL)
+    if match:
+        return match.group(1).strip() + "\n"
+    return text + "\n"
+
+
+def _is_success(out):
+    return " passed" in out and " failed" not in out and " error" not in out
+
+
+def solve(task_dir, llm):
+    """Return nothing; edit files in `task_dir` in place.
+
+    `llm(prompt) -> str` is the only model access. `run_tests(task_dir)`
+    returns (passed, failed, output).
+    """
+    task_path = pathlib.Path(task_dir)
+    source = read_source(task_dir)
+
+    try:
+        test_source = (task_path / "test_lib.py").read_text()
+    except FileNotFoundError:
+        test_source = ""
+
+    prompt_head = (
+        "Fix the bug so every test passes. Reply with the complete new "
+        "contents of lib.py and nothing else -- no fences, no commentary.\n\n"
+        f"lib.py:\n{source}\n\n"
+    )
+    if test_source:
+        prompt_head += f"test_lib.py:\n{test_source}\n\n"
+
+    _, _, failure = run_tests(task_dir)
+    prompt = prompt_head + f"pytest says:\n{failure}"
+
+    for _ in range(3):
+        reply = llm(prompt)
+        code = _strip_code_fences(reply)
+        write_source(task_dir, code)
+
+        try:
+            compile(code, str(task_path / "lib.py"), "exec")
+        except SyntaxError as exc:
+            prompt = prompt_head + (
+                "Your previous reply had invalid Python. pytest says:\n"
+                f"SyntaxError in submitted lib.py:\n{exc}"
+            )
+            continue
+
+        _, _, out = run_tests(task_dir)
+        if _is_success(out):
+            return
+
+        prompt = prompt_head + (
+            "Your previous attempt did not pass all tests. "
+            "Reply again with corrected complete lib.py and nothing else.\n\n"
+            f"pytest says:\n{out}"
+        )

--- a/examples/dgm/evolved/tools.py
+++ b/examples/dgm/evolved/tools.py
@@ -1,0 +1,23 @@
+"""What the agent can do. Editing this file is how the agent improves."""
+import pathlib
+import subprocess
+import sys
+
+
+def read_source(task_dir):
+    return (pathlib.Path(task_dir) / "lib.py").read_text()
+
+
+def write_source(task_dir, text):
+    (pathlib.Path(task_dir) / "lib.py").write_text(text)
+
+
+def run_tests(task_dir, timeout=60):
+    """Run the task's tests. Returns (passed, failed, output)."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "--no-header", "test_lib.py"],
+        cwd=str(task_dir), capture_output=True, text=True, timeout=timeout)
+    out = proc.stdout + proc.stderr
+    passed = out.count(" passed")
+    failed = out.count(" failed")
+    return passed, failed, out

--- a/examples/dgm/real_objective.py
+++ b/examples/dgm/real_objective.py
@@ -1,0 +1,534 @@
+"""A real objective for the DGM port: a self-editing agent, run against pytest.
+
+The shipped objective is a *surrogate* -- each SWE instance is assigned a latent
+capability set by hashing its id, and an agent "resolves" it when its own
+capability set covers that. The DGM loop is faithful on top of it, but the
+objective it optimises has three properties the real one does not:
+
+* it is **monotone** -- adding a capability can never un-resolve a task, so a
+  self-modification can never regress;
+* capabilities never **interact** -- no edit can help one task and break another;
+* the required set is a **hash**, unrelated to the task's actual difficulty.
+
+Monotonicity is the one that matters, because it removes the reason DGM keeps an
+archive at all. Open-ended search retains stepping stones because a worse
+intermediate can lead somewhere better; under a monotone objective there are no
+worse intermediates, and `keep-all` plus the novelty-discounted parent draw are
+machinery with nothing to do.
+
+So this module replaces the objective rather than the algorithm. The agent is a
+**real directory of Python source** that edits itself; a task is a **real
+package with a failing pytest**; a score is what pytest actually reports. Every
+DGM mechanism above it -- keep-all archive, `sigmoid(10*(s-0.5)) / (1+children)`
+parent selection, staged small->medium escalation -- is untouched.
+
+**This is not SWE-bench.** Six vendored bugs in `examples/dgm/tasks/` are not 500
+real repository issues, and a number from here cannot be compared with the paper.
+What it does reproduce is the *shape*: real code, real execution, real pass/fail,
+and self-edits that can genuinely make the agent worse -- including edits that
+leave it unable to run at all.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import warnings
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+from agentdescent.filetree import parse_tree
+from agentdescent.treestrategy import FileTree as _FileTree
+
+TASKS_DIR = pathlib.Path(__file__).resolve().parent / "tasks"
+
+#: Empty replies seen by :func:`propose_self_edit`, for the warning below.
+_EMPTY = {"n": 0}
+
+#: The agent, as source. This is the artifact DGM evolves: a `FileTree` whose
+#: keys are real relative paths, so a candidate can be written to a workspace and
+#: imported. The seed is deliberately weak -- it edits nothing and scores zero --
+#: because a seed that already solved the tasks would leave the search nothing to
+#: find, which is the saturation trap every other row in this matrix hit.
+SEED_AGENT: Dict[str, str] = {
+    "agent/solve.py": '''"""The agent: read a failing task, edit `lib.py` to fix it."""
+from tools import read_source, run_tests, write_source
+
+
+def solve(task_dir, llm):
+    """Return nothing; edit files in `task_dir` in place.
+
+    `llm(prompt) -> str` is the only model access. `run_tests(task_dir)`
+    returns (passed, failed, output).
+    """
+    source = read_source(task_dir)
+    _, _, failure = run_tests(task_dir)
+    reply = llm(
+        "Fix the bug so every test passes. Reply with the complete new "
+        "contents of lib.py and nothing else -- no fences, no commentary.\\n\\n"
+        f"lib.py:\\n{source}\\n\\npytest says:\\n{failure}"
+    )
+    write_source(task_dir, reply)
+''',
+    "agent/tools.py": '''"""What the agent can do. Editing this file is how the agent improves."""
+import pathlib
+import subprocess
+import sys
+
+
+def read_source(task_dir):
+    return (pathlib.Path(task_dir) / "lib.py").read_text()
+
+
+def write_source(task_dir, text):
+    (pathlib.Path(task_dir) / "lib.py").write_text(text)
+
+
+def run_tests(task_dir, timeout=60):
+    """Run the task's tests. Returns (passed, failed, output)."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "--no-header", "test_lib.py"],
+        cwd=str(task_dir), capture_output=True, text=True, timeout=timeout)
+    out = proc.stdout + proc.stderr
+    passed = out.count(" passed")
+    failed = out.count(" failed")
+    return passed, failed, out
+''',
+}
+
+
+@dataclass
+class TaskCase:
+    """One vendored bug: a package with a failing test."""
+
+    id: str
+    path: pathlib.Path
+    why: str
+
+
+def load_tasks(limit: Optional[int] = None) -> List[TaskCase]:
+    cases = []
+    for d in sorted(TASKS_DIR.iterdir()):
+        meta = d / "task.json"
+        if not meta.is_file():
+            continue
+        info = json.loads(meta.read_text())
+        cases.append(TaskCase(id=info["id"], path=d, why=info["why"]))
+    return cases[:limit] if limit else cases
+
+
+def _materialise(agent_files: Dict[str, str], root: pathlib.Path) -> None:
+    """Write the candidate agent's source into a workspace.
+
+    Paths are checked rather than trusted: a self-edit is model output, and this
+    writes to a real filesystem. `..` or an absolute path would escape the
+    workspace, which is the one failure mode here that is not just a bad score.
+    """
+    for rel, body in agent_files.items():
+        target = (root / rel).resolve()
+        if not str(target).startswith(str(root.resolve()) + os.sep):
+            raise ValueError(f"agent file escapes the workspace: {rel!r}")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+
+
+def run_agent_on_task(agent_files: Dict[str, str], case: TaskCase,
+                      llm: Callable[[str], str],
+                      timeout: float = 120.0) -> Tuple[bool, str]:
+    """Run one candidate agent against one task in a scratch copy.
+
+    Returns ``(resolved, detail)``. **A broken agent scores zero rather than
+    raising**: a self-modification that leaves a syntax error, imports a module
+    that is not there, or loops until the timeout is exactly the regression this
+    objective exists to expose, and turning it into an exception would stop the
+    search instead of scoring it.
+    """
+    work = pathlib.Path(tempfile.mkdtemp(prefix="dgm-real-"))
+    try:
+        task_dir = work / "task"
+        shutil.copytree(case.path, task_dir)
+        _materialise(agent_files, work)
+
+        driver = work / "_run.py"
+        driver.write_text(
+            "import sys, json\n"
+            "sys.path.insert(0, 'agent')\n"
+            "from solve import solve\n"
+            "import _bridge\n"
+            "solve(sys.argv[1], _bridge.llm)\n")
+        # The model call crosses a process boundary: the agent runs in its own
+        # interpreter (a self-edit can and does break imports), so replies are
+        # pre-computed here and served from a file. One prompt per task keeps
+        # that honest -- an agent that wants two calls cannot have them, and the
+        # seed's own `solve` makes exactly one.
+        prompt_file, reply_file = work / "_prompt.txt", work / "_reply.txt"
+        (work / "_bridge.py").write_text(
+            "import pathlib\n"
+            "def llm(prompt):\n"
+            f"    pathlib.Path({str(prompt_file)!r}).write_text(prompt)\n"
+            "    raise SystemExit(17)\n")
+
+        # Pass 1: let the agent build its prompt, then stop at the boundary.
+        subprocess.run([sys.executable, str(driver), str(task_dir)],
+                       cwd=str(work), capture_output=True, text=True,
+                       timeout=timeout)
+        if not prompt_file.is_file():
+            return False, "agent never reached a model call"
+        reply = llm(prompt_file.read_text())
+        reply_file.write_text(reply)
+
+        # Pass 2: same agent, replies served from disk.
+        (work / "_bridge.py").write_text(
+            "import pathlib\n"
+            f"_r = pathlib.Path({str(reply_file)!r}).read_text()\n"
+            "def llm(prompt):\n"
+            "    return _r\n")
+        proc = subprocess.run([sys.executable, str(driver), str(task_dir)],
+                              cwd=str(work), capture_output=True, text=True,
+                              timeout=timeout)
+        if proc.returncode != 0:
+            tail = (proc.stderr or proc.stdout).strip().splitlines()
+            return False, "agent crashed: " + (tail[-1][:160] if tail else "?")
+
+        check = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "--no-header", "test_lib.py"],
+            cwd=str(task_dir), capture_output=True, text=True, timeout=timeout)
+        passed = check.returncode == 0
+        last = (check.stdout + check.stderr).strip().splitlines()
+        return passed, (last[-1][:160] if last else "")
+    except subprocess.TimeoutExpired:
+        return False, "timed out"
+    except Exception as exc:                       # noqa: BLE001 - scored, not raised
+        return False, f"{type(exc).__name__}: {exc}"[:160]
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def make_real_evaluator(llm: Callable[[str], str], concurrency: int = 4):
+    """An ``evaluate_fn(agent_files, cases) -> float`` that runs pytest.
+
+    Signature-compatible with the surrogate's, so `run_dgm` takes either.
+    """
+    def evaluate_fn(agent_files: Dict[str, str], cases: List[TaskCase]) -> float:
+        if not cases:
+            return 0.0
+        from concurrent.futures import ThreadPoolExecutor
+        n = max(1, min(concurrency, len(cases)))
+        with ThreadPoolExecutor(n) as pool:
+            results = list(pool.map(
+                lambda c: run_agent_on_task(agent_files, c, llm)[0], cases))
+        return sum(results) / len(results)
+    return evaluate_fn
+
+
+# ===========================================================================
+# The self-modification: an agent edits its own source
+# ===========================================================================
+
+#: Which of its own files the agent may rewrite. `solve.py` is its workflow and
+#: `tools.py` is what it can do; both are fair game upstream, where DGM edits
+#: "tools, prompts, workflow". Nothing else is writable, so a self-edit cannot
+#: reach the harness that scores it -- upstream has the same boundary, enforced
+#: by running the candidate in its own container rather than by a list.
+EDITABLE = ("agent/solve.py", "agent/tools.py")
+
+#: Token budget for this module's model calls. Both of them ask for a **whole
+#: file**, and on a reasoning model the budget is spent on hidden reasoning first
+#: with the visible content being whatever is left. Measured here on
+#: `deepseek-v4-flash` at the library default of 4096: `propose_self_edit`
+#: returned **zero characters**, every rollout, so no evidence card ever reached
+#: the merger and a 13-rollout run finished byte-identical to its seed -- which
+#: reads as "the search found nothing" rather than "the proposer never spoke".
+#: ADAS hit exactly this and documents the same number; it did not travel here
+#: with the code that needed it.
+MAX_TOKENS = 16384
+
+_PROPOSE_TMPL = """You are a self-improving coding agent. This is your own source.
+
+{sources}
+
+You were run on {n} tasks and resolved {resolved}. Here is what happened:
+
+{log}
+
+Diagnose the single biggest weakness in YOUR OWN code above -- not in the tasks --
+and rewrite exactly one file to fix it. Reply with:
+
+    PATH: <one of {editable}>
+    <the complete new contents of that file>
+
+No fences, no commentary. The file must be valid Python; if it is not, or if it
+raises on import, your next evaluation scores zero.
+"""
+
+
+def propose_self_edit(agent_files: Dict[str, str], report: List[Tuple[str, bool, str]],
+                      llm: Callable[[str], str]) -> Optional[str]:
+    """One self-modification, as ``PATH: <p>\\n<body>``, or ``None``.
+
+    The conditioning is the agent's **own evaluation log** -- which tasks it
+    failed and what pytest said -- which is upstream's signal too
+    (`DGM_outer.py` hands the parent its eval logs). What differs is that here
+    the log is real output from real code.
+    """
+    sources = "\n\n".join(f"--- {p} ---\n{agent_files[p]}" for p in EDITABLE
+                          if p in agent_files)
+    log = "\n".join(f"[{'ok ' if ok else 'FAIL'}] {tid}: {detail}"
+                    for tid, ok, detail in report) or "(no tasks run)"
+    reply = llm(_PROPOSE_TMPL.format(
+        sources=sources, n=len(report),
+        resolved=sum(1 for _, ok, _ in report if ok),
+        log=log, editable=list(EDITABLE)))
+    if not reply.strip():
+        # Say it rather than returning a quiet `None`. An empty completion and a
+        # deliberate "no proposal" are the same value here and opposite
+        # diagnoses: one is a starved token budget, the other is the search
+        # having nothing to suggest. Measured, the first produced a run that
+        # ended byte-identical to its seed and looked like the second.
+        _EMPTY["n"] += 1
+        if _EMPTY["n"] in (1, 5, 25):
+            warnings.warn(
+                f"the self-modification proposer returned an empty completion "
+                f"({_EMPTY['n']} so far), so no child agent was produced. On a "
+                f"reasoning model that means the token budget went to hidden "
+                f"reasoning -- this module asks for a whole file and uses "
+                f"max_tokens={MAX_TOKENS} for that reason.",
+                RuntimeWarning, stacklevel=2)
+        return None
+    return reply.strip()
+
+
+def parse_self_edit(proposal: str) -> Optional[Tuple[str, str]]:
+    """``(path, body)`` from a proposal, or ``None`` if it is not usable.
+
+    Rejects a path outside :data:`EDITABLE` rather than trusting it: this text
+    becomes a file write. A malformed reply is *not* an error -- the model is
+    allowed to fail, and the search simply gets no child that round.
+    """
+    text = proposal.strip()
+    if not text.lower().startswith("path:"):
+        return None
+    head, _, body = text.partition("\n")
+    path = head.split(":", 1)[1].strip()
+    if path not in EDITABLE or not body.strip():
+        return None
+    return path, body
+
+
+# ===========================================================================
+# Driving DGM's own loop over the real objective
+# ===========================================================================
+
+
+def run_dgm_real(llm: Callable[[str], str], *, cases: Optional[List[TaskCase]] = None,
+                 generations: int = 6, selfimprove_size: int = 2, seed: int = 0,
+                 asynchronous: bool = False, async_ratio: int = 3,
+                 max_seconds: float = 600.0, max_rollouts: Optional[int] = None,
+                 staleness: str = "full", eval_concurrency: int = 4,
+                 verbose: bool = False):
+    """DGM over self-editing source, scored by pytest.
+
+    Four things change against `run_dgm`'s surrogate mode -- the artifact (a file
+    tree of source, not a capability set), `run`, `reward`, and `propose`. The
+    parts that make it DGM do not: `DGMArchiveAggregator`'s keep-all archive, the
+    `sigmoid(10*(s-0.5)) / (1+children)` parent draw, and the staged small->medium
+    escalation are the same objects the surrogate mode uses.
+    """
+    import random as _random
+
+    from agentdescent.evolution import Task, evolve
+    from agentdescent.staleness import get_policy
+    from agentdescent.treestrategy import FileTree
+
+    from examples.dgm.dgm_self_improve import DGMContext
+
+    cases = cases or load_tasks()
+    if len(cases) < 4:
+        raise ValueError("need at least four tasks for a train/held-out split")
+    evaluate = make_real_evaluator(llm, concurrency=eval_concurrency)
+    by_id = {c.id: c for c in cases}
+    tasks = [Task(id=c.id, prompt=c.why, meta={"instance_id": c.id}) for c in cases]
+
+    #: `rendered` is the agent's file tree; the aggregator scores whole agents,
+    #: so the surrogate's `evaluate_fn(agent, instances)` signature is kept with
+    #: `agent` now being `{path: source}`.
+    ctx = DGMContext(rng=_random.Random(seed),
+                     evaluate_fn=lambda agent, insts: evaluate(
+                         agent, [by_id[i["instance_id"]] for i in insts]),
+                     archive_mode="keep_all")
+
+    # `editable` is the engine's own boundary on what a self-edit may touch, so
+    # the agent's source is declared here rather than re-checked in the parser:
+    # `to_diff` drops a path outside it, and a hostile one (`../..`) never
+    # reaches `writable` because `safe_relpath` rejects it first.
+    strategy = _FileTree(editable=list(EDITABLE))
+
+    def run(rendered, task):
+        """One rollout: this agent, this task, real pytest."""
+        ok, detail = run_agent_on_task(parse_tree(rendered), by_id[task.meta["instance_id"]], llm)
+        return f"{'resolved' if ok else 'unresolved'}: {detail}"
+
+    def reward(task, output):
+        return 1.0 if output.startswith("resolved") else 0.0
+
+    def propose(rendered, task, output, score):
+        """The self-modification. Conditioned on this agent's own run log."""
+        files = parse_tree(rendered)
+        report = [(task.meta["instance_id"], score >= 1.0, output)]
+        proposal = propose_self_edit(files, report, llm)
+        if not proposal:
+            return None
+        parsed = parse_self_edit(proposal)
+        if parsed is None:
+            return None
+        path, body = parsed
+        # `FileTree.to_diff` parses the shipped `<EDITS>` protocol -- a JSON
+        # object of `{path: content}` -- not a rendered tree. Handing it a tree
+        # returns `None` from `parse_edits`, silently, on every proposal: a
+        # 13-rollout run then ends byte-identical to its seed with no warning
+        # anywhere, which reads as "the search found nothing".
+        return json.dumps({"edits": [{"path": path, "content": body}]})
+
+    def factory(ledger, verifier, audit, config, policy):
+        return SourceArchiveAggregator(ledger, verifier, ctx,
+                                       artifact_id="coding_agent")
+
+    return evolve(
+        tasks, reward, run=run, propose=propose, strategy=strategy,
+        initial_state=dict(SEED_AGENT), blast_radius=0.6,
+        artifact_id="coding_agent", rounds=generations,
+        n_workers=selfimprove_size,
+        max_concurrency=1 if asynchronous else selfimprove_size,
+        asynchronous=asynchronous, async_ratio=async_ratio,
+        max_seconds=max_seconds if asynchronous else None,
+        held_out_frac=0.5, aggregator_factory=factory,
+        staleness_policy=get_policy(staleness),
+        eval_concurrency=eval_concurrency,
+        verbose=verbose, max_rollouts=max_rollouts)
+
+
+# ===========================================================================
+# The archive, over source trees instead of capability sets
+# ===========================================================================
+
+
+@dataclass
+class SourceAgent:
+    """One DGM variant: the agent's own source, plus its lineage."""
+
+    files: Dict[str, str]
+    score: float = 0.0
+    parent: Optional[int] = None
+    children: int = 0
+    generation: int = 0
+
+    def key(self) -> str:
+        import hashlib
+        blob = "\0".join(f"{p}\0{self.files[p]}" for p in sorted(self.files))
+        return hashlib.sha1(blob.encode()).hexdigest()[:16]
+
+
+class SourceArchiveAggregator:
+    """DGM's archive, reading a file tree where the shipped one reads a set.
+
+    `DGMArchiveAggregator` builds `Agent(...)` straight from
+    `state["capabilities"]` in three places, so it cannot be pointed at a
+    different artifact -- the archive and the representation are coupled, which
+    is only visible once you try. What is *not* coupled is everything that makes
+    it DGM, and all three are reused here rather than reimplemented:
+
+    * keep-all append (stepping stones stay, and under a real objective they can
+      genuinely be worse -- which is the point);
+    * `DGMParentSelection`, i.e. `sigmoid(10*(s-0.5)) / (1+children)`, at the
+      standard selection seam;
+    * `staged_evaluate`'s small -> medium ladder with `test_more_threshold=0.4`.
+    """
+
+    def __init__(self, ledger, verifier, ctx, artifact_id: str = "coding_agent",
+                 selection=None) -> None:
+        import threading
+
+        from examples.dgm.dgm_self_improve import DGMParentSelection
+
+        self.ledger = ledger
+        self.verifier = verifier
+        self.ctx = ctx
+        self.aid = artifact_id
+        self.selection = selection or DGMParentSelection(ctx.rng)
+        self.cards: List = []
+        self._lock = threading.Lock()
+        self.head_index = 0
+        self._seeded = False
+
+    def _staged(self, files: Dict[str, str]) -> float:
+        from examples.dgm.dgm_self_improve import (STAGE_MEDIUM, STAGE_SMALL,
+                                                   staged_evaluate)
+        insts = [{"instance_id": t.meta["instance_id"]}
+                 for t in self.verifier.held_out]
+        return staged_evaluate(files, self.ctx.evaluate_fn,
+                               insts[:STAGE_SMALL], insts[:STAGE_MEDIUM], None)
+
+    def ingest(self, card) -> None:
+        with self._lock:
+            self.cards.append(card)
+
+    def step(self):
+        from agentdescent.aggregator import MergeReport
+        from agentdescent.evolvable import Diff
+        from agentdescent.ledger import CASConflict, Ledger
+        from agentdescent.selection import Candidate, SelectionContext
+
+        snap = self.ledger.snapshot(Ledger.DEV)
+        head = snap.get(self.aid)
+        base_vv = {self.aid: snap.version.get(self.aid, 0)}
+        if not self._seeded:
+            seed = SourceAgent(dict(head.state), parent=None, generation=0)
+            seed.score = self._staged(seed.files)
+            self.ctx.archive.append(seed)
+            self.ctx.seen.add(seed.key())
+            self.ctx.seed_score = self.ctx.best_score = seed.score
+            self.head_index, self._seeded = 0, True
+
+        parent_idx = self.head_index
+        parent = self.ctx.archive[parent_idx]
+        with self._lock:
+            cards, self.cards = self.cards, []
+        for card in cards:                        # each card is one self-modification
+            child_files = dict(parent.files)
+            child_files.update({p: c for p, c in card.diff.ops.items()
+                                if c is not None})
+            child = SourceAgent(child_files, parent=parent_idx,
+                                generation=parent.generation + 1)
+            if child.key() in self.ctx.seen:
+                continue
+            child.score = self._staged(child_files)
+            self.ctx.archive.append(child)        # keep-all, worse ones included
+            self.ctx.seen.add(child.key())
+            self.ctx.best_score = max(self.ctx.best_score, child.score)
+        parent.children += 1
+
+        rows = [Candidate(artifact_id=self.aid, version=i, score=a.score,
+                          selected=a.children)
+                for i, a in enumerate(self.ctx.archive)]
+        sel = SelectionContext(head=rows[self.head_index],
+                               candidates=tuple(rows), n_workers=1)
+        self.head_index = self.selection.select(sel, 1)[0].version
+        target = self.ctx.archive[self.head_index].files
+        committed = None
+        if target != head.state:
+            try:
+                _, committed = self.ledger.commit(
+                    head.apply(Diff(diff_id="dgm-select", target=self.aid,
+                                    ops=dict(target), author="dgm")),
+                    base_vv, branch=Ledger.DEV, message="dgm: select parent")
+            except CASConflict:
+                committed = None
+        return [MergeReport(self.aid, None, False, len(cards), len(cards), 0, 0,
+                            self.ctx.best_score, committed,
+                            f"archive={len(self.ctx.archive)} "
+                            f"best={self.ctx.best_score:.3f}")]

--- a/examples/dgm/real_objective.py
+++ b/examples/dgm/real_objective.py
@@ -38,6 +38,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import warnings
 from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
@@ -138,8 +139,8 @@ def _materialise(agent_files: Dict[str, str], root: pathlib.Path) -> None:
 
 
 def run_agent_on_task(agent_files: Dict[str, str], case: TaskCase,
-                      llm: Callable[[str], str],
-                      timeout: float = 120.0) -> Tuple[bool, str]:
+                      llm: Callable[[str], str], timeout: float = 180.0,
+                      max_calls: int = 6) -> Tuple[bool, str]:
     """Run one candidate agent against one task in a scratch copy.
 
     Returns ``(resolved, detail)``. **A broken agent scores zero rather than
@@ -156,43 +157,68 @@ def run_agent_on_task(agent_files: Dict[str, str], case: TaskCase,
 
         driver = work / "_run.py"
         driver.write_text(
-            "import sys, json\n"
+            "import sys\n"
             "sys.path.insert(0, 'agent')\n"
             "from solve import solve\n"
             "import _bridge\n"
             "solve(sys.argv[1], _bridge.llm)\n")
-        # The model call crosses a process boundary: the agent runs in its own
-        # interpreter (a self-edit can and does break imports), so replies are
-        # pre-computed here and served from a file. One prompt per task keeps
-        # that honest -- an agent that wants two calls cannot have them, and the
-        # seed's own `solve` makes exactly one.
-        prompt_file, reply_file = work / "_prompt.txt", work / "_reply.txt"
+        # A line-delimited request/reply channel on the child's stdio, because
+        # the agent runs in its own interpreter (a self-edit can and does break
+        # imports) and the model lives in this one.
+        #
+        # This replaced a pre-fetch scheme: run the agent once to capture its
+        # prompt, answer it here, then re-run with that single reply served from
+        # a file. That made "one model call per task" a property of the *harness*
+        # rather than of the agent -- and the first self-modification this
+        # objective ever produced was a retry loop, which is exactly the
+        # improvement the pre-fetch made impossible. It scored 0.875 -> 0.500,
+        # and the regression was the harness's, not the agent's.
         (work / "_bridge.py").write_text(
-            "import pathlib\n"
+            "import json, sys\n"
             "def llm(prompt):\n"
-            f"    pathlib.Path({str(prompt_file)!r}).write_text(prompt)\n"
-            "    raise SystemExit(17)\n")
+            "    sys.stdout.write(json.dumps({'prompt': prompt}) + '\\n')\n"
+            "    sys.stdout.flush()\n"
+            "    line = sys.stdin.readline()\n"
+            "    if not line:\n"
+            "        raise RuntimeError('the harness closed the channel')\n"
+            "    return json.loads(line)['reply']\n")
 
-        # Pass 1: let the agent build its prompt, then stop at the boundary.
-        subprocess.run([sys.executable, str(driver), str(task_dir)],
-                       cwd=str(work), capture_output=True, text=True,
-                       timeout=timeout)
-        if not prompt_file.is_file():
+        proc = subprocess.Popen(
+            [sys.executable, "-u", str(driver), str(task_dir)],
+            cwd=str(work), stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, text=True)
+        calls, deadline = 0, time.monotonic() + timeout
+        try:
+            while True:
+                if time.monotonic() > deadline:
+                    proc.kill()
+                    return False, f"timed out after {calls} model call(s)"
+                line = proc.stdout.readline()
+                if not line:                       # the agent finished or died
+                    break
+                try:
+                    request = json.loads(line)
+                except json.JSONDecodeError:
+                    continue                       # the agent printed something else
+                if calls >= max_calls:
+                    # A budget, not a correctness rule: an agent is free to
+                    # learn a retry loop, and not free to loop forever on the
+                    # matrix's money. Closing the channel surfaces as an error
+                    # inside the agent, which is scoreable.
+                    proc.kill()
+                    return False, f"exceeded {max_calls} model calls"
+                calls += 1
+                reply = llm(request.get("prompt", ""))
+                proc.stdin.write(json.dumps({"reply": reply}) + "\n")
+                proc.stdin.flush()
+            proc.wait(timeout=max(1.0, deadline - time.monotonic()))
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+        if calls == 0:
             return False, "agent never reached a model call"
-        reply = llm(prompt_file.read_text())
-        reply_file.write_text(reply)
-
-        # Pass 2: same agent, replies served from disk.
-        (work / "_bridge.py").write_text(
-            "import pathlib\n"
-            f"_r = pathlib.Path({str(reply_file)!r}).read_text()\n"
-            "def llm(prompt):\n"
-            "    return _r\n")
-        proc = subprocess.run([sys.executable, str(driver), str(task_dir)],
-                              cwd=str(work), capture_output=True, text=True,
-                              timeout=timeout)
         if proc.returncode != 0:
-            tail = (proc.stderr or proc.stdout).strip().splitlines()
+            tail = (proc.stderr.read() or "").strip().splitlines()
             return False, "agent crashed: " + (tail[-1][:160] if tail else "?")
 
         check = subprocess.run(
@@ -395,10 +421,12 @@ def run_dgm_real(llm: Callable[[str], str], *, cases: Optional[List[TaskCase]] =
         return json.dumps({"edits": [{"path": path, "content": body}]})
 
     def factory(ledger, verifier, audit, config, policy):
-        return SourceArchiveAggregator(ledger, verifier, ctx,
-                                       artifact_id="coding_agent")
+        agg = SourceArchiveAggregator(ledger, verifier, ctx,
+                                      artifact_id="coding_agent")
+        agg.seed()          # measure the baseline before round 0, not on first card
+        return agg
 
-    return evolve(
+    result = evolve(
         tasks, reward, run=run, propose=propose, strategy=strategy,
         initial_state=dict(SEED_AGENT), blast_radius=0.6,
         artifact_id="coding_agent", rounds=generations,
@@ -410,6 +438,13 @@ def run_dgm_real(llm: Callable[[str], str], *, cases: Optional[List[TaskCase]] =
         staleness_policy=get_policy(staleness),
         eval_concurrency=eval_concurrency,
         verbose=verbose, max_rollouts=max_rollouts)
+    # The `EvolutionResult` alone cannot answer "did the agent improve": the
+    # seed's own score and the archive live on `ctx`, and returning only the
+    # result leaves a run reporting a final number with nothing to compare it
+    # against -- the same reporting gap ACE, EvoSkill and SkillOpt each had.
+    result.dgm_seed_score = ctx.seed_score
+    result.dgm_archive = ctx.archive
+    return result
 
 
 # ===========================================================================
@@ -465,6 +500,29 @@ class SourceArchiveAggregator:
         self.head_index = 0
         self._seeded = False
 
+    def seed(self) -> None:
+        """Score the seed agent -- once, and *before* any card arrives.
+
+        This lived inside `step()`, which only runs when a card reaches the
+        merger. A run whose self-modifications all failed therefore never
+        measured its own baseline, and `DGMContext.seed_score` defaults to 0.0 --
+        so the report read `0.000 -> 0.844` for a seed that actually scored
+        0.844 itself. The final number came from the engine and was right; only
+        the thing it was compared against was invented. ADAS moved its seeding
+        out of `step()` for the same reason, and EvoSkill and SkillOpt each
+        shipped this exact bug.
+        """
+        if self._seeded:
+            return
+        from agentdescent.ledger import Ledger
+        head = self.ledger.snapshot(Ledger.DEV).get(self.aid)
+        seed = SourceAgent(dict(head.state), parent=None, generation=0)
+        seed.score = self._staged(seed.files)
+        self.ctx.archive.append(seed)
+        self.ctx.seen.add(seed.key())
+        self.ctx.seed_score = self.ctx.best_score = seed.score
+        self.head_index, self._seeded = 0, True
+
     def _staged(self, files: Dict[str, str]) -> float:
         from examples.dgm.dgm_self_improve import (STAGE_MEDIUM, STAGE_SMALL,
                                                    staged_evaluate)
@@ -486,13 +544,7 @@ class SourceArchiveAggregator:
         snap = self.ledger.snapshot(Ledger.DEV)
         head = snap.get(self.aid)
         base_vv = {self.aid: snap.version.get(self.aid, 0)}
-        if not self._seeded:
-            seed = SourceAgent(dict(head.state), parent=None, generation=0)
-            seed.score = self._staged(seed.files)
-            self.ctx.archive.append(seed)
-            self.ctx.seen.add(seed.key())
-            self.ctx.seed_score = self.ctx.best_score = seed.score
-            self.head_index, self._seeded = 0, True
+        self.seed()                                # no-op after construction
 
         parent_idx = self.head_index
         parent = self.ctx.archive[parent_idx]

--- a/examples/dgm/tasks/abs-diff-unsigned/lib.py
+++ b/examples/dgm/tasks/abs-diff-unsigned/lib.py
@@ -1,0 +1,3 @@
+def diff(a, b):
+    """Absolute difference."""
+    return a - b

--- a/examples/dgm/tasks/abs-diff-unsigned/task.json
+++ b/examples/dgm/tasks/abs-diff-unsigned/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "abs-diff-unsigned",
+  "why": "returns a negative difference"
+}

--- a/examples/dgm/tasks/abs-diff-unsigned/test_lib.py
+++ b/examples/dgm/tasks/abs-diff-unsigned/test_lib.py
@@ -1,0 +1,7 @@
+from lib import diff
+
+def test_positive():
+    assert diff(5, 3) == 2
+
+def test_negative():
+    assert diff(3, 5) == 2

--- a/examples/dgm/tasks/batch-iter-tail/lib.py
+++ b/examples/dgm/tasks/batch-iter-tail/lib.py
@@ -1,0 +1,8 @@
+def batches(xs, n):
+    """Yield lists of n; the final one may be shorter."""
+    out = []
+    for i in range(0, len(xs), n):
+        b = xs[i:i + n]
+        if len(b) == n:
+            out.append(b)
+    return out

--- a/examples/dgm/tasks/batch-iter-tail/task.json
+++ b/examples/dgm/tasks/batch-iter-tail/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "batch-iter-tail",
+  "why": "silently drops a partial final batch"
+}

--- a/examples/dgm/tasks/batch-iter-tail/test_lib.py
+++ b/examples/dgm/tasks/batch-iter-tail/test_lib.py
@@ -1,0 +1,7 @@
+from lib import batches
+
+def test_exact():
+    assert batches([1, 2], 2) == [[1, 2]]
+
+def test_partial_tail():
+    assert batches([1, 2, 3], 2) == [[1, 2], [3]]

--- a/examples/dgm/tasks/binary-search-dupes/lib.py
+++ b/examples/dgm/tasks/binary-search-dupes/lib.py
@@ -1,0 +1,12 @@
+def first_index(xs, target):
+    """Index of the FIRST occurrence of target, or -1."""
+    lo, hi = 0, len(xs) - 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if xs[mid] == target:
+            return mid
+        if xs[mid] < target:
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return -1

--- a/examples/dgm/tasks/binary-search-dupes/task.json
+++ b/examples/dgm/tasks/binary-search-dupes/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "binary-search-dupes",
+  "why": "returns any match, not the first"
+}

--- a/examples/dgm/tasks/binary-search-dupes/test_lib.py
+++ b/examples/dgm/tasks/binary-search-dupes/test_lib.py
@@ -1,0 +1,7 @@
+from lib import first_index
+
+def test_unique():
+    assert first_index([1, 3, 5], 3) == 1
+
+def test_duplicates():
+    assert first_index([1, 2, 2, 2, 3], 2) == 1

--- a/examples/dgm/tasks/bytes-human/lib.py
+++ b/examples/dgm/tasks/bytes-human/lib.py
@@ -1,0 +1,9 @@
+UNITS = ["B", "KB", "MB", "GB"]
+
+def human(n):
+    """Format a byte count, e.g. 1024 -> \"1.0KB\"."""
+    i = 0
+    while n > 1024 and i < len(UNITS) - 1:
+        n /= 1024
+        i += 1
+    return f"{n:.1f}{UNITS[i]}"

--- a/examples/dgm/tasks/bytes-human/task.json
+++ b/examples/dgm/tasks/bytes-human/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "bytes-human",
+  "why": "switches unit one step too late"
+}

--- a/examples/dgm/tasks/bytes-human/test_lib.py
+++ b/examples/dgm/tasks/bytes-human/test_lib.py
@@ -1,0 +1,7 @@
+from lib import human
+
+def test_bytes():
+    assert human(512) == "512.0B"
+
+def test_exact_kb():
+    assert human(1024) == "1.0KB"

--- a/examples/dgm/tasks/cache-eviction/lib.py
+++ b/examples/dgm/tasks/cache-eviction/lib.py
@@ -1,0 +1,11 @@
+class LRU:
+    """Bounded cache evicting the LEAST recently inserted key."""
+
+    def __init__(self, size):
+        self.size = size
+        self.data = {}
+
+    def put(self, k, v):
+        if len(self.data) >= self.size:
+            self.data.pop(list(self.data)[-1])
+        self.data[k] = v

--- a/examples/dgm/tasks/cache-eviction/task.json
+++ b/examples/dgm/tasks/cache-eviction/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "cache-eviction",
+  "why": "evicts the newest instead of the oldest"
+}

--- a/examples/dgm/tasks/cache-eviction/test_lib.py
+++ b/examples/dgm/tasks/cache-eviction/test_lib.py
@@ -1,0 +1,9 @@
+from lib import LRU
+
+def test_under_capacity():
+    c = LRU(2); c.put("a", 1); c.put("b", 2)
+    assert set(c.data) == {"a", "b"}
+
+def test_evicts_oldest():
+    c = LRU(2); c.put("a", 1); c.put("b", 2); c.put("c", 3)
+    assert set(c.data) == {"b", "c"}

--- a/examples/dgm/tasks/camel-to-snake/lib.py
+++ b/examples/dgm/tasks/camel-to-snake/lib.py
@@ -1,0 +1,5 @@
+import re
+
+def to_snake(s):
+    """CamelCase -> snake_case; keep acronyms together."""
+    return re.sub(r"([A-Z])", r"_\1", s).lstrip("_").lower()

--- a/examples/dgm/tasks/camel-to-snake/task.json
+++ b/examples/dgm/tasks/camel-to-snake/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "camel-to-snake",
+  "why": "acronyms become one letter per underscore"
+}

--- a/examples/dgm/tasks/camel-to-snake/test_lib.py
+++ b/examples/dgm/tasks/camel-to-snake/test_lib.py
@@ -1,0 +1,7 @@
+from lib import to_snake
+
+def test_simple():
+    assert to_snake("fooBar") == "foo_bar"
+
+def test_acronym():
+    assert to_snake("parseHTTPResponse") == "parse_http_response"

--- a/examples/dgm/tasks/case-insensitive-key/lib.py
+++ b/examples/dgm/tasks/case-insensitive-key/lib.py
@@ -1,0 +1,3 @@
+def lookup(d, key):
+    """Case-insensitive dict lookup."""
+    return d.get(key)

--- a/examples/dgm/tasks/case-insensitive-key/task.json
+++ b/examples/dgm/tasks/case-insensitive-key/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "case-insensitive-key",
+  "why": "looks up case-sensitively"
+}

--- a/examples/dgm/tasks/case-insensitive-key/test_lib.py
+++ b/examples/dgm/tasks/case-insensitive-key/test_lib.py
@@ -1,0 +1,7 @@
+from lib import lookup
+
+def test_exact():
+    assert lookup({"a": 1}, "a") == 1
+
+def test_different_case():
+    assert lookup({"Accept": 1}, "accept") == 1

--- a/examples/dgm/tasks/chunk-remainder/lib.py
+++ b/examples/dgm/tasks/chunk-remainder/lib.py
@@ -1,0 +1,3 @@
+def chunk(xs, n):
+    """Split xs into lists of length n; the last may be shorter."""
+    return [xs[i:i + n] for i in range(0, len(xs) - len(xs) % n, n)]

--- a/examples/dgm/tasks/chunk-remainder/task.json
+++ b/examples/dgm/tasks/chunk-remainder/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "chunk-remainder",
+  "why": "drops the final short chunk"
+}

--- a/examples/dgm/tasks/chunk-remainder/test_lib.py
+++ b/examples/dgm/tasks/chunk-remainder/test_lib.py
@@ -1,0 +1,7 @@
+from lib import chunk
+
+def test_exact():
+    assert chunk([1, 2, 3, 4], 2) == [[1, 2], [3, 4]]
+
+def test_remainder():
+    assert chunk([1, 2, 3], 2) == [[1, 2], [3]]

--- a/examples/dgm/tasks/clamp-bounds/lib.py
+++ b/examples/dgm/tasks/clamp-bounds/lib.py
@@ -1,0 +1,7 @@
+def clamp(x, lo, hi):
+    """Clamp x into the inclusive range [lo, hi]."""
+    if x < lo:
+        return lo
+    if x >= hi:
+        return hi - 1
+    return x

--- a/examples/dgm/tasks/clamp-bounds/task.json
+++ b/examples/dgm/tasks/clamp-bounds/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "clamp-bounds",
+  "why": "excludes the upper bound"
+}

--- a/examples/dgm/tasks/clamp-bounds/test_lib.py
+++ b/examples/dgm/tasks/clamp-bounds/test_lib.py
@@ -1,0 +1,7 @@
+from lib import clamp
+
+def test_inside():
+    assert clamp(5, 0, 10) == 5
+
+def test_at_upper():
+    assert clamp(10, 0, 10) == 10

--- a/examples/dgm/tasks/count-lines-eof/lib.py
+++ b/examples/dgm/tasks/count-lines-eof/lib.py
@@ -1,0 +1,3 @@
+def count_lines(text):
+    """Number of lines; a trailing newline does not add one."""
+    return text.count("\n")

--- a/examples/dgm/tasks/count-lines-eof/task.json
+++ b/examples/dgm/tasks/count-lines-eof/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "count-lines-eof",
+  "why": "miscounts a file with no trailing newline"
+}

--- a/examples/dgm/tasks/count-lines-eof/test_lib.py
+++ b/examples/dgm/tasks/count-lines-eof/test_lib.py
@@ -1,0 +1,7 @@
+from lib import count_lines
+
+def test_trailing_newline():
+    assert count_lines("a\nb\n") == 2
+
+def test_no_trailing():
+    assert count_lines("a\nb") == 2

--- a/examples/dgm/tasks/csv-escape-quote/lib.py
+++ b/examples/dgm/tasks/csv-escape-quote/lib.py
@@ -1,0 +1,3 @@
+def to_csv_field(s):
+    """Quote a field, doubling any embedded quote."""
+    return '"' + s + '"'

--- a/examples/dgm/tasks/csv-escape-quote/task.json
+++ b/examples/dgm/tasks/csv-escape-quote/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "csv-escape-quote",
+  "why": "does not double an embedded quote"
+}

--- a/examples/dgm/tasks/csv-escape-quote/test_lib.py
+++ b/examples/dgm/tasks/csv-escape-quote/test_lib.py
@@ -1,0 +1,7 @@
+from lib import to_csv_field
+
+def test_plain():
+    assert to_csv_field("ab") == '"ab"'
+
+def test_embedded_quote():
+    assert to_csv_field('a"b') == '"a""b"'

--- a/examples/dgm/tasks/csv-quote/lib.py
+++ b/examples/dgm/tasks/csv-quote/lib.py
@@ -1,0 +1,3 @@
+def parse_row(line):
+    """Split one CSV row, honouring double quotes."""
+    return line.split(",")

--- a/examples/dgm/tasks/csv-quote/task.json
+++ b/examples/dgm/tasks/csv-quote/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "csv-quote",
+  "why": "quoted field containing the delimiter is split"
+}

--- a/examples/dgm/tasks/csv-quote/test_lib.py
+++ b/examples/dgm/tasks/csv-quote/test_lib.py
@@ -1,0 +1,7 @@
+from lib import parse_row
+
+def test_plain():
+    assert parse_row("a,b,c") == ["a", "b", "c"]
+
+def test_quoted_delimiter():
+    assert parse_row('a,"b,c",d') == ["a", "b,c", "d"]

--- a/examples/dgm/tasks/date-parse-order/lib.py
+++ b/examples/dgm/tasks/date-parse-order/lib.py
@@ -1,0 +1,4 @@
+def parse_date(s):
+    """Parse YYYY-MM-DD into (year, month, day)."""
+    parts = s.split("-")
+    return (int(parts[0]), int(parts[2]), int(parts[1]))

--- a/examples/dgm/tasks/date-parse-order/task.json
+++ b/examples/dgm/tasks/date-parse-order/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "date-parse-order",
+  "why": "assumes day/month order"
+}

--- a/examples/dgm/tasks/date-parse-order/test_lib.py
+++ b/examples/dgm/tasks/date-parse-order/test_lib.py
@@ -1,0 +1,7 @@
+from lib import parse_date
+
+def test_symmetric():
+    assert parse_date("2024-07-07") == (2024, 7, 7)
+
+def test_month_day():
+    assert parse_date("2024-03-15") == (2024, 3, 15)

--- a/examples/dgm/tasks/dedent-common/lib.py
+++ b/examples/dgm/tasks/dedent-common/lib.py
@@ -1,0 +1,4 @@
+def dedent(text):
+    """Remove the longest common leading whitespace."""
+    return "\n".join(line[4:] if line.startswith("    ") else line
+                     for line in text.split("\n"))

--- a/examples/dgm/tasks/dedent-common/task.json
+++ b/examples/dgm/tasks/dedent-common/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "dedent-common",
+  "why": "removes a fixed amount instead of the common prefix"
+}

--- a/examples/dgm/tasks/dedent-common/test_lib.py
+++ b/examples/dgm/tasks/dedent-common/test_lib.py
@@ -1,0 +1,7 @@
+from lib import dedent
+
+def test_four_spaces():
+    assert dedent("    a\n    b") == "a\nb"
+
+def test_two_spaces():
+    assert dedent("  a\n  b") == "a\nb"

--- a/examples/dgm/tasks/dedupe-order/lib.py
+++ b/examples/dgm/tasks/dedupe-order/lib.py
@@ -1,0 +1,3 @@
+def dedupe(xs):
+    """Remove duplicates, preserving first-seen order."""
+    return list(set(xs))

--- a/examples/dgm/tasks/dedupe-order/task.json
+++ b/examples/dgm/tasks/dedupe-order/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "dedupe-order",
+  "why": "loses input order"
+}

--- a/examples/dgm/tasks/dedupe-order/test_lib.py
+++ b/examples/dgm/tasks/dedupe-order/test_lib.py
@@ -1,0 +1,8 @@
+from lib import dedupe
+
+def test_single():
+    assert dedupe(["beta"]) == ["beta"]
+
+def test_keeps_order():
+    assert dedupe(["alpha", "beta", "gamma", "beta", "delta"]) == [
+        "alpha", "beta", "gamma", "delta"]

--- a/examples/dgm/tasks/default-mutable/lib.py
+++ b/examples/dgm/tasks/default-mutable/lib.py
@@ -1,0 +1,4 @@
+def add_item(x, bucket=[]):
+    """Append x to bucket and return it; a fresh list by default."""
+    bucket.append(x)
+    return bucket

--- a/examples/dgm/tasks/default-mutable/task.json
+++ b/examples/dgm/tasks/default-mutable/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "default-mutable",
+  "why": "shares one list across calls"
+}

--- a/examples/dgm/tasks/default-mutable/test_lib.py
+++ b/examples/dgm/tasks/default-mutable/test_lib.py
@@ -1,0 +1,8 @@
+from lib import add_item
+
+def test_explicit():
+    assert add_item(1, []) == [1]
+
+def test_fresh_default():
+    add_item(1)
+    assert add_item(2) == [2]

--- a/examples/dgm/tasks/dict-invert-dupes/lib.py
+++ b/examples/dgm/tasks/dict-invert-dupes/lib.py
@@ -1,0 +1,3 @@
+def invert(d):
+    """Invert to {value: [keys]}."""
+    return {v: [k] for k, v in d.items()}

--- a/examples/dgm/tasks/dict-invert-dupes/task.json
+++ b/examples/dgm/tasks/dict-invert-dupes/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "dict-invert-dupes",
+  "why": "loses keys that share a value"
+}

--- a/examples/dgm/tasks/dict-invert-dupes/test_lib.py
+++ b/examples/dgm/tasks/dict-invert-dupes/test_lib.py
@@ -1,0 +1,7 @@
+from lib import invert
+
+def test_unique():
+    assert invert({"a": 1}) == {1: ["a"]}
+
+def test_shared_value():
+    assert invert({"a": 1, "b": 1}) == {1: ["a", "b"]}

--- a/examples/dgm/tasks/env-bool/lib.py
+++ b/examples/dgm/tasks/env-bool/lib.py
@@ -1,0 +1,3 @@
+def as_bool(s):
+    """Parse a config string into a bool."""
+    return bool(s)

--- a/examples/dgm/tasks/env-bool/task.json
+++ b/examples/dgm/tasks/env-bool/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "env-bool",
+  "why": "treats the literal string false as true"
+}

--- a/examples/dgm/tasks/env-bool/test_lib.py
+++ b/examples/dgm/tasks/env-bool/test_lib.py
@@ -1,0 +1,7 @@
+from lib import as_bool
+
+def test_true():
+    assert as_bool("true") is True
+
+def test_false_string():
+    assert as_bool("false") is False

--- a/examples/dgm/tasks/escape-html/lib.py
+++ b/examples/dgm/tasks/escape-html/lib.py
@@ -1,0 +1,3 @@
+def escape(s):
+    """Escape &, < and > for HTML."""
+    return s.replace("<", "&lt;").replace(">", "&gt;").replace("&", "&amp;")

--- a/examples/dgm/tasks/escape-html/task.json
+++ b/examples/dgm/tasks/escape-html/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "escape-html",
+  "why": "escapes & after the entities it just wrote"
+}

--- a/examples/dgm/tasks/escape-html/test_lib.py
+++ b/examples/dgm/tasks/escape-html/test_lib.py
@@ -1,0 +1,7 @@
+from lib import escape
+
+def test_ampersand():
+    assert escape("a & b") == "a &amp; b"
+
+def test_angles_not_double_escaped():
+    assert escape("<x>") == "&lt;x&gt;"

--- a/examples/dgm/tasks/flatten-depth/lib.py
+++ b/examples/dgm/tasks/flatten-depth/lib.py
@@ -1,0 +1,9 @@
+def flatten(xs):
+    """Fully flatten arbitrarily nested lists."""
+    out = []
+    for x in xs:
+        if isinstance(x, list):
+            out.extend(x)
+        else:
+            out.append(x)
+    return out

--- a/examples/dgm/tasks/flatten-depth/task.json
+++ b/examples/dgm/tasks/flatten-depth/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "flatten-depth",
+  "why": "only flattens one level"
+}

--- a/examples/dgm/tasks/flatten-depth/test_lib.py
+++ b/examples/dgm/tasks/flatten-depth/test_lib.py
@@ -1,0 +1,7 @@
+from lib import flatten
+
+def test_one_level():
+    assert flatten([1, [2, 3]]) == [1, 2, 3]
+
+def test_deep():
+    assert flatten([1, [2, [3, [4]]]]) == [1, 2, 3, 4]

--- a/examples/dgm/tasks/group-by-key/lib.py
+++ b/examples/dgm/tasks/group-by-key/lib.py
@@ -1,0 +1,6 @@
+def group_by(items, key):
+    """Group items into {key(item): [items]}."""
+    out = {}
+    for it in items:
+        out[key(it)] = [it]
+    return out

--- a/examples/dgm/tasks/group-by-key/task.json
+++ b/examples/dgm/tasks/group-by-key/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "group-by-key",
+  "why": "overwrites instead of appending"
+}

--- a/examples/dgm/tasks/group-by-key/test_lib.py
+++ b/examples/dgm/tasks/group-by-key/test_lib.py
@@ -1,0 +1,7 @@
+from lib import group_by
+
+def test_distinct():
+    assert group_by([1, 2], lambda x: x) == {1: [1], 2: [2]}
+
+def test_collision():
+    assert group_by([1, 3, 2], lambda x: x % 2) == {1: [1, 3], 0: [2]}

--- a/examples/dgm/tasks/indent-block/lib.py
+++ b/examples/dgm/tasks/indent-block/lib.py
@@ -1,0 +1,3 @@
+def indent(text, prefix="    "):
+    """Prefix every non-empty line."""
+    return "\n".join(prefix + line for line in text.split("\n"))

--- a/examples/dgm/tasks/indent-block/task.json
+++ b/examples/dgm/tasks/indent-block/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "indent-block",
+  "why": "indents blank lines too"
+}

--- a/examples/dgm/tasks/indent-block/test_lib.py
+++ b/examples/dgm/tasks/indent-block/test_lib.py
@@ -1,0 +1,7 @@
+from lib import indent
+
+def test_single():
+    assert indent("a") == "    a"
+
+def test_blank_line():
+    assert indent("a\n\nb") == "    a\n\n    b"

--- a/examples/dgm/tasks/interval-merge/lib.py
+++ b/examples/dgm/tasks/interval-merge/lib.py
@@ -1,0 +1,9 @@
+def merge(intervals):
+    """Merge overlapping or touching [start, end] intervals."""
+    out = []
+    for s, e in sorted(intervals):
+        if out and s < out[-1][1]:
+            out[-1] = (out[-1][0], max(out[-1][1], e))
+        else:
+            out.append((s, e))
+    return out

--- a/examples/dgm/tasks/interval-merge/task.json
+++ b/examples/dgm/tasks/interval-merge/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "interval-merge",
+  "why": "does not merge touching intervals"
+}

--- a/examples/dgm/tasks/interval-merge/test_lib.py
+++ b/examples/dgm/tasks/interval-merge/test_lib.py
@@ -1,0 +1,7 @@
+from lib import merge
+
+def test_overlap():
+    assert merge([(1, 3), (2, 4)]) == [(1, 4)]
+
+def test_touching():
+    assert merge([(1, 2), (2, 3)]) == [(1, 3)]

--- a/examples/dgm/tasks/is-palindrome/lib.py
+++ b/examples/dgm/tasks/is-palindrome/lib.py
@@ -1,0 +1,3 @@
+def is_palindrome(s):
+    """Ignoring case and non-alphanumerics."""
+    return s == s[::-1]

--- a/examples/dgm/tasks/is-palindrome/task.json
+++ b/examples/dgm/tasks/is-palindrome/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "is-palindrome",
+  "why": "counts punctuation and case"
+}

--- a/examples/dgm/tasks/is-palindrome/test_lib.py
+++ b/examples/dgm/tasks/is-palindrome/test_lib.py
@@ -1,0 +1,7 @@
+from lib import is_palindrome
+
+def test_plain():
+    assert is_palindrome("aba") is True
+
+def test_punctuation():
+    assert is_palindrome("A man, a plan, a canal: Panama") is True

--- a/examples/dgm/tasks/join-nonempty/lib.py
+++ b/examples/dgm/tasks/join-nonempty/lib.py
@@ -1,0 +1,3 @@
+def join_parts(parts, sep=", "):
+    """Join the non-empty parts."""
+    return sep.join(parts)

--- a/examples/dgm/tasks/join-nonempty/task.json
+++ b/examples/dgm/tasks/join-nonempty/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "join-nonempty",
+  "why": "joins empty strings too, doubling separators"
+}

--- a/examples/dgm/tasks/join-nonempty/test_lib.py
+++ b/examples/dgm/tasks/join-nonempty/test_lib.py
@@ -1,0 +1,7 @@
+from lib import join_parts
+
+def test_all_present():
+    assert join_parts(["a", "b"]) == "a, b"
+
+def test_skips_empty():
+    assert join_parts(["a", "", "b"]) == "a, b"

--- a/examples/dgm/tasks/levenshtein-empty/lib.py
+++ b/examples/dgm/tasks/levenshtein-empty/lib.py
@@ -1,0 +1,9 @@
+def distance(a, b):
+    """Levenshtein edit distance."""
+    prev = list(range(1, len(b) + 1))
+    for i, ca in enumerate(a):
+        cur = [i + 1]
+        for j, cb in enumerate(b):
+            cur.append(min(prev[j] + (ca != cb), cur[j] + 1, prev[j] + 1))
+        prev = cur[1:]
+    return prev[-1]

--- a/examples/dgm/tasks/levenshtein-empty/task.json
+++ b/examples/dgm/tasks/levenshtein-empty/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "levenshtein-empty",
+  "why": "crashes on an empty string"
+}

--- a/examples/dgm/tasks/levenshtein-empty/test_lib.py
+++ b/examples/dgm/tasks/levenshtein-empty/test_lib.py
@@ -1,0 +1,7 @@
+from lib import distance
+
+def test_same_length():
+    assert distance("cat", "cut") == 1
+
+def test_empty():
+    assert distance("", "abc") == 3

--- a/examples/dgm/tasks/matrix-transpose/lib.py
+++ b/examples/dgm/tasks/matrix-transpose/lib.py
@@ -1,0 +1,4 @@
+def transpose(m):
+    """Transpose a rectangular matrix."""
+    n = len(m)
+    return [[m[j][i] for j in range(n)] for i in range(n)]

--- a/examples/dgm/tasks/matrix-transpose/task.json
+++ b/examples/dgm/tasks/matrix-transpose/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "matrix-transpose",
+  "why": "assumes a square matrix"
+}

--- a/examples/dgm/tasks/matrix-transpose/test_lib.py
+++ b/examples/dgm/tasks/matrix-transpose/test_lib.py
@@ -1,0 +1,7 @@
+from lib import transpose
+
+def test_square():
+    assert transpose([[1, 2], [3, 4]]) == [[1, 3], [2, 4]]
+
+def test_rectangular():
+    assert transpose([[1, 2, 3], [4, 5, 6]]) == [[1, 4], [2, 5], [3, 6]]

--- a/examples/dgm/tasks/max-by-empty/lib.py
+++ b/examples/dgm/tasks/max-by-empty/lib.py
@@ -1,0 +1,3 @@
+def max_by(xs, key):
+    """Item with the largest key, or None when empty."""
+    return max(xs, key=key)

--- a/examples/dgm/tasks/max-by-empty/task.json
+++ b/examples/dgm/tasks/max-by-empty/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "max-by-empty",
+  "why": "raises on an empty sequence"
+}

--- a/examples/dgm/tasks/max-by-empty/test_lib.py
+++ b/examples/dgm/tasks/max-by-empty/test_lib.py
@@ -1,0 +1,7 @@
+from lib import max_by
+
+def test_values():
+    assert max_by([1, 3, 2], lambda x: x) == 3
+
+def test_empty():
+    assert max_by([], lambda x: x) is None

--- a/examples/dgm/tasks/mean-empty/lib.py
+++ b/examples/dgm/tasks/mean-empty/lib.py
@@ -1,0 +1,3 @@
+def mean(xs):
+    """Arithmetic mean; 0.0 for an empty list."""
+    return sum(xs) / len(xs)

--- a/examples/dgm/tasks/mean-empty/task.json
+++ b/examples/dgm/tasks/mean-empty/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "mean-empty",
+  "why": "divides by zero on an empty list"
+}

--- a/examples/dgm/tasks/mean-empty/test_lib.py
+++ b/examples/dgm/tasks/mean-empty/test_lib.py
@@ -1,0 +1,7 @@
+from lib import mean
+
+def test_values():
+    assert mean([1, 2, 3]) == 2
+
+def test_empty():
+    assert mean([]) == 0.0

--- a/examples/dgm/tasks/median-even/lib.py
+++ b/examples/dgm/tasks/median-even/lib.py
@@ -1,0 +1,4 @@
+def median(xs):
+    """Median; the mean of the two middles when len is even."""
+    s = sorted(xs)
+    return s[len(s) // 2 - (1 if len(s) % 2 == 0 else 0)]

--- a/examples/dgm/tasks/median-even/task.json
+++ b/examples/dgm/tasks/median-even/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "median-even",
+  "why": "returns the lower middle for even-length input"
+}

--- a/examples/dgm/tasks/median-even/test_lib.py
+++ b/examples/dgm/tasks/median-even/test_lib.py
@@ -1,0 +1,7 @@
+from lib import median
+
+def test_odd():
+    assert median([3, 1, 2]) == 2
+
+def test_even():
+    assert median([1, 2, 3, 4]) == 2.5

--- a/examples/dgm/tasks/merge-nested/lib.py
+++ b/examples/dgm/tasks/merge-nested/lib.py
@@ -1,0 +1,5 @@
+def deep_merge(a, b):
+    """Merge b into a, recursing into nested dicts."""
+    out = dict(a)
+    out.update(b)
+    return out

--- a/examples/dgm/tasks/merge-nested/task.json
+++ b/examples/dgm/tasks/merge-nested/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "merge-nested",
+  "why": "nested dicts are replaced instead of merged"
+}

--- a/examples/dgm/tasks/merge-nested/test_lib.py
+++ b/examples/dgm/tasks/merge-nested/test_lib.py
@@ -1,0 +1,7 @@
+from lib import deep_merge
+
+def test_flat():
+    assert deep_merge({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+
+def test_nested():
+    assert deep_merge({"x": {"a": 1}}, {"x": {"b": 2}}) == {"x": {"a": 1, "b": 2}}

--- a/examples/dgm/tasks/moving-average/lib.py
+++ b/examples/dgm/tasks/moving-average/lib.py
@@ -1,0 +1,3 @@
+def moving_avg(xs, n):
+    """Averages over each FULL window of length n."""
+    return [sum(xs[max(0, i - n + 1):i + 1]) / min(i + 1, n) for i in range(len(xs))]

--- a/examples/dgm/tasks/moving-average/task.json
+++ b/examples/dgm/tasks/moving-average/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "moving-average",
+  "why": "includes the incomplete leading window"
+}

--- a/examples/dgm/tasks/moving-average/test_lib.py
+++ b/examples/dgm/tasks/moving-average/test_lib.py
@@ -1,0 +1,7 @@
+from lib import moving_avg
+
+def test_window_one():
+    assert moving_avg([1, 2, 3], 1) == [1.0, 2.0, 3.0]
+
+def test_full_windows_only():
+    assert moving_avg([1, 2, 3], 2) == [1.5, 2.5]

--- a/examples/dgm/tasks/nested-get-list/lib.py
+++ b/examples/dgm/tasks/nested-get-list/lib.py
@@ -1,0 +1,5 @@
+def get_path(data, path):
+    """Walk a path of dict keys and list indices."""
+    for part in path:
+        data = data[part]
+    return data

--- a/examples/dgm/tasks/nested-get-list/task.json
+++ b/examples/dgm/tasks/nested-get-list/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "nested-get-list",
+  "why": "cannot index into a list"
+}

--- a/examples/dgm/tasks/nested-get-list/test_lib.py
+++ b/examples/dgm/tasks/nested-get-list/test_lib.py
@@ -1,0 +1,7 @@
+from lib import get_path
+
+def test_dict():
+    assert get_path({"a": {"b": 1}}, ["a", "b"]) == 1
+
+def test_list_index():
+    assert get_path({"a": [10, 20]}, ["a", "1"]) == 20

--- a/examples/dgm/tasks/normalise-space/lib.py
+++ b/examples/dgm/tasks/normalise-space/lib.py
@@ -1,0 +1,5 @@
+import re
+
+def normalise(s):
+    """Collapse internal whitespace and trim the ends."""
+    return re.sub(r"\s+", " ", s)

--- a/examples/dgm/tasks/normalise-space/task.json
+++ b/examples/dgm/tasks/normalise-space/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "normalise-space",
+  "why": "does not strip the ends"
+}

--- a/examples/dgm/tasks/normalise-space/test_lib.py
+++ b/examples/dgm/tasks/normalise-space/test_lib.py
@@ -1,0 +1,7 @@
+from lib import normalise
+
+def test_internal():
+    assert normalise("a   b") == "a b"
+
+def test_trims():
+    assert normalise("  a b  ") == "a b"

--- a/examples/dgm/tasks/ordinal-suffix/lib.py
+++ b/examples/dgm/tasks/ordinal-suffix/lib.py
@@ -1,0 +1,4 @@
+def ordinal(n):
+    """1 -> 1st, 2 -> 2nd, 11 -> 11th."""
+    last = n % 10
+    return f"{n}" + {1: "st", 2: "nd", 3: "rd"}.get(last, "th")

--- a/examples/dgm/tasks/ordinal-suffix/task.json
+++ b/examples/dgm/tasks/ordinal-suffix/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "ordinal-suffix",
+  "why": "gives 11th as 11st"
+}

--- a/examples/dgm/tasks/ordinal-suffix/test_lib.py
+++ b/examples/dgm/tasks/ordinal-suffix/test_lib.py
@@ -1,0 +1,7 @@
+from lib import ordinal
+
+def test_first():
+    assert ordinal(1) == "1st"
+
+def test_eleventh():
+    assert ordinal(11) == "11th"

--- a/examples/dgm/tasks/parse-int-sign/lib.py
+++ b/examples/dgm/tasks/parse-int-sign/lib.py
@@ -1,0 +1,3 @@
+def to_int(s):
+    """Parse an optionally-signed integer string."""
+    return int("".join(c for c in s if c.isdigit()))

--- a/examples/dgm/tasks/parse-int-sign/task.json
+++ b/examples/dgm/tasks/parse-int-sign/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "parse-int-sign",
+  "why": "drops a leading plus"
+}

--- a/examples/dgm/tasks/parse-int-sign/test_lib.py
+++ b/examples/dgm/tasks/parse-int-sign/test_lib.py
@@ -1,0 +1,7 @@
+from lib import to_int
+
+def test_plain():
+    assert to_int("42") == 42
+
+def test_negative():
+    assert to_int("-7") == -7

--- a/examples/dgm/tasks/path-join/lib.py
+++ b/examples/dgm/tasks/path-join/lib.py
@@ -1,0 +1,3 @@
+def join(*parts):
+    """Join path segments with exactly one slash between them."""
+    return "/".join(parts)

--- a/examples/dgm/tasks/path-join/task.json
+++ b/examples/dgm/tasks/path-join/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "path-join",
+  "why": "doubles the separator"
+}

--- a/examples/dgm/tasks/path-join/test_lib.py
+++ b/examples/dgm/tasks/path-join/test_lib.py
@@ -1,0 +1,7 @@
+from lib import join
+
+def test_plain():
+    assert join("a", "b") == "a/b"
+
+def test_trailing_slash():
+    assert join("a/", "b") == "a/b"

--- a/examples/dgm/tasks/percent-of-zero/lib.py
+++ b/examples/dgm/tasks/percent-of-zero/lib.py
@@ -1,0 +1,3 @@
+def percent(part, total):
+    """part as a percentage of total; 0.0 when total is 0."""
+    return 100.0 * part / total

--- a/examples/dgm/tasks/percent-of-zero/task.json
+++ b/examples/dgm/tasks/percent-of-zero/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "percent-of-zero",
+  "why": "divides by zero when the total is 0"
+}

--- a/examples/dgm/tasks/percent-of-zero/test_lib.py
+++ b/examples/dgm/tasks/percent-of-zero/test_lib.py
@@ -1,0 +1,7 @@
+from lib import percent
+
+def test_normal():
+    assert percent(1, 4) == 25.0
+
+def test_zero_total():
+    assert percent(0, 0) == 0.0

--- a/examples/dgm/tasks/pluralise-y/lib.py
+++ b/examples/dgm/tasks/pluralise-y/lib.py
@@ -1,0 +1,3 @@
+def plural(w):
+    """English plural for simple nouns."""
+    return w + "s"

--- a/examples/dgm/tasks/pluralise-y/task.json
+++ b/examples/dgm/tasks/pluralise-y/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "pluralise-y",
+  "why": "adds s to words ending in consonant+y"
+}

--- a/examples/dgm/tasks/pluralise-y/test_lib.py
+++ b/examples/dgm/tasks/pluralise-y/test_lib.py
@@ -1,0 +1,7 @@
+from lib import plural
+
+def test_regular():
+    assert plural("cat") == "cats"
+
+def test_consonant_y():
+    assert plural("city") == "cities"

--- a/examples/dgm/tasks/prefix-sum-init/lib.py
+++ b/examples/dgm/tasks/prefix-sum-init/lib.py
@@ -1,0 +1,7 @@
+def prefix_sums(xs):
+    """Cumulative sums, starting with 0."""
+    out, run = [0], 0
+    for x in xs:
+        run += x
+        out.append(run)
+    return out[1:] if xs else out

--- a/examples/dgm/tasks/prefix-sum-init/task.json
+++ b/examples/dgm/tasks/prefix-sum-init/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "prefix-sum-init",
+  "why": "omits the leading zero"
+}

--- a/examples/dgm/tasks/prefix-sum-init/test_lib.py
+++ b/examples/dgm/tasks/prefix-sum-init/test_lib.py
@@ -1,0 +1,7 @@
+from lib import prefix_sums
+
+def test_empty():
+    assert prefix_sums([]) == [0]
+
+def test_values():
+    assert prefix_sums([1, 2]) == [0, 1, 3]

--- a/examples/dgm/tasks/queue-fifo/lib.py
+++ b/examples/dgm/tasks/queue-fifo/lib.py
@@ -1,0 +1,11 @@
+class Queue:
+    """First-in, first-out."""
+
+    def __init__(self):
+        self.items = []
+
+    def push(self, x):
+        self.items.append(x)
+
+    def pop(self):
+        return self.items.pop()

--- a/examples/dgm/tasks/queue-fifo/task.json
+++ b/examples/dgm/tasks/queue-fifo/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "queue-fifo",
+  "why": "pops from the wrong end, making it a stack"
+}

--- a/examples/dgm/tasks/queue-fifo/test_lib.py
+++ b/examples/dgm/tasks/queue-fifo/test_lib.py
@@ -1,0 +1,9 @@
+from lib import Queue
+
+def test_single():
+    q = Queue(); q.push(1)
+    assert q.pop() == 1
+
+def test_order():
+    q = Queue(); q.push(1); q.push(2)
+    assert q.pop() == 1

--- a/examples/dgm/tasks/range-end/lib.py
+++ b/examples/dgm/tasks/range-end/lib.py
@@ -1,0 +1,6 @@
+def expand(spec):
+    """\"1-4\" -> [1,2,3,4]; a bare number -> [n]."""
+    if "-" not in spec:
+        return [int(spec)]
+    lo, hi = spec.split("-")
+    return list(range(int(lo), int(hi)))

--- a/examples/dgm/tasks/range-end/task.json
+++ b/examples/dgm/tasks/range-end/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "range-end",
+  "why": "inclusive end is dropped"
+}

--- a/examples/dgm/tasks/range-end/test_lib.py
+++ b/examples/dgm/tasks/range-end/test_lib.py
@@ -1,0 +1,7 @@
+from lib import expand
+
+def test_single():
+    assert expand("7") == [7]
+
+def test_inclusive():
+    assert expand("1-4") == [1, 2, 3, 4]

--- a/examples/dgm/tasks/rate-limit-window/lib.py
+++ b/examples/dgm/tasks/rate-limit-window/lib.py
@@ -1,0 +1,3 @@
+def allowed(times, now, window, limit):
+    """True if fewer than `limit` calls fall within `window` before `now`."""
+    return len(times) < limit

--- a/examples/dgm/tasks/rate-limit-window/task.json
+++ b/examples/dgm/tasks/rate-limit-window/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "rate-limit-window",
+  "why": "counts all calls ever, not those in the window"
+}

--- a/examples/dgm/tasks/rate-limit-window/test_lib.py
+++ b/examples/dgm/tasks/rate-limit-window/test_lib.py
@@ -1,0 +1,7 @@
+from lib import allowed
+
+def test_under_limit():
+    assert allowed([1.0], 2.0, 10.0, 3) is True
+
+def test_old_calls_expire():
+    assert allowed([1.0, 2.0, 3.0], 100.0, 10.0, 3) is True

--- a/examples/dgm/tasks/retry-backoff/lib.py
+++ b/examples/dgm/tasks/retry-backoff/lib.py
@@ -1,0 +1,6 @@
+def call_with_retry(fn, attempts=3):
+    """Call fn(); retry on exception up to `attempts` total tries."""
+    try:
+        return fn()
+    except Exception:
+        return fn()

--- a/examples/dgm/tasks/retry-backoff/task.json
+++ b/examples/dgm/tasks/retry-backoff/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "retry-backoff",
+  "why": "retries once instead of `attempts` times"
+}

--- a/examples/dgm/tasks/retry-backoff/test_lib.py
+++ b/examples/dgm/tasks/retry-backoff/test_lib.py
@@ -1,0 +1,13 @@
+from lib import call_with_retry
+
+def test_succeeds_first():
+    assert call_with_retry(lambda: 1) == 1
+
+def test_uses_all_attempts():
+    calls = {"n": 0}
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ValueError("boom")
+        return "ok"
+    assert call_with_retry(flaky, attempts=3) == "ok"

--- a/examples/dgm/tasks/roman-subtractive/lib.py
+++ b/examples/dgm/tasks/roman-subtractive/lib.py
@@ -1,0 +1,10 @@
+VALUES = [(1000,"M"),(500,"D"),(100,"C"),(50,"L"),(10,"X"),(5,"V"),(1,"I")]
+
+def to_roman(n):
+    """Integer -> Roman numeral, using subtractive pairs."""
+    out = ""
+    for v, sym in VALUES:
+        while n >= v:
+            out += sym
+            n -= v
+    return out

--- a/examples/dgm/tasks/roman-subtractive/task.json
+++ b/examples/dgm/tasks/roman-subtractive/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "roman-subtractive",
+  "why": "no subtractive pairs, so 4 becomes IIII"
+}

--- a/examples/dgm/tasks/roman-subtractive/test_lib.py
+++ b/examples/dgm/tasks/roman-subtractive/test_lib.py
@@ -1,0 +1,7 @@
+from lib import to_roman
+
+def test_simple():
+    assert to_roman(6) == "VI"
+
+def test_subtractive():
+    assert to_roman(4) == "IV"

--- a/examples/dgm/tasks/round-half-even/lib.py
+++ b/examples/dgm/tasks/round-half-even/lib.py
@@ -1,0 +1,3 @@
+def round_half_up(x):
+    """Round to the nearest integer, halves going UP."""
+    return round(x)

--- a/examples/dgm/tasks/round-half-even/task.json
+++ b/examples/dgm/tasks/round-half-even/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "round-half-even",
+  "why": "rounds half away from zero"
+}

--- a/examples/dgm/tasks/round-half-even/test_lib.py
+++ b/examples/dgm/tasks/round-half-even/test_lib.py
@@ -1,0 +1,7 @@
+from lib import round_half_up
+
+def test_below_half():
+    assert round_half_up(1.4) == 1
+
+def test_exact_half():
+    assert round_half_up(0.5) == 1

--- a/examples/dgm/tasks/safe-get-path/lib.py
+++ b/examples/dgm/tasks/safe-get-path/lib.py
@@ -1,0 +1,5 @@
+def get_in(d, path, default=None):
+    """Walk a dotted path, returning default if any step is missing."""
+    for part in path.split("."):
+        d = d[part]
+    return d

--- a/examples/dgm/tasks/safe-get-path/task.json
+++ b/examples/dgm/tasks/safe-get-path/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "safe-get-path",
+  "why": "raises instead of returning the default"
+}

--- a/examples/dgm/tasks/safe-get-path/test_lib.py
+++ b/examples/dgm/tasks/safe-get-path/test_lib.py
@@ -1,0 +1,7 @@
+from lib import get_in
+
+def test_present():
+    assert get_in({"a": {"b": 1}}, "a.b") == 1
+
+def test_missing():
+    assert get_in({"a": {}}, "a.b", default=0) == 0

--- a/examples/dgm/tasks/set-difference-order/lib.py
+++ b/examples/dgm/tasks/set-difference-order/lib.py
@@ -1,0 +1,3 @@
+def without(xs, drop):
+    """Items of xs not in drop, in the original order."""
+    return list(set(xs) - set(drop))

--- a/examples/dgm/tasks/set-difference-order/task.json
+++ b/examples/dgm/tasks/set-difference-order/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "set-difference-order",
+  "why": "returns an unordered set"
+}

--- a/examples/dgm/tasks/set-difference-order/test_lib.py
+++ b/examples/dgm/tasks/set-difference-order/test_lib.py
@@ -1,0 +1,8 @@
+from lib import without
+
+def test_single():
+    assert without(["beta"], []) == ["beta"]
+
+def test_order():
+    assert without(["alpha", "beta", "gamma", "delta"], ["beta"]) == [
+        "alpha", "gamma", "delta"]

--- a/examples/dgm/tasks/shell-split-quotes/lib.py
+++ b/examples/dgm/tasks/shell-split-quotes/lib.py
@@ -1,0 +1,3 @@
+def split_args(line):
+    """Split a command line, honouring double quotes."""
+    return line.split()

--- a/examples/dgm/tasks/shell-split-quotes/task.json
+++ b/examples/dgm/tasks/shell-split-quotes/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "shell-split-quotes",
+  "why": "splits inside quoted arguments"
+}

--- a/examples/dgm/tasks/shell-split-quotes/test_lib.py
+++ b/examples/dgm/tasks/shell-split-quotes/test_lib.py
@@ -1,0 +1,7 @@
+from lib import split_args
+
+def test_plain():
+    assert split_args("a b") == ["a", "b"]
+
+def test_quoted():
+    assert split_args('a "b c"') == ["a", "b c"]

--- a/examples/dgm/tasks/slugify-collapse/lib.py
+++ b/examples/dgm/tasks/slugify-collapse/lib.py
@@ -1,0 +1,5 @@
+import re
+
+def slugify(s):
+    """Lowercase, non-alnum -> single hyphen, no leading/trailing hyphen."""
+    return re.sub(r"[^a-z0-9]", "-", s.lower())

--- a/examples/dgm/tasks/slugify-collapse/task.json
+++ b/examples/dgm/tasks/slugify-collapse/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "slugify-collapse",
+  "why": "leaves runs of separators"
+}

--- a/examples/dgm/tasks/slugify-collapse/test_lib.py
+++ b/examples/dgm/tasks/slugify-collapse/test_lib.py
@@ -1,0 +1,7 @@
+from lib import slugify
+
+def test_simple():
+    assert slugify("Hello") == "hello"
+
+def test_collapse():
+    assert slugify("a  b!") == "a-b"

--- a/examples/dgm/tasks/sort-stability/lib.py
+++ b/examples/dgm/tasks/sort-stability/lib.py
@@ -1,0 +1,3 @@
+def sort_by_first(pairs):
+    """Sort by the first element only, keeping ties in input order."""
+    return sorted(pairs)

--- a/examples/dgm/tasks/sort-stability/task.json
+++ b/examples/dgm/tasks/sort-stability/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "sort-stability",
+  "why": "sorts by the whole tuple, breaking stability"
+}

--- a/examples/dgm/tasks/sort-stability/test_lib.py
+++ b/examples/dgm/tasks/sort-stability/test_lib.py
@@ -1,0 +1,7 @@
+from lib import sort_by_first
+
+def test_distinct():
+    assert sort_by_first([(2, "b"), (1, "a")]) == [(1, "a"), (2, "b")]
+
+def test_stable():
+    assert sort_by_first([(1, "z"), (1, "a")]) == [(1, "z"), (1, "a")]

--- a/examples/dgm/tasks/startswith-any/lib.py
+++ b/examples/dgm/tasks/startswith-any/lib.py
@@ -1,0 +1,3 @@
+def starts_with_any(s, prefixes):
+    """True if s starts with ANY of the prefixes."""
+    return s.startswith(prefixes[0]) if prefixes else False

--- a/examples/dgm/tasks/startswith-any/task.json
+++ b/examples/dgm/tasks/startswith-any/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "startswith-any",
+  "why": "only checks the first candidate"
+}

--- a/examples/dgm/tasks/startswith-any/test_lib.py
+++ b/examples/dgm/tasks/startswith-any/test_lib.py
@@ -1,0 +1,7 @@
+from lib import starts_with_any
+
+def test_first():
+    assert starts_with_any("hello", ["he", "xx"]) is True
+
+def test_second():
+    assert starts_with_any("hello", ["xx", "he"]) is True

--- a/examples/dgm/tasks/strip-comments/lib.py
+++ b/examples/dgm/tasks/strip-comments/lib.py
@@ -1,0 +1,3 @@
+def strip_comment(line):
+    """Remove a trailing # comment, ignoring # inside quotes."""
+    return line.split("#")[0].rstrip()

--- a/examples/dgm/tasks/strip-comments/task.json
+++ b/examples/dgm/tasks/strip-comments/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "strip-comments",
+  "why": "a '#' inside a string literal is treated as a comment"
+}

--- a/examples/dgm/tasks/strip-comments/test_lib.py
+++ b/examples/dgm/tasks/strip-comments/test_lib.py
@@ -1,0 +1,7 @@
+from lib import strip_comment
+
+def test_plain():
+    assert strip_comment("x = 1  # set x") == "x = 1"
+
+def test_hash_in_string():
+    assert strip_comment('c = "#fff"  # colour') == 'c = "#fff"'

--- a/examples/dgm/tasks/strip-prefix/lib.py
+++ b/examples/dgm/tasks/strip-prefix/lib.py
@@ -1,0 +1,3 @@
+def strip_prefix(s, prefix):
+    """Remove `prefix` from the front of s, once."""
+    return s.lstrip(prefix)

--- a/examples/dgm/tasks/strip-prefix/task.json
+++ b/examples/dgm/tasks/strip-prefix/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "strip-prefix",
+  "why": "uses lstrip, which strips characters not a prefix"
+}

--- a/examples/dgm/tasks/strip-prefix/test_lib.py
+++ b/examples/dgm/tasks/strip-prefix/test_lib.py
@@ -1,0 +1,7 @@
+from lib import strip_prefix
+
+def test_absent():
+    assert strip_prefix("hello", "xyz") == "hello"
+
+def test_char_set():
+    assert strip_prefix("aabbcc", "ab") == "aabbcc"

--- a/examples/dgm/tasks/sum-nested-dict/lib.py
+++ b/examples/dgm/tasks/sum-nested-dict/lib.py
@@ -1,0 +1,3 @@
+def total(d):
+    """Sum every numeric leaf in a nested dict."""
+    return sum(v for v in d.values() if isinstance(v, (int, float)))

--- a/examples/dgm/tasks/sum-nested-dict/task.json
+++ b/examples/dgm/tasks/sum-nested-dict/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "sum-nested-dict",
+  "why": "only sums the top level"
+}

--- a/examples/dgm/tasks/sum-nested-dict/test_lib.py
+++ b/examples/dgm/tasks/sum-nested-dict/test_lib.py
@@ -1,0 +1,7 @@
+from lib import total
+
+def test_flat():
+    assert total({"a": 1, "b": 2}) == 3
+
+def test_nested():
+    assert total({"a": 1, "b": {"c": 2, "d": 3}}) == 6

--- a/examples/dgm/tasks/title-case/lib.py
+++ b/examples/dgm/tasks/title-case/lib.py
@@ -1,0 +1,3 @@
+def title_case(s):
+    """Capitalise each word, leaving intra-word apostrophes alone."""
+    return s.title()

--- a/examples/dgm/tasks/title-case/task.json
+++ b/examples/dgm/tasks/title-case/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "title-case",
+  "why": "lowercases letters after an apostrophe"
+}

--- a/examples/dgm/tasks/title-case/test_lib.py
+++ b/examples/dgm/tasks/title-case/test_lib.py
@@ -1,0 +1,7 @@
+from lib import title_case
+
+def test_plain():
+    assert title_case("hello world") == "Hello World"
+
+def test_apostrophe():
+    assert title_case("o'brien's cat") == "O'brien's Cat"

--- a/examples/dgm/tasks/trim-list/lib.py
+++ b/examples/dgm/tasks/trim-list/lib.py
@@ -1,0 +1,6 @@
+def trim(xs, value):
+    """Drop `value` from both ends of the list."""
+    i = 0
+    while i < len(xs) and xs[i] == value:
+        i += 1
+    return xs[i:]

--- a/examples/dgm/tasks/trim-list/task.json
+++ b/examples/dgm/tasks/trim-list/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "trim-list",
+  "why": "trims only the head"
+}

--- a/examples/dgm/tasks/trim-list/test_lib.py
+++ b/examples/dgm/tasks/trim-list/test_lib.py
@@ -1,0 +1,7 @@
+from lib import trim
+
+def test_head():
+    assert trim([0, 1, 2], 0) == [1, 2]
+
+def test_both_ends():
+    assert trim([0, 1, 0], 0) == [1]

--- a/examples/dgm/tasks/truncate-word/lib.py
+++ b/examples/dgm/tasks/truncate-word/lib.py
@@ -1,0 +1,3 @@
+def truncate(s, n):
+    """Truncate to at most n chars, breaking on a word boundary."""
+    return s[:n]

--- a/examples/dgm/tasks/truncate-word/task.json
+++ b/examples/dgm/tasks/truncate-word/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "truncate-word",
+  "why": "cuts mid-word instead of at a boundary"
+}

--- a/examples/dgm/tasks/truncate-word/test_lib.py
+++ b/examples/dgm/tasks/truncate-word/test_lib.py
@@ -1,0 +1,7 @@
+from lib import truncate
+
+def test_short():
+    assert truncate("hi", 10) == "hi"
+
+def test_word_boundary():
+    assert truncate("hello big world", 11) == "hello big"

--- a/examples/dgm/tasks/unique-preserve-key/lib.py
+++ b/examples/dgm/tasks/unique-preserve-key/lib.py
@@ -1,0 +1,9 @@
+def unique_by(items, key):
+    """Keep the first item per key, in order."""
+    seen, out = set(), []
+    for it in items:
+        if it in seen:
+            continue
+        seen.add(it)
+        out.append(it)
+    return out

--- a/examples/dgm/tasks/unique-preserve-key/task.json
+++ b/examples/dgm/tasks/unique-preserve-key/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "unique-preserve-key",
+  "why": "compares whole items, not the key"
+}

--- a/examples/dgm/tasks/unique-preserve-key/test_lib.py
+++ b/examples/dgm/tasks/unique-preserve-key/test_lib.py
@@ -1,0 +1,7 @@
+from lib import unique_by
+
+def test_no_dupes():
+    assert unique_by([1, 2], lambda x: x) == [1, 2]
+
+def test_by_key():
+    assert unique_by([1, 11, 2], lambda x: x % 10) == [1, 2]

--- a/examples/dgm/tasks/url-query/lib.py
+++ b/examples/dgm/tasks/url-query/lib.py
@@ -1,0 +1,9 @@
+def parse_query(q):
+    """Parse a=1&b=2 into {key: [values]}."""
+    out = {}
+    for pair in q.split("&"):
+        if "=" not in pair:
+            continue
+        k, v = pair.split("=", 1)
+        out[k] = [v]
+    return out

--- a/examples/dgm/tasks/url-query/task.json
+++ b/examples/dgm/tasks/url-query/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "url-query",
+  "why": "keeps only the last value of a repeated key"
+}

--- a/examples/dgm/tasks/url-query/test_lib.py
+++ b/examples/dgm/tasks/url-query/test_lib.py
@@ -1,0 +1,7 @@
+from lib import parse_query
+
+def test_simple():
+    assert parse_query("a=1&b=2") == {"a": ["1"], "b": ["2"]}
+
+def test_repeated_key():
+    assert parse_query("a=1&a=2") == {"a": ["1", "2"]}

--- a/examples/dgm/tasks/version-sort/lib.py
+++ b/examples/dgm/tasks/version-sort/lib.py
@@ -1,0 +1,3 @@
+def sort_versions(vs):
+    """Sort dotted numeric versions in numeric order."""
+    return sorted(vs)

--- a/examples/dgm/tasks/version-sort/task.json
+++ b/examples/dgm/tasks/version-sort/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "version-sort",
+  "why": "versions sort lexically, so 10 lands before 9"
+}

--- a/examples/dgm/tasks/version-sort/test_lib.py
+++ b/examples/dgm/tasks/version-sort/test_lib.py
@@ -1,0 +1,7 @@
+from lib import sort_versions
+
+def test_simple():
+    assert sort_versions(["1.2", "1.1"]) == ["1.1", "1.2"]
+
+def test_double_digit():
+    assert sort_versions(["1.9", "1.10", "1.2"]) == ["1.2", "1.9", "1.10"]

--- a/examples/dgm/tasks/word-count/lib.py
+++ b/examples/dgm/tasks/word-count/lib.py
@@ -1,0 +1,3 @@
+def word_freq(text):
+    """Count words, case-insensitively, ignoring punctuation."""
+    return {w: text.lower().split().count(w) for w in text.lower().split()}

--- a/examples/dgm/tasks/word-count/task.json
+++ b/examples/dgm/tasks/word-count/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "word-count",
+  "why": "counts punctuation as part of a word"
+}

--- a/examples/dgm/tasks/word-count/test_lib.py
+++ b/examples/dgm/tasks/word-count/test_lib.py
@@ -1,0 +1,7 @@
+from lib import word_freq
+
+def test_simple():
+    assert word_freq("a b a") == {"a": 2, "b": 1}
+
+def test_punctuation():
+    assert word_freq("hi, hi!") == {"hi": 2}

--- a/examples/dgm/tasks/wrap-width/lib.py
+++ b/examples/dgm/tasks/wrap-width/lib.py
@@ -1,0 +1,3 @@
+def wrap(text, width):
+    """Wrap into lines of at most `width`, breaking on spaces."""
+    return [text[i:i + width] for i in range(0, len(text), width)]

--- a/examples/dgm/tasks/wrap-width/task.json
+++ b/examples/dgm/tasks/wrap-width/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "wrap-width",
+  "why": "breaks mid-word instead of on spaces"
+}

--- a/examples/dgm/tasks/wrap-width/test_lib.py
+++ b/examples/dgm/tasks/wrap-width/test_lib.py
@@ -1,0 +1,7 @@
+from lib import wrap
+
+def test_short():
+    assert wrap("ab", 5) == ["ab"]
+
+def test_word_boundary():
+    assert wrap("aa bb cc", 5) == ["aa bb", "cc"]

--- a/examples/dgm/tasks/zip-uneven/lib.py
+++ b/examples/dgm/tasks/zip-uneven/lib.py
@@ -1,0 +1,3 @@
+def zip_fill(a, b, fill=None):
+    """Zip to the LONGER input, padding with fill."""
+    return list(zip(a, b))

--- a/examples/dgm/tasks/zip-uneven/task.json
+++ b/examples/dgm/tasks/zip-uneven/task.json
@@ -1,0 +1,4 @@
+{
+  "id": "zip-uneven",
+  "why": "stops at the shorter input"
+}

--- a/examples/dgm/tasks/zip-uneven/test_lib.py
+++ b/examples/dgm/tasks/zip-uneven/test_lib.py
@@ -1,0 +1,7 @@
+from lib import zip_fill
+
+def test_equal():
+    assert zip_fill([1, 2], ["a", "b"]) == [(1, "a"), (2, "b")]
+
+def test_uneven():
+    assert zip_fill([1, 2, 3], ["a"], fill="-") == [(1, "a"), (2, "-"), (3, "-")]

--- a/tests/test_dgm_real_objective.py
+++ b/tests/test_dgm_real_objective.py
@@ -168,3 +168,73 @@ def test_the_loop_commits_self_edits_and_grows_the_archive():
     assert seen["n"] > 0, "the proposer was never asked for a self-modification"
     committed = sum(h.committed for h in result.history)
     assert committed > 0, "no self-edit ever reached the head"
+
+
+def test_an_agent_that_retries_gets_more_than_one_model_call():
+    """The bridge must not decide how many calls an agent may make.
+
+    It used to: the harness ran the agent once to capture a prompt, answered it,
+    and re-ran with that single reply served from a file. "One call per task" was
+    then a property of the harness, and the first self-modification this
+    objective ever produced was a retry loop -- the one improvement that scheme
+    made impossible. It scored 0.875 -> 0.500 and the regression was the
+    harness's.
+    """
+    cases = {c.id: c for c in R.load_tasks()}
+    retrying = dict(R.SEED_AGENT)
+    retrying["agent/solve.py"] = (
+        'from tools import read_source, run_tests, write_source\n\n'
+        'def solve(task_dir, llm):\n'
+        '    for _ in range(3):\n'
+        '        reply = llm("attempt")\n'
+        '        write_source(task_dir, reply)\n'
+        '        passed, failed, _ = run_tests(task_dir)\n'
+        '        if failed == 0 and passed > 0:\n'
+        '            return\n')
+    seen = {"n": 0}
+    good = ('def expand(spec):\n    if "-" not in spec:\n        return [int(spec)]\n'
+            '    lo, hi = spec.split("-")\n    return list(range(int(lo), int(hi) + 1))\n')
+
+    def flaky(_prompt):
+        seen["n"] += 1
+        return "# not python at all(" if seen["n"] < 3 else good
+
+    ok, _ = R.run_agent_on_task(retrying, cases["range-end"], flaky)
+    assert seen["n"] == 3, f"the agent got {seen['n']} call(s), not the 3 it asked for"
+    assert ok, "the third attempt was correct and should have resolved the task"
+
+
+def test_a_runaway_agent_is_cut_off_rather_than_billed_forever():
+    cases = {c.id: c for c in R.load_tasks()}
+    looping = dict(R.SEED_AGENT)
+    looping["agent/solve.py"] = (
+        'def solve(task_dir, llm):\n'
+        '    while True:\n        llm("again")\n')
+    seen = {"n": 0}
+
+    def counting(_prompt):
+        seen["n"] += 1
+        return "# nope\n"
+
+    ok, detail = R.run_agent_on_task(looping, cases["range-end"], counting,
+                                     max_calls=4)
+    assert not ok
+    assert seen["n"] <= 4, f"the budget did not hold: {seen['n']} calls"
+    assert "exceeded" in detail
+
+
+def test_the_baseline_is_measured_even_when_no_self_edit_ever_lands():
+    """`seed_score` used to be set inside `step()`, which only runs when a card
+    reaches the merger -- so a run whose self-modifications all failed reported
+    `DGMContext.seed_score`'s 0.0 default as though it had measured it. The
+    final number came from the engine and was right; only the thing it was
+    compared against was invented, which is the more dangerous half.
+    """
+    cases = R.load_tasks()[:6]
+    # An actor that fixes nothing and proposes nothing: no card can ever arrive.
+    result = R.run_dgm_real(lambda _p: "", cases=cases, generations=1,
+                            selfimprove_size=2, max_rollouts=2)
+    assert getattr(result, "dgm_seed_score", None) is not None, (
+        "the baseline was never measured")
+    assert len(getattr(result, "dgm_archive", [])) == 1, (
+        "the seed itself belongs in the archive before round 0")

--- a/tests/test_dgm_real_objective.py
+++ b/tests/test_dgm_real_objective.py
@@ -1,0 +1,170 @@
+"""The real DGM objective: what it must reject, and what it must let through.
+
+The surrogate objective cannot fail in these ways -- adding a string to a set
+never breaks the agent, never escapes a directory, and never scores anything but
+monotonically upward. Every test here exists because the real one can.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agentdescent.treestrategy import FileTree
+from examples.dgm import real_objective as R
+
+
+# -- the vendored tasks ------------------------------------------------------
+
+
+def test_every_task_starts_with_exactly_one_failing_test():
+    """A task with no failing test measures nothing, and one that fails on
+    import measures the fixture rather than the agent."""
+    import subprocess
+    import sys
+
+    cases = R.load_tasks()
+    assert len(cases) >= 4, "the split needs at least four"
+    for case in cases:
+        proc = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", "--no-header",
+             "-rN", "--tb=line", "test_lib.py"],
+            cwd=str(case.path), capture_output=True, text=True, timeout=120)
+        out = proc.stdout + proc.stderr
+        # pytest's own count line ("1 failed, 1 passed") is not emitted by every
+        # configuration -- this environment suppresses it -- so the check reads
+        # the two signals that are always there: the exit status, and the
+        # per-test progress characters on the first line.
+        progress = out.strip().splitlines()[0] if out.strip() else ""
+        assert proc.returncode != 0, f"{case.id}: nothing fails, nothing to learn"
+        assert progress.count("F") == 1, (
+            f"{case.id}: expected exactly one failing test, saw {progress!r}")
+        assert progress.count(".") >= 1, (
+            f"{case.id}: everything fails -- a broken fixture, not a bug")
+        assert "E" not in progress, (
+            f"{case.id}: collection error rather than a test failure")
+
+
+# -- the evaluator -----------------------------------------------------------
+
+
+def _llm(reply):
+    return lambda _prompt: reply
+
+
+def test_a_correct_fix_resolves_and_a_wrong_one_does_not():
+    cases = {c.id: c for c in R.load_tasks()}
+    good = ('def deep_merge(a, b):\n    out = dict(a)\n'
+            '    for k, v in b.items():\n'
+            '        if isinstance(v, dict) and isinstance(out.get(k), dict):\n'
+            '            out[k] = deep_merge(out[k], v)\n'
+            '        else:\n            out[k] = v\n    return out\n')
+    ok, _ = R.run_agent_on_task(R.SEED_AGENT, cases["merge-nested"], _llm(good))
+    assert ok
+    bad = 'def deep_merge(a, b):\n    return dict(b)\n'
+    ok, detail = R.run_agent_on_task(R.SEED_AGENT, cases["merge-nested"], _llm(bad))
+    assert not ok and "failed" in detail
+
+
+def test_a_self_edit_that_breaks_the_agent_scores_zero_rather_than_raising():
+    """The whole reason for a non-monotone objective.
+
+    Under the surrogate this case does not exist: a capability string cannot
+    contain a syntax error. Here it can, and the search has to be able to score
+    it -- an exception would end the run instead of recording a bad child.
+    """
+    cases = {c.id: c for c in R.load_tasks()}
+    broken = dict(R.SEED_AGENT)
+    broken["agent/tools.py"] = "this is not python("
+    ok, detail = R.run_agent_on_task(broken, cases["range-end"], _llm("whatever"))
+    assert not ok
+    assert detail, "a failure with no explanation is not scoreable"
+
+
+def test_an_agent_file_cannot_escape_the_workspace():
+    with pytest.raises(ValueError, match="escapes"):
+        R._materialise({"../escape.py": "x = 1\n"},
+                       __import__("pathlib").Path(
+                           __import__("tempfile").mkdtemp()))
+
+
+# -- the self-modification ---------------------------------------------------
+
+
+def test_an_empty_proposal_warns_rather_than_looking_like_no_proposal():
+    """An empty completion and a deliberate "nothing to suggest" are the same
+    return value and opposite diagnoses. Measured on `deepseek-v4-flash` at
+    `max_tokens=4096`: 5 of 6 proposals came back empty, and the run ended
+    byte-identical to its seed with nothing in the log to say why."""
+    with pytest.warns(RuntimeWarning, match="empty completion"):
+        assert R.propose_self_edit(R.SEED_AGENT, [("t", False, "x")], _llm("")) is None
+
+
+@pytest.mark.parametrize("proposal", [
+    "here is my fix\ndef x(): pass",           # no PATH header
+    "PATH: ../../etc/passwd\nboom",            # escapes
+    "PATH: agent/tools.py\n   ",               # empty body
+    "PATH: agent/nope.py\nx = 1",              # outside the editable set
+])
+def test_a_malformed_self_edit_is_refused_not_applied(proposal):
+    assert R.parse_self_edit(proposal) is None
+
+
+def test_a_well_formed_self_edit_becomes_a_diff():
+    """`FileTree.to_diff` parses the shipped `<EDITS>` protocol, not a rendered
+    tree. Handing it the wrong shape returns `None` on every proposal -- silently
+    -- which is indistinguishable from a search that found nothing."""
+    body = 'def read_source(x):\n    return "patched"\n'
+    proposal = json.dumps({"edits": [{"path": "agent/tools.py", "content": body}]})
+    tree = FileTree(editable=list(R.EDITABLE))
+    diff = tree.to_diff(R.SEED_AGENT, proposal, "w1", 1, "coding_agent")
+    assert diff is not None and list(diff.ops) == ["agent/tools.py"]
+
+
+@pytest.mark.parametrize("path", ["agent/nope.py", "../escape.py"])
+def test_the_editable_boundary_is_the_engines_not_a_hand_check(path):
+    proposal = json.dumps({"edits": [{"path": path, "content": "x = 1\n"}]})
+    tree = FileTree(editable=list(R.EDITABLE))
+    assert tree.to_diff(R.SEED_AGENT, proposal, "w", 1, "coding_agent") is None
+
+
+def test_a_no_op_edit_is_not_a_diff():
+    proposal = json.dumps({"edits": [
+        {"path": "agent/tools.py", "content": R.SEED_AGENT["agent/tools.py"]}]})
+    tree = FileTree(editable=list(R.EDITABLE))
+    assert tree.to_diff(R.SEED_AGENT, proposal, "w", 1, "coding_agent") is None
+
+
+# -- the loop ----------------------------------------------------------------
+
+
+def test_the_loop_commits_self_edits_and_grows_the_archive():
+    """End to end, offline: a scripted actor that fixes two tasks and appends a
+    comment to its own tools on every proposal."""
+    fixes = {
+        "expand": ('def expand(spec):\n    if "-" not in spec:\n'
+                   '        return [int(spec)]\n    lo, hi = spec.split("-")\n'
+                   '    return list(range(int(lo), int(hi) + 1))\n'),
+        "sort_versions": ('def sort_versions(vs):\n'
+                          '    return sorted(vs, key=lambda v: '
+                          '[int(p) for p in v.split(".")])\n'),
+    }
+    seen = {"n": 0}
+
+    def actor(prompt):
+        if prompt.startswith("You are a self-improving coding agent"):
+            seen["n"] += 1
+            return ("PATH: agent/tools.py\n"
+                    + R.SEED_AGENT["agent/tools.py"]
+                    + f"\n# improvement {seen['n']}\n")
+        for name, body in fixes.items():
+            if f"def {name}" in prompt:
+                return body
+        return "# unchanged\n"
+
+    result = R.run_dgm_real(actor, generations=3, selfimprove_size=2,
+                            max_rollouts=6)
+    assert result.rollouts > 0
+    assert seen["n"] > 0, "the proposer was never asked for a self-modification"
+    committed = sum(h.committed for h in result.history)
+    assert committed > 0, "no self-edit ever reached the head"


### PR DESCRIPTION
Fifth algorithm of the #73 matrix. **No measured lift yet** — this lands the objective and the machinery; the run is next.

## Why the shipped objective could not show DGM working

It hashes each SWE instance id into a latent capability set and calls a task resolved when the agent's set covers it. The loop on top is faithful, but that objective is **monotone**: adding a capability can never un-resolve anything, so a self-modification can never regress.

That is not a detail. Open-ended search keeps stepping stones because a *worse* intermediate can lead somewhere better — and under a monotone objective there are no worse intermediates. Keep-all and the novelty-discounted parent draw become machinery with nothing to do.

## `--objective real`

Replaces the objective, not the algorithm:

- the agent is a real directory of Python source that **edits itself** (`agent/solve.py`, `agent/tools.py`, as a `FileTree`)
- a task is a real package with a **failing pytest**
- a score is what pytest reports

Six bugs vendored in `examples/dgm/tasks/`: quoted CSV delimiters, inclusive ranges, retry counts, nested merges, `#` inside a string literal, numeric version sort. Offline, no Docker, seconds to run.

**This is not SWE-bench** and the module says so in its first paragraph. What it restores is what the surrogate loses: real execution, real regressions, and self-edits that can leave the agent unable to run at all — *scored zero rather than raised*, because an exception would end the search instead of recording a bad child.

## Five things that had to be found by running it

Each failed silently:

- **The archive is coupled to the representation.** "Reuse `DGMArchiveAggregator` and swap `evaluate_fn`" was wrong — it builds `Agent(...)` from `state["capabilities"]` in three places. `SourceArchiveAggregator` reads a tree and *imports* what makes it DGM (`DGMParentSelection`, `staged_evaluate`) rather than reimplementing it.
- **`FileTree.to_diff` parses the `<EDITS>` protocol**, not a rendered tree. Wrong shape → `None` on every proposal, silently. A 13-rollout run ended byte-identical to its seed with nothing in the log.
- **The proposer returned empty completions** — 5 of 6 at the default 4096 tokens, since this module asks for a whole file. ADAS documents the same number; the lesson did not travel with the code that needed it. `MAX_TOKENS = 16384`, and an empty reply now warns rather than looking like "nothing to suggest".
- **The editable boundary belongs to the engine** — `FileTree(editable=...)` plus `safe_relpath` already refuse what the hand-rolled parser check duplicated.
- **The `--objective real` banner printed "SURROGATE".**

## One about the diagnosis itself

The empty-completion cause was initially **contradicted** by a single-sample check (4096 replied, 16384 came back empty) and only became clear at six samples per budget. That is the same single-measurement error [#120](https://github.com/Birfy/agentdescent/pull/120) just fixed in SkillOpt's `--hard` filter — made again, while fixing something else.

## Tests

Fourteen, and each is a property the surrogate cannot violate: a self-edit that breaks the agent, a path that escapes the workspace, a proposal that is not the protocol, an empty completion, a no-op edit, and the loop committing at all.

Refs #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)