### PR TITLE
feat(aflow): the selection rule was uniform, and reported that it was not

### DIFF
--- a/bench/results/aflow-upstream-selection.json
+++ b/bench/results/aflow-upstream-selection.json
@@ -1,0 +1,81 @@
+{
+ "experiment": "AFlow soft-mixed workflow search on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "FoundationAgents/AFlow@3f457218 (ICLR 2025)",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": true,
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "alpha": 0.2,
+  "lambda": 0.3,
+  "top_k": 4,
+  "score_scale": 100,
+  "domain": "money, 48 items, 16/16/16 splits"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.0,
+    0.812
+   ],
+   "validation": [
+    0.0,
+    0.938
+   ],
+   "accepted": 3,
+   "invalid": 0,
+   "wall_s": 247.6,
+   "engine_s": 136.1,
+   "calls": 767
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.0,
+    0.938
+   ],
+   "validation": [
+    0.0,
+    0.938
+   ],
+   "accepted": 2,
+   "invalid": 1,
+   "wall_s": 226.8,
+   "engine_s": 117.7,
+   "calls": 728
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.0,
+    0.938
+   ],
+   "validation": [
+    0.0,
+    1.0
+   ],
+   "accepted": 3,
+   "invalid": 1,
+   "wall_s": 219.7,
+   "engine_s": 116.4,
+   "calls": 767
+  }
+ ],
+ "summary": {
+  "test_quality": {
+   "min": 0.812,
+   "median": 0.938,
+   "max": 0.938,
+   "mean": 0.896
+  },
+  "seeds_that_moved": 3,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-aflow.md
+++ b/docs/algo-aflow.md
@@ -38,15 +38,68 @@ modifications and whether each helped — injected into the prompt.
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`--reflective-merge`, `deepseek-v4-flash` at temperature 0.7 with thinking
+disabled. Recorded in
+[`bench/results/aflow-upstream-selection.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/aflow-upstream-selection.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
-|---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| seed | test quality | validation | accepted | calls | wall |
+|---|---|---|---|---|---|
+| 0 | 0.000 → **0.812** | 0.000 → 0.938 | 3/80 | 767 | 248 s |
+| 1 | 0.000 → **0.938** | 0.000 → 0.938 | 2/80 | 728 | 227 s |
+| 2 | 0.000 → **0.938** | 0.000 → 1.000 | 3/80 | 767 | 220 s |
+
+Three of three seeds moved, mean 0.896, against a domain whose ceiling is 1.000.
+
+### Why this clears the domain when PromptBreeder does not
+
+[PromptBreeder](algo-promptbreeder.md) reaches 0.271 on the same 48 items, the
+same model, the same budget, and its successful seeds stall just under the
+*format-only* ceiling of 0.479: it discovers what the grader wants and not that
+it may reason first. AFlow does both, and the reason is topology rather than
+tuning. Its workflow is two nodes — **Solve**, then **ReviewAndRevise** — so the
+arithmetic and the output convention have separate places to live. A single
+instruction has to hold both at once, and the prompts that nail the format are
+the ones that forbid the working.
+
+That is the comparison the matrix exists for: same domain, same runtime, same
+budget, and the mechanism is the variable.
+
+!!! danger "The selection rule was uniform, and said it was not"
+    The port implemented `λ·uniform + (1−λ)·softmax(α·(s−s_max))` and dropped
+    one line of upstream's `select_round`:
+
+    ```python
+    scores = [item["score"] * 100 for item in sorted_items]
+    ```
+
+    Upstream's α is 0.2 *against percentages*, so the effective temperature is
+    20 against accuracies in `[0, 1]` — and this port's scores are accuracies in
+    `[0, 1]` exactly as upstream's are, so the scaling is not a unit conversion.
+    It **is** the temperature. Over a pool scoring 0.50 / 0.40 / 0.25 / 0.10:
+
+    | | pick distribution |
+    |---|---|
+    | upstream | `[0.688, 0.158, 0.079, 0.075]` |
+    | this port, before | `[0.265, 0.257, 0.245, 0.233]` |
+    | uniform | `[0.250, 0.250, 0.250, 0.250]` |
+
+    Uniform to three digits. The port ran, logged "soft mixed probability", and
+    had no exploitation at all.
+
+    Three smaller departures went with it. **α and λ were the paper's 0.4 / 0.2**
+    rather than the pinned code's own `DEFAULT_ALPHA = 0.2` /
+    `DEFAULT_LAMBDA = 0.3` — where released code and paper disagree about a
+    constant, the code is what produced the published numbers. **The seed
+    workflow was force-appended to the pool**; upstream's `get_top_rounds` moves
+    round 1 to the front only when it already made the cut, and `select_round`
+    re-sorts by score immediately after, so that move changes nothing and
+    membership is the whole rule. And **experience carried neither the parent's
+    score nor whether each past modification helped**, where upstream's
+    `format_experience` reports both and `check_modification` regenerates rather
+    than accept a repeat.
+
+    An offline test had pinned the wrong behaviour:
+    `test_soft_mixed_keeps_the_seed_and_favours_scores` asserted the seed was
+    always reachable, which was true only because of the force-append. The test
+    was protecting the bug.

--- a/examples/aflow/aflow_workflow_search.py
+++ b/examples/aflow/aflow_workflow_search.py
@@ -2,26 +2,42 @@
 
 Preserved: the *actual* selection rule at the pinned revision -- **soft mixed
 probability**, ``λ·uniform + (1−λ)·softmax(α·(s−s_max))`` over the top-k scored
-workflows **plus the seed workflow** (`data_utils._compute_probabilities`; it is
-not UCT and keeps no visit counts) -- and expansion prompts that carry the
-selected parent's **experience**: its prior modifications and whether each
-helped, upstream's ``experience.json``.
+workflows (`data_utils.select_round`; it is not UCT and keeps no visit counts) --
+and expansion prompts carrying the selected parent's **experience**: its score,
+and every modification already tried from it with whether it helped, which is
+upstream's ``experience.json`` and its ``format_experience``.
+
+**The scores are scaled by 100 before the softmax**, exactly as
+``select_round`` does, and that single line is the difference between AFlow and
+a coin flip. Upstream's α is 0.2 *against percentages*, so the effective
+temperature is 20 against accuracies in ``[0, 1]``. Without the scaling, on a
+pool scoring 0.50 / 0.40 / 0.25 / 0.10 the pick distribution is
+``[0.265, 0.257, 0.245, 0.233]`` -- uniform to three digits -- where upstream's
+is ``[0.688, 0.158, 0.079, 0.075]``. A port missing it still runs, still reports
+"soft mixed probability", and has no exploitation at all.
+
+``α = 0.2`` and ``λ = 0.3`` are the pinned code's own defaults
+(``DataUtils.DEFAULT_ALPHA`` / ``DEFAULT_LAMBDA``), not the paper's 0.4 / 0.2.
+Where the released code and the paper disagree about a constant, the code is what
+produced the published numbers.
 
 The workflow is a :class:`~examples._method_policy.FieldSlots` artifact (solve
 node, review node, modification note), so field edits union-merge and contested
 fields are model-merged without ranking evaluations.
 
 Boundaries: two fixed model nodes instead of code-level graph rewrites; search
-depth is the candidate budget instead of 20 rounds; paper hyper-parameters
-α=0.4, λ=0.2 (the pinned code itself uses 0.2/0.3).
+depth is the candidate budget instead of 20 rounds; upstream regenerates
+*without bound* until the proposed modification is one it has not tried from
+that parent, and this retries once.
 """
 
 from __future__ import annotations
 
+import json
 import math
 import random
 import threading
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from agentdescent.evolution import Task
 from agentdescent.policies import Policies
@@ -38,20 +54,47 @@ FIDELITY = "mechanism_microport"
 
 REVIEW_INSTRUCTION = "Check the arithmetic and return only the corrected answer."
 
+#: `select_round` computes `scores = [item["score"] * 100 ...]` before the
+#: softmax. Upstream's benchmark scores are accuracies in [0, 1] exactly like
+#: this port's, so the scaling is not a unit conversion -- it *is* the
+#: temperature, and dropping it flattens the distribution to uniform.
+SCORE_SCALE = 100.0
+
+#: `DataUtils.DEFAULT_ALPHA` / `DEFAULT_LAMBDA` at the pinned revision.
+ALPHA = 0.2
+LAMBDA = 0.3
+
+#: `run.py --sample`, default 4.
+TOP_K = 4
+
 
 class SoftMixed(SingleHead):
     """AFlow's node selection: λ-uniform mixed with a score softmax over top-k.
 
-    The seed workflow (the first candidate) is always kept in the pool --
-    upstream's "including the initial workflow ensures persistent exploration".
+    The pool is the top-k *by score*. The seed workflow competes for a place
+    like any other and is not force-included: upstream's ``get_top_rounds``
+    moves round 1 to the front of the list **only when it already made the
+    cut**, and ``select_round`` re-sorts by score immediately afterwards, so
+    that reordering changes nothing and membership is all that is left.
     """
 
-    def __init__(self, alpha: float = 0.4, lam: float = 0.2, top_k: int = 4,
-                 seed: int = 0) -> None:
+    def __init__(self, alpha: float = ALPHA, lam: float = LAMBDA,
+                 top_k: int = TOP_K, seed: int = 0,
+                 scale: float = SCORE_SCALE) -> None:
         self.alpha = alpha
         self.lam = lam
         self.top_k = top_k
+        self.scale = scale
         self.rng = random.Random(seed)
+
+    def probabilities(self, scores: Sequence[float]) -> List[float]:
+        """`_compute_probabilities`, on scores already multiplied by `scale`."""
+        scaled = [s * self.scale for s in scores]
+        s_max = max(scaled)
+        weights = [math.exp(self.alpha * (s - s_max)) for s in scaled]
+        total = sum(weights)
+        return [self.lam / len(scaled) + (1 - self.lam) * w / total
+                for w in weights]
 
     def select(self, ctx: SelectionContext, n: int) -> Sequence:
         candidates = list(ctx.candidates)
@@ -59,18 +102,62 @@ class SoftMixed(SingleHead):
             return super().select(ctx, n)
         pool = sorted(candidates, key=lambda c: c.score or 0.0,
                       reverse=True)[:self.top_k]
-        if candidates[0] not in pool:
-            pool.append(candidates[0])
-        s_max = max(c.score or 0.0 for c in pool)
-        weights = [math.exp(self.alpha * ((c.score or 0.0) - s_max)) for c in pool]
-        total = sum(weights)
-        probs = [self.lam / len(pool) + (1 - self.lam) * w / total for w in weights]
+        probs = self.probabilities([c.score or 0.0 for c in pool])
         return [self.rng.choices(pool, weights=probs, k=1)[0] for _ in range(n)]
 
 
+class Experience:
+    """Upstream's ``experience.json``, in memory and keyed by parent workflow.
+
+    Each entry is one modification tried *from* that parent, with the parent's
+    score before it and whether it helped -- ``create_experience_data`` plus
+    ``update_experience``. ``format_experience`` renders both the successes and
+    the failures as things to prohibit, because what it is preventing is
+    *repetition*, not failure.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._rows: Dict[str, List[Tuple[str, float, Optional[bool]]]] = {}
+
+    def record(self, parent: str, modification: str, before: float) -> None:
+        with self._lock:
+            self._rows.setdefault(parent, []).append((modification, before, None))
+
+    def resolve(self, parent: str, modification: str, after: float) -> None:
+        with self._lock:
+            rows = self._rows.get(parent, [])
+            for index, (mod, before, done) in enumerate(rows):
+                if mod == modification and done is None:
+                    rows[index] = (mod, before, bool(after > before))
+                    break
+
+    def tried(self, parent: str) -> List[str]:
+        with self._lock:
+            return [mod for mod, _, _ in self._rows.get(parent, ())]
+
+    def render(self, parent: str, score: float) -> str:
+        with self._lock:
+            rows = list(self._rows.get(parent, ()))
+        if not rows:
+            return f"No experience data found for this workflow (score {score:.3f})."
+        lines = [f"Original Score: {score:.3f}",
+                 "These are some conclusions drawn from experience:", ""]
+        for mod, before, succeeded in rows:
+            if succeeded is False:
+                lines.append(f"-Absolutely prohibit {mod} (Score: {before:.3f})")
+            else:
+                lines.append(f"-Absolutely prohibit {mod}")
+        lines.append(
+            "\nNote: Take into account past failures and avoid repeating the "
+            "same mistakes, as these failures indicate that these approaches are "
+            "ineffective. You must fundamentally change your way of thinking, "
+            "rather than simply rewording the instruction.")
+        return "\n".join(lines)
+
+
 def build(seed: int) -> MethodPolicy:
-    experience: Dict[str, List[str]] = {}
-    lock = threading.Lock()
+    experience = Experience()
 
     def solve(llm, rendered: str, task: Task) -> str:
         graph = read_fields(rendered)
@@ -89,41 +176,46 @@ def build(seed: int) -> MethodPolicy:
 
     def propose(llm, rendered: str, task: Task, output: str,
                 reward: float) -> Optional[str]:
-        with lock:
-            past = list(experience.get(rendered, ()))[-3:]
-        history = (
-            "Experience on this workflow (do not repeat these modifications):\n"
-            + "\n".join(f"- {entry}" for entry in past)
-            if past else "Experience on this workflow: none yet."
+        prompt = (
+            "You are AFlow's graph optimizer. Expand the selected workflow "
+            "from its execution feedback while preserving exactly two nodes: "
+            "Solve, then ReviewAndRevise.\n\n"
+            f"Current workflow:\n{rendered}\n\n"
+            f"{experience.render(rendered, reward)}\n"
+            f"Reward: {reward}\n{feedback(task, output)}\n\n"
+            "Return JSON only with modification, solve_instruction, and "
+            "review_instruction strings."
         )
-        raw = llm(
-            (
-                "You are AFlow's graph optimizer. Expand the selected workflow "
-                "from its execution feedback while preserving exactly two nodes: "
-                "Solve, then ReviewAndRevise.\n\n"
-                f"Current workflow:\n{rendered}\n\n{history}\n"
-                f"Reward: {reward}\n{feedback(task, output)}\n\n"
-                "Return JSON only with modification, solve_instruction, and "
-                "review_instruction strings."
-            ),
-            unit=task.id,
-        )
-        try:
-            note = str(parse_json_object(raw).get("modification", ""))[:200]
-        except ValueError:
-            note = "(unparseable modification)"
-        with lock:
-            experience.setdefault(rendered, []).append(
-                f"{note} (trigger reward {reward})")
+        raw = llm(prompt, unit=task.id)
+        # `check_modification`: a modification already tried from this parent is
+        # regenerated rather than accepted. Upstream loops without bound; one
+        # retry is the declared boundary here, and the second attempt is what
+        # `proposal_calls_per_candidate = 2` reserves.
+        note = _modification(raw)
+        if note and note in experience.tried(rendered):
+            raw = llm(
+                prompt + f"\n\nYou already proposed {note!r} from this workflow "
+                         "and it was rejected for that reason. Propose a "
+                         "different modification.",
+                unit=f"{task.id}:regenerate")
+            note = _modification(raw)
+        experience.record(rendered, note or "(unparseable modification)", reward)
         return raw
+
+    def _modification(raw: str) -> str:
+        try:
+            return str(parse_json_object(raw).get("modification", ""))[:200]
+        except (KeyError, TypeError, ValueError):
+            return ""
 
     train, held_out, test = money_splits(seed)
     return MethodPolicy(
         name="aflow",
         fidelity=FIDELITY,
         notes=(
-            "The pinned revision's soft mixed selection (not UCT) runs through the population aggregator over the archive of committed workflows, seed always included.",
-            "Expansion prompts carry the selected parent's modification experience, as upstream's experience.json does.",
+            "The pinned revision's soft mixed selection (not UCT) runs through the population aggregator over the archive of committed workflows, with upstream's own alpha=0.2, lambda=0.3 and its score-by-100 scaling -- without which the distribution is uniform.",
+            "Expansion prompts carry the selected parent's score and every modification already tried from it, as upstream's experience.json and format_experience do.",
+            "A modification already tried from this parent is regenerated once, as check_modification does without bound.",
             "Every candidate keeps the same two model nodes, fixing workflow topology across modes.",
         ),
         strategy=FieldSlots(
@@ -140,7 +232,7 @@ def build(seed: int) -> MethodPolicy:
         solve=solve,
         propose=propose,
         reward=money_reward,
-        proposal_calls_per_candidate=1,
+        proposal_calls_per_candidate=2,
         engine=Policies(selection=SoftMixed(seed=seed)),
         reflective=True,
     )

--- a/tests/test_aflow_upstream.py
+++ b/tests/test_aflow_upstream.py
@@ -1,0 +1,118 @@
+"""AFlow against `FoundationAgents/AFlow@3f457218`, not against its own docstring.
+
+The port ran, reported "soft mixed probability", and picked uniformly. Every test
+here is a line of upstream that the port had paraphrased rather than implemented.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from examples.aflow import aflow_workflow_search as af
+
+
+def test_the_probability_formula_matches_compute_probabilities():
+    """`mixed = lambda_ * (1/n) + (1 - lambda_) * exp(a*(s-s_max))/sum(...)`."""
+    import math
+
+    scores = [0.9, 0.55, 0.4]
+    policy = af.SoftMixed()
+    scaled = [s * af.SCORE_SCALE for s in scores]
+    s_max = max(scaled)
+    weights = [math.exp(af.ALPHA * (s - s_max)) for s in scaled]
+    total = sum(weights)
+    expected = [af.LAMBDA / 3 + (1 - af.LAMBDA) * w / total for w in weights]
+
+    got = policy.probabilities(scores)
+    assert [round(p, 12) for p in got] == [round(p, 12) for p in expected]
+    assert abs(sum(got) - 1.0) < 1e-9
+
+
+def test_a_flat_pool_is_uniform_and_a_spread_pool_is_not():
+    policy = af.SoftMixed()
+    flat = policy.probabilities([0.5, 0.5, 0.5, 0.5])
+    assert max(flat) - min(flat) < 1e-9
+    # λ/n + (1-λ) is the ceiling the mixture allows, and an 0.8 gap saturates it:
+    # exp(0.2*100*-0.8) is 1e-7, so the softmax term is entirely on the leader.
+    spread = policy.probabilities([0.9, 0.1])
+    ceiling = af.LAMBDA / 2 + (1 - af.LAMBDA)
+    assert spread[0] == pytest.approx(ceiling, rel=1e-6), (
+        f"exploitation is missing: {spread}")
+
+
+def test_lambda_is_the_floor_a_hopeless_workflow_keeps():
+    """The uniform term is why a workflow that scores zero is still reachable --
+    upstream's exploration, and the reason λ is not folded into α."""
+    policy = af.SoftMixed()
+    probs = policy.probabilities([1.0, 0.0, 0.0, 0.0])
+    assert min(probs) == pytest.approx(af.LAMBDA / 4, rel=1e-6)
+
+
+# -- experience --------------------------------------------------------------
+
+
+def test_experience_reports_the_parents_score_and_prohibits_every_past_edit():
+    """`format_experience` prohibits successes *and* failures. What it prevents
+    is repetition, not failure -- a port that only listed failures would keep
+    proposing the modifications that already worked, which upstream's
+    `check_modification` rejects outright."""
+    exp = af.Experience()
+    exp.record("workflow-A", "add a units check", 0.40)
+    exp.resolve("workflow-A", "add a units check", 0.55)      # succeeded
+    exp.record("workflow-A", "shorten the prompt", 0.40)
+    exp.resolve("workflow-A", "shorten the prompt", 0.20)     # failed
+
+    text = exp.render("workflow-A", 0.40)
+    assert "Original Score: 0.400" in text
+    assert "-Absolutely prohibit add a units check" in text
+    assert "-Absolutely prohibit shorten the prompt (Score: 0.400)" in text
+    assert exp.tried("workflow-A") == ["add a units check", "shorten the prompt"]
+
+
+def test_experience_is_per_parent_not_global():
+    """Upstream keys `experience.json` on the *father node*: a modification tried
+    from one workflow says nothing about trying it from another."""
+    exp = af.Experience()
+    exp.record("workflow-A", "add a units check", 0.4)
+    assert exp.tried("workflow-B") == []
+    assert "No experience data found" in exp.render("workflow-B", 0.0)
+
+
+def test_a_repeated_modification_is_regenerated_once():
+    """`check_modification` loops until the modification is new. Accepting a
+    repeat instead spends a candidate on an edit already known not to help."""
+    policy = af.build(0)
+    rendered = policy.strategy.render(policy.strategy.initial())
+    task = _task()
+
+    replies = [
+        json.dumps({"modification": "same edit", "solve_instruction": "a",
+                    "review_instruction": "b"}),
+        json.dumps({"modification": "a different edit", "solve_instruction": "c",
+                    "review_instruction": "d"}),
+    ]
+    units = []
+
+    def llm(prompt, **kw):
+        units.append(kw.get("unit", ""))
+        return replies[min(len(units) - 1, len(replies) - 1)]
+
+    policy.propose(llm, rendered, task, "140", 0.0)   # records "same edit"
+    units.clear()
+    replies[:] = [replies[0], replies[1]]
+    out = policy.propose(llm, rendered, task, "140", 0.0)
+
+    assert len(units) == 2, "the repeat was accepted instead of regenerated"
+    assert units[1].endswith(":regenerate")
+    assert json.loads(out)["modification"] == "a different edit"
+
+
+def test_the_regeneration_is_inside_the_declared_budget():
+    assert af.build(0).proposal_calls_per_candidate == 2
+
+
+def _task():
+    from agentdescent.evolution import Task
+    return Task(id="train:m00", prompt="A pen costs $1.40. What is the total?",
+                meta={"answer_cents": "140", "split": "train"})

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -67,17 +67,29 @@ def test_guarded_discards_more_than_reflective():
         f"guarded wasted {g.discarded_stale}/{g.proposals} of its evidence and "
         f"reflective {r.discarded_stale}/{r.proposals}; rebasing is supposed to "
         "recover what the budget would otherwise throw away")
-    # Recovering that work cannot leave Reflective *materially* behind, and both
-    # must progress. Not `r >= g`: both runs stop at the first sweep that crosses
-    # `target_accuracy` (0.95 here), so the value each one *lands* on is a
-    # stopping artifact rather than a measure of the policy. Guarded takes
-    # hundreds of small sweeps and can land exactly on 1.000; Reflective takes
-    # ~8 large ones and lands wherever its batch put it (0.966 is common). That
-    # made the strict comparison fail roughly one run in six, on an assertion the
-    # test is not about. Both stopped past the same bar, so the widest legitimate
-    # gap is the width of the band above it.
-    assert r.final_dev_accuracy >= g.final_dev_accuracy - 0.05
-    assert g.final_dev_accuracy > 0.0
+    # Both policies must have got somewhere, and neither may end below the seed.
+    #
+    # What is deliberately *not* asserted is the two accuracies against each
+    # other. That comparison was here twice -- first as `r >= g`, then widened to
+    # `r >= g - 0.05` -- and failed CI both times, most recently at 0.931 against
+    # 1.000 on 3.11 while 3.9 and 3.12 passed. Widening it a third time would be
+    # the wrong move, because the assertion cannot succeed for a policy reason:
+    #
+    #   * These runs stop at whichever comes first, crossing `target_accuracy`
+    #     or exhausting `max_seconds`. When *both* cross the bar, both land in
+    #     [0.95, 1.0] and a 0.05 band is satisfied by arithmetic, testing
+    #     nothing. When one runs out of wall-clock instead, the gap measures how
+    #     many rollouts the CI runner fit into 12 seconds.
+    #   * So every value it can distinguish is a stopping artifact, and every
+    #     value it cannot is a tautology.
+    #
+    # The claim the test is actually named for -- guarded wastes work, reflective
+    # recovers it -- is the two assertions above, and they are stable because a
+    # discard *rate* does not depend on how long the machine ran.
+    assert g.final_dev_accuracy > 0.0 and r.final_dev_accuracy > 0.0
+    for name, stats in (("guarded", g), ("reflective", r)):
+        assert stats.commits >= 1, f"{name} never committed anything"
+        assert stats.error is None, f"{name} ended on {stats.error}"
 
 
 def test_stable_branch_promotes_under_async():

--- a/tests/test_candidate_methods.py
+++ b/tests/test_candidate_methods.py
@@ -315,16 +315,57 @@ def test_binary_tournament_prefers_the_pair_winner():
     assert tally[0.9] > tally[0.1]
 
 
-def test_soft_mixed_keeps_the_seed_and_favours_scores():
+def test_soft_mixed_pool_is_top_k_by_score_with_no_seat_reserved_for_the_seed():
+    """This used to assert the seed was always reachable, which the port
+    guaranteed by appending it to the pool. Upstream does not: `get_top_rounds`
+    moves round 1 to the *front* only when it already made the cut, and
+    `select_round` re-sorts by score immediately afterwards -- so the reordering
+    changes nothing and membership is the whole rule."""
     policy = SoftMixed(alpha=5.0, lam=0.2, top_k=2, seed=0)
     seed_candidate = SimpleNamespace(score=0.0)
     ctx = SimpleNamespace(
         candidates=[seed_candidate] + _candidates([0.2, 0.9, 0.8]))
     picks = policy.select(ctx, 200)
     scores = [p.score for p in picks]
-    assert scores.count(0.9) > scores.count(0.8) >= 0
-    # λ-uniform keeps the seed reachable even at score 0.
-    assert 0.0 in scores
+    assert set(scores) <= {0.9, 0.8}, "a candidate outside the top-2 was picked"
+    assert scores.count(0.9) > scores.count(0.8) > 0
+
+    # Inside the pool, λ-uniform keeps even a zero-scoring workflow reachable.
+    wide = SoftMixed(alpha=5.0, lam=0.2, top_k=4, seed=0)
+    reachable = [p.score for p in wide.select(ctx, 400)]
+    assert 0.0 in reachable
+
+
+def test_soft_mixed_scales_scores_by_a_hundred_or_it_is_a_coin_flip():
+    """`select_round` computes `scores = [item["score"] * 100 ...]` before the
+    softmax, and upstream's benchmark scores are accuracies in [0, 1] exactly
+    like this port's -- so the scaling is not a unit conversion, it *is* the
+    temperature.
+
+    Dropping it does not raise, does not change the shape of the code, and does
+    not stop the port reporting "soft mixed probability". It just deletes AFlow's
+    exploitation: over a pool scoring 0.50 / 0.40 / 0.25 / 0.10 the distribution
+    goes from [0.688, 0.158, 0.079, 0.075] to [0.265, 0.257, 0.245, 0.233],
+    which is uniform to three digits.
+    """
+    scores = [0.50, 0.40, 0.25, 0.10]
+    upstream = SoftMixed().probabilities(scores)
+    assert [round(p, 3) for p in upstream] == [0.688, 0.158, 0.079, 0.075]
+
+    unscaled = SoftMixed(scale=1.0).probabilities(scores)
+    assert max(unscaled) - min(unscaled) < 0.05, (
+        "without the scaling this should be indistinguishable from uniform")
+    assert upstream[0] > 4 * upstream[1], "the top workflow is barely preferred"
+
+
+def test_soft_mixed_uses_the_pinned_revisions_own_constants():
+    """0.2 / 0.3 are `DataUtils.DEFAULT_ALPHA` / `DEFAULT_LAMBDA`; the paper says
+    0.4 / 0.2. Where released code and paper disagree about a constant, the code
+    is what produced the published numbers -- the same call as OpenEvolve's
+    `exploitation_ratio`, where the example's own config beat the library default.
+    """
+    policy = SoftMixed()
+    assert (policy.alpha, policy.lam, policy.top_k) == (0.2, 0.3, 4)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Second of the eleven unmeasured MethodPolicy rows in #73. **Also fixes the flake that turned `main` red** — see the last section.

## One missing line deleted AFlow's exploitation

`select_round` scales scores by 100 before the softmax:

```python
scores = [item["score"] * 100 for item in sorted_items]
```

The port dropped it. Upstream's `alpha` is 0.2 *against percentages*, so the effective temperature is 20 against accuracies in `[0, 1]` — and this port's scores are accuracies in `[0, 1]` exactly as upstream's are, so the scaling is **not a unit conversion. It is the temperature.**

Over a pool scoring 0.50 / 0.40 / 0.25 / 0.10:

| | pick distribution |
|---|---|
| upstream | `[0.688, 0.158, 0.079, 0.075]` |
| this port, before | `[0.265, 0.257, 0.245, 0.233]` |
| uniform | `[0.250, 0.250, 0.250, 0.250]` |

Uniform to three digits. The port ran, logged "soft mixed probability", and had no exploitation at all.

**An offline test was protecting the bug.** `test_soft_mixed_keeps_the_seed_and_favours_scores` asserted the seed workflow was always reachable — true only because the port appended it to the pool unconditionally. Upstream's `get_top_rounds` moves round 1 to the *front* only when it already made the cut, and `select_round` re-sorts by score immediately after, so that move changes nothing and membership is the whole rule.

## Three smaller departures

| upstream (`3f457218`) | was |
|---|---|
| `DEFAULT_ALPHA = 0.2`, `DEFAULT_LAMBDA = 0.3` | the paper's 0.4 / 0.2 |
| `format_experience` reports the parent's score and prohibits successes *and* failures | last 3 modifications, no score, no outcome |
| `check_modification` regenerates rather than accept a repeated modification | a repeat was accepted |

On the constants: where released code and paper disagree, the code is what produced the published numbers — the same call as OpenEvolve's `exploitation_ratio`. On experience: upstream prohibits successes too, because what it prevents is *repetition*, not failure. The regeneration retries once (upstream loops without bound), declared with `proposal_calls_per_candidate = 2`.

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`, `--reflective-merge`, `deepseek-v4-flash`:

| seed | test | validation | accepted | calls |
|---|---|---:|---:|---:|
| 0 | 0.000 → **0.812** | 0.000 → 0.938 | 3/80 | 767 |
| 1 | 0.000 → **0.938** | 0.000 → 0.938 | 2/80 | 728 |
| 2 | 0.000 → **0.938** | 0.000 → 1.000 | 3/80 | 767 |

Three of three seeds moved, mean **0.896**, against a domain ceiling of 1.000.

### The cross-algorithm comparison

[PromptBreeder](https://github.com/Birfy/agentdescent/blob/main/docs/algo-promptbreeder.md) reaches **0.271** on the same 48 items, same model, same budget — and its successful seeds stall just under the *format-only* ceiling of 0.479: it discovers what the grader wants and not that it may reason first.

AFlow does both, and the reason is **topology, not tuning**. Its workflow is two nodes — Solve, then ReviewAndRevise — so the arithmetic and the output convention have separate places to live. A single instruction has to hold both at once, and the prompts that nail the format are the ones that forbid the working.

Same domain, same runtime, same budget; the mechanism is the variable. That is what the matrix is for.

## The `main` flake

`test_guarded_discards_more_than_reflective` compared the two policies' final accuracies. That assertion had **already been widened once** (`r >= g` → `r >= g - 0.05`) and failed again at 0.931 against 1.000 on 3.11, while 3.9 and 3.12 passed.

Removed rather than widened a third time, because it cannot succeed or fail for a policy reason:

- These runs stop at whichever comes first — crossing `target_accuracy` or exhausting `max_seconds`.
- When **both** cross the bar, both land in `[0.95, 1.0]` and a 0.05 band is satisfied by arithmetic, testing nothing.
- When one runs out of wall-clock instead, the gap measures how many rollouts the CI runner fit into 12 seconds.

Every value it can distinguish is a stopping artifact; every value it cannot is a tautology. The claim the test is named for — guarded wastes work, reflective recovers it — is the two **discard-rate** assertions, and a rate does not depend on how long the machine ran. Repeated 6× locally after the change.

## Verification

Full offline suite green (exit 0), including 8 new tests in `tests/test_aflow_upstream.py` written against the pinned upstream source rather than the port's docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)