### PR TITLE
fix(method-policy): clip_text discarded long answers instead of clipping them

### DIFF
--- a/bench/results/r-zero-challenger-solver.json
+++ b/bench/results/r-zero-challenger-solver.json
@@ -1,0 +1,90 @@
+{
+ "experiment": "R-Zero challenger/solver co-evolution on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "Chengsong-Huang/R-Zero@5699329d",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": true,
+  "solver_samples": 4,
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "domain": "self-play carts, 16 slots + 16/16 frozen"
+ },
+ "before_clip_text_clipped": {
+  "test": [
+   0.25,
+   0.375,
+   0.438
+  ],
+  "invalid": [
+   41,
+   44,
+   48
+  ],
+  "note": "`clip_text` discarded any value over 900 characters instead of truncating it, and R-Zero's two update prompts ask for a policy statement. Over half of every run's proposals were dropped before the gate and counted as invalid"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.062,
+    0.188
+   ],
+   "validation": [
+    0.125,
+    0.438
+   ],
+   "accepted": 2,
+   "invalid": 0,
+   "wall_s": 279.4,
+   "engine_s": 203.8,
+   "calls": 943
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.062,
+    0.375
+   ],
+   "validation": [
+    0.125,
+    0.375
+   ],
+   "accepted": 3,
+   "invalid": 0,
+   "wall_s": 293.3,
+   "engine_s": 214.8,
+   "calls": 941
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.062,
+    0.312
+   ],
+   "validation": [
+    0.062,
+    0.312
+   ],
+   "accepted": 1,
+   "invalid": 0,
+   "wall_s": 311.3,
+   "engine_s": 235.1,
+   "calls": 926
+  }
+ ],
+ "summary": {
+  "test_gain": {
+   "mean": 0.23
+  },
+  "test_final_mean": 0.292,
+  "invalid_total": 0,
+  "seeds_that_moved": 3,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-r-zero.md
+++ b/docs/algo-r-zero.md
@@ -37,15 +37,61 @@ revision; the paper says 25–75%). Both are trained with GRPO.
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`deepseek-v4-flash` at temperature 0.7. Recorded in
+[`bench/results/r-zero-challenger-solver.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/r-zero-challenger-solver.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
-|---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| seed | test quality | validation | accepted | invalid | calls |
+|---|---|---|---|---|---|
+| 0 | 0.062 → **0.188** | 0.125 → 0.438 | 2/80 | 0 | 943 |
+| 1 | 0.062 → **0.375** | 0.125 → 0.375 | 3/80 | 0 | 941 |
+| 2 | 0.062 → **0.312** | 0.062 → 0.312 | 1/80 | 0 | 926 |
+
+All three seeds moved; mean gain +0.230. As on
+[Absolute Zero](algo-absolute-zero.md#measured-results), read the *gain*: the
+carts are generated, so the baseline is not 0.000 and the ceiling is not 1.000.
+
+See the caveat on [PromptBreeder](algo-promptbreeder.md#measured-results): one
+run per seed does not pin a number here either.
+
+!!! danger "Half of every run's proposals were being thrown away, and counted as invalid"
+    The first runs reported `invalid` of **41, 44 and 48 out of 80** — against 2
+    to 11 for every other port. The proposals were
+    `{"challenger_memory":"","solver_memory":""}`, and the update calls that
+    produced them were fine: asked directly, they return 564 to 1632 characters
+    of usable policy.
+
+    `clip_text` was the cause, and it is shared by all eleven ports:
+
+    ```python
+    if not cleaned or len(cleaned) > max_len:   # max_len = 900
+        return fallback                          # ""
+    ```
+
+    A function named `clip_text` that **discards** a 901-character answer and
+    keeps a 900-character one. The cost lands twice: the proposal is lost, and it
+    is counted as *invalid*, which reads in the metrics as the model producing
+    junk. R-Zero was hit hardest because its two update prompts ask for a policy
+    statement and the model writes one — four of six sampled replies ran over the
+    limit.
+
+    It truncates now, on a word boundary. `invalid` went to **0, 0, 0**.
+
+!!! danger "The Challenger's signal had ground truth in it"
+    `question_evaluate/evaluate.py` computes
+    `score = max_count / len(results)` over `--num_samples` (default **9**)
+    solver samples: the share agreeing with the **majority answer**. R-Zero has
+    no ground truth for a question its Challenger just wrote — that is the
+    premise — and rewards questions the Solver is *self-inconsistent* on.
+
+    This port computed `p_hat = (score + agreement * score) / 2`, mixing in the
+    grounded verifier's reward. `p_hat` is the majority share now, over four
+    samples rather than two: two give it only 0.5 and 1.0, so the Challenger saw
+    a coin flip rather than a frontier. Unparseable replies count as their own
+    distinct answers rather than being dropped — a Solver that cannot state an
+    answer is not one that agrees with itself, and dropping them makes an
+    incoherent batch read as certain.
+
+    `min(p, 1-p)` now peaks at a half, which is what `DifficultyWeighted`'s
+    `4p(1-p)` is attached here to match — and why it is *not* attached to
+    Absolute Zero, whose `1-r` is monotone.

--- a/examples/_method_policy.py
+++ b/examples/_method_policy.py
@@ -42,12 +42,33 @@ Reward = Callable[[Task, str], float]
 
 
 def clip_text(value, *, fallback: str = "", max_len: int = 900) -> str:
+    """Normalise whitespace and **truncate** to `max_len`.
+
+    It used to discard: `if not cleaned or len(cleaned) > max_len: return
+    fallback`. A function named `clip_text` that drops a 901-character answer
+    and keeps a 900-character one is not a validation rule anyone chose, and the
+    cost lands twice -- the proposal is lost, and it is counted as *invalid*,
+    which reads in the metrics as the model producing junk.
+
+    Measured on R-Zero, whose two update prompts ask for a policy statement and
+    get one: four of six replies ran 977-1632 characters, so both its fields
+    came back empty and the run reported `invalid=41/80`, `44/80`, `48/80`
+    against 2-11 for the ports whose prompts ask for a single sentence. Nothing
+    was wrong with those proposals except their length.
+
+    Truncation is on a word boundary where one is near the limit, so a clipped
+    instruction ends mid-sentence rather than mid-word.
+    """
     if not isinstance(value, str):
         return fallback
     cleaned = " ".join(value.split()).strip()
-    if not cleaned or len(cleaned) > max_len:
+    if not cleaned:
         return fallback
-    return cleaned
+    if len(cleaned) <= max_len:
+        return cleaned
+    head = cleaned[:max_len]
+    space = head.rfind(" ")
+    return head[:space] if space > max_len * 0.8 else head
 
 
 @dataclass

--- a/examples/r_zero/r_zero_challenger_solver.py
+++ b/examples/r_zero/r_zero_challenger_solver.py
@@ -39,6 +39,28 @@ FIDELITY = "inference_analogue"
 _FALLBACK = CartTask((125, 240), (1, 2))
 CHALLENGER_SEED = "Increase curriculum difficulty gradually."
 
+#: Solver samples per generated question. `question_evaluate/evaluate.py` uses
+#: `--num_samples`, default **9**, and takes `score = max_count / len(results)`:
+#: the share agreeing with the *majority* answer. Four is the smallest count
+#: that gives that share more than two values while keeping a training rollout
+#: affordable.
+SOLVER_SAMPLES = 4
+
+
+def majority_share(finals: list) -> float:
+    """`max_count / len(results)`: the share agreeing with the majority answer.
+
+    Unparseable replies count as their own distinct answers rather than being
+    dropped -- a Solver that cannot state an answer is not a Solver that agrees
+    with itself, and dropping them would make an incoherent batch look certain.
+    """
+    counts: dict = {}
+    for index, final in enumerate(finals):
+        parsed = parse_integer_answer(final.strip())
+        key = parsed if parsed is not None else f"__unparsed_{index}"
+        counts[key] = counts.get(key, 0) + 1
+    return max(counts.values()) / float(len(finals)) if finals else 1.0
+
 
 def build(seed: int) -> MethodPolicy:
     def solve(llm, rendered: str, task: Task) -> str:
@@ -57,26 +79,27 @@ def build(seed: int) -> MethodPolicy:
             cart = validate_generated(parse_json_object(raw))
         except ValueError:
             cart, valid = _FALLBACK, False
-        # Two solver samples give the Challenger its uncertainty signal; the
-        # first is the trajectory's answer.
+        # `score = max_count / len(results)` -- the share of solver samples
+        # agreeing with the majority answer. R-Zero has **no ground truth** for
+        # a question its Challenger just wrote, which is the premise of the
+        # method; the Challenger is rewarded for producing questions the Solver
+        # is *self-inconsistent* on. Mixing the grounded verifier's reward into
+        # this number, as this port did, measures something the paper cannot.
         finals = [
             llm(solver_prompt(cart.question, solver_memory),
                 subphase="solver", unit=task.id)
-            for _ in range(2)
+            for _ in range(SOLVER_SAMPLES)
         ]
-        parsed = [parse_integer_answer(f.strip()) for f in finals]
-        agreement = float(parsed[0] is not None and parsed[0] == parsed[1])
         record = parse_json_object(trajectory(cart, finals[0], valid=valid))
-        record["agreement"] = agreement
+        record["self_consistency"] = majority_share(finals)
         return canonical_json(record)
 
     def propose(llm, rendered: str, task: Task, output: str,
                 score: float) -> Optional[str]:
         try:
-            agreement = float(parse_json_object(output).get("agreement", 1.0))
+            p_hat = float(parse_json_object(output).get("self_consistency", 1.0))
         except ValueError:
-            agreement = 1.0
-        p_hat = (score + agreement * score) / 2 if score else agreement / 2
+            p_hat = 1.0
         uncertainty = min(p_hat, 1.0 - p_hat)
         challenger = llm(
             (
@@ -112,7 +135,7 @@ def build(seed: int) -> MethodPolicy:
         fidelity=FIDELITY,
         notes=(
             "Separate Challenger and Solver role memories receive separate updates and union-merge across fields.",
-            "Two solver samples per generated task give the Challenger upstream's min(p,1-p) uncertainty signal.",
+            "The Challenger's p-hat is the solver's self-consistency over repeated samples -- the majority answer's share, as score = max_count / len(results) is -- and carries no ground truth, because R-Zero has none for a question it just wrote.",
             "AdvantageAcceptance carries GRPO's group-relative shape at the acceptance seam; DifficultyWeighted's 4p(1-p) matches the frontier target.",
             "Verbal role memories replace two GRPO checkpoints; the BLEU repetition penalty is omitted; evaluation carts are frozen.",
         ),

--- a/tests/test_method_runner_flags.py
+++ b/tests/test_method_runner_flags.py
@@ -70,3 +70,58 @@ def test_the_recorded_configuration_reports_what_actually_ran():
 def test_the_banner_says_when_it_was_overridden():
     source = inspect.getsource(mr.standard_main)
     assert "(overridden)" in source
+
+
+# -- clip_text: the shared truncation every port's artifact goes through ------
+
+
+def test_clip_text_truncates_rather_than_discards():
+    """It used to read `if not cleaned or len(cleaned) > max_len: return
+    fallback` -- a function named `clip_text` that drops a 901-character answer
+    and keeps a 900-character one.
+
+    The cost lands twice: the proposal is lost, and it is counted as *invalid*,
+    which reads in the metrics as the model producing junk. Measured on R-Zero,
+    whose two update prompts ask for a policy statement and get one -- four of
+    six replies ran 977-1632 characters, both fields came back empty, and the
+    runs reported `invalid` of 41, 44 and 48 out of 80, against 2-11 for the
+    ports whose prompts ask for a single sentence.
+    """
+    from examples._method_policy import clip_text
+
+    long = "word " * 400
+    out = clip_text(long)
+    assert out, "a long but perfectly good answer was discarded"
+    assert len(out) <= 900
+    assert out.startswith("word word")
+
+    # Truncation lands on a word boundary when one is near the limit.
+    assert not out.endswith("wor")
+    # ...and still returns something when there is no boundary to find.
+    assert len(clip_text("x" * 2000)) == 900
+
+
+def test_clip_text_still_rejects_what_is_actually_empty():
+    from examples._method_policy import clip_text
+
+    assert clip_text("") == ""
+    assert clip_text("   \n  ") == ""
+    assert clip_text(None) == ""
+    assert clip_text(["not", "a", "string"]) == ""
+    assert clip_text("", fallback="seed") == "seed"
+
+
+def test_a_long_field_proposal_becomes_a_diff_rather_than_an_invalid_count():
+    """The end-to-end consequence: `FieldSlots` counted a too-long value as an
+    invalid proposal, so a run's `invalid` number measured verbosity."""
+    import json
+
+    from examples._measure import parse_json_object
+    from examples._method_policy import FieldSlots
+
+    slots = FieldSlots(fields={"memory": "seed"}, parse=parse_json_object)
+    proposal = json.dumps({"memory": "sentence. " * 200})
+    diff = slots.to_diff({"memory": "seed"}, proposal, "w", 1, "artifact")
+    assert diff is not None, "a verbose but valid proposal was rejected"
+    assert slots.invalid_proposals == 0
+    assert len(diff.ops["memory"]) <= 900

--- a/tests/test_selfplay_upstream.py
+++ b/tests/test_selfplay_upstream.py
@@ -90,3 +90,57 @@ def test_the_reward_is_zero_at_both_extremes():
         policy.propose(lambda p, **k: (seen.setdefault("p", p), "x")[1],
                        "memory", task, "{}", 0.0)
         assert f"1-r = {want}" in seen["p"], (outcomes, seen["p"])
+
+
+# -- R-Zero -------------------------------------------------------------------
+
+
+def test_the_challengers_signal_carries_no_ground_truth():
+    """`question_evaluate/evaluate.py` takes `score = max_count / len(results)`
+    over `--num_samples` solver samples: the share agreeing with the **majority
+    answer**. R-Zero has no ground truth for a question its Challenger just
+    wrote -- that is the premise -- and rewards questions the Solver is
+    *self-inconsistent* on.
+
+    This port computed `p_hat = (score + agreement * score) / 2`, mixing in the
+    grounded verifier's reward, which measures something the paper cannot.
+    """
+    from examples.r_zero.r_zero_challenger_solver import majority_share
+
+    assert majority_share(["300", "300", "300", "300"]) == 1.0
+    assert majority_share(["300", "300", "300", "999"]) == 0.75
+    assert majority_share(["300", "300", "999", "999"]) == 0.5
+    assert majority_share(["1", "2", "3", "4"]) == 0.25
+    # A correct majority and a wrong one are the same number: no truth involved.
+    assert (majority_share(["300", "300", "999"])
+            == majority_share(["999", "999", "300"]))
+
+
+def test_unparseable_replies_do_not_look_like_agreement():
+    """Dropping them would make an incoherent batch read as certain, which is
+    the opposite of the Challenger's target."""
+    from examples.r_zero.r_zero_challenger_solver import majority_share
+
+    assert majority_share(["$3.00", "three", "?", ""]) == 0.25
+
+
+def test_the_uncertainty_reward_peaks_at_a_half():
+    """`min(score, 1 - score)`, maximal when the Solver agrees with itself half
+    the time -- and this is why `DifficultyWeighted`'s 4p(1-p) is attached here
+    and not to Absolute Zero, whose 1-r is monotone instead."""
+    from examples.r_zero.r_zero_challenger_solver import majority_share
+
+    rates = [majority_share(f) for f in (["1", "1", "1", "1"],
+                                         ["1", "1", "1", "2"],
+                                         ["1", "1", "2", "2"])]
+    rewards = [min(p, 1 - p) for p in rates]
+    assert rewards == [0.0, 0.25, 0.5]
+    assert rewards[2] == max(rewards)
+
+
+def test_r_zero_samples_the_solver_more_than_twice():
+    """Two samples give the majority share only two values, 0.5 and 1.0, so the
+    Challenger sees a coin flip rather than a frontier."""
+    from examples.r_zero import r_zero_challenger_solver as rz
+
+    assert rz.SOLVER_SAMPLES >= 4


### PR DESCRIPTION
Eighth of the eleven unmeasured MethodPolicy rows in #73 — and a shared-infrastructure bug that touches all eleven.

## A function named `clip_text` that does not clip

```python
if not cleaned or len(cleaned) > max_len:   # max_len = 900
    return fallback                          # ""
```

It **discards** a 901-character answer and keeps a 900-character one. That is not a validation rule anyone chose, and the cost lands twice: the proposal is lost, **and it is counted as `invalid`** — so a run's invalid number measures verbosity and reads in the metrics as the model producing junk.

### R-Zero surfaced it

Its runs reported `invalid` of **41, 44 and 48 out of 80** — against 2 to 11 for every other port. The rejected proposals were:

```json
{"challenger_memory":"","solver_memory":""}
```

The update calls that produced them were fine. Asked directly, they return **564 to 1632 characters** of usable policy, and four of six sampled replies ran over the limit — because R-Zero's two update prompts ask for a *policy statement* and the model writes one.

`clip_text` truncates now, on a word boundary where one is near the limit, and still refuses what is actually empty or not a string.

**`invalid` went to 0, 0, 0.**

## The Challenger's signal had ground truth in it

`question_evaluate/evaluate.py`:

```python
score = max_count / len(results)          # --num_samples, default 9
final_score = min(score, 1 - score) - penalty
```

That is the share of solver samples agreeing with the **majority answer**. R-Zero has **no ground truth** for a question its Challenger just wrote — that is the premise of the method — and rewards questions the Solver is *self-inconsistent* on.

This port computed `p_hat = (score + agreement * score) / 2`, mixing in the grounded verifier's reward, which measures something the paper cannot.

`p_hat` is the majority share now, over **four** samples rather than two: two give it only 0.5 and 1.0, so the Challenger saw a coin flip rather than a frontier. Unparseable replies count as their own distinct answers rather than being dropped — a Solver that cannot state an answer is not one that agrees with itself, and dropping them makes an incoherent batch read as *certain*.

`min(p, 1-p)` now peaks at a half, which is what `DifficultyWeighted`'s `4p(1-p)` is attached here to match — and why it is *not* attached to Absolute Zero, whose `1-r` is monotone.

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`:

| seed | test | validation | accepted | invalid | calls |
|---|---|---:|---:|---:|---:|
| 0 | 0.062 → **0.188** | 0.125 → 0.438 | 2/80 | **0** | 943 |
| 1 | 0.062 → **0.375** | 0.125 → 0.375 | 3/80 | **0** | 941 |
| 2 | 0.062 → **0.312** | 0.062 → 0.312 | 1/80 | **0** | 926 |

All three seeds moved; mean gain **+0.230**. As on Absolute Zero the carts are generated, so the baseline is not 0.000 and the ceiling is not 1.000 — read the gain.

## Verification

CI. 3 new `clip_text` tests in `tests/test_method_runner_flags.py` (including the end-to-end one: a verbose `FieldSlots` proposal now becomes a diff instead of an invalid count) and 4 new R-Zero tests in `tests/test_selfplay_upstream.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)