### PR TITLE
feat(voyager): three seeds scored 0.000 against a world that could not be solved

### DIFF
--- a/bench/results/voyager-skill-library.json
+++ b/bench/results/voyager-skill-library.json
@@ -1,0 +1,96 @@
+{
+ "experiment": "Voyager skill library on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "MineDojo/Voyager@55e45a88",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": false,
+  "self_verify": true,
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "domain": "crafting world, 48 goals, 16/16/16 splits"
+ },
+ "before_the_world_was_learnable": {
+  "test": [
+   0.0,
+   0.0,
+   0.0
+  ],
+  "accepted": [
+   0,
+   0,
+   0
+  ],
+  "invalid": [
+   0,
+   0,
+   0
+  ],
+  "note": "well-formed skills against an unreachable target: two required arguments the world never named, and a feedback message that reported an out-of-order step as a missing one"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.0,
+    1.0
+   ],
+   "validation": [
+    0.0,
+    1.0
+   ],
+   "accepted": 2,
+   "invalid": 0,
+   "wall_s": 300.5,
+   "engine_s": 218.0,
+   "calls": 1207
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.0,
+    1.0
+   ],
+   "validation": [
+    0.0,
+    1.0
+   ],
+   "accepted": 1,
+   "invalid": 0,
+   "wall_s": 333.3,
+   "engine_s": 251.5,
+   "calls": 1207
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.0,
+    0.0
+   ],
+   "validation": [
+    0.0,
+    0.0
+   ],
+   "accepted": 0,
+   "invalid": 0,
+   "wall_s": 366.4,
+   "engine_s": 279.2,
+   "calls": 1287
+  }
+ ],
+ "summary": {
+  "test_quality": {
+   "min": 0.0,
+   "median": 1.0,
+   "max": 1.0,
+   "mean": 0.667
+  },
+  "seeds_that_moved": 2,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-voyager.md
+++ b/docs/algo-voyager.md
@@ -38,15 +38,63 @@ from a gold program.
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`self_verify` on (the critic), `deepseek-v4-flash` at temperature 0.7. Recorded
+in
+[`bench/results/voyager-skill-library.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/voyager-skill-library.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
+| seed | test quality | validation | accepted | calls |
 |---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| 0 | 0.000 → **1.000** | 0.000 → 1.000 | 2/80 | 1207 |
+| 1 | 0.000 → **1.000** | 0.000 → 1.000 | 1/80 | 1207 |
+| 2 | 0.000 → 0.000 | 0.000 → 0.000 | 0/80 | 1287 |
+
+Two seeds clear the world outright and one finds nothing. `accepted` is 2, 1 and
+0 of eighty, which is the shape of the mechanism rather than an accident: every
+proposal is re-rolled by the critic before it reaches the gate, and one skill
+that works is all the run needs.
+
+See the caveat on [PromptBreeder](algo-promptbreeder.md#measured-results): one
+run per seed does not pin a number here either.
+
+!!! danger "Three seeds scored 0.000 against a world that could not be solved"
+    The first runs reported `quality 0.000 -> 0.000`, `accepted=0/80`, and
+    **`invalid=0`** on every seed. Well-formed skills, none of them accepted.
+    Reading the trajectories rather than the summary showed the solver had
+    already discovered all three missing steps, and was failing on things the
+    world never said.
+
+    **Two arguments the world never named.** The required sequence contains
+    `combine:water+mint` and `sanitize:vessel`, matched by string equality. The
+    `X+Y` syntax appears in no primitive list, no seed skill and no feedback
+    message; neither does the word "vessel". The solver wrote
+    `combine:water_clove`, `combine:berry:water`, `combine:thyme_water` — every
+    plausible spelling but that one — and `sanitize:water`, `sanitize:berry`.
+    Steps are matched on **verb plus content** now: an argument the world does
+    not name is matched on the verb alone, and an argument that follows from the
+    goal must still contain it.
+
+    **A feedback message that was wrong, not merely terse.** With `sanitize`
+    written after the two `collect`s, the world consumed the sanitize, looked for
+    a collect among the actions *after* it, found none, and reported *"a
+    'collect' step never happened"* — to an agent that had written two. An agent
+    that believes it adds a third collect; it never reorders. The message now
+    separates a step that is **absent** from one that is **late**, while still
+    naming neither the step nor where it belongs.
+
+    Not handing over the required program and withholding what the world observed
+    are different things, and upstream conflates neither: Minecraft tells the
+    agent what it is missing. What has to be discovered here is still the
+    **sequence**, which is the skill the paper is about.
+
+!!! note "The library overwrites; it is not add-only"
+    This page used to claim "an add-only skill library ... matching upstream's
+    versioned, never-overwritten library". `SkillManager.add_new_skill` prints
+    *"Skill {name} already exists. Rewriting!"*, deletes the vector-store entry
+    and reassigns `self.skills[program_name]`. The older code is dumped to disk
+    as `{name}V2.js` and **retrieval never reads it** — `retrieve_skills` returns
+    `self.skills[...]["code"]`. Versioned on disk and overwritten in memory are
+    different libraries, and only the second one is the algorithm.
+
+    The domain was also 12 goals in 4/4/4 splits, which `run_port` refuses at
+    eight workers; it is 48 in 16/16/16 now.

--- a/examples/voyager/voyager_skill_library.py
+++ b/examples/voyager/voyager_skill_library.py
@@ -1,23 +1,36 @@
 """Environment analogue: **Voyager** (MineDojo/Voyager@55e45a88).
 
-Preserved: an **add-only skill library** (one entry per goal key; entries
-accumulate and union-merge, matching upstream's versioned, never-overwritten
-library); repair driven by **environment feedback** -- the deterministic world
-executes the attempt and reports the first failed step, which is what the
-repair prompt sees (never a gold trace); the **critic** as the engine's worker
-self-check (`self_verify`): every proposal is re-rolled and judged by the
-environment reward before it reaches the gate, upstream's "judge success from
-the environment, not the agent's claim"; and frontier task focus via the
+Preserved: a skill is added **only when the critic says the task succeeded**
+(`voyager.py`: ``if info["success"]: self.skill_manager.add_new_skill(info)``);
+repair driven by **environment feedback** -- the deterministic world executes
+the attempt and reports the first failed step, which is what the repair prompt
+sees (never a gold trace); the **critic** as the engine's worker self-check
+(`self_verify`): every proposal is re-rolled and judged by the environment
+reward before it reaches the gate, upstream's "judge success from the
+environment, not the agent's claim"; and frontier task focus via the
 :class:`~agentdescent.sampling.DifficultyWeighted` sampler.
 
+**The library is not add-only, and this port used to say it was.**
+`SkillManager.add_new_skill` prints *"Skill {name} already exists. Rewriting!"*,
+deletes the vector-store entry and reassigns ``self.skills[program_name]``. The
+older code is dumped to disk as ``{name}V2.js`` and **retrieval never reads
+it**: ``retrieve_skills`` returns ``self.skills[...]["code"]``, so the live
+library holds exactly one version per name -- the newest. Versioned-on-disk and
+overwritten-in-memory are different libraries, and only the second one is the
+algorithm. Each goal key here therefore holds the latest accepted skill rather
+than an accumulation.
+
 Boundaries: a deterministic crafting world replaces Minecraft; key-match
-retrieval replaces embedding retrieval; the task pool plus difficulty sampling
-is an analogue of the generative curriculum, which proposes novel tasks.
+retrieval replaces embedding retrieval over descriptions (``retrieval_top_k=5``,
+so upstream shows the action agent several skills and this shows one); the task
+pool plus difficulty sampling is an analogue of the generative curriculum, which
+proposes novel tasks.
 """
 
 from __future__ import annotations
 
 import random
+import re
 from typing import List, Optional, Sequence, Tuple
 
 from agentdescent.evolution import Task
@@ -31,23 +44,54 @@ from examples._method_runner import standard_main
 
 FIDELITY = "environment_analogue"
 
+#: 48, not 12, and the size is a constraint rather than a garnish: `run_port`
+#: refuses a run whose train split is smaller than the worker count, so twelve
+#: goals split 4/4/4 capped this port at four workers with a four-goal gate.
 INGREDIENTS = (
     "mint", "berry", "lemon", "ginger", "apple", "peach",
     "pear", "plum", "orange", "basil", "cherry", "melon",
+    "thyme", "sage", "clove", "fennel", "anise", "cocoa",
+    "papaya", "guava", "lychee", "quince", "damson", "medlar",
+    "nutmeg", "cassia", "sorrel", "borage", "hyssop", "lovage",
+    "banana", "mango", "grape", "fig", "date", "apricot",
+    "rosehip", "elder", "juniper", "lavender", "chamomile", "verbena",
+    "tamarind", "persimmon", "kumquat", "pomelo", "cranberry", "blackcurrant",
 )
 
 PRIMITIVES = "sanitize, collect, heat, combine, serve (as 'primitive:argument')"
 
 
+#: What each required step needs, beyond its verb. A step whose argument the
+#: world never names -- the *vessel* that gets sanitized, the *drink* that gets
+#: served -- is matched on the verb alone; a step whose argument is derivable
+#: from the goal must contain it.
+#:
+#: Measured against string equality, both unnamed arguments were lotteries. The
+#: solver discovered all three missing steps and still scored zero, writing
+#: `sanitize:water` / `sanitize:berry` (never `vessel`, a word that appears
+#: nowhere it can see) and `combine:berry:water` / `combine:water_clove` /
+#: `combine:thyme_water` (never `water+berry`). Three seeds, 0.000 each,
+#: `accepted=0/80`, and **no invalid proposals** -- well-formed skills against an
+#: unreachable target.
+_STEPS = (
+    ("sanitize", ()),               # of what, the world does not say
+    ("collect", ("water",)),
+    ("collect", ("{ingredient}",)),
+    ("heat", ("water",)),
+    ("combine", ("water", "{ingredient}")),
+    ("serve", ()),                  # what is served, the world does not say
+)
+
+
 def _required(ingredient: str) -> List[str]:
-    return [
-        "sanitize:vessel",
-        "collect:water",
-        f"collect:{ingredient}",
-        "heat:water",
-        f"combine:water+{ingredient}",
-        "serve:drink",
-    ]
+    """The canonical rendering of the required sequence, for display and tests."""
+    out = []
+    for verb, terms in _STEPS:
+        filled = [t.replace("{ingredient}", ingredient) for t in terms]
+        out.append(f"{verb}:{'+'.join(filled)}" if filled else f"{verb}:vessel"
+                   if verb == "sanitize" else f"{verb}:drink" if not filled
+                   else f"{verb}:{'+'.join(filled)}")
+    return [item.lower() for item in out]
 
 
 def _action_list(text: str, key: str) -> List[str]:
@@ -60,6 +104,21 @@ def _action_list(text: str, key: str) -> List[str]:
     return [item.strip().lower() for item in value]
 
 
+def _matches(action: str, index: int, ingredient: str) -> bool:
+    """Does this action perform the required step at `index`?
+
+    Verb plus *content*, not string equality -- see `_STEPS` for why. What still
+    has to be discovered is the **sequence**, which is the skill the paper is
+    about; the spelling of an argument the world never names is not.
+    """
+    verb, _, argument = action.partition(":")
+    want_verb, terms = _STEPS[index]
+    if verb.strip() != want_verb:
+        return False
+    return all(term.replace("{ingredient}", ingredient) in argument
+               for term in terms)
+
+
 def simulate(actions: Sequence[str], ingredient: str) -> Tuple[bool, str]:
     """Execute an action sequence; report the first unmet step, Voyager-style.
 
@@ -69,15 +128,32 @@ def simulate(actions: Sequence[str], ingredient: str) -> Tuple[bool, str]:
     required = _required(ingredient)
     cursor = 0
     for action in actions:
-        if cursor < len(required) and action == required[cursor]:
+        if cursor < len(required) and _matches(action, cursor, ingredient):
             cursor += 1
     if cursor == len(required):
         return True, "goal reached: drink served"
-    missing = required[cursor]
-    verb = missing.split(":", 1)[0]
+    verb = _STEPS[cursor][0]
+    # Whether the verb is *absent* or merely *late* is the difference between
+    # "add a step" and "reorder". Saying only "a 'collect' step never happened"
+    # to an agent that wrote two of them is not a terse error, it is a wrong
+    # one -- and the agent does the only thing it says, which is add a third.
+    #
+    # Measured: the solver had already discovered all six actions and was
+    # writing `[collect, collect, sanitize, heat, combine, serve]` against a
+    # world that wants sanitize first. Three seeds, 0.000, `accepted=0/80`.
+    # Naming the ordering keeps the rule the docstring claims -- no gold trace,
+    # nothing about the steps still to come -- while describing what happened.
+    written = [a.partition(":")[0].strip() for a in actions]
+    late = written.count(verb) > sum(
+        1 for i in range(cursor) if _STEPS[i][0] == verb)
+    if late:
+        detail = (f"a '{verb}' step is present but out of order: the "
+                  f"environment reached it after steps it has to come before")
+    else:
+        detail = (f"the environment expected a '{verb}' step that never "
+                  f"happened")
     return False, (
-        f"execution stopped before '{verb}' succeeded: the environment "
-        f"expected a '{verb}' step that never happened in order (progress "
+        f"execution stopped before '{verb}' succeeded: {detail} (progress "
         f"{cursor}/{len(required)}). Available primitives: {PRIMITIVES}."
     )
 
@@ -101,7 +177,8 @@ def _tasks() -> List[Task]:
 def _split(seed: int) -> Tuple[List[Task], List[Task], List[Task]]:
     rows = _tasks()
     random.Random(seed).shuffle(rows)
-    return rows[:4], rows[4:8], rows[8:12]
+    third = len(rows) // 3
+    return rows[:third], rows[third:2 * third], rows[2 * third:3 * third]
 
 
 def _retrieve(rendered: str, ingredient: str) -> str:
@@ -176,7 +253,8 @@ def build(seed: int) -> MethodPolicy:
         name="voyager",
         fidelity=FIDELITY,
         notes=(
-            "Skills accumulate under goal keys and are never overwritten, matching the add-only library.",
+            "A skill is added only when the environment judges the attempt successful, as add_new_skill is called only under info['success'].",
+            "A goal key holds the latest accepted skill, not an accumulation: add_new_skill rewrites self.skills in place and retrieve_skills reads that, so upstream's on-disk V2 dumps are never retrieved.",
             "Repair sees the environment's first-failure feedback, never a gold trace.",
             "The critic is the engine's self-verify rollout: proposals are re-run and judged by the environment reward.",
             "A deterministic crafting world replaces Minecraft; the task pool plus difficulty sampling stands in for the generative curriculum.",

--- a/tests/test_voyager_upstream.py
+++ b/tests/test_voyager_upstream.py
@@ -1,0 +1,215 @@
+"""Voyager against `MineDojo/Voyager@55e45a88`.
+
+The library is the mechanism, and the port described it backwards.
+"""
+from __future__ import annotations
+
+from examples._measure import canonical_json
+from examples.voyager import voyager_skill_library as vy
+
+
+def test_a_second_skill_for_a_goal_replaces_the_first():
+    """`add_new_skill` prints "Skill {name} already exists. Rewriting!", deletes
+    the vector-store entry and reassigns `self.skills[program_name]`. The older
+    code is dumped to disk as `{name}V2.js` and **retrieval never reads it** --
+    `retrieve_skills` returns `self.skills[...]["code"]`. Versioned on disk and
+    overwritten in memory are different libraries, and only the second one is
+    the algorithm.
+    """
+    policy = vy.build(0)
+    state = policy.strategy.initial()
+
+    first = canonical_json({"steps": ["collect:water", "serve:drink"]})
+    diff = policy.strategy.to_diff(state, f"skill generic: {first}", "w", 1,
+                                   "candidate-voyager")
+    state = {**state, **diff.ops}
+
+    second = canonical_json({"steps": ["sanitize:vessel", "collect:water",
+                                       "serve:drink"]})
+    diff = policy.strategy.to_diff(state, f"skill generic: {second}", "w", 2,
+                                   "candidate-voyager")
+    assert diff is not None
+    state = {**state, **diff.ops}
+
+    assert state["skill generic"] == second
+    assert first not in state.values(), "the replaced skill is still retrievable"
+
+
+def test_a_skill_for_a_different_goal_does_not_disturb_another():
+    """Different `program_name`s coexist; only a repeat of the same name
+    rewrites."""
+    policy = vy.build(0)
+    state = policy.strategy.initial()
+    for key in ("skill mint", "skill berry"):
+        value = canonical_json({"steps": [f"collect:{key.split()[1]}"]})
+        diff = policy.strategy.to_diff(state, f"{key}: {value}", "w", 1,
+                                       "candidate-voyager")
+        state = {**state, **diff.ops}
+    assert "skill mint" in state and "skill berry" in state
+    assert state["skill generic"], "the seed entry was displaced"
+
+
+def test_the_environment_reports_the_first_unmet_step_and_no_gold_trace():
+    """Upstream's repair prompt sees the critique and the events, never the
+    program that would have worked. A message containing the required sequence
+    turns repair into transcription."""
+    ok, message = vy.simulate(["collect:water"], "mint")
+    assert not ok
+    required = vy._required("mint")
+    for step in required:
+        assert step not in message, f"the feedback hands over {step!r}"
+    assert "progress" in message and "primitives" in message
+
+
+def test_a_complete_sequence_reaches_the_goal():
+    ok, message = vy.simulate(vy._required("mint"), "mint")
+    assert ok and "goal reached" in message
+
+
+def test_extra_actions_do_not_break_a_correct_ordering():
+    """`simulate` advances a cursor, so a skill that does more than the minimum
+    still succeeds -- the world judges the goal, not the transcript."""
+    noisy = ["heat:water"] + vy._required("mint") + ["serve:drink"]
+    ok, _ = vy.simulate(noisy, "mint")
+    assert ok
+
+
+def test_out_of_order_actions_fail():
+    reversed_steps = list(reversed(vy._required("mint")))
+    ok, _ = vy.simulate(reversed_steps, "mint")
+    assert not ok
+
+
+def test_the_critic_is_the_engines_self_verify_rollout():
+    """`check_task_success` judges from the environment rather than the agent's
+    claim, and a skill is added only under `info["success"]`."""
+    assert vy.build(0).self_verify is True
+
+
+def test_the_overwrite_semantics_are_declared_rather_than_called_add_only():
+    notes = " ".join(vy.build(0).notes).lower()
+    assert "not an accumulation" in notes or "latest accepted skill" in notes
+    assert "add_new_skill" in notes
+
+
+# -- the world has to be learnable from what it says --------------------------
+
+
+def test_the_required_argument_syntax_is_not_a_guessing_game():
+    """`combine:water+mint` was matched by string equality, and that `X+Y` syntax
+    appears nowhere the agent can see: not in `PRIMITIVES`, not in the seed
+    skill, not in any feedback message -- which names only the failing verb.
+
+    One step of six was therefore a lottery, and the reward is all-or-nothing.
+    All three seeds scored 0.000 with `accepted=0/80` and **no invalid
+    proposals**: the port was proposing well-formed skills against a target it
+    could not reach by reasoning.
+    """
+    required = vy._required("mint")
+    assert "water+mint" in required[4], "the fixture changed; update this test"
+
+    seed = vy.build(0).strategy.initial()["skill generic"]
+    assert "+" not in seed
+    assert "+" not in vy.PRIMITIVES
+    _, message = vy.simulate(required[:4], "mint")
+    assert "+" not in message, "the feedback now hands over the syntax"
+
+    # Content, not spelling: each of these performs the step the world wants.
+    for phrasing in ("combine:water+mint", "combine:mint+water",
+                     "combine:water and mint", "combine:water_with_mint"):
+        ok, _ = vy.simulate(required[:4] + [phrasing, "serve:drink"], "mint")
+        assert ok, f"{phrasing!r} does the required thing and was refused"
+
+
+def test_arguments_the_world_never_names_are_matched_on_the_verb_alone():
+    """`sanitize:vessel` was the second lottery, and the harder one: "vessel"
+    appears nowhere the agent can see, so *every* sanitize it wrote was refused.
+    Measured -- the solver discovered all three missing steps and still scored
+    zero, writing `sanitize:water` and `sanitize:berry`.
+
+    A step whose argument the world does not name is matched on the verb; a step
+    whose argument follows from the goal still has to contain it.
+    """
+    required = vy._required("mint")
+    assert required[0] == "sanitize:vessel" and required[5] == "serve:drink"
+    for word in ("vessel", "drink"):
+        _, message = vy.simulate([], "mint")
+        assert word not in message
+    assert word not in vy.PRIMITIVES
+
+    for sanitize in ("sanitize:vessel", "sanitize:water", "sanitize:mint",
+                     "sanitize:everything"):
+        ok, _ = vy.simulate([sanitize] + required[1:], "mint")
+        assert ok, f"{sanitize!r} sanitizes something and was refused"
+    for serve in ("serve:drink", "serve:tea", "serve:cup"):
+        ok, _ = vy.simulate(required[:5] + [serve], "mint")
+        assert ok, f"{serve!r} serves something and was refused"
+
+
+def test_content_matching_does_not_make_the_world_permissive():
+    """The sequence is still the skill. Loosening the *spelling* of an argument
+    must not loosen what has to happen or in what order."""
+    required = vy._required("mint")
+    # Missing the ingredient entirely is still wrong.
+    ok, _ = vy.simulate(required[:4] + ["combine:water", "serve:drink"], "mint")
+    assert not ok
+    # Wrong ingredient is still wrong.
+    ok, _ = vy.simulate(required[:4] + ["combine:water+berry", "serve:drink"], "mint")
+    assert not ok
+    # Order still matters.
+    assert not vy.simulate(list(reversed(required)), "mint")[0]
+    # And the seed skill, which skips three steps, still fails.
+    assert not vy.simulate(["collect:water", "collect:mint", "serve:drink"], "mint")[0]
+
+
+def test_every_required_step_is_reachable_from_the_verbs_the_world_names():
+    """Each feedback message names the verb the world is waiting for, so the
+    sequence is discoverable one step at a time. This asserts the chain has no
+    rung that cannot be climbed."""
+    for ingredient in ("mint", "cocoa", "lychee"):
+        required = vy._required(ingredient)
+        for i in range(len(required)):
+            _, message = vy.simulate(required[:i], ingredient)
+            verb = required[i].split(":", 1)[0]
+            assert f"'{verb}'" in message, (
+                f"{ingredient} step {i}: the world does not say it wants {verb}")
+
+
+def test_the_feedback_distinguishes_a_missing_step_from_a_late_one():
+    """"A 'collect' step never happened", said to an agent that wrote two of
+    them, is not a terse error -- it is a wrong one, and the agent does the only
+    thing it says, which is add a third.
+
+    Measured: the solver had discovered all six actions and was writing
+    `[collect, collect, sanitize, heat, combine, serve]` against a world that
+    wants sanitize first. The world consumed the sanitize, looked for a collect
+    among the actions *after* it, found none, and reported the collect missing.
+    Three seeds scored 0.000 with `accepted=0/80` and no invalid proposals.
+    """
+    late = ["collect:water", "collect:mint", "sanitize:vessel", "heat:water",
+            "combine:water+mint", "serve:drink"]
+    ok, message = vy.simulate(late, "mint")
+    assert not ok
+    assert "out of order" in message
+    assert "never happened" not in message
+
+    absent = ["collect:water", "collect:mint", "heat:water",
+              "combine:water+mint", "serve:drink"]
+    ok, message = vy.simulate(absent, "mint")
+    assert not ok
+    assert "never happened" in message and "out of order" not in message
+
+
+def test_the_ordering_message_still_hands_over_nothing():
+    """It says a step is late. It does not say which step, where it belongs, or
+    what comes after -- the rule the port claims is that repair sees the failure
+    and never the required program."""
+    late = ["collect:water", "collect:mint", "sanitize:vessel", "heat:water",
+            "combine:water+mint", "serve:drink"]
+    _, message = vy.simulate(late, "mint")
+    # `PRIMITIVES` lists every verb by design, so the check is on the *steps*:
+    # no `verb:argument` pair, and no hint of which one is in the wrong place.
+    body = message.split("Available primitives:")[0]
+    for step in vy._required("mint"):
+        assert step not in message
+    assert "sanitize" not in body, "the message names the step to move"


### PR DESCRIPTION
Fifth of the eleven unmeasured MethodPolicy rows in #73.

## The symptom

`quality 0.000 -> 0.000`, `accepted=0/80`, **`invalid=0`** — on every seed. Eighty well-formed skills, none accepted. `invalid=0` is the part that rules out "the model is producing junk".

Reading the trajectories rather than the summary showed the solver had **already discovered all three missing steps** and was failing on things the world never said.

## Two arguments the world never named

The required sequence contains `combine:water+mint` and `sanitize:vessel`, matched by **string equality**. The `X+Y` syntax appears in no primitive list, no seed skill, and no feedback message. Neither does the word "vessel".

What the solver actually wrote:

```
["collect:water","collect:berry","sanitize:water","sanitize:berry","heat:water","combine:berry:water","serve:drink"]
["collect:water","collect:clove","sanitize:clove","combine:water_clove","heat:mixture","serve:drink"]
["collect:water","collect:thyme","sanitize:thyme","sanitize:water","heat:water","combine:thyme_water","serve:drink"]
```

Every plausible spelling of `combine` except the required one, and never `vessel`. Verified offline: `combine:water`, `combine:mint+water` and `combine:water+mint` produce **byte-identical** feedback.

Steps are matched on **verb plus content** now, declared once in `_STEPS`: an argument the world does not name is matched on the verb alone; an argument that follows from the goal must still contain it. Order, wrong ingredient, and missing steps all still fail.

## A feedback message that was wrong, not merely terse

With `sanitize` written after the two `collect`s, the world consumed the sanitize, looked for a collect among the actions **after** it, found none, and reported:

> a 'collect' step that never happened

…to an agent that had written **two**. An agent that believes it adds a third collect. It never reorders — and that was the loop.

The message now separates a step that is **absent** from one that is **late**, and still names neither the step nor where it belongs.

> Not handing over the required program and withholding what the world observed are different things, and upstream conflates neither: Minecraft tells the agent what it is missing.

What has to be discovered is still the **sequence**, which is the skill the paper is about.

## The library overwrites; this page claimed it was add-only

It said *"an add-only skill library … matching upstream's versioned, never-overwritten library"*. `SkillManager.add_new_skill`:

```python
print(f"Skill {program_name} already exists. Rewriting!")
self.vectordb._collection.delete(ids=[program_name])
...
self.skills[program_name] = {"code": program_code, ...}
```

The older code is dumped to disk as `{name}V2.js` and **retrieval never reads it** — `retrieve_skills` returns `self.skills[...]["code"]`. Versioned on disk and overwritten in memory are different libraries, and only the second one is the algorithm.

## The domain was too small to start

12 goals in 4/4/4 splits, which `run_port` refuses at eight workers — the first run crashed outright rather than producing a number. 48 goals in 16/16/16 now.

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`, critic (`self_verify`) on:

| seed | test | validation | accepted | calls |
|---|---|---:|---:|---:|
| 0 | 0.000 → **1.000** | 0.000 → 1.000 | 2/80 | 1207 |
| 1 | 0.000 → **1.000** | 0.000 → 1.000 | 1/80 | 1207 |
| 2 | 0.000 → 0.000 | 0.000 → 0.000 | 0/80 | 1287 |

Two seeds clear the world outright, one finds nothing. `accepted` of 2, 1 and 0 out of eighty is the shape of the mechanism rather than an accident: every proposal is re-rolled by the critic before it reaches the gate, and one skill that works is all the run needs.

## Verification

CI. 14 tests in `tests/test_voyager_upstream.py`, including one that walks the required chain and asserts every rung names the verb the world is waiting for — so a step that cannot be climbed fails the suite rather than a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)