### PR TITLE
fix(method-runner): --reflective-merge was accepted by eleven ports and never read

### DIFF
--- a/bench/results/promptbreeder-algorithm1.json
+++ b/bench/results/promptbreeder-algorithm1.json
@@ -27,59 +27,91 @@
    "seed": 0,
    "test": [
     0.0,
-    0.438
+    0.875
    ],
    "validation": [
     0.0,
-    0.312
+    0.688
    ],
-   "accepted": 5,
-   "invalid": 2,
-   "wall_s": 364.9,
-   "engine_s": 307.1,
-   "calls": 631
+   "accepted": 4,
+   "invalid": 11,
+   "wall_s": 400.4,
+   "engine_s": 329.8,
+   "calls": 627
   },
   {
    "seed": 1,
    "test": [
     0.0,
-    0.0
+    1.0
    ],
    "validation": [
     0.0,
-    0.0
+    1.0
    ],
-   "accepted": 1,
-   "invalid": 4,
-   "wall_s": 594.4,
-   "engine_s": 532.1,
+   "accepted": 3,
+   "invalid": 10,
+   "wall_s": 426.6,
+   "engine_s": 350.8,
    "calls": 638
   },
   {
    "seed": 2,
    "test": [
     0.0,
-    0.375
+    1.0
    ],
    "validation": [
     0.0,
-    0.375
+    1.0
    ],
-   "accepted": 4,
-   "invalid": 2,
-   "wall_s": 376.9,
-   "engine_s": 315.1,
-   "calls": 640
+   "accepted": 3,
+   "invalid": 9,
+   "wall_s": 372.1,
+   "engine_s": 306.9,
+   "calls": 592
   }
  ],
  "summary": {
   "test_quality": {
-   "min": 0.0,
-   "median": 0.375,
-   "max": 0.438,
-   "mean": 0.271
+   "min": 0.875,
+   "median": 1.0,
+   "max": 1.0,
+   "mean": 0.958
   },
-  "seeds_that_moved": 2,
+  "seeds_that_moved": 3,
   "total_seeds": 3
+ },
+ "an_earlier_run_of_this_exact_command": {
+  "test": [
+   0.438,
+   0.0,
+   0.375
+  ],
+  "note": "same script, same code, same seeds. The seed fixes the data splits and the operator sampler, not the model, which is sampled at temperature 0.7 -- so one run per seed does not pin a number"
+ },
+ "reflective_merge_control": {
+  "note": "paired runs at the same seed with the model merge on and off. `--reflective-merge` was accepted by all eleven ports and never read, so an earlier version of this control compared two identical configurations",
+  "seed_0": {
+   "on": {
+    "test": 0.875,
+    "calls": 627
+   },
+   "off": {
+    "test": 0.875,
+    "calls": 1749
+   }
+  },
+  "seed_1": {
+   "on": {
+    "test": 1.0,
+    "calls": 638
+   },
+   "off": {
+    "test": 0.938,
+    "calls": 1739
+   }
+  },
+  "finding": "the model merge costs 2.7-2.8x fewer calls at no cost in quality, because it replaces ranking contested diffs on the cheap layer and ranking needs evaluations"
  }
 }

--- a/docs/algo-aflow.md
+++ b/docs/algo-aflow.md
@@ -65,6 +65,15 @@ the ones that forbid the working.
 That is the comparison the matrix exists for: same domain, same runtime, same
 budget, and the mechanism is the variable.
 
+
+!!! note "These cross-algorithm figures demonstrate that each port runs, not which is best"
+    Every row is one run per seed, and the seed fixes the data splits and the
+    method's own sampler -- **not the model**, which is sampled at temperature
+    0.7. Re-running an identical command at an identical seed moves the number:
+    PromptBreeder's seed 0 scored 0.438 on one run and 0.875 on the next, from
+    the same script and the same code. Read the table as evidence the mechanism
+    executes end to end and produces a plausible artifact; a ranking would need
+    repeats per seed, which these runs do not have.
 !!! danger "The selection rule was uniform, and said it was not"
     The port implemented `λ·uniform + (1−λ)·softmax(α·(s−s_max))` and dropped
     one line of upstream's `select_round`:

--- a/docs/algo-promptbreeder.md
+++ b/docs/algo-promptbreeder.md
@@ -73,13 +73,49 @@ disabled. Recorded in
 
 | seed | test quality | validation | accepted | calls | wall |
 |---|---|---|---|---|---|
-| 0 | 0.000 → **0.438** | 0.000 → 0.312 | 5/80 | 631 | 365 s |
-| 1 | 0.000 → 0.000 | 0.000 → 0.000 | 1/80 | 638 | 594 s |
-| 2 | 0.000 → **0.375** | 0.000 → 0.375 | 4/80 | 640 | 377 s |
+| 0 | 0.000 → **0.875** | 0.000 → 0.688 | 4/80 | 627 | 400 s |
+| 1 | 0.000 → **1.000** | 0.000 → 1.000 | 3/80 | 638 | 427 s |
+| 2 | 0.000 → **1.000** | 0.000 → 1.000 | 3/80 | 592 | 372 s |
 
-**Two of three seeds moved; one found nothing.** The mean is 0.271 and the range
-is the result, not noise around it — a single seed here would have supported
-either "it works" or "it does not", depending which one was run.
+Mean 0.958 against a ceiling of 1.000. All three seeds moved.
+
+!!! warning "One run per seed does not pin a number, and this row proves it"
+    An earlier run of **this exact command, at these exact seeds, on this exact
+    code** produced 0.438 / 0.000 / 0.375 — mean 0.271 against the 0.958 above.
+    Nothing changed between them but the model's sampling.
+
+    The seed fixes the data splits and the operator sampler. It does not fix the
+    model, which is sampled at temperature 0.7, so a "three seeds" label here
+    buys three *split* draws and three *sampling* draws at once, and the second
+    kind is large. Both sets of numbers are real runs; neither is the number.
+
+    Read the table as evidence that Algorithm 1 executes end to end and evolves a
+    prompt that clears the domain. A ranking against the other ports would need
+    repeats per seed, which these runs do not have.
+
+### The merge that costs 2.8x fewer calls
+
+Paired runs at the same seed, with the model merge on and off:
+
+| seed | | test | calls |
+|---|---|---:|---:|
+| 0 | merge on | 0.875 | **627** |
+| 0 | merge off | 0.875 | 1749 |
+| 1 | merge on | 1.000 | **638** |
+| 1 | merge off | 0.938 | 1739 |
+
+`reflective_merge` replaces *ranking* contested diffs on the cheap layer, and
+ranking needs evaluations — so turning it off does not remove a model call, it
+adds a pile of evaluation ones. Quality is unchanged within the run-to-run
+spread above.
+
+That control could not have been run before this change: `--reflective-merge`
+was accepted by all eleven MethodPolicy ports and **never read**. `run_port`
+used `policy.reflective`, a per-method constant, so a run that passed the flag
+printed `reflective_merge=True` because the *policy* said so and was identical
+to a run that did not. An earlier version of this control compared two identical
+configurations, found them identical, and concluded the merge layer was not
+implicated in a failure — a refutation built on a no-op.
 
 ### What the numbers mean against the domain's own ceilings
 

--- a/docs/algo-reflexion.md
+++ b/docs/algo-reflexion.md
@@ -64,6 +64,15 @@ Reflexion is being asked a question its paper does not ask. Upstream's memory is
 port shares one memory across the domain, so what is measured is whether verbal
 reflection **transfers**. The answer here is "partly, and unreliably".
 
+
+!!! note "These cross-algorithm figures demonstrate that each port runs, not which is best"
+    Every row is one run per seed, and the seed fixes the data splits and the
+    method's own sampler -- **not the model**, which is sampled at temperature
+    0.7. Re-running an identical command at an identical seed moves the number:
+    PromptBreeder's seed 0 scored 0.438 on one run and 0.875 on the next, from
+    the same script and the same code. Read the table as evidence the mechanism
+    executes end to end and produces a plausible artifact; a ranking would need
+    repeats per seed, which these runs do not have.
 !!! danger "Without the worked examples, the reflector answered the arithmetic"
     `_generate_reflection_query` prepends `FEW_SHOT_EXAMPLES` under *"Here are
     two examples:"* — two failed trajectories each followed by its `New plan:`.

--- a/docs/algo-self-refine.md
+++ b/docs/algo-self-refine.md
@@ -64,6 +64,15 @@ that the fidelity fix below restored — where AFlow spends two calls per *rollo
 on its two workflow nodes. Fixing the fidelity halved the cost and did not trade
 anything for it.
 
+
+!!! note "These cross-algorithm figures demonstrate that each port runs, not which is best"
+    Every row is one run per seed, and the seed fixes the data splits and the
+    method's own sampler -- **not the model**, which is sampled at temperature
+    0.7. Re-running an identical command at an identical seed moves the number:
+    PromptBreeder's seed 0 scored 0.438 on one run and 0.875 on the next, from
+    the same script and the same code. Read the table as evidence the mechanism
+    executes end to end and produces a plausible artifact; a ranking would need
+    repeats per seed, which these runs do not have.
 !!! danger "FEEDBACK and REFINE are one call in the task whose domain this is"
     `GSMFeedback.__call__` makes a **single** request and splits the completion
     on a marker: `entire_output.split("def solution():")`, prose before is the

--- a/examples/_method_runner.py
+++ b/examples/_method_runner.py
@@ -187,6 +187,7 @@ def run_port(
     max_seconds: float = 300.0,
     shutdown_grace: float = 120.0,
     staleness: str = "guarded",
+    reflective: Optional[bool] = None,
 ) -> MethodRunResult:
     """Run one method through AgentDescent with an equal candidate budget."""
     if mode not in MODES:
@@ -218,7 +219,19 @@ def run_port(
         candidate_budget,
     )
     engine = policy.engine
-    if policy.reflective:
+    # `reflective=None` means "whatever the method declares", which is the
+    # fidelity statement: AFlow's contested workflow fields are model-merged
+    # because its optimizer rewrites a whole workflow, and Voyager's are not
+    # because its library overwrites a key. An explicit True/False is a
+    # deliberate override, for a control run that needs to vary exactly this.
+    #
+    # It used to be `policy.reflective` alone while `--reflective-merge` sat in
+    # the shared parser being ignored, so a run could pass the flag, print
+    # `reflective_merge=True` because the *policy* said so, and be identical to
+    # a run that did not pass it. A control experiment built on that flag
+    # measured nothing, and one in this series did.
+    use_reflective = policy.reflective if reflective is None else bool(reflective)
+    if use_reflective:
         engine = engine.merged_with(
             **reflective_merge(lambda prompt: merge_llm(prompt, unit="merge")))
     aggregator_factory = None
@@ -371,7 +384,7 @@ def run_port(
             "max_concurrency": (
                 workers if mode in ("sync_parallel", "async_pipeline") else 1
             ),
-            "reflective_merge": policy.reflective,
+            "reflective_merge": use_reflective,
             "self_verify": policy.self_verify,
             "baseline_reward": baseline_validation,
             "final_reward": result.final_reward,
@@ -391,6 +404,26 @@ def run_port(
     )
 
 
+def _reflective_override(args, policy: MethodPolicy) -> Optional[bool]:
+    """`True`/`False` when a flag says so, `None` to keep the method's own.
+
+    Both flags at once is refused rather than silently resolved: a run that asked
+    for the merge and against it has not said what it wants, and picking one is
+    how a control arm ends up measuring the other.
+    """
+    on = bool(getattr(args, "reflective_merge", False))
+    off = bool(getattr(args, "no_reflective_merge", False))
+    if on and off:
+        raise SystemExit(
+            "--reflective-merge and --no-reflective-merge are contradictory; "
+            "pass neither to use the method's own declaration")
+    if on:
+        return True
+    if off:
+        return False
+    return None
+
+
 def standard_main(build: Callable[[int], MethodPolicy],
                   argv: Optional[Sequence[str]] = None) -> int:
     """The shared ``main`` for one method's folder module.
@@ -403,6 +436,12 @@ def standard_main(build: Callable[[int], MethodPolicy],
     add_standard_args(parser, model_default="glm-5.2")
     parser.add_argument("--workers", type=int, default=2)
     parser.add_argument("--candidates", type=int, default=2)
+    parser.add_argument(
+        "--no-reflective-merge", action="store_true",
+        help=("turn the model merge off for a method that declares it. The "
+              "shared `--reflective-merge` turns it on for a method that does "
+              "not; without either, the method's own declaration stands, and "
+              "that declaration is a fidelity statement rather than a knob"))
     parser.add_argument("--staleness", default="guarded",
                         choices=["guarded", "reflective", "full"],
                         help="what to do with a diff proposed against a head the "
@@ -431,11 +470,14 @@ def standard_main(build: Callable[[int], MethodPolicy],
     mode = ("serial" if args.serial
             else "async_pipeline" if args.asynchronous
             else "sync_parallel")
+    override = _reflective_override(args, policy)
+    merge_on = policy.reflective if override is None else override
     if args.dry_run:
         print(f"{policy.name} [{policy.fidelity}] mode={mode} "
               f"candidates={args.candidates} workers={args.workers} "
               f"proposal calls={args.candidates * policy.proposal_calls_per_candidate} "
-              f"reflective_merge={policy.reflective} self_verify={policy.self_verify}")
+              f"reflective_merge={merge_on}{'' if override is None else ' (overridden)'} "
+              f"self_verify={policy.self_verify}")
         for note in policy.notes:
             print(f"  - {note}")
         print("[dry-run] no dataset or model API was accessed.")
@@ -452,7 +494,7 @@ def standard_main(build: Callable[[int], MethodPolicy],
     outcome = run_port(
         policy, recorder, mode=mode, seed=args.seed, workers=args.workers,
         candidate_budget=args.candidates, max_seconds=args.max_seconds,
-        staleness=args.staleness,
+        staleness=args.staleness, reflective=_reflective_override(args, policy),
     )
     print(f"{policy.name}/{mode}: quality {outcome.baseline_quality:.3f} -> "
           f"{outcome.final_quality:.3f}, validation "

--- a/tests/test_method_runner_flags.py
+++ b/tests/test_method_runner_flags.py
@@ -1,0 +1,72 @@
+"""Flags this runner accepts, and whether it reads them.
+
+`--reflective-merge` sat in the shared parser for all eleven MethodPolicy ports
+and was never read: `run_port` used `policy.reflective`, a per-method constant.
+A run could pass the flag, print `reflective_merge=True` because the *policy*
+said so, and be byte-identical to a run that did not pass it.
+
+That is not only a dead flag. A control experiment in this series varied exactly
+that flag, found the two arms identical, and concluded the merge layer was not
+the cause of a failure -- a refutation built on a no-op.
+"""
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from examples import _method_runner as mr
+
+
+def _args(**kw):
+    base = dict(reflective_merge=False, no_reflective_merge=False)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _policy(reflective: bool):
+    from examples.promptbreeder import promptbreeder_genetic_prompts as pb
+    from dataclasses import replace
+    return replace(pb.build(0), reflective=reflective)
+
+
+def test_no_flag_keeps_the_methods_own_declaration():
+    """`reflective` is a fidelity statement, not a knob: AFlow's contested
+    workflow fields are model-merged because its optimizer rewrites a whole
+    workflow, and Voyager's are not because its library overwrites a key."""
+    assert mr._reflective_override(_args(), _policy(True)) is None
+    assert mr._reflective_override(_args(), _policy(False)) is None
+
+
+def test_the_flag_turns_it_on_and_the_negation_turns_it_off():
+    assert mr._reflective_override(_args(reflective_merge=True), _policy(False)) is True
+    assert mr._reflective_override(_args(no_reflective_merge=True), _policy(True)) is False
+
+
+def test_both_flags_at_once_is_refused_rather_than_resolved():
+    """A run that asked for the merge and against it has not said what it wants,
+    and picking one is how a control arm ends up measuring the other."""
+    with pytest.raises(SystemExit, match="contradictory"):
+        mr._reflective_override(
+            _args(reflective_merge=True, no_reflective_merge=True), _policy(True))
+
+
+def test_run_port_reads_the_override_rather_than_the_policy_field():
+    source = inspect.getsource(mr.run_port)
+    assert "policy.reflective if reflective is None else" in source, (
+        "the override is not threaded, so the flag is decorative again")
+    assert "if policy.reflective:" not in source, (
+        "the policy field is still deciding on its own")
+
+
+def test_the_recorded_configuration_reports_what_actually_ran():
+    """`reflective_merge` in the payload used to echo `policy.reflective`, so a
+    run's own record could not distinguish an override from a declaration."""
+    source = inspect.getsource(mr.run_port)
+    assert '"reflective_merge": use_reflective' in source
+
+
+def test_the_banner_says_when_it_was_overridden():
+    source = inspect.getsource(mr.standard_main)
+    assert "(overridden)" in source


### PR DESCRIPTION
## The flag did nothing

`run_port` used `policy.reflective` — a per-method constant. A run that passed `--reflective-merge` printed `reflective_merge=True` because the **policy** said so, and was byte-identical to a run that did not pass it.

That is not only a dead flag. **A control experiment in this series varied exactly that flag**, found both arms identical, and concluded the merge layer was not implicated in a PromptBreeder failure. Both arms were the same configuration. The refutation was built on a no-op.

### The fix

`run_port(reflective=None)` means *"whatever the method declares"* — and that declaration is a fidelity statement, not a knob: AFlow's contested workflow fields are model-merged because its optimizer rewrites a whole workflow; Voyager's are not because its library overwrites a key.

- `--reflective-merge` / `--no-reflective-merge` override it
- the banner marks the run `(overridden)`
- the recorded configuration reports what **actually ran** instead of echoing the policy field
- **both flags at once is refused**, not resolved — a run that asked for the merge and against it has not said what it wants, and picking one for it is how a control arm ends up measuring the other

## The control, now that it runs

Paired at the same seed:

| seed | | test | calls |
|---|---|---:|---:|
| 0 | merge **on** | 0.875 | **627** |
| 0 | merge off | 0.875 | 1749 |
| 1 | merge **on** | 1.000 | **638** |
| 1 | merge off | 0.938 | 1739 |

The model merge costs **2.7–2.8× fewer calls at no cost in quality**, because it replaces *ranking* contested diffs on the cheap layer — and ranking needs evaluations. Turning it off does not remove a model call; it adds a pile of evaluation ones.

## PromptBreeder's numbers are replaced

| seed | test | validation | accepted | calls |
|---|---|---:|---:|---:|
| 0 | 0.000 → **0.875** | 0.000 → 0.688 | 4/80 | 627 |
| 1 | 0.000 → **1.000** | 0.000 → 1.000 | 3/80 | 638 |
| 2 | 0.000 → **1.000** | 0.000 → 1.000 | 3/80 | 592 |

Mean **0.958** against a ceiling of 1.000.

The previous entry said 0.438 / 0.000 / 0.375, mean 0.271 — from **this exact command, at these exact seeds, on this exact code**. Nothing changed between the two but the model's sampling.

The seed fixes the data splits and the operator sampler. It does **not** fix the model, which is sampled at temperature 0.7, so a "three seeds" label buys three *split* draws and three *sampling* draws at once, and the second kind is large. Both sets are real runs; neither is *the* number.

## Consequence for the cross-algorithm tables

The four measured pages now carry a caveat: those tables are evidence that each mechanism **executes end to end**, not a ranking. A ranking would need repeats per seed, which these runs do not have. PromptBreeder moving from 0.271 to 0.958 without a code change is the demonstration.

## Verification

CI. `tests/test_method_runner_flags.py` (6 new tests) and the docs gates pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)