### PR TITLE
feat(reflexion): the reflector was answering the arithmetic, not reflecting

### DIFF
--- a/bench/results/reflexion-episodic-memory.json
+++ b/bench/results/reflexion-episodic-memory.json
@@ -1,0 +1,86 @@
+{
+ "experiment": "Reflexion episodic memory on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "noahshinn/reflexion@218cf0ef",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": true,
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "window": 3,
+  "domain": "money, 48 items, 16/16/16 splits"
+ },
+ "without_few_shot_examples": {
+  "test": [
+   0.125,
+   0.0,
+   0.062
+  ],
+  "note": "the reflector answered the arithmetic instead of planning: 40 reflections produced 40 bare numbers, 1 mentioned the output convention, and the memory finished empty"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.0,
+    0.125
+   ],
+   "validation": [
+    0.0,
+    0.312
+   ],
+   "accepted": 4,
+   "invalid": 0,
+   "wall_s": 98.5,
+   "engine_s": 43.5,
+   "calls": 440
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.0,
+    0.125
+   ],
+   "validation": [
+    0.0,
+    0.188
+   ],
+   "accepted": 2,
+   "invalid": 0,
+   "wall_s": 98.4,
+   "engine_s": 42.6,
+   "calls": 455
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.0,
+    0.812
+   ],
+   "validation": [
+    0.0,
+    0.875
+   ],
+   "accepted": 1,
+   "invalid": 0,
+   "wall_s": 108.5,
+   "engine_s": 49.5,
+   "calls": 487
+  }
+ ],
+ "summary": {
+  "test_quality": {
+   "min": 0.125,
+   "median": 0.125,
+   "max": 0.812,
+   "mean": 0.354
+  },
+  "seeds_that_moved": 3,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-reflexion.md
+++ b/docs/algo-reflexion.md
@@ -36,15 +36,57 @@ append-only and bounded to the last Ω entries (Ω=1–3 in the paper;
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`--reflective-merge`, `deepseek-v4-flash` at temperature 0.7. Recorded in
+[`bench/results/reflexion-episodic-memory.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/reflexion-episodic-memory.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
+| seed | test quality | validation | accepted | calls |
 |---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| 0 | 0.000 → **0.125** | 0.000 → 0.312 | 4/80 | 440 |
+| 1 | 0.000 → **0.125** | 0.000 → 0.188 | 2/80 | 455 |
+| 2 | 0.000 → **0.812** | 0.000 → 0.875 | 1/80 | 487 |
+
+Mean 0.354. All three seeds moved, and the spread — two at 0.125 against one at
+0.812 — is the result rather than noise around a central value.
+
+### Against the other mechanisms
+
+Same 48 items, same model, same 80-rollout budget:
+
+| | mean test |
+|---|---|
+| [AFlow](algo-aflow.md) | 0.896 |
+| **Reflexion** | 0.354 |
+| [PromptBreeder](algo-promptbreeder.md) | 0.271 |
+
+Reflexion is being asked a question its paper does not ask. Upstream's memory is
+**per task instance** and its whole premise is retrying *that* instance; this
+port shares one memory across the domain, so what is measured is whether verbal
+reflection **transfers**. The answer here is "partly, and unreliably".
+
+!!! danger "Without the worked examples, the reflector answered the arithmetic"
+    `_generate_reflection_query` prepends `FEW_SHOT_EXAMPLES` under *"Here are
+    two examples:"* — two failed trajectories each followed by its `New plan:`.
+    A first version of this port matched upstream's **wording** and dropped that
+    **structure**, and the run scored 0.125 / 0.000 / 0.062.
+
+    Measured over 40 reflections with no examples:
+
+    | | |
+    |---|---|
+    | reflections generated | 40 |
+    | that mentioned the output convention | **1** |
+    | the first four, verbatim | `925`, `264`, `465`, `$32.15` |
+    | entries in the final memory | **0** |
+
+    The query ends in `New plan:` and contains a question and its answer, so with
+    nothing to imitate the likelier continuation is simply to answer it. The
+    entries were then useless, nothing cleared the acceptance gate, the memory
+    stayed empty, and every rollout saw the bare seed instruction. Adding the
+    examples took the mean from 0.062 to 0.354.
+
+    The first draft of those examples used `m03` and `m11` — real domain items,
+    which land in held-out or test depending on the seed, so every reflection
+    prompt in the run handed over two graded answers.
+    `test_the_examples_do_not_hand_over_a_held_out_answer` caught it; the items
+    are invented now.

--- a/examples/reflexion/reflexion_episodic_memory.py
+++ b/examples/reflexion/reflexion_episodic_memory.py
@@ -1,16 +1,33 @@
 """Mechanism microport: **Reflexion** (noahshinn/reflexion@218cf0ef).
 
-Preserved: the memory is **append-only and bounded** -- upstream appends each
-verbal reflection and prompts with the last Ω (`memory[-3:]` in the alfworld
-runs; the paper bounds Ω to 1-3). :class:`~examples._method_policy.WindowedMemory`
-is exactly that shape: every accepted reflection is a new commit-ordered ledger
-key, the rendered prompt shows the last three, and parallel workers'
-reflections **union-merge** with no ranking evaluation, because appends never
-contradict.
+Preserved: the reflection query carries **two worked examples** of a failed
+attempt followed by its plan (`FEW_SHOT_EXAMPLES`, prepended by
+`_generate_reflection_query` under "Here are two examples:"); reflection happens
+**only after a failure**
+(`generate_reflections.update_memory`: ``if not env['is_success'] and not
+env['skip']``; `agents.py`: ``if self.step_n > 0 and not self.is_correct()``);
+the reflection prompt asks for a **plan that accounts for the mistake**, shown
+the previous plans numbered by trial, which is `_generate_reflection_query`; and
+memory is **append-only and bounded**, prompted with the last Ω
+(``memory[-3:]`` in the alfworld runs).
+:class:`~examples._method_policy.WindowedMemory` is that: every accepted
+reflection is a new commit-ordered ledger key, the rendered prompt shows the
+last three, and parallel workers' reflections **union-merge** with no ranking
+evaluation, because appends never contradict.
 
-Boundaries: upstream retries the same failed instance; the framework's
-held-out rerun is the analogue. The equal-budget design requests a reflection
-after every rollout, where upstream reflects only on failure.
+Declared generalisation -- **memory is global here, and per-instance upstream.**
+`env_configs[i]['memory']` is one list per task instance, and the HotpotQA header
+says so outright: *"You have attempted to answer following question before and
+failed."* Reflexion is an inference-time method that retries **the same
+instance**, and it does not claim transfer to unseen ones. A faithful
+per-instance memory would be empty for every held-out task, so the row would
+measure nothing at all; this port carries one shared memory instead and is
+therefore asking a question Reflexion does not ask -- whether verbal reflection
+*transfers*. That is worth measuring and is not what the paper measured, so it
+is stated here rather than implied by a window that happens to match.
+
+Boundary: upstream retries the same failed instance; the framework's held-out
+rerun is the analogue.
 """
 
 from __future__ import annotations
@@ -19,13 +36,56 @@ from typing import Optional
 
 from agentdescent.evolution import Task
 
-from examples._method_policy import MethodPolicy, WindowedMemory
+from examples._method_policy import MethodPolicy, WindowedMemory, read_fields
 from examples._method_runner import standard_main
 from examples._money_domain import (STARTING_INSTRUCTION, feedback,
                                     money_reward, money_splits, solve_money)
 
 
 FIDELITY = "mechanism_microport"
+
+#: `prompts.REFLECTION_HEADER`, with "question" generalised to "problem" because
+#: this memory is shared across the domain rather than bound to one instance.
+MEMORY_HEADER = (
+    "# Plans from past attempts. You have attempted problems like this before "
+    "and failed; these plans say how to avoid failing the same way. Use them to "
+    "improve your strategy (most recent last)."
+)
+
+#: `reflexion_few_shot_examples.txt`, in this domain. Without them the reflector
+#: does not write a plan -- it answers the arithmetic. Measured: 40 reflections
+#: against no examples produced 40 bare numbers (`925`, `264`, `$32.15`), one of
+#: which mentioned the output convention, and the memory finished empty because
+#: nothing that useless ever cleared the acceptance gate. The prompt ends in
+#: "New plan:" and contains a question and its answer; with nothing to imitate,
+#: answering the question is the likelier continuation.
+#:
+#: The two items are **invented**, not drawn from `TASKS`. The first draft used
+#: `m03` and `m11`, which land in held-out or test depending on the seed, so
+#: every reflection prompt in the run handed over two graded answers --
+#: `test_the_examples_do_not_hand_over_a_held_out_answer` is what caught it.
+FEW_SHOT_EXAMPLES = """A ticket is $6.30 and a badge is $1.20. What is the total amount?
+Attempt: The total is $7.50.
+The evaluator read the final line of the reply: '$7.50'
+It wanted: '750'
+STATUS: FAIL
+New plan: I computed the sum correctly and then reported it the way a person \
+writes money, with a dollar sign and a decimal point. The evaluator did not \
+accept that string. I should have converted the dollar amount to whole cents \
+and written that integer on its own line with nothing else on it. Next time I \
+will finish the arithmetic in dollars, multiply by 100, and put only that \
+integer on the final line.
+
+Five friends split a $21.50 bill equally. What amount does each pay?
+Attempt: 2150
+The evaluator read the final line of the reply: '2150'
+It wanted: '430'
+STATUS: FAIL
+New plan: I wrote the total in cents instead of each person's share -- I had \
+the output convention right and skipped an operation the question asked for. I \
+should have divided by the number of people before converting. Next time I will \
+restate which quantity is being asked for before computing, and check that every \
+operation named in the question appears in my working."""
 
 
 def build(seed: int) -> MethodPolicy:
@@ -34,14 +94,27 @@ def build(seed: int) -> MethodPolicy:
 
     def propose(llm, rendered: str, task: Task, output: str,
                 reward: float) -> Optional[str]:
+        # `if not env['is_success'] and not env['skip']`. Reflecting on a success
+        # too is not a cheaper version of Reflexion -- it fills the window with
+        # entries the paper's memory never contains, and the window is bounded,
+        # so each one evicts a lesson drawn from an actual failure. The runner's
+        # budget check is `observed <= expected`, so declining costs nothing.
+        if reward >= 1.0:
+            return None
         return llm(
             (
-                "You are Reflexion's verbal reflection module. Convert the failed "
-                "trajectory and external evaluator signal into one reusable "
-                "episodic memory entry for retry.\n\n"
-                f"Current memory:\n{rendered}\n\n"
-                f"Reward: {reward}\n{feedback(task, output)}\n\n"
-                "Return only one reusable lesson; omit item-specific numbers."
+                "You will be given the history of a past attempt at a problem "
+                "you were unsuccessful at. Do not summarize the problem; think "
+                "about the strategy you took. Devise a concise, new plan of "
+                "action that accounts for your mistake, with reference to the "
+                "specific steps you should have taken. Write the plan, not an "
+                "answer. Here are two examples:\n\n"
+                f"{FEW_SHOT_EXAMPLES}\n\n"
+                f"{rendered}\n\n"
+                f"Here is the attempt:\n{feedback(task, output)}\n"
+                f"External evaluator reward: {reward}\n"
+                "STATUS: FAIL\n\n"
+                "New plan:"
             ),
             unit=task.id,
         )
@@ -51,11 +124,15 @@ def build(seed: int) -> MethodPolicy:
         name="reflexion",
         fidelity=FIDELITY,
         notes=(
+            "The reflection query carries two worked examples of a failed attempt and its plan, as _generate_reflection_query prepends FEW_SHOT_EXAMPLES; without them the reflector answers the arithmetic instead of planning.",
+            "Reflection is requested only after a failed rollout, as update_memory and Agent.run both gate on success.",
+            "The reflection prompt asks for a plan that accounts for the mistake and shows the previous plans, matching _generate_reflection_query.",
             "Memory is append-only and rendered as the last three entries, matching upstream's bounded window.",
-            "Attempt, external feedback, verbal reflection, and retry map to rollout, proposal, and gate rerun.",
+            "Memory is global where upstream's is per task instance: Reflexion retries the same instance and claims no transfer, so this port asks whether reflection transfers at all.",
             "A deterministic arithmetic evaluator replaces HotpotQA/ALFWorld.",
         ),
-        strategy=WindowedMemory(seed_text=STARTING_INSTRUCTION, window=3),
+        strategy=WindowedMemory(seed_text=STARTING_INSTRUCTION, window=3,
+                                title=MEMORY_HEADER),
         train_tasks=tuple(train),
         held_out_tasks=tuple(held_out),
         test_tasks=tuple(test),

--- a/tests/test_reflexion_upstream.py
+++ b/tests/test_reflexion_upstream.py
@@ -1,0 +1,154 @@
+"""Reflexion against `noahshinn/reflexion@218cf0ef`.
+
+The trigger is the mechanism. Reflexion reflects on *failure*; a port that
+reflects on every rollout still runs, still fills a memory, and fills it with
+entries the paper's memory never contains -- while the window is bounded, so each
+one evicts a lesson drawn from an actual failure.
+"""
+from __future__ import annotations
+
+from agentdescent.evolution import Task
+
+from examples.reflexion import reflexion_episodic_memory as rx
+
+
+def _task():
+    return Task(id="train:m00", prompt="A pen costs $1.40. What is the total?",
+                meta={"answer_cents": "140", "split": "train"})
+
+
+def _policy():
+    return rx.build(0)
+
+
+def test_a_successful_rollout_produces_no_reflection():
+    """`update_memory`: `if not env['is_success'] and not env['skip']`.
+    `agents.Agent.run`: `if self.step_n > 0 and not self.is_correct()`."""
+    policy = _policy()
+    calls = []
+    llm = lambda prompt, **kw: calls.append(prompt) or "a plan"
+
+    rendered = policy.strategy.render(policy.strategy.initial())
+    assert policy.propose(llm, rendered, _task(), "140", 1.0) is None
+    assert calls == [], "a reflection was requested after a success"
+
+
+def test_a_failed_rollout_does_produce_one():
+    policy = _policy()
+    calls = []
+    llm = lambda prompt, **kw: (calls.append(prompt), "a plan")[1]
+
+    rendered = policy.strategy.render(policy.strategy.initial())
+    assert policy.propose(llm, rendered, _task(), "$1.40", 0.0) == "a plan"
+    assert len(calls) == 1
+
+
+def test_the_reflection_prompt_asks_for_a_plan_and_shows_the_past_ones():
+    """`_generate_reflection_query` asks for "a concise, new plan of action that
+    accounts for your mistake with reference to specific actions you should have
+    taken", and appends the previous plans. A prompt asking instead for "one
+    reusable lesson, omit item-specific numbers" is a different operator."""
+    policy = _policy()
+    seen = {}
+
+    def llm(prompt, **kw):
+        seen["prompt"] = prompt
+        return "a plan"
+
+    state = policy.strategy.initial()
+    diff = policy.strategy.to_diff(state, "check the units before answering",
+                                   "w", 1, "candidate-reflexion")
+    state = {**state, **diff.ops}
+    policy.propose(llm, policy.strategy.render(state), _task(), "$1.40", 0.0)
+
+    prompt = seen["prompt"]
+    assert "new plan of action that accounts for your mistake" in prompt
+    assert "specific steps you should have taken" in prompt
+    assert "check the units before answering" in prompt, (
+        "the previous plans were not shown to the reflector")
+    assert prompt.rstrip().endswith("New plan:")
+
+
+def test_the_window_is_the_last_three_entries():
+    """`memory[-3:]` in the alfworld runs; the paper bounds omega to 1-3."""
+    policy = _policy()
+    state = policy.strategy.initial()
+    for i in range(5):
+        diff = policy.strategy.to_diff(state, f"plan {i}", "w", i,
+                                       "candidate-reflexion")
+        state = {**state, **diff.ops}
+    rendered = policy.strategy.render(state)
+    assert "plan 4" in rendered and "plan 3" in rendered and "plan 2" in rendered
+    assert "plan 0" not in rendered and "plan 1" not in rendered
+
+
+def test_the_rendered_memory_frames_the_entries_as_plans_after_failure():
+    """`REFLECTION_HEADER` tells the solver these are plans from *failed*
+    attempts. Rendering them as an undifferentiated list drops the framing the
+    solver is meant to act on."""
+    policy = _policy()
+    rendered = policy.strategy.render(policy.strategy.initial())
+    assert "failed" in rendered.lower() and "plan" in rendered.lower()
+
+
+def test_the_global_memory_generalisation_is_declared():
+    """Upstream keys memory on the task instance (`env_configs[i]['memory']`) and
+    its header says "You have attempted to answer following question before".
+    This port shares one memory across the domain, which is a different question
+    -- whether reflection *transfers* -- and the notes have to say so, because a
+    reader comparing the window alone would find them identical."""
+    notes = " ".join(_policy().notes).lower()
+    assert "per task instance" in notes and "transfer" in notes
+
+
+def test_the_reflection_query_carries_worked_examples():
+    """`_generate_reflection_query` prepends `FEW_SHOT_EXAMPLES` under "Here are
+    two examples:", and dropping them is not a shortened prompt -- it changes
+    what the module does.
+
+    Measured without them: 40 reflections produced 40 bare numbers -- `925`,
+    `264`, `$32.15` -- one of which mentioned the output convention, and the
+    memory finished empty because nothing that useless cleared the gate. The
+    query ends in "New plan:" and contains a question and its answer; with
+    nothing to imitate, answering the question is the likelier continuation.
+    """
+    policy = _policy()
+    seen = {}
+
+    def llm(prompt, **kw):
+        seen["prompt"] = prompt
+        return "a plan"
+
+    rendered = policy.strategy.render(policy.strategy.initial())
+    policy.propose(llm, rendered, _task(), "$1.40", 0.0)
+
+    prompt = seen["prompt"]
+    assert "Here are two examples:" in prompt
+    assert prompt.count("New plan:") >= 3, (
+        "the examples must show the answer shape, not just ask for it")
+    assert prompt.count("STATUS: FAIL") >= 3
+    assert rx.FEW_SHOT_EXAMPLES in prompt
+
+
+def test_the_examples_are_plans_rather_than_answers():
+    """An example that ends in a bare number teaches the model to end in a bare
+    number, which is exactly the failure the examples exist to prevent."""
+    for block in rx.FEW_SHOT_EXAMPLES.split("New plan: ")[1:]:
+        plan = block.split("\n")[0]
+        assert len(plan) > 80, f"too terse to be a plan: {plan!r}"
+        assert "next time" in plan.lower() or "should have" in plan.lower()
+
+
+def test_the_examples_do_not_hand_over_a_held_out_answer():
+    """They are worked examples, so they contain answers -- which makes it worth
+    checking that the items they use are the domain's own, and that a method
+    memorising them learns nothing a held-out item would reward."""
+    from examples._money_domain import money_splits
+
+    for seed in (0, 1, 2):
+        _, held_out, test = money_splits(seed)
+        for task in list(held_out) + list(test):
+            answer = str(task.meta["answer_cents"])
+            shown = f"It wanted: '{answer}'"
+            assert shown not in rx.FEW_SHOT_EXAMPLES, (
+                f"seed {seed}: the examples hand over {task.id}'s answer")


### PR DESCRIPTION
Third of the eleven unmeasured MethodPolicy rows in #73.

## The reflector never reflected

`_generate_reflection_query` prepends `FEW_SHOT_EXAMPLES` under *"Here are two examples:"* — two failed trajectories, each followed by its `New plan:`. This port matched upstream's **wording** and dropped that **structure**.

Measured over 40 reflections with no examples:

| | |
|---|---|
| reflections generated | 40 |
| that mentioned the output convention | **1** |
| the first four, verbatim | `925`, `264`, `465`, `$32.15` |
| entries in the final memory | **0** |

The query ends in `New plan:` and contains a question and its answer, so with nothing to imitate the likelier continuation is simply to **answer it**. The entries were then useless, nothing cleared the acceptance gate, the memory stayed empty, and every rollout saw the bare seed instruction.

Mean test quality **0.062 → 0.354** once the examples were added.

## Two more departures

| upstream (`218cf0ef`) | was |
|---|---|
| reflect **only on failure** (`if not env['is_success']`; `if not self.is_correct()`) | reflected after every rollout |
| ask for "a concise, new plan of action that accounts for your mistake, with reference to specific actions you should have taken" | asked for "one reusable lesson; omit item-specific numbers" |

Reflecting on successes is not a cheaper Reflexion: the window is bounded at three, so each such entry **evicts a lesson drawn from an actual failure**. The rendered memory now also carries `REFLECTION_HEADER`'s framing — these are plans from attempts that *failed*.

## Declared, not implied: memory scope

`env_configs[i]['memory']` is one list **per task instance**, and the HotpotQA header says it outright: *"You have attempted to answer following question before and failed."* Reflexion is an inference-time method that retries **the same instance** and claims no transfer.

A faithful per-instance memory would be empty for every held-out task, so the row would measure nothing at all. This port shares one memory and is therefore asking a question the paper does not — whether verbal reflection **transfers**. Two notes and a test now say so, because a reader comparing the window length alone would find the two identical.

## A leak my own test caught

The first draft of the worked examples used `m03` and `m11` — real domain items, which land in held-out or test depending on the seed, so **every reflection prompt in the run handed over two graded answers**. `test_the_examples_do_not_hand_over_a_held_out_answer` caught it; the items are invented now.

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`, `--reflective-merge`, `deepseek-v4-flash`:

| seed | test | validation | accepted | calls |
|---|---|---:|---:|---:|
| 0 | 0.000 → **0.125** | 0.000 → 0.312 | 4/80 | 440 |
| 1 | 0.000 → **0.125** | 0.000 → 0.188 | 2/80 | 455 |
| 2 | 0.000 → **0.812** | 0.000 → 0.875 | 1/80 | 487 |

Mean 0.354; all three seeds moved, and the spread — two at 0.125 against one at 0.812 — is the result rather than noise around a centre.

### Three mechanisms, same 48 items, same model, same budget

| | mean test |
|---|---|
| [AFlow](https://github.com/Birfy/agentdescent/blob/main/docs/algo-aflow.md) | 0.896 |
| **Reflexion** | 0.354 |
| [PromptBreeder](https://github.com/Birfy/agentdescent/blob/main/docs/algo-promptbreeder.md) | 0.271 |

AFlow's gain is structural — two nodes, so arithmetic and output convention have separate homes, and every seed benefits. Reflexion's depends on which failures it happened to draw, which is why its spread is the widest of the three.

## Verification

CI. The offline suite was green locally through 87% when it was stopped in favour of running the gate here; 9 new tests in `tests/test_reflexion_upstream.py` and the full `tests/test_candidate_methods.py` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)