### PR TITLE
feat(promptbreeder): Algorithm 1 as written, and the grader that made it unmeasurable

### DIFF
--- a/bench/results/promptbreeder-algorithm1.json
+++ b/bench/results/promptbreeder-algorithm1.json
@@ -1,0 +1,85 @@
+{
+ "experiment": "PromptBreeder Algorithm 1 on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "arXiv:2309.16797 (no released code)",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": true,
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "population_size": 8,
+  "fitness_batch": 4,
+  "domain": "money, 48 items, 16/16/16 splits"
+ },
+ "domain_reference_points": {
+  "baseline_instruction": 0.0,
+  "format_only_prompt": 0.479,
+  "working_plus_final_line_prompt": 1.0,
+  "note": "measured directly on all 48 items at temperature 0.0; the two ceilings are what a prompt can reach by naming the convention alone versus also teaching the working"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.0,
+    0.438
+   ],
+   "validation": [
+    0.0,
+    0.312
+   ],
+   "accepted": 5,
+   "invalid": 2,
+   "wall_s": 364.9,
+   "engine_s": 307.1,
+   "calls": 631
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.0,
+    0.0
+   ],
+   "validation": [
+    0.0,
+    0.0
+   ],
+   "accepted": 1,
+   "invalid": 4,
+   "wall_s": 594.4,
+   "engine_s": 532.1,
+   "calls": 638
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.0,
+    0.375
+   ],
+   "validation": [
+    0.0,
+    0.375
+   ],
+   "accepted": 4,
+   "invalid": 2,
+   "wall_s": 376.9,
+   "engine_s": 315.1,
+   "calls": 640
+  }
+ ],
+ "summary": {
+  "test_quality": {
+   "min": 0.0,
+   "median": 0.375,
+   "max": 0.438,
+   "mean": 0.271
+  },
+  "seeds_that_moved": 2,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-promptbreeder.md
+++ b/docs/algo-promptbreeder.md
@@ -10,7 +10,7 @@ paper-benchmark reproduction.
 | Paper | "Promptbreeder: Self-Referential Self-Improvement Via Prompt Evolution", Fernando et al., 2023 ([arXiv:2309.16797](https://arxiv.org/abs/2309.16797)) |
 | Upstream code (pinned) | paper only — no official released code |
 | Definition | [`examples/promptbreeder/promptbreeder_genetic_prompts.py`](https://github.com/Birfy/agentdescent/blob/main/examples/promptbreeder/promptbreeder_genetic_prompts.py) |
-| Domain | deterministic integer-cents arithmetic (12 tasks, disjoint splits) |
+| Domain | deterministic integer-cents arithmetic (48 tasks, disjoint 16/16/16 splits) |
 
 ## The mechanism
 
@@ -26,27 +26,113 @@ measured on a 100-item training batch; the paper runs a population of 50 for
 
 | Upstream mechanism | Where it lives here |
 |---|---|
-| Binary tournament replication | `BinaryTournament(SelectionPolicy)`, driven by the population aggregator: committed candidates enter an archive, the tournament's pick becomes the next parent by ledger commit |
+| Binary tournament replication | `PromptBreederPopulation`, in the engine's `aggregator_factory` seam: two units sampled uniformly, both re-scored, winner committed as the head the next batch mutates |
+| **Loser overwritten**, population fixed at N | the same class: the tournament records the loser's slot and the next committed child replaces it |
 | Task/mutation-prompt unit | `FieldSlots` genome: two plain-text ledger keys that union-merge on disjoint edits and model-merge when contested |
-| Nine mutation operators | three implemented (zero-order, first-order, hyper-mutation), rotated per replication event |
-| Fitness on a training batch | the engine's held-out gate |
+| Nine mutation operators, uniformly drawn | `_promptbreeder_operators.py`; all nine, sampled uniformly per replication event, with the realised histogram reported |
+| Population-conditioned operators (EDA, EDA-rank-and-index, lineage, crossover) | `PopulationView`, the handle the aggregator writes and `propose` reads |
+| Fitness on a random training batch | `PopulationContext.fitness(state, batch)` — a resampled batch of the **train** split |
+| N-unit initialisation from description x mutation-prompt x thinking-style | `seed_population`, billed to an `init:` phase rather than to the proposal budget |
+
+!!! warning "Three of these were missing, and each changed the search rather than the bookkeeping"
+    The port ran, returned a number, and was wrong in ways nothing asserted --
+    an archive that only grows still returns a best unit, a tournament ranked on
+    held-out still picks a winner, and three operators in rotation still mutate.
+
+    | | was | is |
+    |---|---|---|
+    | replacement | archive grew forever, no unit ever died | `\|P\| = N`, the loser's slot is reused |
+    | fitness | the held-out split — the acceptance gate's own signal, which makes the tournament a second gate rather than a fitness measure | a random batch of the train split, resampled per tournament |
+    | operators | 3 of 9, in fixed rotation | 9 of 9, uniformly sampled |
+
+    Rotation is the subtle one: it *guarantees* each operator's share where
+    sampling does not, so a run's operator mix was an assumption rather than an
+    observation.
+
+    Algorithm 1's tournament cannot be a `SelectionPolicy`, which is why it moved:
+    a selection policy receives candidates carrying cached scores and returns one,
+    while the paper's tournament has to **evaluate** both sampled units and
+    **replace** the loser.
 
 ## Boundaries
 
-- Population 50 and batch 100 are budget-sized down.
-- Three of nine mutation operators; no few-shot workings-out in the unit.
+- Population 8 and fitness batch 4, against the paper's 50 and 100.
+- The unit carries no few-shot context, so context shuffling is expressed as
+  prompt crossover over the population rather than over exemplars.
+- The domain was 12 items in 4/4/4 splits. `run_port` refuses a run whose train
+  split is smaller than the worker count, so that capped this port — and the ten
+  others sharing the domain — at four workers, with the acceptance gate resting
+  on four items. It is now 48 items in 16/16/16.
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`--reflective-merge`, `deepseek-v4-flash` at temperature 0.7 with thinking
+disabled. Recorded in
+[`bench/results/promptbreeder-algorithm1.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/promptbreeder-algorithm1.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
-|---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| seed | test quality | validation | accepted | calls | wall |
+|---|---|---|---|---|---|
+| 0 | 0.000 → **0.438** | 0.000 → 0.312 | 5/80 | 631 | 365 s |
+| 1 | 0.000 → 0.000 | 0.000 → 0.000 | 1/80 | 638 | 594 s |
+| 2 | 0.000 → **0.375** | 0.000 → 0.375 | 4/80 | 640 | 377 s |
+
+**Two of three seeds moved; one found nothing.** The mean is 0.271 and the range
+is the result, not noise around it — a single seed here would have supported
+either "it works" or "it does not", depending which one was run.
+
+### What the numbers mean against the domain's own ceilings
+
+Measured directly, on all 48 items, at temperature 0.0:
+
+| a prompt that… | scores |
+|---|---|
+| is the starting instruction | 0.000 |
+| names the integer-cents convention | 0.479 |
+| also tells the model to work the arithmetic out and end with a final answer line | **1.000** |
+
+The two successful seeds land at 0.375 and 0.438 — just under the *format-only*
+ceiling. So the search reliably discovers **what the grader wants** (an integer
+number of cents, stated nowhere in the problems) and does not discover that it is
+**allowed to think first**. The remaining headroom is a single idea, and no
+operator found it in 80 rollouts.
+
+!!! note "Four things had to be fixed before any of this measured the algorithm"
+    Each produced a run that completed, reported a number, and was wrong in a way
+    nothing asserted.
+
+    **The port was not Algorithm 1.** Its archive only grew, so no unit ever
+    died; its tournament ranked on the held-out split, which is the acceptance
+    gate's own signal and makes the tournament a second gate rather than a
+    fitness measure; and three of the nine operators ran in a fixed rotation,
+    which *guarantees* each operator's share where sampling does not. See the
+    table above.
+
+    **Hypermutation stopped halfway.** The paper writes a new mutation-prompt and
+    then *applies it to the task-prompt*. Step one alone leaves the task-prompt
+    unchanged, so such a candidate cannot move the score by construction — one
+    seed spent 29 of its 80 draws on exactly that and finished at 0.000.
+
+    **The grader forbade a chain of thought.** `parse_integer_answer` matched the
+    whole reply, so the output convention and the reasoning were mutually
+    exclusive: every method evolved prompts saying "no explanation", and without
+    the working the arithmetic collapsed. Same model, same convention, all 48
+    items: no working scored 0.562, *with* working scored **0.000** because the
+    working itself failed the match, and with working under a final-line grader
+    scored 0.979. A correct answer scored zero for having shown its arithmetic.
+
+    **The feedback then described the old grader.** After the fix the reply's
+    body was free, and the feedback still implied otherwise — so the search was
+    being optimised against a false statement about its own channel.
+
+    Two hypotheses were tested and **refuted** on the way, which is why they are
+    named here rather than in a fix: that `--reflective-merge` was blending the
+    eight workers' discoveries into mush (a no-merge control scored the same
+    0.000), and that `finalize()` was picking the wrong unit off a 4-item batch
+    (the whole population scored 0.000 — the maximum was a tie among zeros).
+
+### Cost
+
+Roughly 630 model calls per seed. The budget check passes in every run
+(`observed_proposal_calls <= expected`), with hypermutation's second step
+declared: `proposal_calls_per_candidate = 2`.

--- a/examples/_method_policy.py
+++ b/examples/_method_policy.py
@@ -235,6 +235,38 @@ class SkillLibrary:
 
 
 @dataclass(frozen=True)
+class PopulationContext:
+    """What a method's own population layer gets from the runner.
+
+    :class:`~examples._population.PopulationAggregator` covers the common case --
+    keep every committed head, ask a `SelectionPolicy` who the next parent is.
+    A method whose published algorithm says more than that needs more than that:
+    PromptBreeder's Algorithm 1 keeps a **fixed-size** population, evaluates the
+    two sampled units on a **training batch**, and **replaces the loser**, none
+    of which the shared aggregator does or should.
+
+    ``fitness(state, batch)`` scores a state on a **random batch** of the
+    *training* split, which is where several papers put their selection signal;
+    the shared aggregator's held-out score is the acceptance gate's, a different
+    question. The batch is the caller's: PromptBreeder's Algorithm 1 evaluates
+    "on a random batch of training data", and scoring the whole split instead is
+    both a departure -- the sampling noise is what keeps the tournament a
+    comparison rather than a verdict -- and, at one model call per item per unit
+    per tournament, the dominant cost of a run.
+    """
+
+    selection: object
+    artifact_id: str
+    conflict: object
+    fusion: object
+    acceptance: object
+    llm: Callable[..., str]
+    fitness: Callable[[Dict[str, str], int], float]
+    train_size: int
+    seed: int
+
+
+@dataclass(frozen=True)
 class MethodPolicy:
     """One candidate method, declaratively.
 
@@ -259,6 +291,16 @@ class MethodPolicy:
     engine: Policies = field(default_factory=Policies)
     reflective: bool = True
     self_verify: bool = False
+    #: Optional replacement for the shared population layer, for a method whose
+    #: paper specifies population dynamics the generic archive does not have.
+    #: Takes a :class:`PopulationContext`, returns an ``aggregator_factory``.
+    population: Optional[Callable[["PopulationContext"], object]] = None
+    #: Optional lines about what this method's own mechanism actually did, printed
+    #: after the run summary. For anything a run *chooses* rather than is told:
+    #: PromptBreeder samples its operator uniformly, so the realised mix is an
+    #: observation, and claiming it is reported without printing it anywhere is
+    #: how a documented property turns out to have no code behind it.
+    report: Optional[Callable[[], str]] = None
 
     @property
     def engine_tasks(self) -> List[Task]:

--- a/examples/_method_runner.py
+++ b/examples/_method_runner.py
@@ -14,6 +14,7 @@ evaluation -- rather than each candidate paying its own ranking evaluation.
 from __future__ import annotations
 
 import argparse
+import random
 import threading
 import time
 from dataclasses import dataclass, replace
@@ -28,7 +29,7 @@ from agentdescent.fusion import reflective_merge
 
 from ._common import add_standard_args, completion_for, confirm
 from ._measure import MODES, PhasedLLM, Recorder, compact_events, usage_dict
-from ._method_policy import MethodPolicy
+from ._method_policy import MethodPolicy, PopulationContext
 from ._population import population_factory
 
 
@@ -128,6 +129,30 @@ class MethodRunResult:
         }
 
 
+def _batch(tasks, size: int, seed: int):
+    """A random batch of the training split, or all of it when `size` covers it.
+
+    Seeded from the run's seed and the requested size, so a run is reproducible
+    while still resampling as the size changes -- the sampling is part of the
+    algorithm for a method whose fitness is defined on a batch, not a caching
+    detail.
+    """
+    if size <= 0 or size >= len(tasks):
+        return list(tasks)
+    # An int, not a tuple: `Random(tuple)` seeds by hashing, which Python 3.9
+    # deprecates and which is `PYTHONHASHSEED`-dependent -- the batch would
+    # differ between processes and the run would stop being reproducible.
+    return random.Random(seed * 1_000_003 + size * 1009 + len(tasks)).sample(
+        list(tasks), size)
+
+
+def _default_population(ctx: PopulationContext):
+    """The shared archive: keep every committed head, ask `selection` who is next."""
+    return population_factory(
+        ctx.selection, ctx.artifact_id, conflict=ctx.conflict,
+        fusion=ctx.fusion, acceptance=ctx.acceptance)
+
+
 def _evaluate(policy: MethodPolicy, llm: PhasedLLM, rendered: str,
               tasks: Sequence[Task]) -> float:
     if not tasks:
@@ -175,6 +200,11 @@ def run_port(
     prop_llm = PhasedLLM(recorder, f"proposal:{policy.name}")
     eval_llm = PhasedLLM(recorder, f"eval:{policy.name}")
     merge_llm = PhasedLLM(recorder, f"fusion:{policy.name}")
+    # A population layer that seeds itself -- PromptBreeder generates its N
+    # initial units -- spends model calls that are not proposals. Recording them
+    # under `proposal:` would blow the budget check that makes these rows
+    # comparable, and hide initialisation cost inside the search's cost.
+    init_llm = PhasedLLM(recorder, f"init:{policy.name}")
 
     initial = policy.strategy.render(policy.strategy.initial())
     started = time.monotonic()
@@ -200,10 +230,24 @@ def run_port(
         # bypasses the bundle's decision fields, so they travel through the
         # factory and are stripped from the bundle -- carried in both places,
         # one copy would be silently ignored.
-        aggregator_factory = population_factory(
-            engine.selection, f"candidate-{policy.name}",
+        pop_ctx = PopulationContext(
+            selection=engine.selection,
+            artifact_id=f"candidate-{policy.name}",
             conflict=engine.conflict, fusion=engine.fusion,
-            acceptance=engine.acceptance)
+            acceptance=engine.acceptance,
+            llm=lambda prompt, **kw: init_llm(prompt, **kw),
+            # The *training* split, which is where PromptBreeder's Algorithm 1
+            # puts its tournament: "evaluate the fitness of both units on a
+            # random batch of training data". The held-out score the shared
+            # archive uses is the acceptance gate's signal, a different question,
+            # and using it to rank a population is a departure worth not making
+            # silently.
+            fitness=lambda state, batch: _evaluate(
+                policy, eval_llm, policy.strategy.render(state),
+                _batch(policy.train_tasks, batch, seed)),
+            train_size=len(policy.train_tasks),
+            seed=seed)
+        aggregator_factory = (policy.population or _default_population)(pop_ctx)
         engine = replace(engine, selection=None, conflict=None, fusion=None,
                          acceptance=None)
     common = {
@@ -363,6 +407,14 @@ def standard_main(build: Callable[[int], MethodPolicy],
                         choices=["guarded", "reflective", "full"],
                         help="what to do with a diff proposed against a head the "
                              "merger has since moved (agentdescent.staleness)")
+    parser.add_argument(
+        "--temperature", type=float, default=1.0,
+        help=("sampling temperature. Every other port in this repository takes "
+              "one; this runner passed none, so these eleven ran at the API "
+              "default. Measured on deepseek-v4-flash over the money domain, a "
+              "prompt that works the arithmetic out scores 1.000 / 0.958 / 0.875 "
+              "at 0.0 / 0.7 / 1.0, so it is second-order next to what the prompt "
+              "says -- but it is not nothing, and it was not reportable"))
     parser.add_argument("--max-tokens", type=int, default=1024)
     parser.add_argument("--timeout", type=float, default=180.0)
     args = parser.parse_args(argv)
@@ -394,7 +446,7 @@ def standard_main(build: Callable[[int], MethodPolicy],
     usage = Usage()
     recorder = Recorder(
         completion_for(args, usage=usage, max_tokens=args.max_tokens,
-                       timeout=args.timeout),
+                       timeout=args.timeout, temperature=args.temperature),
         usage,
     )
     outcome = run_port(
@@ -409,4 +461,8 @@ def standard_main(build: Callable[[int], MethodPolicy],
           f"invalid={outcome.invalid_candidates} "
           f"wall={outcome.wall_seconds:.1f}s engine={outcome.engine_wall_seconds:.1f}s "
           f"calls={outcome.model_usage['calls']} budget={outcome.budget['matched']}")
+    if policy.report is not None:
+        detail = policy.report()
+        if detail:
+            print(detail)
     return 0

--- a/examples/_money_domain.py
+++ b/examples/_money_domain.py
@@ -1,9 +1,32 @@
 """Deterministic money domain shared by the candidate-method experiments.
 
-One grader. ``parse_integer_answer`` accepts a bare integer or an
-``Answer: <int>`` line and rejects dollars, decimals, and prose; every port that
-scores against this domain scores through :func:`score_answer`, and the offline
-tests exercise the same function the live runs use.
+One grader. ``parse_integer_answer`` reads the **final line** of a reply and
+accepts a bare integer or an ``Answer: <int>`` line there, rejecting dollars,
+decimals, and prose; every port that scores against this domain scores through
+:func:`score_answer`, and the offline tests exercise the same function the live
+runs use.
+
+*Final line*, not the whole reply, and the difference is the domain's ceiling.
+The grader used to ``fullmatch`` the entire response, which made the output
+convention and the reasoning **mutually exclusive**: a prompt that satisfied the
+format had to forbid the working, and without the working the model's arithmetic
+collapsed. Measured on `deepseek-v4-flash` over all 48 items, same model, same
+convention:
+
+===================================  =====
+prompt / grader                      score
+===================================  =====
+no working, whole-reply grader       0.562
+with working, whole-reply grader     0.000   <- the working itself failed
+with working, final-line grader      0.979
+===================================  =====
+
+The middle row is the one that matters: a *correct* answer scored zero because it
+was shown its arithmetic. That is not difficulty, it is a grader that forbids a
+chain of thought -- and the benchmarks these ports come from do the opposite,
+GSM8K extracting the final number after its ``####`` marker. What the port still
+has to discover is unchanged: that the amount is an **integer number of cents**,
+stated nowhere in the problems.
 """
 
 from __future__ import annotations
@@ -31,6 +54,25 @@ class MoneyTask:
 # The questions deliberately ask for an amount without revealing the evaluator's
 # integer-cents convention. Evolution sees that convention only through training
 # feedback; validation and test answers are never inserted into candidate prompts.
+#
+# 48 items in ten arithmetic families -- sum, difference, n-of-one-plus-one,
+# equal split, percent tip, mixed multi-item, change due, n-times-price, percent
+# tax, percent discount. The size is not decoration: `run_port` refuses a run
+# whose train split is smaller than the worker count, so the original twelve
+# capped every port in this family at four workers and put the acceptance gate on
+# four held-out items, where one arithmetic slip moves the score by 0.25.
+#
+# Nor is the domain a single on/off convention. Measured on `deepseek-v4-flash`:
+# the starting instruction scores **0.000** -- every answer comes back as
+# `$4.15` -- but simply stating the convention outright only reaches **0.417**,
+# because forcing a bare integer surfaces real arithmetic errors (`27` for a
+# $2.70 half-split, `1320` for a bill that still needed dividing). A prompt has
+# to teach the convention *and* the working to clear the domain.
+#
+# The 36 items after `m11` were generated and each answer was re-derived from the
+# dollar figures its own question prints, using Decimal rather than the integer
+# cents the table was built in. A wrong answer here does not raise -- it silently
+# becomes an unsolvable task and reads as a method that failed to learn.
 TASKS: Tuple[MoneyTask, ...] = (
     MoneyTask("m00", "A notebook costs $2.75 and a pen costs $1.40. What is the total amount?", "415"),
     MoneyTask("m01", "A ticket costs $12.50 and a coupon removes $3.25. What amount remains?", "925"),
@@ -44,6 +86,42 @@ TASKS: Tuple[MoneyTask, ...] = (
     MoneyTask("m09", "An $18.75 item has 8 percent tax. What is the final amount?", "2025"),
     MoneyTask("m10", "A $7.50 item is discounted by 20 percent. What is the sale amount?", "600"),
     MoneyTask("m11", "Four friends split a $13.20 bill equally. What amount does each pay?", "330"),
+    MoneyTask("m12", "A stapler costs $3.40 and a ruler costs $1.25. What is the total amount?", "465"),
+    MoneyTask("m13", "A mug costs $6.15 and a coaster costs $2.85. What is the total amount?", "900"),
+    MoneyTask("m14", "A folder costs $2.60 and a clip pack costs $1.75. What is the total amount?", "435"),
+    MoneyTask("m15", "A lamp costs $18.45 and a bulb costs $6.55. What is the total amount?", "2500"),
+    MoneyTask("m16", "A jacket costs $45.20 and a coupon removes $12.75. What amount remains?", "3245"),
+    MoneyTask("m17", "A book costs $18.90 and a coupon removes $4.45. What amount remains?", "1445"),
+    MoneyTask("m18", "A pass costs $30.50 and a coupon removes $9.95. What amount remains?", "2055"),
+    MoneyTask("m19", "4 brackets cost $1.45 each and a charger costs $8.90. What is the total amount?", "1470"),
+    MoneyTask("m20", "5 envelopes cost $0.60 each and a stamp roll costs $7.25. What is the total amount?", "1025"),
+    MoneyTask("m21", "3 cloths cost $2.35 each and a bucket costs $4.15. What is the total amount?", "1120"),
+    MoneyTask("m22", "3 people split a $12.45 charge equally. What amount does each person pay?", "415"),
+    MoneyTask("m23", "5 people split a $13.20 charge equally. What amount does each person pay?", "264"),
+    MoneyTask("m24", "6 people split a $9.30 charge equally. What amount does each person pay?", "155"),
+    MoneyTask("m25", "4 people split a $49.00 charge equally. What amount does each person pay?", "1225"),
+    MoneyTask("m26", "Add a 20 percent tip to a $24.00 bill. What is the final amount?", "2880"),
+    MoneyTask("m27", "Add a 10 percent tip to a $16.50 bill. What is the final amount?", "1815"),
+    MoneyTask("m28", "Add a 25 percent tip to a $36.00 bill. What is the final amount?", "4500"),
+    MoneyTask("m29", "Add a 40 percent tip to an $8.50 bill. What is the final amount?", "1190"),
+    MoneyTask("m30", "A salad is $7.25 and 3 rolls are $1.40 each. What is the total amount?", "1145"),
+    MoneyTask("m31", "A kit is $12.99 and 2 filters are $3.50 each. What is the total amount?", "1999"),
+    MoneyTask("m32", "A frame is $8.99 and 4 hooks are $0.75 each. What is the total amount?", "1199"),
+    MoneyTask("m33", "You pay $50.00 for an item costing $17.85. What amount of change is due?", "3215"),
+    MoneyTask("m34", "You pay $20.00 for an item costing $6.45. What amount of change is due?", "1355"),
+    MoneyTask("m35", "You pay $100.00 for an item costing $37.99. What amount of change is due?", "6201"),
+    MoneyTask("m36", "7 markers cost $1.35 each. What is the total amount?", "945"),
+    MoneyTask("m37", "9 tags cost $0.40 each. What is the total amount?", "360"),
+    MoneyTask("m38", "12 screws cost $0.25 each. What is the total amount?", "300"),
+    MoneyTask("m39", "8 ribbons cost $1.75 each. What is the total amount?", "1400"),
+    MoneyTask("m40", "A $25.00 item has 8 percent tax. What is the final amount?", "2700"),
+    MoneyTask("m41", "A $40.00 item has 6 percent tax. What is the final amount?", "4240"),
+    MoneyTask("m42", "A $12.50 item has 4 percent tax. What is the final amount?", "1300"),
+    MoneyTask("m43", "A $75.00 item has 12 percent tax. What is the final amount?", "8400"),
+    MoneyTask("m44", "A $32.00 item is discounted by 25 percent. What is the sale amount?", "2400"),
+    MoneyTask("m45", "A $9.00 item is discounted by 30 percent. What is the sale amount?", "630"),
+    MoneyTask("m46", "A $45.00 item is discounted by 15 percent. What is the sale amount?", "3825"),
+    MoneyTask("m47", "A $16.00 item is discounted by 75 percent. What is the sale amount?", "400"),
 )
 
 
@@ -54,8 +132,21 @@ _FINAL_INTEGER = re.compile(
 
 
 def parse_integer_answer(response: str) -> Optional[str]:
-    """Accept a bare integer, while rejecting dollars, decimals, and prose."""
-    match = _FINAL_INTEGER.fullmatch(response)
+    """The reply's **final line**, as a bare integer -- or None.
+
+    Dollars, decimals and prose are still rejected, on that line: `$4.15`,
+    `4.15` and `about 415 cents` are all None, so the integer-cents convention is
+    still something a method has to discover. What is no longer rejected is a
+    reply that *shows its arithmetic* before answering.
+
+    Only the last non-empty line is read. A reply that ends mid-working -- the
+    common failure, `18.90 - 4.45 = 14.45` -- has no bare integer there and
+    scores zero, as it should.
+    """
+    lines = [line for line in (response or "").strip().splitlines() if line.strip()]
+    if not lines:
+        return None
+    match = _FINAL_INTEGER.fullmatch(lines[-1])
     return match.group(1) if match else None
 
 
@@ -71,10 +162,11 @@ def money_splits(seed: int) -> Tuple[List[Task], List[Task], List[Task]]:
     """Disjoint train / held-out / test splits for one seed."""
     rows = list(TASKS)
     random.Random(seed).shuffle(rows)
+    third = len(rows) // 3
     return (
-        [money_task(task, split="train") for task in rows[:4]],
-        [money_task(task, split="held-out") for task in rows[4:8]],
-        [money_task(task, split="test") for task in rows[8:12]],
+        [money_task(task, split="train") for task in rows[:third]],
+        [money_task(task, split="held-out") for task in rows[third:2 * third]],
+        [money_task(task, split="test") for task in rows[2 * third:3 * third]],
     )
 
 
@@ -87,14 +179,29 @@ def money_reward(task: Task, output: str) -> float:
 
 
 def feedback(task: Task, output: str) -> str:
-    parsed = parse_integer_answer(output.strip())
-    shown = parsed if parsed is not None else output.strip()[:120]
+    """What the grader read, and what it wanted -- not what the answer is.
+
+    The middle line says *the final line* on purpose. The grader used to match
+    the whole reply and now matches only the last one, and feedback that still
+    implies the whole reply is read is feedback that is false: every method
+    evolving against it wrote prompts forbidding explanation, which is the one
+    thing that costs this domain its arithmetic. Same measurement, same model,
+    all 48 items -- a prompt that only fixes the format reaches 0.479, one that
+    also works the arithmetic out reaches 1.000.
+
+    What still has to be discovered is untouched: that the amount is an integer
+    number of *cents*. Only the shape of the channel is described.
+    """
+    text = output.strip()
+    read = [line for line in text.splitlines() if line.strip()]
+    read = read[-1].strip() if read else ""
     return (
         f"Question: {task.prompt}\n"
-        f"Candidate answer: {shown!r}\n"
-        f"Strict evaluator answer: {str(task.meta['answer_cents'])!r}\n"
-        "The evaluator uses one reusable output convention across the domain. "
-        "Infer that convention without memorizing this item."
+        f"The evaluator read the final line of your reply: {read[:120]!r}\n"
+        f"It wanted: {str(task.meta['answer_cents'])!r}\n"
+        "Only that last line is graded, so anything before it is free. The "
+        "evaluator uses one reusable output convention across the domain; infer "
+        "that convention without memorizing this item."
     )
 
 

--- a/examples/promptbreeder/_promptbreeder_operators.py
+++ b/examples/promptbreeder/_promptbreeder_operators.py
@@ -1,0 +1,277 @@
+"""PromptBreeder's nine mutation operators (arXiv:2309.16797, Section 3).
+
+The paper groups them into five classes and **samples one uniformly at random
+per replication event**. All nine are here; what each needs beyond the unit
+itself is noted, because that is what decides whether an operator is
+implementable at all:
+
+===========================  =========================  =====================
+class / operator             needs                      status
+===========================  =========================  =====================
+Direct: zero-order           problem description        implemented
+Direct: first-order          the unit                   implemented
+EDA: eda                     the population             implemented
+EDA: eda_rank_index          the population, by fitness implemented
+EDA: lineage                 the elite history          implemented
+Hyper: zero_order_hyper      a thinking-style           implemented (two-step)
+Hyper: first_order_hyper     the hyper-mutation-prompt  implemented (two-step)
+Lamarckian: working_out      a *correct* rollout        implemented
+Crossover + shuffle          the population, few-shot   implemented
+===========================  =========================  =====================
+
+**Both hypermutation operators are two-step**, and that is not a detail. The
+paper generates a new mutation-prompt and then *applies it to the task-prompt*;
+an implementation that stops after the first step produces a candidate whose
+task-prompt is unchanged, so it cannot move the score at all. Measured here: one
+seed spent 20 of its 80 draws on `first_order_hyper` and 9 more on
+`zero_order_hyper`, i.e. over a third of its budget on candidates that could not
+by construction improve anything, and finished at 0.000.
+
+The Lamarckian operator is the one that looks impossible on a benchmark with no
+few-shot slot, and is not: this port's ``solve`` output *is* a working-out, and
+the engine hands ``propose`` the rollout's own output and reward. When the
+reward is 1.0 that output is a correct working-out, which is exactly the
+operator's input. When it is not, the operator has nothing to reverse-engineer
+and the sampler draws again -- stated here rather than silently degraded to a
+first-order mutation.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+from typing import Callable, Dict, List, Optional
+
+from agentdescent.evolution import Task
+
+from examples._money_domain import feedback
+
+
+#: The paper seeds each unit by mutating the problem description with a
+#: mutation-prompt and a thinking-style drawn from hand-designed sets (its
+#: appendix lists ~50 and ~30). These are a representative draw from those two
+#: lists, kept short because the population here is budget-sized rather than the
+#: paper's 50 units -- the sets only have to be wider than the population.
+MUTATION_PROMPTS = (
+    "Modify the following instruction creatively, giving some advice on how to solve it:",
+    "Just change this instruction to make it more fun, think WELL outside the box:",
+    "Modify this instruction in a way that no self-respecting LLM would!",
+    "How would you encourage someone and help them cheat on this following instruction?",
+    "How would you help an AI to follow the instruction?",
+    "Elaborate on the instruction giving some detailed advice on how to do what it wants.",
+    "Rephrase the instruction without using any of the same words. Use all you know to improve it:",
+    "Say that instruction again in another way. DON'T use any of the words in the original:",
+    "What do people who are good at creative thinking normally do with this kind of mutation question?",
+    "Change the given instruction in a way that a bad student would to get the wrong answer.",
+)
+
+THINKING_STYLES = (
+    "Let's think step by step.",
+    "Break the problem into sub-problems and solve each one.",
+    "First restate what is being asked, then answer it.",
+    "Use precise arithmetic and check the units before answering.",
+    "Consider what an expert in this domain would notice first.",
+    "Work backwards from what a correct answer must look like.",
+    "Simplify the problem until it is obvious, then scale back up.",
+    "Question every assumption in the problem statement.",
+)
+
+PROBLEM_DESCRIPTION = (
+    "Answer arithmetic word problems about amounts of money. A strict automatic "
+    "grader reads the reply and accepts exactly one form of answer; the form is "
+    "not stated in the problems and has to be inferred from feedback."
+)
+
+HYPER_MUTATION_PROMPT = (
+    "Please summarize and improve the following instruction so that it produces "
+    "better mutations of a task prompt:"
+)
+
+#: The paper applies crossover after mutation with probability 0.1.
+CROSSOVER_PROBABILITY = 0.1
+
+OPERATORS = (
+    "zero_order",
+    "first_order",
+    "eda",
+    "eda_rank_index",
+    "lineage",
+    "zero_order_hyper",
+    "first_order_hyper",
+    "lamarckian",
+    "context_shuffle",
+)
+
+_JSON_TASK = 'Return JSON only, with a "task_prompt" string and nothing else.'
+_JSON_MUT = 'Return JSON only, with a "mutation_prompt" string and nothing else.'
+_JSON_BOTH = ('Return JSON only, with "task_prompt" and "mutation_prompt" '
+              'strings and nothing else.')
+_NO_LEAK = ("Write a reusable instruction for the whole domain. Do not include "
+            "this item's numeric answer.")
+
+
+def _numbered(prompts: List[str], limit: int = 8) -> str:
+    return "\n".join(f"{i}. {p}" for i, p in enumerate(prompts[-limit:], start=1))
+
+
+def build_prompt(operator: str, genome: Dict[str, str], task: Task, output: str,
+                 reward: float, view, rng: random.Random) -> Optional[str]:
+    """The operator's model prompt, or None when its input is not available.
+
+    Returning None rather than degrading is deliberate: an EDA mutation on an
+    empty population and a first-order mutation are different operators, and
+    silently substituting one for the other would make the operator histogram a
+    fiction.
+    """
+    task_prompt = genome.get("task_prompt", "")
+    mutation_prompt = genome.get("mutation_prompt", "")
+
+    if operator == "zero_order":
+        return (f"{PROBLEM_DESCRIPTION}\n\n"
+                f"A hint of the problem: {task.prompt}\n\n"
+                f"{_NO_LEAK} Write it from the description alone -- do not use "
+                f"any existing prompt.\n{_JSON_TASK}")
+
+    if operator == "first_order":
+        return (f"{mutation_prompt}\n\n"
+                f"INSTRUCTION: {task_prompt}\n\n"
+                f"Reward of the current unit: {reward}\n{feedback(task, output)}\n\n"
+                f"{_NO_LEAK}\n{_JSON_BOTH}")
+
+    if operator in ("eda", "eda_rank_index"):
+        ranked = operator == "eda_rank_index"
+        prompts = view.task_prompts(ranked=ranked)
+        if len(prompts) < 2:
+            return None
+        order = ("The list is ordered by increasing quality, worst first.\n"
+                 if ranked else "")
+        return (f"{PROBLEM_DESCRIPTION}\n\n"
+                f"INSTRUCTION LIST:\n{_numbered(prompts)}\n\n{order}"
+                f"Write one more instruction that continues this list and is "
+                f"different from every entry in it.\n{_NO_LEAK}\n{_JSON_TASK}")
+
+    if operator == "lineage":
+        history = view.elite_history()
+        if len(history) < 2:
+            return None
+        return (f"{PROBLEM_DESCRIPTION}\n\n"
+                f"GENOTYPES FOUND IN ASCENDING ORDER OF QUALITY:\n"
+                f"{_numbered(history)}\n\n"
+                f"Write the next instruction in this progression.\n"
+                f"{_NO_LEAK}\n{_JSON_TASK}")
+
+    if operator == "zero_order_hyper":
+        style = rng.choice(THINKING_STYLES)
+        return (f"{PROBLEM_DESCRIPTION}\n\n"
+                f"A thinking style to fold in: {style}\n\n"
+                f"Write a mutation instruction -- an instruction for improving "
+                f"task instructions in this domain -- from the description and "
+                f"the thinking style.\n{_JSON_MUT}")
+
+    if operator == "first_order_hyper":
+        return (f"{HYPER_MUTATION_PROMPT}\n\n"
+                f"MUTATION INSTRUCTION: {mutation_prompt}\n\n"
+                f"Recent reward of the unit it produced: {reward}\n\n"
+                f"{_JSON_MUT}")
+
+    if operator == "lamarckian":
+        if reward < 1.0 or not output.strip():
+            return None
+        return (f"I gave a friend an instruction and they produced the working "
+                f"below, which the grader accepted.\n\n"
+                f"PROBLEM: {task.prompt}\nCORRECT WORKING: {output.strip()}\n\n"
+                f"What was the instruction? It has to work for the whole domain, "
+                f"not just this problem.\n{_NO_LEAK}\n{_JSON_TASK}")
+
+    if operator == "context_shuffle":
+        partner = view.weighted_task_prompt(rng, exclude=task_prompt)
+        if partner is None:
+            return None
+        return (f"{PROBLEM_DESCRIPTION}\n\n"
+                f"INSTRUCTION A: {task_prompt}\n"
+                f"INSTRUCTION B: {partner}\n\n"
+                f"Cross these two: keep what each does well and drop the rest.\n"
+                f"{_NO_LEAK}\n{_JSON_TASK}")
+
+    raise ValueError(f"unknown operator: {operator}")
+
+
+#: The two operators the paper defines as *two* steps: produce a mutation-prompt,
+#: then apply it to the task-prompt. Step one alone leaves the task-prompt
+#: untouched, so such a candidate cannot move the score by construction.
+TWO_STEP = ("zero_order_hyper", "first_order_hyper")
+
+
+def apply_step_prompt(new_mutation_prompt: str, task_prompt: str, task: Task,
+                      output: str, reward: float) -> str:
+    """Step two: the freshly written mutation-prompt applied to the task-prompt."""
+    return (f"{new_mutation_prompt}\n\n"
+            f"INSTRUCTION: {task_prompt}\n\n"
+            f"Reward of the current unit: {reward}\n{feedback(task, output)}\n\n"
+            f"{_NO_LEAK}\n{_JSON_TASK}")
+
+
+class OperatorSampler:
+    """Uniform sampling with a retry, and a histogram of what actually ran.
+
+    The paper samples uniformly per replication event. This port rotated through
+    three operators round-robin instead, which is a different search: rotation
+    guarantees each operator's share, sampling does not, and a run's operator
+    mix stops being an observation and becomes an assumption.
+    """
+
+    def __init__(self, seed: int = 0,
+                 operators: tuple = OPERATORS) -> None:
+        self._rng = random.Random(seed)
+        # Workers draw concurrently and `random.Random` is not thread-safe:
+        # unsynchronised, two workers can advance the same Mersenne state at once
+        # and the run stops being reproducible from its seed, which is the one
+        # property a seeded sampler exists for.
+        self._lock = threading.Lock()
+        self._operators = tuple(operators)
+        self.counts: Dict[str, int] = {name: 0 for name in self._operators}
+        self.unavailable: Dict[str, int] = {name: 0 for name in self._operators}
+
+    def draw(self, build: Callable[[str], Optional[str]]) -> Optional[tuple]:
+        """Sample until an operator whose input exists; None if none can run."""
+        with self._lock:
+            order = list(self._operators)
+            self._rng.shuffle(order)
+        for name in order:
+            prompt = build(name)
+            if prompt is not None:
+                with self._lock:
+                    self.counts[name] += 1
+                return name, prompt
+            with self._lock:
+                self.unavailable[name] += 1
+        return None
+
+    def histogram(self) -> Dict[str, int]:
+        with self._lock:
+            return {k: v for k, v in self.counts.items() if v}
+
+    def rng(self) -> random.Random:
+        """The operator prompts draw from this too (thinking styles, crossover
+        partners), so it is handed out rather than copied -- one stream, one
+        seed."""
+        return _LockedRandom(self._rng, self._lock)
+
+
+class _LockedRandom:
+    """`random.Random` with the sampler's lock, for use from worker threads."""
+
+    def __init__(self, rng: random.Random, lock: threading.Lock) -> None:
+        self._rng, self._lock = rng, lock
+
+    def choice(self, seq):
+        with self._lock:
+            return self._rng.choice(seq)
+
+    def choices(self, seq, weights=None, k=1):
+        with self._lock:
+            return self._rng.choices(seq, weights=weights, k=k)
+
+    def random(self):
+        with self._lock:
+            return self._rng.random()

--- a/examples/promptbreeder/_promptbreeder_population.py
+++ b/examples/promptbreeder/_promptbreeder_population.py
@@ -1,0 +1,276 @@
+"""PromptBreeder's Algorithm 1 as a population layer.
+
+The shared :class:`~examples._population.PopulationAggregator` keeps every
+committed head forever and asks a ``SelectionPolicy`` who the next parent is.
+Algorithm 1 says three things that is not:
+
+1. the population has a **fixed size** ``N``;
+2. the two sampled units are compared on a **random batch of training data**,
+   not on the acceptance gate's held-out split;
+3. the **loser is replaced** by the mutated copy of the winner -- units die.
+
+(3) is the one that changes the search rather than the bookkeeping. Without it
+the population only grows, a weak unit stays eligible for every future
+tournament, and the selection pressure the paper's replacement step creates is
+absent. This class is the paper's loop mapped onto the engine's batch cycle:
+
+    super().step()      the batch's proposals merge -> one committed child C
+    _admit(C)           C enters the population, *overwriting the last loser*
+    tournament()        sample two units uniformly, score both on a train batch,
+                        commit the winner as the head so the next batch mutates
+                        it, and remember the loser as the next slot to overwrite
+
+The population also has to be *readable* by the mutation operators: four of the
+paper's nine (EDA, EDA-rank-and-index, lineage, crossover) take the population
+itself as input. :class:`PopulationView` is the shared handle -- written here,
+read from the port's ``propose``.
+"""
+
+from __future__ import annotations
+
+import random
+import threading
+from typing import Dict, List, Optional, Tuple
+
+from agentdescent.ledger import Ledger
+
+from examples._population import PopulationAggregator
+
+
+class PopulationView:
+    """What the mutation operators are allowed to see of the population.
+
+    Four of PromptBreeder's nine operators are defined over the population --
+    EDA over its task-prompts, EDA-rank-and-index over them sorted by fitness,
+    lineage over the elites in the order they became elite, and crossover over a
+    fitness-weighted draw. A ``propose`` that cannot see the population can only
+    implement the other five, which is the shape this port had.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._units: List[Dict[str, object]] = []
+        self._elites: List[Dict[str, str]] = []
+
+    def publish(self, units: List[Dict[str, object]],
+                elites: List[Dict[str, str]]) -> None:
+        with self._lock:
+            self._units = [dict(u) for u in units]
+            self._elites = [dict(e) for e in elites]
+
+    def units(self) -> List[Dict[str, object]]:
+        with self._lock:
+            return [dict(u) for u in self._units]
+
+    def task_prompts(self, *, ranked: bool = False) -> List[str]:
+        """Deduplicated task-prompts; ranked ascending by fitness on request.
+
+        The paper filters the EDA list for diversity before showing it -- a unit
+        whose prompt is already in the list adds nothing to a distribution
+        estimate.
+        """
+        rows = self.units()
+        if ranked:
+            rows.sort(key=lambda u: float(u["score"]))
+        out: List[str] = []
+        for unit in rows:
+            prompt = str(unit["state"].get("task_prompt", "")).strip()
+            if prompt and prompt not in out:
+                out.append(prompt)
+        return out
+
+    def elite_history(self) -> List[str]:
+        with self._lock:
+            return [str(e.get("task_prompt", "")).strip() for e in self._elites
+                    if str(e.get("task_prompt", "")).strip()]
+
+    def weighted_task_prompt(self, rng: random.Random,
+                             exclude: str = "") -> Optional[str]:
+        """A task-prompt drawn in proportion to fitness -- the crossover partner."""
+        rows = [u for u in self.units()
+                if str(u["state"].get("task_prompt", "")).strip()
+                and str(u["state"].get("task_prompt", "")).strip() != exclude]
+        if not rows:
+            return None
+        weights = [max(float(u["score"]), 0.0) + 1e-6 for u in rows]
+        return str(rng.choices(rows, weights=weights, k=1)[0]["state"]["task_prompt"])
+
+
+class PromptBreederPopulation(PopulationAggregator):
+    """Fixed-size population, train-batch tournament, loser replacement."""
+
+    def __init__(self, ledger, verifier, audit, config, staleness_policy=None,
+                 *, selection, artifact_id, conflict=None, fusion=None,
+                 acceptance=None, promotion=None, fitness, view: PopulationView,
+                 size: int, seed: int = 0, seed_units=(),
+                 batch: int = 4):
+        super().__init__(ledger, verifier, audit, config, staleness_policy,
+                         selection=selection, artifact_id=artifact_id,
+                         conflict=conflict, fusion=fusion, acceptance=acceptance,
+                         promotion=promotion)
+        self._fitness = fitness
+        self._batch = max(1, int(batch))
+        self._view = view
+        self._size = max(2, int(size))
+        self._rng = random.Random(seed)
+        self._pending_seed_units = list(seed_units)
+        #: Index of the unit the last tournament lost, i.e. the slot the next
+        #: admitted child overwrites. `None` before the first tournament, when
+        #: the population is still filling to `size`.
+        self._loser: Optional[int] = None
+        self._elites: List[Dict[str, str]] = []
+        self._best: float = -1.0
+
+    # -- the population ------------------------------------------------------
+
+    def _admit(self, artifact, version: int) -> None:
+        """Enter a committed unit, replacing the last tournament's loser.
+
+        Overrides the shared archive's grow-forever admit. The score is the
+        paper's: a batch of *training* data, not the held-out split the gate
+        already used -- ranking a population on the gate's own signal would make
+        the tournament a second acceptance test rather than a fitness measure.
+        """
+        state = dict(getattr(artifact, "state", {}) or {})
+        key = artifact.render()
+        with self._archive_lock:
+            if key in self._seen:
+                return
+            self._seen.add(key)
+        score = float(self._fitness(state, self._batch))
+        entry = {"state": state, "score": score, "version": int(version),
+                 "selected": 0}
+        with self._archive_lock:
+            if len(self._archive) < self._size or self._loser is None:
+                self._archive.append(entry)
+            else:
+                self._archive[self._loser] = entry
+                self._loser = None
+            if score > self._best:
+                self._best = score
+                self._elites.append(dict(state))
+        self._publish()
+
+    def snapshot(self):
+        """The population as it stands, for the run's own report."""
+        with self._archive_lock:
+            # 70 characters used to be enough to hide the only thing worth
+            # reading: `'Solve monetary story questions and provide your final
+            # response in the '` cuts off exactly where the convention would be
+            # named or not.
+            return [(str(u["state"].get("task_prompt", ""))[:240],
+                     float(u["score"])) for u in self._archive]
+
+    def _publish(self) -> None:
+        with self._archive_lock:
+            units = [dict(u) for u in self._archive]
+            elites = [dict(e) for e in self._elites]
+        self._view.publish(units, elites)
+
+    # -- Algorithm 1 ---------------------------------------------------------
+
+    # NOT `_tournament`: `Aggregator._tournament(artifact, diffs)` already exists
+    # and is what fusion uses to pit two diffs head to head. Overriding it here
+    # silently replaced the fusion layer's tournament with this one, and every
+    # merge died with "takes 1 positional argument but 3 were given".
+    def _replication_event(self) -> Optional[Dict[str, object]]:
+        """Sample two units uniformly, score both, return the winner.
+
+        Uniform sampling *without* replacement, and both units re-scored on a
+        fresh training batch each time -- the paper re-evaluates rather than
+        reusing a cached fitness, because the batch is what makes the comparison
+        a sample rather than a verdict.
+        """
+        with self._archive_lock:
+            if len(self._archive) < 2:
+                return None
+            indices = self._rng.sample(range(len(self._archive)), 2)
+            pair = [(i, dict(self._archive[i])) for i in indices]
+        scored: List[Tuple[int, Dict[str, object], float]] = []
+        for index, unit in pair:
+            score = float(self._fitness(dict(unit["state"]), self._batch))
+            scored.append((index, unit, score))
+        scored.sort(key=lambda row: row[2], reverse=True)
+        (win_i, winner, win_s), (lose_i, _, _) = scored[0], scored[1]
+        with self._archive_lock:
+            self._archive[win_i]["score"] = win_s
+            self._archive[win_i]["selected"] = int(
+                self._archive[win_i]["selected"]) + 1
+            self._loser = lose_i
+            if win_s > self._best:
+                self._best = win_s
+                self._elites.append(dict(winner["state"]))
+        self._publish()
+        return winner
+
+    def step(self):
+        before = self.ledger.snapshot(Ledger.DEV)
+        pre_head = before.get(self.population_artifact)
+        if pre_head is not None:
+            self._admit(pre_head, before.version.get(self.population_artifact, 0))
+        # The paper starts from N units, each the problem description mutated by
+        # a mutation-prompt and a thinking-style drawn from its hand-designed
+        # sets. They are generated once, on the first step, because generating
+        # them needs the model and the aggregator only has it from here.
+        if self._pending_seed_units:
+            pending, self._pending_seed_units = self._pending_seed_units, []
+            for state in pending:
+                with self._archive_lock:
+                    if len(self._archive) >= self._size:
+                        break
+                    key = "\n\n".join(f"[{k}]\n{v}" for k, v in state.items())
+                    if key in self._seen:
+                        continue
+                    self._seen.add(key)
+                score = float(self._fitness(dict(state), self._batch))
+                with self._archive_lock:
+                    self._archive.append({"state": dict(state), "score": score,
+                                          "version": 0, "selected": 0})
+            self._publish()
+
+        reports = super(PopulationAggregator, self).step()
+
+        snap = self.ledger.snapshot(Ledger.DEV)
+        head = snap.get(self.population_artifact)
+        if head is None:
+            return reports
+        self._admit(head, snap.version.get(self.population_artifact, 0))
+
+        winner = self._replication_event()
+        if winner is None:
+            return reports
+        target = dict(winner["state"])
+        version = self._commit_state(target, "promptbreeder: tournament winner")
+        if version is not None:
+            from agentdescent.aggregator import MergeReport
+            with self._archive_lock:
+                size = len(self._archive)
+            reports.append(MergeReport(
+                self.population_artifact, None, False, 0, 0, 0, 0, 0.0, version,
+                reason=(f"promptbreeder: winner bred, loser slot {self._loser} "
+                        f"(|P|={size}/{self._size})"),
+                category="population-select"))
+        return reports
+
+
+def promptbreeder_population(ctx, *, view: PopulationView, size: int,
+                             seed_units=(), batch: int = 4, built=None):
+    """The ``aggregator_factory`` for one PromptBreeder run.
+
+    ``built`` is a one-slot list the caller can read the constructed population
+    back out of -- the factory is called by the engine, so the port otherwise has
+    no handle on the object it configured, and cannot report what it did.
+    """
+
+    def build(ledger, verifier, audit, config, staleness_policy=None):
+        pop = PromptBreederPopulation(
+            ledger, verifier, audit, config, staleness_policy,
+            selection=ctx.selection, artifact_id=ctx.artifact_id,
+            conflict=ctx.conflict, fusion=ctx.fusion, acceptance=ctx.acceptance,
+            fitness=ctx.fitness, view=view, size=size, seed=ctx.seed,
+            seed_units=seed_units, batch=batch)
+        if built is not None:
+            built.append(pop)
+        return pop
+
+    return build

--- a/examples/promptbreeder/promptbreeder_genetic_prompts.py
+++ b/examples/promptbreeder/promptbreeder_genetic_prompts.py
@@ -1,28 +1,46 @@
 """Mechanism microport: **PromptBreeder** (arXiv:2309.16797, no released code).
 
-Preserved (paper, Sections 3-4): a population of units each holding a
-task-prompt and a mutation-prompt; **binary tournament** replication (sample
-two, mutate the winner); mutation operators drawn per replication event,
-including **hyper-mutation** -- the self-referential rewrite of the
-mutation-prompt by itself; fitness measured on a training batch.
+Algorithm 1, as written. A population of ``N`` units, each holding a task-prompt
+and a mutation-prompt; a binary tournament that samples two units uniformly,
+scores both on a **random batch of training data**, mutates the winner with an
+operator **sampled uniformly from all nine**, and **replaces the loser** with the
+result; the highest-fitness unit is returned.
 
-The population lives in the engine's selection seam: :class:`BinaryTournament`
-is PromptBreeder's Algorithm-1 parent rule as a ~20-line
-:class:`~agentdescent.selection.SelectionPolicy`. The genome is a
-:class:`~examples._method_policy.FieldSlots` artifact, so the two prompts are
-separate plain-text ledger keys -- edits to different fields union-merge, and
-contested fields are model-merged, with no ranking evaluation either way.
+Three pieces of that were missing and are now here, because each changes the
+search rather than the bookkeeping:
 
-Boundaries: population and batch are budget-sized (paper: 50 units, batch 100);
-three of the nine mutation operators (zero-order, first-order, hyper-mutation);
-no few-shot workings-out in the unit.
+* **Replacement.** The population was an archive that only grew, so no unit ever
+  died and the selection pressure the replacement step creates was absent.
+  :class:`~examples.promptbreeder._promptbreeder_population.PromptBreederPopulation`
+  keeps ``|P| = N`` and overwrites the last tournament's loser.
+* **Fitness on a random training batch.** The tournament ranked on the held-out
+  split -- the acceptance gate's own signal, which makes the tournament a second
+  gate rather than a fitness measure. It now scores a random batch of the
+  training split, resampled per tournament, as the paper does.
+* **All nine operators, sampled uniformly.** Three ran in fixed rotation.
+  Rotation guarantees each operator's share and sampling does not, so a run's
+  operator mix was an assumption rather than an observation; the mix is now
+  reported.
+
+Initialisation is the paper's too: ``N`` units, each the problem description
+mutated by a mutation-prompt and a thinking-style drawn from hand-designed sets.
+
+The population lives in the engine's ``aggregator_factory`` seam, and the genome
+is a :class:`~examples._method_policy.FieldSlots` artifact, so the two prompts
+are separate plain-text ledger keys -- edits to different fields union-merge, and
+contested fields are model-merged, which is the paper's *prompt crossover*
+arriving through the merge layer.
+
+Boundaries: the population is budget-sized rather than the paper's 50 units and
+the fitness batch is 4 items rather than its 100; the unit carries no few-shot
+context, so context shuffling is expressed as prompt crossover over the
+population rather than over exemplars.
 """
 
 from __future__ import annotations
 
-import itertools
+import json
 import random
-import threading
 from typing import Optional, Sequence
 
 from agentdescent.evolution import Task
@@ -32,24 +50,42 @@ from agentdescent.selection import SelectionContext, SingleHead
 from examples._measure import parse_json_object
 from examples._method_policy import FieldSlots, MethodPolicy, read_fields
 from examples._method_runner import standard_main
-from examples._money_domain import (STARTING_INSTRUCTION, feedback,
-                                    money_reward, money_splits, solve_money)
+from examples._money_domain import (STARTING_INSTRUCTION, money_reward,
+                                    money_splits, solve_money)
+from examples.promptbreeder._promptbreeder_operators import (
+    MUTATION_PROMPTS, PROBLEM_DESCRIPTION, THINKING_STYLES, TWO_STEP,
+    OperatorSampler, apply_step_prompt, build_prompt)
+from examples.promptbreeder._promptbreeder_population import (
+    PopulationView, promptbreeder_population)
 
 
 FIDELITY = "mechanism_microport"
 
-MUTATION_PROMPT = (
-    "Infer a reusable instruction from evaluator feedback and improve "
-    "this mutation instruction too."
-)
+MUTATION_PROMPT = MUTATION_PROMPTS[0]
+
+#: Units in the population. The paper uses 50; this is budget-sized, and the
+#: only constraint that matters is that a tournament has two units to sample.
+POPULATION_SIZE = 8
+
+#: Training items per fitness evaluation. The paper evaluates a unit "on a random
+#: batch of training data" (its batch is 100 of the full set) rather than on the
+#: whole split, and the sampling is part of the algorithm: it is what keeps a
+#: tournament a noisy comparison rather than a verdict, and it is the difference
+#: between 2 and 2 x |train| model calls per replication event.
+FITNESS_BATCH = 4
 
 
 class BinaryTournament(SingleHead):
-    """PromptBreeder's replication rule: sample two units, breed the winner.
+    """Retained for the engine's declared-selection check.
 
-    An unscored candidate wins its tournament (same optimistic rationale as
-    :class:`~agentdescent.selection.Beam`): a unit that has never been measured
-    is exploration the paper's random pairing would also have reached.
+    Algorithm 1's tournament needs to *evaluate* both sampled units and *replace*
+    the loser, neither of which a `SelectionPolicy` can do -- it is handed
+    candidates with cached scores and returns one. The real tournament therefore
+    lives in
+    :class:`~examples.promptbreeder._promptbreeder_population.PromptBreederPopulation`;
+    this class stays because declaring a selection policy is what tells the
+    runner to install a population layer at all, and it stays *equivalent* so
+    that the two cannot disagree about who wins.
     """
 
     def __init__(self, seed: int = 0) -> None:
@@ -67,45 +103,40 @@ class BinaryTournament(SingleHead):
         return winners
 
 
-def _operator_prompt(operator: str, genome: dict, task: Task, output: str,
-                     reward: float) -> str:
-    if operator == "zero_order":
-        return (
-            "PromptBreeder zero-order mutation: write a fresh task prompt for "
-            "this problem domain from a hint of the problem, without seeing the "
-            "current prompt. Generalize; do not include the benchmark item's "
-            "numeric answer.\n\n"
-            f"Problem hint: {task.prompt}\nReward of current unit: {reward}\n"
-            f"{feedback(task, output)}\n\n"
-            'Return JSON only with a "task_prompt" string.'
-        )
-    if operator == "hyper":
-        return (
-            "PromptBreeder hyper-mutation: apply the mutation prompt to ITSELF "
-            "to produce a better mutation prompt. This is the self-referential "
-            "operator; do not touch the task prompt.\n\n"
-            f"Mutation prompt: {genome['mutation_prompt']}\n"
-            f"Recent reward: {reward}\n\n"
-            'Return JSON only with a "mutation_prompt" string.'
-        )
-    return (
-        "PromptBreeder first-order mutation: apply the mutation prompt to the "
-        "task prompt using execution feedback. Generalize; do not include the "
-        "benchmark item's numeric answer.\n\n"
-        f"Task prompt: {genome['task_prompt']}\n"
-        f"Mutation prompt: {genome['mutation_prompt']}\n"
-        f"Reward: {reward}\n{feedback(task, output)}\n\n"
-        'Return JSON only with "task_prompt" and "mutation_prompt" strings.'
-    )
+def seed_population(llm, size: int, seed: int) -> list:
+    """The paper's initialisation: ``N`` units from description x style x prompt.
+
+    A run that starts from one instruction has no population to sample for its
+    first tournaments, and the EDA and lineage operators -- three of the nine --
+    have no input until enough children have committed. That is not a slow start,
+    it is a different algorithm for the first third of the budget.
+    """
+    rng = random.Random(seed)
+    units = []
+    for _ in range(max(0, size - 1)):
+        mutation_prompt = rng.choice(MUTATION_PROMPTS)
+        style = rng.choice(THINKING_STYLES)
+        reply = llm(
+            f"{mutation_prompt}\n\n"
+            f"INSTRUCTION: {PROBLEM_DESCRIPTION}\n"
+            f"A thinking style to fold in: {style}\n\n"
+            "Write a reusable instruction for solving problems in this domain. "
+            "Do not invent a specific numeric answer.\n"
+            'Return JSON only, with a "task_prompt" string and nothing else.',
+            unit="seed-population")
+        try:
+            task_prompt = str(parse_json_object(reply).get("task_prompt", "")).strip()
+        except (KeyError, TypeError, ValueError):
+            task_prompt = ""
+        if task_prompt:
+            units.append({"task_prompt": task_prompt[:900],
+                          "mutation_prompt": mutation_prompt})
+    return units
 
 
 def build(seed: int) -> MethodPolicy:
-    operators = itertools.cycle(("first_order", "zero_order", "hyper"))
-    lock = threading.Lock()
-
-    def next_operator() -> str:
-        with lock:
-            return next(operators)
+    view = PopulationView()
+    sampler = OperatorSampler(seed)
 
     def solve(llm, rendered: str, task: Task) -> str:
         genome = read_fields(rendered)
@@ -117,20 +148,72 @@ def build(seed: int) -> MethodPolicy:
         genome = read_fields(rendered)
         genome.setdefault("task_prompt", STARTING_INSTRUCTION)
         genome.setdefault("mutation_prompt", MUTATION_PROMPT)
-        return llm(
-            _operator_prompt(next_operator(), genome, task, output, reward),
-            unit=task.id,
-        )
+        drawn = sampler.draw(lambda name: build_prompt(
+            name, genome, task, output, reward, view, sampler.rng()))
+        if drawn is None:
+            return None
+        name, prompt = drawn
+        reply = llm(prompt, unit=f"{task.id}:{name}")
+        if name not in TWO_STEP:
+            return reply
+        # Hypermutation is two steps in the paper: write a mutation-prompt, then
+        # *apply it to the task-prompt*. Stopping after step one returns a
+        # candidate whose task-prompt is unchanged, which cannot move the score
+        # at all -- one seed spent over a third of its budget on exactly that and
+        # finished at 0.000.
+        try:
+            fresh = str(parse_json_object(reply).get("mutation_prompt", "")).strip()
+        except (KeyError, TypeError, ValueError):
+            fresh = ""
+        if not fresh:
+            return reply
+        applied = llm(
+            apply_step_prompt(fresh, genome["task_prompt"], task, output, reward),
+            unit=f"{task.id}:{name}:apply")
+        try:
+            task_prompt = str(parse_json_object(applied).get("task_prompt", "")).strip()
+        except (KeyError, TypeError, ValueError):
+            task_prompt = ""
+        if not task_prompt:
+            return reply
+        return json.dumps({"task_prompt": task_prompt, "mutation_prompt": fresh})
+
+    built = []
+
+    def population(ctx):
+        return promptbreeder_population(
+            ctx, view=view, size=POPULATION_SIZE, batch=FITNESS_BATCH,
+            seed_units=seed_population(ctx.llm, POPULATION_SIZE, seed),
+            built=built)
+
+    def report() -> str:
+        # The operator is *sampled*, so which nine ran is an observation. Saying
+        # in the docs that the mix is reported, while printing it nowhere, is a
+        # documented property with no code behind it.
+        mix = ", ".join(f"{k}={v}" for k, v in sorted(
+            sampler.histogram().items(), key=lambda kv: -kv[1]))
+        lines = [f"  operators: {mix or 'none drawn'}"]
+        skipped = {k: v for k, v in sampler.unavailable.items() if v}
+        if skipped:
+            lines.append("  declined (input absent): " + ", ".join(
+                f"{k}={v}" for k, v in sorted(skipped.items(), key=lambda kv: -kv[1])))
+        if built:
+            units = built[0].snapshot()
+            lines.append(f"  population ({len(units)}/{POPULATION_SIZE}), "
+                         f"fitness on a {FITNESS_BATCH}-item train batch:")
+            for prompt, score in sorted(units, key=lambda u: -u[1]):
+                lines.append(f"    {score:.3f}  {prompt!r}")
+        return "\n".join(lines)
 
     train, held_out, test = money_splits(seed)
     return MethodPolicy(
         name="promptbreeder",
         fidelity=FIDELITY,
         notes=(
-            "Binary tournament replication runs through the population aggregator: committed candidates enter an archive and the tournament's pick is committed back as the next parent (the GEPA/DGM pattern, generalised).",
-            "Task/mutation-prompt co-evolution follows Algorithm 1.",
-            "Zero-order, first-order, and hyper-mutation operators rotate per replication event (3 of the paper's 9).",
-            "Population and fitness batch are budget-sized; PromptBreeder has no official released implementation.",
+            "Algorithm 1 as written: fixed-size population, binary tournament on a random training batch, and the loser replaced by the mutated winner.",
+            "All nine mutation operators, sampled uniformly per replication event; the realised mix is reported rather than assumed.",
+            "Initialisation is the paper's -- N units from the problem description crossed with hand-designed mutation-prompts and thinking-styles.",
+            "Population is budget-sized rather than the paper's 50 units, and the unit carries no few-shot context, so context shuffling is expressed as prompt crossover over the population.",
         ),
         strategy=FieldSlots(
             fields={"task_prompt": STARTING_INSTRUCTION,
@@ -143,9 +226,14 @@ def build(seed: int) -> MethodPolicy:
         solve=solve,
         propose=propose,
         reward=money_reward,
-        proposal_calls_per_candidate=1,
+        # Two, not one: the paper's hypermutation operators are two model calls,
+        # and declaring one would make the budget check fail on a run that spent
+        # exactly what the algorithm asks for.
+        proposal_calls_per_candidate=2,
         engine=Policies(selection=BinaryTournament(seed)),
         reflective=True,
+        population=population,
+        report=report,
     )
 
 

--- a/tests/test_candidate_methods.py
+++ b/tests/test_candidate_methods.py
@@ -50,19 +50,29 @@ def _money_answer(prompt):
 
 def fake_completion(prompt):
     lower = prompt.lower()
-    if "promptbreeder zero-order mutation" in lower:
-        return json.dumps(
-            {"task_prompt": "Compute carefully and return integer cents only."})
-    if "promptbreeder hyper-mutation" in lower:
-        return json.dumps(
-            {"mutation_prompt": "Generalize evaluator feedback into strict domain output rules."})
-    if "promptbreeder first-order mutation" in lower:
+    # PromptBreeder's nine operators and its population seeding all end with one
+    # of three JSON contracts, so the fake answers the contract rather than each
+    # operator's wording. Keying on the wording is how this stub silently stopped
+    # covering the port: the operators were rewritten, every match fell through
+    # to the prose fallback, `parse_json_object` rejected it, and the offline run
+    # produced no valid proposal at all while still passing a
+    # `final >= baseline` assertion.
+    if 'with "task_prompt" and "mutation_prompt" strings' in lower:
         return json.dumps(
             {
                 "task_prompt": "Compute carefully and return integer cents only.",
                 "mutation_prompt": "Generalize evaluator feedback into domain rules.",
             }
         )
+    if 'with a "mutation_prompt" string' in lower:
+        return json.dumps(
+            {"mutation_prompt": "Generalize evaluator feedback into strict domain output rules."})
+    if 'with a "task_prompt" string' in lower:
+        # Varied per prompt so the population is a population: identical units
+        # deduplicate to one entry and no tournament ever has two to sample.
+        tag = abs(hash(prompt)) % 1000
+        return json.dumps(
+            {"task_prompt": f"Compute carefully and return integer cents only. [{tag}]"})
     if "aflow's graph optimizer" in lower:
         return json.dumps(
             {
@@ -326,13 +336,103 @@ def test_strict_grader_is_the_one_the_ports_use():
     assert parse_integer_answer("415") == "415"
     assert parse_integer_answer("$4.15") is None
     assert parse_integer_answer("about 415 cents") is None
+    # The convention is still something a method has to discover -- these are the
+    # forms it must NOT accept, on the line it reads.
+    assert parse_integer_answer("2.75 + 1.40 = 4.15") is None
+    assert parse_integer_answer("") is None
 
 
-def test_money_splits_are_disjoint_and_complete():
-    train, held_out, test = money_splits(0)
+def test_the_grader_reads_the_final_line_so_working_and_format_are_not_exclusive():
+    """It used to `fullmatch` the whole reply, which made the output convention
+    and the reasoning mutually exclusive: a prompt that satisfied the format had
+    to forbid the working, and without the working the arithmetic collapsed.
+
+    Measured on `deepseek-v4-flash` across all 48 items -- same model, same
+    convention: no working scored 0.562, *with* working scored **0.000** because
+    the working itself failed the grader, and with working under a final-line
+    grader scored 0.979. The middle number is the point: a correct answer scored
+    zero for having shown its arithmetic.
+    """
+    worked = ("Notebook 2.75 and pen 1.40.\n"
+              "2.75 + 1.40 = 4.15 dollars\n"
+              "4.15 x 100 = 415 cents\n"
+              "Answer: 415")
+    assert parse_integer_answer(worked) == "415"
+    # A reply that stops mid-working still scores zero: the last line is not an
+    # answer, and reading further back would start grading intermediate values.
+    assert parse_integer_answer("2.75 + 1.40 = 4.15\n4.15 x 100 = 415 cents") is None
+    assert parse_integer_answer("Answer: 415\nbut I am not sure") is None
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_money_splits_are_disjoint_and_complete(seed):
+    train, held_out, test = money_splits(seed)
     ids = [{task.id for task in rows} for rows in (train, held_out, test)]
-    assert [len(rows) for rows in ids] == [4, 4, 4]
+    assert [len(rows) for rows in ids] == [16, 16, 16]
     assert not (ids[0] & ids[1] or ids[0] & ids[2] or ids[1] & ids[2])
+
+
+def test_the_train_split_is_wide_enough_for_the_workers_the_matrix_runs():
+    """`run_port` refuses a run whose train split is smaller than the worker
+    count, so the domain's size *is* the ceiling on this family's parallelism.
+    At twelve items the splits were 4/4/4 and every one of these eleven ports
+    was capped at four workers with a four-item acceptance gate."""
+    train, held_out, _ = money_splits(0)
+    assert len(train) >= 16 and len(held_out) >= 16
+
+
+def test_every_money_answer_survives_an_independent_rederivation():
+    """A wrong answer in this table does not raise. It silently becomes a task no
+    method can solve, and the run then reads as a method that failed to learn --
+    so the arithmetic is checked rather than trusted.
+
+    The table is built in integer cents; this recomputes each row with `Decimal`
+    from the dollar figures the question itself prints, which is a different
+    numeric type applied to a different source of truth (the prose, not the
+    generator).
+    """
+    import re
+    from decimal import Decimal
+
+    checked = 0
+    for task in TASKS:
+        q = task.question
+        dollars = [Decimal(m) for m in re.findall(r"\$(\d+\.\d\d)", q)]
+        counts = [int(m) for m in re.findall(r"(?<![.\d$])\b(\d+)\b(?!\.\d)", q)]
+        pct = re.search(r"(\d+) percent", q)
+        counts = [c for c in counts if not (pct and str(c) == pct.group(1))]
+        # The original twelve spell their multipliers as words ("Three labels",
+        # "Four friends"); the generated rows use digits. Both are read here, so
+        # this check covers the hand-written half of the table too.
+        words = {"two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+                 "seven": 7, "eight": 8, "nine": 9, "ten": 10, "twelve": 12}
+        counts += [words[w] for w in re.findall(r"\b([A-Za-z]+)\b", q.lower())
+                   if w in words]
+
+        if "coupon removes" in q or "change is due" in q:
+            want = dollars[0] - dollars[1]
+        elif "split" in q:
+            want = dollars[0] / counts[0]
+        elif "tip to" in q or "percent tax" in q:
+            want = dollars[0] * (100 + Decimal(pct.group(1))) / 100
+        elif "discounted by" in q:
+            want = dollars[0] * (100 - Decimal(pct.group(1))) / 100
+        elif "each and" in q:                      # n of one, plus one other
+            want = counts[0] * dollars[0] + dollars[1]
+        elif " are $" in q:                        # one item, plus n of another
+            want = dollars[0] + counts[0] * dollars[1]
+        elif len(dollars) == 2:
+            want = dollars[0] + dollars[1]
+        elif counts:                               # n at one price
+            want = counts[0] * dollars[0]
+        else:
+            raise AssertionError(f"no rule matched, so nothing was checked: {q}")
+
+        assert int(want * 100) == int(task.answer_cents), (
+            f"{task.id}: prose says {want}, table says {task.answer_cents}")
+        assert f"${want}" not in q, f"{task.id} prints its own answer"
+        checked += 1
+    assert checked == len(TASKS) == 48
 
 
 def test_selfplay_evaluation_splits_are_frozen_and_seeded():
@@ -434,11 +534,21 @@ def test_dry_run_counts_two_call_proposals(capsys):
 # ---------------------------------------------------------------------------
 
 def test_population_aggregator_feeds_selection_a_real_archive():
+    """AFlow rather than PromptBreeder.
+
+    PromptBreeder used to be the vehicle here, and stopped being one when its
+    tournament moved out of the selection seam: Algorithm 1 has to *evaluate*
+    both sampled units on a training batch and *replace* the loser, and a
+    `SelectionPolicy` can do neither -- it receives candidates with cached scores
+    and returns one. AFlow's `SoftMixed` is a selection rule in the sense the
+    seam means, so it is the honest test of the shared aggregator.
+    """
     from dataclasses import replace as _replace
 
     from agentdescent.policies import Policies as _Policies
+    from examples.aflow.aflow_workflow_search import SoftMixed
 
-    class RecordingTournament(BinaryTournament):
+    class RecordingSelection(SoftMixed):
         def __init__(self):
             super().__init__(seed=0)
             self.sizes = []
@@ -447,8 +557,8 @@ def test_population_aggregator_feeds_selection_a_real_archive():
             self.sizes.append(len(ctx.candidates))
             return super().select(ctx, n)
 
-    spy = RecordingTournament()
-    _, builder = ALGORITHMS["promptbreeder"]
+    spy = RecordingSelection()
+    _, builder = ALGORITHMS["aflow"]
     policy = _replace(builder(0), engine=_Policies(selection=spy))
     usage = Usage()
     recorder = Recorder(metered(fake_completion, usage), usage)
@@ -457,7 +567,7 @@ def test_population_aggregator_feeds_selection_a_real_archive():
         candidate_budget=4, max_seconds=30.0, shutdown_grace=5.0,
     ).compact()
     # The archive held the seed plus at least one committed candidate, so the
-    # tournament was run over a genuine population at least once.
+    # selection rule ran over a genuine population at least once.
     assert spy.sizes, "selection policy was never consulted"
     assert max(spy.sizes) >= 2, f"archive never grew: {spy.sizes}"
     assert payload["final_quality"] >= payload["baseline_quality"]

--- a/tests/test_promptbreeder_algorithm1.py
+++ b/tests/test_promptbreeder_algorithm1.py
@@ -1,0 +1,340 @@
+"""PromptBreeder's Algorithm 1, and the three ways this port used to miss it.
+
+Each test here exists because the port ran, produced a number, and was wrong in
+a way no assertion could see: an archive that only grows still returns a best
+unit, a tournament ranked on held-out still picks a winner, and three operators
+in rotation still mutate. None of those raise.
+"""
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from examples._method_policy import PopulationContext
+from examples.promptbreeder import promptbreeder_genetic_prompts as pb
+from examples.promptbreeder._promptbreeder_operators import (
+    OPERATORS, OperatorSampler, build_prompt)
+from examples.promptbreeder._promptbreeder_population import (
+    PopulationView, PromptBreederPopulation)
+
+
+# -- the operators -----------------------------------------------------------
+
+
+def test_all_nine_operators_are_present_and_none_is_a_duplicate():
+    assert len(OPERATORS) == 9 == len(set(OPERATORS))
+
+
+def test_sampling_is_uniform_rather_than_a_rotation():
+    """The port cycled three operators round-robin. Rotation guarantees each
+    operator's share and sampling does not, so with rotation a run's operator mix
+    was an assumption; the paper samples uniformly per replication event."""
+    sampler = OperatorSampler(seed=0)
+    drawn = [sampler.draw(lambda name: f"prompt for {name}")[0] for _ in range(200)]
+
+    assert set(drawn) == set(OPERATORS), "some operator was never sampled"
+    counts = [drawn.count(name) for name in OPERATORS]
+    assert max(counts) - min(counts) > 0, "a perfectly even split is a rotation"
+    # A rotation of period 9 repeats exactly; sampling does not.
+    assert drawn[0:9] != drawn[9:18]
+
+
+def test_the_sampler_is_reproducible_from_its_seed():
+    a = OperatorSampler(seed=7)
+    b = OperatorSampler(seed=7)
+    pull = lambda s: [s.draw(lambda n: n)[0] for _ in range(30)]
+    assert pull(a) == pull(b)
+
+
+def test_concurrent_draws_do_not_corrupt_the_histogram():
+    """`random.Random` is not thread-safe and the workers draw concurrently."""
+    sampler = OperatorSampler(seed=1)
+    barrier = threading.Barrier(8)
+
+    def worker():
+        barrier.wait()
+        for _ in range(50):
+            sampler.draw(lambda name: f"prompt for {name}")
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert sum(sampler.counts.values()) == 8 * 50
+
+
+def _genome():
+    return {"task_prompt": "answer it", "mutation_prompt": "improve it"}
+
+
+def _task():
+    from agentdescent.evolution import Task
+    return Task(id="train:m00", prompt="A pen costs $1.40. What is the total?",
+                meta={"answer_cents": "140", "split": "train"})
+
+
+@pytest.mark.parametrize("operator", OPERATORS)
+def test_every_operator_either_builds_a_prompt_or_says_why_not(operator):
+    """An operator whose input does not exist returns None so the sampler draws
+    again. Degrading it to a first-order mutation instead would make the operator
+    histogram a fiction -- the run would report nine operators and have run one.
+    """
+    view = PopulationView()
+    view.publish(
+        [{"state": {"task_prompt": f"prompt {i}"}, "score": i / 4.0}
+         for i in range(4)],
+        [{"task_prompt": "elite a"}, {"task_prompt": "elite b"}])
+    sampler = OperatorSampler(seed=0)
+    prompt = build_prompt(operator, _genome(), _task(), "140", 1.0, view,
+                          sampler.rng())
+    assert prompt, f"{operator} could not build a prompt from a full population"
+    # The gold answer appears only where the paper's operator is *defined* over
+    # execution feedback, and only for a train item -- see
+    # `test_proposals_only_ever_see_the_train_split` for why that is safe.
+    if "140" in prompt:
+        assert operator in ("first_order", "lamarckian"), (
+            f"{operator} shows the item's answer without consuming feedback")
+
+
+@pytest.mark.parametrize("operator,missing", [
+    ("eda", "an empty population"),
+    ("eda_rank_index", "an empty population"),
+    ("lineage", "no elite history"),
+    ("context_shuffle", "no crossover partner"),
+])
+def test_population_operators_decline_when_the_population_is_empty(operator, missing):
+    sampler = OperatorSampler(seed=0)
+    assert build_prompt(operator, _genome(), _task(), "x", 0.0,
+                        PopulationView(), sampler.rng()) is None, missing
+
+
+def test_lamarckian_needs_a_correct_working_not_just_any_output():
+    """Its input is a working-out the grader *accepted*; reverse-engineering an
+    instruction from a wrong answer teaches the wrong instruction."""
+    view, sampler = PopulationView(), OperatorSampler(seed=0)
+    assert build_prompt("lamarckian", _genome(), _task(), "140", 0.0, view,
+                        sampler.rng()) is None
+    assert build_prompt("lamarckian", _genome(), _task(), "", 1.0, view,
+                        sampler.rng()) is None
+    assert build_prompt("lamarckian", _genome(), _task(), "140", 1.0, view,
+                        sampler.rng())
+
+
+# -- Algorithm 1's population ------------------------------------------------
+
+
+class _Artifact:
+    def __init__(self, state):
+        self.state = dict(state)
+
+    def render(self):
+        return json.dumps(self.state, sort_keys=True)
+
+
+def _population(fitness, size=4, seed_units=(), batch=4):
+    view = PopulationView()
+    pop = PromptBreederPopulation.__new__(PromptBreederPopulation)
+    # The aggregator's own __init__ needs a ledger, verifier and audit trail;
+    # the population half under test needs none of them, so it is initialised
+    # directly rather than behind a stack of fakes that would themselves need
+    # asserting.
+    pop._archive, pop._seen = [], set()
+    pop._archive_lock = threading.Lock()
+    pop._fitness, pop._view, pop._size = fitness, view, size
+    pop._batch = batch
+    import random as _random
+    pop._rng = _random.Random(0)
+    pop._pending_seed_units = list(seed_units)
+    pop._loser, pop._elites, pop._best = None, [], -1.0
+    return pop, view
+
+
+def test_the_population_is_fixed_size_and_the_loser_is_the_slot_reused():
+    """The port's archive only grew, so no unit ever died and the selection
+    pressure Algorithm 1's replacement step creates was simply absent."""
+    scores = {"a": 0.9, "b": 0.1, "c": 0.5, "d": 0.4, "e": 0.8, "f": 0.2}
+    pop, _ = _population(lambda s, b: scores[s["task_prompt"]], size=4)
+
+    for name in "abcd":
+        pop._admit(_Artifact({"task_prompt": name}), 1)
+    assert len(pop._archive) == 4
+
+    winner = pop._replication_event()
+    assert winner is not None
+    loser = pop._loser
+    assert loser is not None, "the tournament did not name a slot to reuse"
+    doomed = pop._archive[loser]["state"]["task_prompt"]
+
+    pop._admit(_Artifact({"task_prompt": "e"}), 2)
+    living = [u["state"]["task_prompt"] for u in pop._archive]
+    assert len(pop._archive) == 4, "the population grew past N"
+    assert doomed not in living, "the loser survived its own replacement"
+    assert "e" in living
+
+
+def test_the_tournament_scores_on_training_data_not_the_held_out_gate():
+    """Ranking a population on the acceptance gate's own signal makes the
+    tournament a second gate rather than a fitness measure."""
+    seen = []
+    pop, _ = _population(
+        lambda s, b: (seen.append((s["task_prompt"], b)), 0.5)[1], size=4)
+    for name in "abcd":
+        pop._admit(_Artifact({"task_prompt": name}), 1)
+    seen.clear()
+    pop._replication_event()
+    assert len(seen) == 2, "both sampled units must be re-scored, not cached"
+    assert {b for _, b in seen} == {4}, (
+        "the tournament asked for the whole training split, not a batch -- the "
+        "paper's fitness is a sample, and scoring every item is both a departure "
+        "and the dominant cost of a run")
+    # `fitness` is the runner's train-split evaluator; the held-out verifier is
+    # never consulted here, and `_population` gives this object no verifier at
+    # all -- if the shared archive's `_admit` were still in play this would raise.
+    assert not hasattr(pop, "verifier")
+
+
+def test_the_winner_is_the_higher_scoring_of_the_two_sampled():
+    scores = {"lo": 0.1, "hi": 0.9}
+    pop, _ = _population(lambda s, b: scores[s["task_prompt"]], size=2)
+    pop._admit(_Artifact({"task_prompt": "lo"}), 1)
+    pop._admit(_Artifact({"task_prompt": "hi"}), 1)
+    winner = pop._replication_event()
+    assert winner["state"]["task_prompt"] == "hi"
+    assert pop._archive[pop._loser]["state"]["task_prompt"] == "lo"
+
+
+def test_a_population_of_one_cannot_hold_a_tournament():
+    pop, _ = _population(lambda s, b: 1.0, size=4)
+    pop._admit(_Artifact({"task_prompt": "only"}), 1)
+    assert pop._replication_event() is None
+
+
+def test_the_view_the_operators_read_tracks_the_population():
+    scores = {"a": 0.2, "b": 0.9, "c": 0.5}
+    pop, view = _population(lambda s, b: scores[s["task_prompt"]], size=4)
+    for name in "abc":
+        pop._admit(_Artifact({"task_prompt": name}), 1)
+    assert view.task_prompts() and set(view.task_prompts()) == {"a", "b", "c"}
+    assert view.task_prompts(ranked=True) == ["a", "c", "b"], "not ascending by fitness"
+    assert view.elite_history()[-1] == "b", "the best unit is not the last elite"
+
+
+# -- initialisation ----------------------------------------------------------
+
+
+def test_seeding_produces_a_population_rather_than_one_instruction():
+    """A run that starts from a single instruction has nothing to sample for its
+    first tournaments, and three of the nine operators have no input until enough
+    children commit -- that is a different algorithm for the first stretch of the
+    budget, not a slow start."""
+    calls = []
+
+    def llm(prompt, **kw):
+        calls.append(kw.get("unit"))
+        return json.dumps({"task_prompt": f"instruction {len(calls)}"})
+
+    units = pb.seed_population(llm, size=6, seed=0)
+    assert len(units) == 5, "N-1 generated units, the seed itself being the Nth"
+    assert len({u["task_prompt"] for u in units}) == 5, "the units are identical"
+    assert all(u["mutation_prompt"] for u in units), "no mutation-prompt drawn"
+    assert set(calls) == {"seed-population"}
+
+
+def test_seeding_survives_a_reply_it_cannot_parse():
+    units = pb.seed_population(lambda prompt, **kw: "not json at all", size=6,
+                               seed=0)
+    assert units == []
+
+
+def test_seed_calls_are_not_billed_as_proposals():
+    """`observed_proposal_calls <= expected` is what makes the matrix rows
+    comparable. Seeding is initialisation, and recording it under `proposal:`
+    would both break that check and hide setup cost inside the search's cost."""
+    import inspect
+
+    from examples import _method_runner
+
+    source = inspect.getsource(_method_runner.run_port)
+    assert 'init_llm = PhasedLLM' in inspect.getsource(_method_runner)
+    assert "llm=lambda prompt, **kw: init_llm(prompt, **kw)" in source, (
+        "the population hook is being handed the proposal-phase LLM")
+
+
+def test_proposals_only_ever_see_the_train_split():
+    """Two operators put the grader's answer in the prompt, which is the domain's
+    whole teaching signal -- and is only safe because the item is always a
+    training item.
+
+    The engine splits `tasks` positionally: `cut = round(len(tasks) * (1 -
+    held_out_frac))`. The runner passes `engine_tasks = train + held_out` with
+    `shuffle=False` and `held_out_frac = len(held_out)/len(engine_tasks)`, so the
+    cut lands exactly on the boundary between the two lists. Shuffle them, or
+    size the splits unevenly, and held-out answers start reaching proposal
+    prompts -- silently, and the gate would still report a rising score.
+    """
+    policy = pb.build(0)
+    tasks = policy.engine_tasks
+    cut = max(1, round(len(tasks) * (1 - policy.held_out_frac)))
+    assert [t.id for t in tasks[:cut]] == [t.id for t in policy.train_tasks]
+    assert [t.id for t in tasks[cut:]] == [t.id for t in policy.held_out_tasks]
+    assert all(t.meta["split"] == "train" for t in tasks[:cut])
+
+
+def test_the_population_hook_is_what_the_port_declares():
+    policy = pb.build(0)
+    assert policy.population is not None, "the port fell back to the shared archive"
+    ctx = PopulationContext(
+        selection=policy.engine.selection, artifact_id="candidate-promptbreeder",
+        conflict=None, fusion=None, acceptance=None,
+        llm=lambda prompt, **kw: json.dumps({"task_prompt": "x"}),
+        fitness=lambda state, batch: 0.5, train_size=16, seed=0)
+    factory = policy.population(ctx)
+    assert callable(factory)
+
+
+def test_hypermutation_is_two_steps_and_ends_at_the_task_prompt():
+    """The paper's hypermutation writes a mutation-prompt and then **applies it
+    to the task-prompt**. Stopping after step one returns a candidate whose
+    task-prompt is unchanged, which cannot move the score by construction -- one
+    seed spent 29 of its 80 draws on exactly that and finished at 0.000.
+    """
+    from examples.promptbreeder._promptbreeder_operators import TWO_STEP
+
+    assert set(TWO_STEP) == {"zero_order_hyper", "first_order_hyper"}
+
+    policy = pb.build(0)
+    calls = []
+
+    def llm(prompt, **kw):
+        calls.append((kw.get("unit", ""), prompt))
+        if 'with a "mutation_prompt" string' in prompt:
+            return json.dumps({"mutation_prompt": "sharpen the output convention"})
+        return json.dumps({"task_prompt": "state the amount in integer cents"})
+
+    rendered = policy.strategy.render(policy.strategy.initial())
+    # Draw until a two-step operator comes up; the sampler is uniform, so this
+    # terminates quickly and does not assume an order.
+    for _ in range(200):
+        before = len(calls)
+        payload = policy.propose(llm, rendered, _task(), "140", 1.0)
+        drawn = [u for u, _ in calls[before:]]
+        if any(u.endswith(":apply") for u in drawn):
+            assert len(drawn) == 2, "the second step did not run"
+            assert json.loads(payload)["task_prompt"] == (
+                "state the amount in integer cents"), (
+                "the two-step operator returned only its new mutation-prompt, so "
+                "the task-prompt would be unchanged")
+            assert json.loads(payload)["mutation_prompt"] == (
+                "sharpen the output convention")
+            break
+    else:
+        raise AssertionError("no two-step operator was drawn in 200 attempts")
+
+
+def test_the_declared_proposal_budget_covers_the_second_step():
+    """`observed_proposal_calls <= expected` is what makes these rows comparable,
+    and hypermutation legitimately costs two calls."""
+    assert pb.build(0).proposal_calls_per_candidate == 2


### PR DESCRIPTION
First of the eleven unmeasured MethodPolicy rows in #73. The port ran, returned a number, and was not PromptBreeder.

## The port was not Algorithm 1

| Algorithm 1 | was | is |
|---|---|---|
| population fixed at N, **loser replaced** | archive grew forever, no unit ever died | `\|P\| = N`, the loser's slot is reused by the next committed child |
| two units compared on a **random training batch** | ranked on the held-out split | a resampled batch of the train split |
| operator **sampled uniformly from nine** | 3 of 9, fixed rotation | 9 of 9, uniform, histogram printed |
| **N-unit initialisation** from description × mutation-prompt × thinking-style | one instruction | the paper's, billed to an `init:` phase |

None of these raise. An archive that only grows still returns a best unit; a tournament ranked on held-out still picks a winner; three operators in rotation still mutate. Rotation is the subtle one — it *guarantees* each operator's share where sampling does not, so the operator mix was an assumption rather than an observation.

**Algorithm 1's tournament cannot be a `SelectionPolicy`.** One receives candidates carrying cached scores and returns one; the paper's has to **evaluate** both sampled units and **replace** the loser. Hence `MethodPolicy.population`, and the shared-aggregator test moves to AFlow — `SoftMixed` is a selection rule in the sense the seam means.

Four of the nine operators (EDA, EDA-rank-and-index, lineage, crossover) are defined *over the population*, so `PopulationView` is the handle the aggregator writes and `propose` reads. An operator whose input is absent returns `None` and the sampler draws again, rather than degrading to a first-order mutation — otherwise the histogram would be a fiction.

## Hypermutation stopped halfway

The paper writes a new mutation-prompt and then **applies it to the task-prompt**. Step one alone leaves the task-prompt unchanged, so the candidate cannot move the score *by construction*. One seed spent **29 of its 80 draws** on exactly that and finished at 0.000. Both hyper operators are two-step now, and `proposal_calls_per_candidate = 2` so the budget check still means something.

## The grader forbade a chain of thought

`parse_integer_answer` matched the whole reply, so the output convention and the reasoning were **mutually exclusive**. Every method evolved prompts saying "no explanation", and without the working the arithmetic collapsed. Same model, same convention, all 48 items:

| prompt / grader | score |
|---|---|
| no working, whole-reply grader | 0.562 |
| with working, whole-reply grader | **0.000** ← the working itself failed the match |
| with working, final-line grader | 0.979 |

A correct answer scored zero for having shown its arithmetic. The grader reads the final line now; `$4.15`, `4.15` and prose are still rejected *there*, so the integer-cents convention is still something a method has to discover. GSM8K and friends do the same thing with `####`.

**The feedback then described the old grader** — the search was being optimised against a false statement about its own channel. It now says which line was read.

## The domain was too small to run

`run_port` refuses a run whose train split is under the worker count, so 12 items in 4/4/4 splits capped this port — **and the ten others sharing the domain** — at four workers, with the acceptance gate resting on four items. Now 48 items in 16/16/16.

The 36 new answers were each re-derived with `Decimal` from the dollar figures their own question prints (the table is built in integer cents), and `test_every_money_answer_survives_an_independent_rederivation` keeps it that way: a wrong answer here does not raise, it silently becomes an unsolvable task and reads as a method that failed to learn.

`--temperature` reaches this runner at all now. Every other port takes one; these eleven ran at the API default and could not report it.

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`, `--reflective-merge`, `deepseek-v4-flash`:

| seed | test | validation | accepted | calls |
|---|---|---:|---:|---:|
| 0 | 0.000 → **0.438** | 0.000 → 0.312 | 5/80 | 631 |
| 1 | 0.000 → 0.000 | 0.000 → 0.000 | 1/80 | 638 |
| 2 | 0.000 → **0.375** | 0.000 → 0.375 | 4/80 | 640 |

Two of three seeds moved and one found nothing — **the range is the result**. A single seed would have supported either conclusion depending which was run.

Against the domain's own ceilings (0.479 for a prompt that only names the convention, 1.000 for one that also teaches the working), the two successful seeds sit just under the *format-only* ceiling. The search reliably finds **what the grader wants** and does not find that it is **allowed to think first**. That is a stated boundary, not noise.

## Refuted along the way

Recorded rather than fixed, because both were wrong:

- **`--reflective-merge` blending eight workers' discoveries into mush** — a no-merge control scored the same 0.000.
- **`finalize()` picking the wrong unit off a 4-item batch** — the whole population scored 0.000, so the maximum was a tie among zeros.

## Verification

Full offline suite green (exit 0), including 30 new tests in `tests/test_promptbreeder_algorithm1.py`.

Also fixed: `_tournament` collided with `Aggregator._tournament` (fusion's), and the offline stub `fake_completion` still keyed on the old operators' wording — every new operator fell through to a non-JSON fallback, so offline runs produced no valid proposal at all while still passing a `final >= baseline` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)