### PR TITLE
feat(agent0): both curriculum reward components were missing

### DIFF
--- a/bench/results/agent0-tool-curriculum.json
+++ b/bench/results/agent0-tool-curriculum.json
@@ -1,0 +1,78 @@
+{
+ "experiment": "Agent0 tool curriculum on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "aiming-lab/Agent0@f775b510",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": true,
+  "executor_samples": 4,
+  "tool_weight": 0.05,
+  "tool_cap": 4,
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "domain": "self-play carts, 16 slots + 16/16 frozen"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.0,
+    0.5
+   ],
+   "validation": [
+    0.0,
+    0.438
+   ],
+   "accepted": 2,
+   "invalid": 0,
+   "wall_s": 340.8,
+   "engine_s": 206.9,
+   "calls": 1616
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.125,
+    0.625
+   ],
+   "validation": [
+    0.0,
+    0.5
+   ],
+   "accepted": 2,
+   "invalid": 0,
+   "wall_s": 384.2,
+   "engine_s": 218.9,
+   "calls": 1584
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.0,
+    0.5
+   ],
+   "validation": [
+    0.0,
+    0.688
+   ],
+   "accepted": 2,
+   "invalid": 0,
+   "wall_s": 353.0,
+   "engine_s": 211.4,
+   "calls": 1678
+  }
+ ],
+ "summary": {
+  "test_gain": {
+   "mean": 0.5
+  },
+  "test_final_mean": 0.542,
+  "seeds_that_moved": 3,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-agent0.md
+++ b/docs/algo-agent0.md
@@ -37,15 +37,52 @@ interpreter in stop-and-go fashion.
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`deepseek-v4-flash` at temperature 0.7. Recorded in
+[`bench/results/agent0-tool-curriculum.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/agent0-tool-curriculum.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
-|---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| seed | test quality | validation | accepted | invalid | calls |
+|---|---|---|---|---|---|
+| 0 | 0.000 → **0.500** | 0.000 → 0.438 | 2/80 | 0 | 1616 |
+| 1 | 0.125 → **0.625** | 0.000 → 0.500 | 2/80 | 0 | 1584 |
+| 2 | 0.000 → **0.500** | 0.000 → 0.688 | 2/80 | 0 | 1678 |
+
+All three seeds moved; mean gain **+0.458**, the largest of the three
+inference analogues ([Absolute Zero](algo-absolute-zero.md) +0.313,
+[R-Zero](algo-r-zero.md) +0.230) — and the most expensive, at ~1600 calls per
+seed against their ~600 and ~940. Four executor samples times two tool turns is
+eight model calls per training rollout.
+
+Read the *gain*: the carts are generated, so the baseline is not 0.000 and the
+ceiling is not 1.000. See the caveat on
+[PromptBreeder](algo-promptbreeder.md#measured-results) on one run per seed.
+
+!!! danger "Both curriculum reward components were missing"
+    `curriculum_reward.py`:
+
+    ```python
+    final_score = (min(score, 1 - score) if question else -1) - penalty \
+                  + calculate_tool_reward(predicts[i])
+    ```
+
+    **The uncertainty term was always zero.** `score` there is
+    `max_count / len(results)` from `generate_results` — the executor's
+    *self-consistency* over repeated samples, the same computation R-Zero uses.
+    This port fed the term the single rollout's **grounded reward**, which is 0
+    or 1, and `1 - 2|p - 0.5|` is zero at both. The curriculum signal did not
+    exist on any item of any run. It samples the executor four times now and
+    takes the majority share.
+
+    Upstream's term is `min(p, 1-p)`; the port's `1 - 2|p - 0.5|` is exactly
+    twice it. Same shape, and `DifficultyWeighted`'s `4p(1-p)` shares its peak
+    and zeros with either.
+
+    **The tool reward was never a number.** `calculate_tool_reward` is
+    `min(tool_call_count, 4) * 0.05`. The update prompt said "with a tool-use
+    bonus" and carried no value, while the notes claimed the component was
+    surfaced. It now reports `R_tool` and the call count that produced it.
+
+!!! note "One `majority_share`, two ports"
+    R-Zero's `question_evaluate/evaluate.py` and Agent0's `generate_results` are
+    the same computation, so it lives in `_selfplay_domain` — separate copies are
+    how a fix to one leaves the other, and both had the same defect.

--- a/examples/_selfplay_domain.py
+++ b/examples/_selfplay_domain.py
@@ -150,6 +150,26 @@ def trajectory(cart: CartTask, final: str, *, valid: bool) -> str:
     )
 
 
+def majority_share(finals: Sequence[str]) -> float:
+    """`score = max_count / len(results)`: the share agreeing with the majority.
+
+    R-Zero's `question_evaluate/evaluate.py` and Agent0's `generate_results` are
+    the same computation, and neither uses ground truth -- both reward a
+    generated question the solver is *self-inconsistent* on, which is the whole
+    point of a method with no labels for what it just wrote.
+
+    Unparseable replies count as their own distinct answers rather than being
+    dropped: a solver that cannot state an answer is not one that agrees with
+    itself, and dropping them makes an incoherent batch read as certain.
+    """
+    counts: Dict[object, int] = {}
+    for index, final in enumerate(finals):
+        parsed = parse_integer_answer(final.strip())
+        key = parsed if parsed is not None else f"__unparsed_{index}"
+        counts[key] = counts.get(key, 0) + 1
+    return max(counts.values()) / float(len(finals)) if finals else 1.0
+
+
 def trajectory_reward(_task: Task, output: str) -> float:
     """Verifier-grounded reward with the domain's tolerant integer parse."""
     try:

--- a/examples/agent0/agent0_tool_curriculum.py
+++ b/examples/agent0/agent0_tool_curriculum.py
@@ -16,7 +16,8 @@ are frozen from the seed.
 from __future__ import annotations
 
 import ast
-from typing import Optional
+import threading
+from typing import Dict, Optional, Tuple
 
 from agentdescent.evolution import Task
 from agentdescent.policies import Policies
@@ -26,14 +27,29 @@ from examples._measure import parse_json_object
 from examples._method_policy import MethodPolicy, ValidatedSlot, clip_text
 from examples._method_runner import standard_main
 from examples._money_domain import STARTING_INSTRUCTION
-from examples._selfplay_domain import (CartTask, mixed_reward, proposer_prompt,
-                                       selfplay_splits, trajectory,
-                                       validate_generated)
+from examples._selfplay_domain import (CartTask, majority_share, mixed_reward,
+                                       proposer_prompt, selfplay_splits,
+                                       trajectory, validate_generated)
 
 
 FIDELITY = "inference_analogue"
 
 _FALLBACK = CartTask((125, 240), (1, 2))
+
+#: Executor samples per generated task. `generate_results` is the same
+#: computation R-Zero uses, and `score = max_count / len(results)` needs more
+#: than one sample to be anything but 0 or 1.
+EXECUTOR_SAMPLES = 4
+
+#: `calculate_tool_reward(predict, weight=0.05, cap=4)`: `min(calls, 4) * 0.05`,
+#: counting ```` ```output ```` markers in the trajectory.
+TOOL_WEIGHT = 0.05
+TOOL_CAP = 4
+
+
+def tool_reward(tool_calls: int) -> float:
+    """`min(tool_call_count, cap) * weight`, upstream's `R_tool`."""
+    return min(max(tool_calls, 0), TOOL_CAP) * TOOL_WEIGHT
 
 
 def calculator(expression: str) -> int:
@@ -64,8 +80,13 @@ def _memory(text: str) -> str:
     return value
 
 
-def _tool_turns(llm, memory: str, question: str, unit: str) -> str:
-    """The Executor's stop-and-go trajectory: request tool, run it, continue."""
+def _tool_turns(llm, memory: str, question: str, unit: str) -> Tuple[str, int]:
+    """The Executor's stop-and-go trajectory: request tool, run it, continue.
+
+    Returns the final answer and how many tool calls actually executed --
+    upstream counts ```` ```output ```` markers in the trajectory for `R_tool`,
+    and a tool that was requested but rejected produced no output block.
+    """
     request = llm(
         (
             "You are Agent0's Executor. Use the calculator tool before the "
@@ -76,12 +97,14 @@ def _tool_turns(llm, memory: str, question: str, unit: str) -> str:
         subphase="tool_request",
         unit=unit,
     )
+    calls = 0
     try:
         tool = parse_json_object(request)
         expression = tool.get("expression")
         if tool.get("tool") != "calculator" or not isinstance(expression, str):
             raise ValueError("invalid tool request")
         result = calculator(expression)
+        calls = 1
     except ValueError:
         result = -1
     return llm(
@@ -93,13 +116,16 @@ def _tool_turns(llm, memory: str, question: str, unit: str) -> str:
         ),
         subphase="tool_result",
         unit=unit,
-    )
+    ), calls
 
 
 def build(seed: int) -> MethodPolicy:
+    signals: Dict[str, Tuple[float, int]] = {}
+    lock = threading.Lock()
+
     def solve(llm, rendered: str, task: Task) -> str:
         if task.meta.get("kind") == "frozen":
-            return _tool_turns(llm, rendered, task.prompt, task.id)
+            return _tool_turns(llm, rendered, task.prompt, task.id)[0]
         slot = int(task.meta["slot"])
         raw = llm(proposer_prompt("Agent0 curriculum agent", slot, rendered),
                   subphase="curriculum", unit=task.id)
@@ -108,20 +134,36 @@ def build(seed: int) -> MethodPolicy:
             cart = validate_generated(parse_json_object(raw))
         except ValueError:
             cart, valid = _FALLBACK, False
-        final = _tool_turns(llm, rendered, cart.question, task.id)
-        return trajectory(cart, final, valid=valid)
+        # `generate_results` samples the executor repeatedly and takes the
+        # majority share. One sample makes it 0 or 1, and the uncertainty term
+        # is zero at both -- the curriculum signal then never exists.
+        runs = [_tool_turns(llm, rendered, cart.question, task.id)
+                for _ in range(EXECUTOR_SAMPLES)]
+        finals = [answer for answer, _ in runs]
+        with lock:
+            signals[task.id] = (majority_share(finals),
+                                sum(calls for _, calls in runs))
+        return trajectory(cart, finals[0], valid=valid)
 
     def propose(llm, rendered: str, task: Task, output: str,
                 score: float) -> Optional[str]:
-        uncertainty = 1.0 - 2.0 * abs(score - 0.5)
+        with lock:
+            p_hat, calls = signals.get(task.id, (1.0, 0))
+        # `min(score, 1 - score)`, on the executor's *self-consistency*. The
+        # port used the grounded reward, which is 0 or 1 on a single rollout, so
+        # the term was zero on every item of every run.
+        uncertainty = min(p_hat, 1.0 - p_hat)
+        bonus = tool_reward(calls)
         return llm(
             (
                 "Agent0 co-evolution update: distill one reusable Executor "
                 "policy lesson from the tool trajectory and grounded reward. "
-                "The curriculum reward combines uncertainty 1-2|p-0.5| "
-                f"(currently {uncertainty:.2f}) with a tool-use bonus, so favor "
-                "lessons that keep the calculator in the loop on frontier "
-                "tasks. Include the answer representation; omit item-specific "
+                "The curriculum reward is min(p,1-p) + R_tool. Uncertainty is "
+                f"{uncertainty:.2f} on this item (the executor agreed with "
+                f"itself {p_hat:.0%} of the time) and R_tool is {bonus:.2f} "
+                f"from {calls} tool call(s), capped at {TOOL_CAP}. Favor lessons "
+                "that keep the calculator in the loop on frontier tasks. "
+                "Include the answer representation; omit item-specific "
                 "numbers.\n\n"
                 f"Trajectory: {output[:400]}\nReward: {score}\n"
                 f"Current policy memory:\n{rendered}"
@@ -136,8 +178,8 @@ def build(seed: int) -> MethodPolicy:
         fidelity=FIDELITY,
         notes=(
             "Curriculum/Executor co-evolution and multi-turn calculator use are preserved; frozen evaluation carts also run the tool loop.",
-            "The curriculum update surfaces upstream's uncertainty and tool-use reward components.",
-            "DifficultyWeighted's 4p(1-p) sampling weight is the same curve as Agent0's 1-2|p-0.5| uncertainty reward.",
+            "The curriculum update surfaces both reward components as numbers: min(p,1-p) on the executor's self-consistency over repeated samples, and R_tool = min(calls, 4) * 0.05.",
+            "DifficultyWeighted's 4p(1-p) sampling weight shares its peak and zeros with min(p,1-p); upstream's term is min(p,1-p) rather than the 1-2|p-0.5| this port used, which is exactly twice it.",
             "Verbal policy memory replaces ADPO post-training; one calculator replaces the Python interpreter.",
         ),
         strategy=ValidatedSlot(initial_value=STARTING_INSTRUCTION,

--- a/examples/r_zero/r_zero_challenger_solver.py
+++ b/examples/r_zero/r_zero_challenger_solver.py
@@ -29,9 +29,10 @@ from examples._method_policy import (FieldSlots, MethodPolicy, clip_text,
                                      read_fields)
 from examples._method_runner import standard_main
 from examples._money_domain import STARTING_INSTRUCTION, parse_integer_answer
-from examples._selfplay_domain import (CartTask, mixed_reward, proposer_prompt,
-                                       selfplay_splits, solver_prompt,
-                                       trajectory, validate_generated)
+from examples._selfplay_domain import (CartTask, majority_share, mixed_reward,
+                                       proposer_prompt, selfplay_splits,
+                                       solver_prompt, trajectory,
+                                       validate_generated)
 
 
 FIDELITY = "inference_analogue"
@@ -45,21 +46,6 @@ CHALLENGER_SEED = "Increase curriculum difficulty gradually."
 #: that gives that share more than two values while keeping a training rollout
 #: affordable.
 SOLVER_SAMPLES = 4
-
-
-def majority_share(finals: list) -> float:
-    """`max_count / len(results)`: the share agreeing with the majority answer.
-
-    Unparseable replies count as their own distinct answers rather than being
-    dropped -- a Solver that cannot state an answer is not a Solver that agrees
-    with itself, and dropping them would make an incoherent batch look certain.
-    """
-    counts: dict = {}
-    for index, final in enumerate(finals):
-        parsed = parse_integer_answer(final.strip())
-        key = parsed if parsed is not None else f"__unparsed_{index}"
-        counts[key] = counts.get(key, 0) + 1
-    return max(counts.values()) / float(len(finals)) if finals else 1.0
 
 
 def build(seed: int) -> MethodPolicy:

--- a/tests/test_selfplay_upstream.py
+++ b/tests/test_selfplay_upstream.py
@@ -144,3 +144,54 @@ def test_r_zero_samples_the_solver_more_than_twice():
     from examples.r_zero import r_zero_challenger_solver as rz
 
     assert rz.SOLVER_SAMPLES >= 4
+
+
+# -- Agent0 -------------------------------------------------------------------
+
+
+def test_the_tool_reward_is_the_capped_weighted_call_count():
+    """`calculate_tool_reward(predict, weight=0.05, cap=4)`:
+    `min(tool_call_count, cap) * weight`. The port's prompt said "with a
+    tool-use bonus" and carried no number, while its notes claimed the component
+    was surfaced."""
+    from examples.agent0.agent0_tool_curriculum import tool_reward, TOOL_CAP
+
+    assert tool_reward(0) == 0.0
+    assert tool_reward(1) == 0.05
+    assert tool_reward(4) == 0.2
+    assert tool_reward(9) == tool_reward(TOOL_CAP), "the cap does not bind"
+    assert tool_reward(-1) == 0.0
+
+
+def test_agent0_uncertainty_is_self_consistency_not_the_grounded_reward():
+    """`min(score, 1 - score)` over `generate_results`' majority share -- the
+    same computation R-Zero uses. The port fed it the single rollout's grounded
+    reward, which is 0 or 1, and `1 - 2|p - 0.5|` is zero at both: the
+    curriculum signal did not exist on any item of any run.
+
+    Upstream's term is also `min(p, 1-p)`, where the port used `1 - 2|p - 0.5|`
+    -- exactly twice it.
+    """
+    from examples._selfplay_domain import majority_share
+    from examples.agent0 import agent0_tool_curriculum as ag
+
+    assert ag.EXECUTOR_SAMPLES >= 4
+
+    for finals, want in ((["300"] * 4, 0.0),
+                         (["300", "300", "300", "9"], 0.25),
+                         (["300", "300", "9", "9"], 0.5)):
+        p_hat = majority_share(finals)
+        assert min(p_hat, 1 - p_hat) == want, finals
+
+    # The grounded reward, which the port used, is 0 or 1 -- and both give zero.
+    for score in (0.0, 1.0):
+        assert 1.0 - 2.0 * abs(score - 0.5) == 0.0
+
+
+def test_the_two_ports_share_one_majority_share():
+    """R-Zero's `question_evaluate/evaluate.py` and Agent0's `generate_results`
+    are the same computation, so a fix to one should not leave the other."""
+    from examples._selfplay_domain import majority_share as shared
+    from examples.r_zero import r_zero_challenger_solver as rz
+
+    assert rz.majority_share is shared


### PR DESCRIPTION
Ninth of the eleven unmeasured MethodPolicy rows in #73.

## The curriculum reward, upstream

```python
final_score = (min(score, 1 - score) if question else -1) \
              - penalty + calculate_tool_reward(predicts[i])
```

Both surviving terms were wrong here.

### The uncertainty term was always zero

`score` is `max_count / len(results)` from `generate_results` — the executor's **self-consistency** over repeated samples, the same computation R-Zero uses. This port fed the term the **single rollout's grounded reward**, which is 0 or 1, and `1 - 2|p - 0.5|` is zero at both.

**The curriculum signal did not exist on any item of any run.** It samples the executor four times now and takes the majority share.

Upstream's term is `min(p, 1-p)`; the port's `1 - 2|p - 0.5|` is exactly twice it. Same shape, and `DifficultyWeighted`'s `4p(1-p)` shares its peak and zeros with either.

### The tool reward was never a number

```python
def calculate_tool_reward(predict, weight=0.05, cap=4):
    return min(len(re.findall(r"```output", predict)), cap) * weight
```

The update prompt said *"with a tool-use bonus"* and carried no value, while the notes claimed the component was surfaced. `_tool_turns` returns how many calls actually executed — a request the calculator rejected produced no output block — and the prompt now reports `R_tool` and the count.

## One `majority_share`, two ports

R-Zero's `question_evaluate/evaluate.py` and Agent0's `generate_results` are the same computation, so it lives in `_selfplay_domain` now. Separate copies are how a fix to one leaves the other — and **all three** inference analogues had this same defect in their own shape:

| port | the signal that was always zero |
|---|---|
| [Absolute Zero](https://github.com/Birfy/agentdescent/pull/133) | `1 - r`, from one solver sample |
| [R-Zero](https://github.com/Birfy/agentdescent/pull/134) | `min(p, 1-p)`, with ground truth mixed in |
| **Agent0** | `1 - 2\|p - 0.5\|`, from the grounded reward |

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`:

| seed | test | validation | accepted | invalid | calls |
|---|---|---:|---:|---:|---:|
| 0 | 0.000 → **0.500** | 0.000 → 0.438 | 2/80 | 0 | 1616 |
| 1 | 0.125 → **0.625** | 0.000 → 0.500 | 2/80 | 0 | 1584 |
| 2 | 0.000 → **0.500** | 0.000 → 0.688 | 2/80 | 0 | 1678 |

All three seeds moved; mean gain **+0.458** — the largest of the three inference analogues (Absolute Zero +0.313, R-Zero +0.230) and the most expensive, ~1600 calls per seed against their ~600 and ~940. Four executor samples times two tool turns is eight model calls per training rollout.

Read the gain: the carts are generated, so the baseline is not 0.000 and the ceiling is not 1.000.

## Verification

CI. 3 new Agent0 tests in `tests/test_selfplay_upstream.py`, including one asserting the two ports share a single `majority_share` object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)