### PR TITLE
feat(sica): the next base was sampled where upstream takes the maximum

### DIFF
--- a/agentdescent/selection.py
+++ b/agentdescent/selection.py
@@ -238,11 +238,21 @@ class Archive(SingleHead):
     like a greedy hill climb. ``'uniform'`` is the ablation, and having it here
     means the archive's contribution can be measured rather than assumed.
 
+    ``'best'`` does not sample at all: it returns the highest scorer every time,
+    which is SICA's rule -- ``get_best_agent_iteration`` takes ``idxmax()`` of
+    the mean benchmark score and the next meta-improvement starts from exactly
+    that agent. It is here rather than inside one example because it is a
+    published archive rule, and because the difference from ``'performance'`` is
+    easy to miss: a softmax over scores in ``[0, 1]`` at temperature 1 puts
+    ``exp(1)/exp(0) = 2.7`` between the best and worst candidate, so a run
+    configured as "performance" picks the worst entry roughly a quarter of the
+    time where SICA would never pick it.
+
     Deterministic given ``seed``: an archive that samples differently on a
     re-run makes a seeded comparison meaningless.
     """
 
-    MODES = ("performance", "novelty", "uniform")
+    MODES = ("performance", "novelty", "uniform", "best")
 
     def __init__(self, sampling: str = "novelty", temperature: float = 1.0,
                  seed: int = 0) -> None:
@@ -268,6 +278,12 @@ class Archive(SingleHead):
 
         if len(ctx.candidates) <= 1:
             return super().select(ctx, n)
+        if self.sampling == "best":
+            # First maximum, as `idxmax` takes: ties go to the earlier entry, so
+            # a later candidate has to actually beat the incumbent to displace it.
+            best = max(ctx.candidates,
+                       key=lambda c: (0.0 if c.score is None else c.score))
+            return [best] * n
         # An int, not a tuple: tuple seeding is deprecated from 3.9 and would
         # eventually start raising in the middle of a long run.
         rng = random.Random(self.seed * 1_000_003 + ctx.round)

--- a/bench/results/sica-self-edit.json
+++ b/bench/results/sica-self-edit.json
@@ -1,0 +1,78 @@
+{
+ "experiment": "SICA self-editing policy source on AgentDescent",
+ "model": "deepseek-v4-flash",
+ "provider": "claude",
+ "reference": "MaximeRobeyns/self_improving_coding_agent@ed8275dc",
+ "config": {
+  "arm": "async_pipeline",
+  "budget_rollouts": 80,
+  "workers": 8,
+  "async_ratio": 2,
+  "staleness": "full",
+  "reflective_merge": false,
+  "selection": "Archive(sampling='best')",
+  "temperature": 0.7,
+  "thinking": "disabled",
+  "domain": "money, 48 items, 16/16/16 splits"
+ },
+ "cells": [
+  {
+   "seed": 0,
+   "test": [
+    0.0,
+    0.562
+   ],
+   "validation": [
+    0.0,
+    0.812
+   ],
+   "accepted": 3,
+   "invalid": 0,
+   "wall_s": 135.7,
+   "engine_s": 75.3,
+   "calls": 599
+  },
+  {
+   "seed": 1,
+   "test": [
+    0.0,
+    0.188
+   ],
+   "validation": [
+    0.0,
+    0.625
+   ],
+   "accepted": 1,
+   "invalid": 2,
+   "wall_s": 294.8,
+   "engine_s": 231.1,
+   "calls": 1351
+  },
+  {
+   "seed": 2,
+   "test": [
+    0.0,
+    0.938
+   ],
+   "validation": [
+    0.0,
+    1.0
+   ],
+   "accepted": 3,
+   "invalid": 1,
+   "wall_s": 196.0,
+   "engine_s": 127.3,
+   "calls": 807
+  }
+ ],
+ "summary": {
+  "test_quality": {
+   "min": 0.188,
+   "median": 0.562,
+   "max": 0.938,
+   "mean": 0.563
+  },
+  "seeds_that_moved": 3,
+  "total_seeds": 3
+ }
+}

--- a/docs/algo-sica.md
+++ b/docs/algo-sica.md
@@ -35,15 +35,48 @@ either). The selected agent then edits its own source and is re-benchmarked.
 
 ## Measured results
 
-*Pending: this section is populated from the live matrix
-(`bench/results/candidate-methods-framework-final.json`) after the
-post-restructuring rerun. See the
-[matrix overview](matrix-overview.md) for the matrix-wide
-tables (quality, [parallel speedup](matrix-parallel-speedup.md), and
-[async behaviour](matrix-async.md)).*
+Three seeds, `async_pipeline`, 80 rollouts each, 8 workers, `--staleness full`,
+`deepseek-v4-flash` at temperature 0.7. Recorded in
+[`bench/results/sica-self-edit.json`](https://github.com/Birfy/agentdescent/blob/main/bench/results/sica-self-edit.json).
 
-| Mode | Quality (test, before → after) | E2E seconds | Engine seconds | TTQ |
+| seed | test quality | validation | accepted | calls |
 |---|---|---|---|---|
-| serial | *TBD* | *TBD* | *TBD* | *TBD* |
-| sync_parallel | *TBD* | *TBD* | *TBD* | *TBD* |
-| async_pipeline | *TBD* | *TBD* | *TBD* | *TBD* |
+| 0 | 0.000 → **0.562** | 0.000 → 0.812 | 3/80 | 599 |
+| 1 | 0.000 → **0.188** | 0.000 → 0.625 | 1/80 | 1351 |
+| 2 | 0.000 → **0.938** | 0.000 → 1.000 | 3/80 | 807 |
+
+Mean 0.563, all three seeds moving. The call counts vary by more than a factor
+of two because `reflective=False` is a *fidelity* choice here — a model-synthesised
+merge of Python source would bypass the AST gate that makes executing it safe —
+so contested edits to the single policy slot are resolved by **ranking**, and
+ranking costs evaluations. The seed that accepted least spent most.
+
+See the caveat on [PromptBreeder](algo-promptbreeder.md#measured-results): one
+run per seed does not pin a number here either.
+
+!!! danger "The next base was sampled where upstream takes the maximum"
+    `get_best_agent_iteration` takes `idxmax()` of the mean benchmark score, and
+    `runner.py` then runs `archive.agent_{best_iter}.agent_code`. There is no
+    sampling in it.
+
+    This port used `Archive(sampling="performance")` — a softmax over score,
+    which at temperature 1 over scores in `[0, 1]` leaves only
+    `exp(1)/exp(0) = 2.7` between the best and the worst entry. Measured over a
+    four-candidate archive scoring 0.2 / 0.9 / 0.5 / 0.9, that mode starts from
+    the **worst** agent 8 times in 40.
+
+    This page had the rule right in prose — "selects by best mean score" — and
+    named a mode that does something else. `Archive` gains a `best` mode, in the
+    shared selection seam rather than inside this example, because a
+    deterministic argmax over the archive is a published rule and belongs beside
+    `performance`, `novelty` and the `uniform` ablation. Ties go to the earlier
+    entry, as `idxmax` does, so a later candidate has to beat the incumbent
+    rather than merely equal it.
+
+!!! note "The gate was checked before the run, not after"
+    A self-edit analogue whose editable surface cannot express a solution is
+    [Voyager](algo-voyager.md#measured-results)'s failure in another shape: three
+    seeds of 0.000 with no invalid proposals, against a target the world does not
+    accept. `test_the_gate_admits_a_prompt_that_can_clear_the_domain` compiles a
+    policy that teaches integer cents and working-out and asserts the gate lets
+    it through, so a zero here would be the algorithm's and not the harness's.

--- a/examples/sica/sica_self_edit.py
+++ b/examples/sica/sica_self_edit.py
@@ -1,10 +1,15 @@
 """Self-edit analogue: **SICA** (MaximeRobeyns/self_improving_coding_agent@ed8275dc).
 
 Preserved: the meta loop edits real Python policy source through an AST gate,
-utility is the measured benchmark score, and the next base is drawn from an
-**archive of prior versions** -- the pinned revision selects by best mean score
-(its paper's cost/time composite is unimplemented upstream too), which is the
-`Archive` selection policy's performance mode.
+utility is the measured benchmark score, and the next base is the **best agent
+in the archive of prior versions** -- `get_best_agent_iteration` takes
+``idxmax()`` of the mean benchmark score, and `runner.py` then runs
+``archive.agent_{best_iter}.agent_code``. That is `Archive`'s ``best`` mode, not
+its ``performance`` one: a softmax over scores in ``[0, 1]`` at temperature 1
+leaves only ``exp(1)/exp(0) = 2.7`` between the best and worst entry, so a run
+configured as "performance" starts from the worst agent in the archive about a
+quarter of the time. (The paper's cost/time composite is unimplemented upstream
+too.)
 
 An unparseable self-edit costs its candidate and produces no diff -- there is
 no substitute source. ``reflective=False``: synthesised merges of Python source
@@ -110,7 +115,7 @@ def build(seed: int) -> MethodPolicy:
         fidelity=FIDELITY,
         notes=(
             "The meta loop edits real Python policy source and the framework gate measures utility.",
-            "Archive selection (performance mode, matching the pinned revision's best-mean-score rule) runs through the population aggregator; the run finalises on the archive's best scorer.",
+            "Archive selection in `best` mode -- `get_best_agent_iteration` takes idxmax() of the mean benchmark score, so the next meta-improvement starts from exactly that agent and never from a sampled one; the run finalises on the archive's best scorer.",
             "An unparseable self-edit costs its candidate and produces no diff; there is no substitute source.",
             "The editable surface is one AST-gated function rather than SWE-bench Docker.",
         ),
@@ -123,7 +128,7 @@ def build(seed: int) -> MethodPolicy:
         propose=propose,
         reward=money_reward,
         proposal_calls_per_candidate=1,
-        engine=Policies(selection=Archive(sampling="performance", seed=seed)),
+        engine=Policies(selection=Archive(sampling="best", seed=seed)),
         reflective=False,
     )
 

--- a/tests/test_sica_upstream.py
+++ b/tests/test_sica_upstream.py
@@ -1,0 +1,105 @@
+"""SICA against `MaximeRobeyns/self_improving_coding_agent@ed8275dc`."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentdescent.selection import Archive, Candidate
+from examples.sica import sica_self_edit as sica
+
+
+def _ctx(scores):
+    pool = [Candidate("a", i, score=s) for i, s in enumerate(scores)]
+    return SimpleNamespace(candidates=tuple(pool), round=1, head=pool[0],
+                           n_workers=1)
+
+
+def test_the_next_base_is_the_best_agent_not_a_sampled_one():
+    """`get_best_agent_iteration` takes `idxmax()` of the mean benchmark score,
+    and `runner.py` runs `archive.agent_{best_iter}.agent_code`. There is no
+    sampling in it.
+
+    The port used `Archive(sampling="performance")`, a softmax over scores in
+    [0, 1] at temperature 1 -- which leaves only `exp(1)/exp(0) = 2.7` between
+    the best and worst entry. Measured over a four-candidate archive scoring
+    0.2 / 0.9 / 0.5 / 0.9, that mode starts from the **worst** agent 8 times in
+    40. SICA never would.
+    """
+    assert sica.build(0).engine.selection.sampling == "best"
+
+    ctx = _ctx([0.2, 0.9, 0.5, 0.9])
+    picks = Archive(sampling="best", seed=0).select(ctx, 40)
+    assert {p.score for p in picks} == {0.9}
+
+    sampled = [p.score for p in Archive(sampling="performance", seed=0)
+               .select(ctx, 40)]
+    assert 0.2 in sampled, "the contrast this test exists for has gone"
+
+
+def test_best_mode_breaks_ties_toward_the_incumbent():
+    """`idxmax` returns the first maximum, so a later candidate has to actually
+    beat the incumbent rather than merely equal it."""
+    ctx = _ctx([0.9, 0.5, 0.9])
+    assert Archive(sampling="best").select(ctx, 1)[0].version == 0
+
+
+def test_best_mode_is_a_declared_archive_mode():
+    assert "best" in Archive.MODES
+    with pytest.raises(ValueError, match="sampling must be one of"):
+        Archive(sampling="greedy")
+
+
+# -- the AST gate -------------------------------------------------------------
+
+
+def test_the_gate_admits_a_prompt_that_can_clear_the_domain():
+    """A self-edit analogue whose editable surface cannot express a solution is
+    Voyager's failure in another shape: three seeds of 0.000 with no invalid
+    proposals, against a target the world does not accept.
+
+    This checks the gate *before* the run: the domain needs a prompt that teaches
+    integer cents and working-out, and the gate has to let one through.
+    """
+    teaches = (
+        'def agent_prompt(question):\n'
+        '    return "Work the arithmetic out in dollars, then convert to whole '
+        'cents. End your reply with a final line containing only that integer.'
+        '\\n\\n" + question\n'
+    )
+    functions = sica.compile_policy(teaches, {"agent_prompt": 1})
+    from examples._money_domain import money_splits
+    rendered = sica.policy_prompt(functions["agent_prompt"], money_splits(0)[0][0])
+    assert "cents" in rendered and "final line" in rendered
+
+    suffix = (
+        'def agent_prompt(question):\n'
+        '    return "Solve:\\n" + question + "\\nAnswer in integer cents."\n'
+    )
+    assert sica.compile_policy(suffix, {"agent_prompt": 1})
+
+
+@pytest.mark.parametrize("source,reason", [
+    ('def agent_prompt(question):\n    return f"Solve {question}"\n', "JoinedStr"),
+    ('def agent_prompt(question):\n    p = "x"\n    return p + question\n', "Assign"),
+    ('def agent_prompt(question):\n    return "x" + question.strip()\n', "Call"),
+    ('def agent_prompt(q, extra):\n    return "x" + q\n', "arity"),
+    ('def other(question):\n    return question\n', "surface"),
+    ('def agent_prompt(question):\n    return question\n', None),
+])
+def test_the_gate_refuses_what_it_declares_it_refuses(source, reason):
+    if reason is None:
+        assert sica.compile_policy(source, {"agent_prompt": 1})
+        return
+    with pytest.raises(ValueError):
+        sica.compile_policy(source, {"agent_prompt": 1})
+
+
+def test_an_unparseable_self_edit_costs_its_candidate_and_proposes_nothing():
+    """There is no substitute source: a broken edit is a spent candidate, which
+    is why `reflective=False` -- a synthesised merge of Python would bypass the
+    gate that makes this safe."""
+    policy = sica.build(0)
+    assert policy.reflective is False
+    state = {"policy": sica.SICA_INITIAL_SOURCE}
+    assert policy.strategy.to_diff(state, "not python at all", "w", 1, "a") is None


### PR DESCRIPTION
Tenth of the eleven unmeasured MethodPolicy rows in #73.

## Upstream does not sample

```python
best_iter = aa.get_best_agent_iteration()      # idxmax() of mean_benchmark_score
...
agent_module = f"archive.agent_{best_iter}.agent_code"
```

This port used `Archive(sampling="performance")` — a softmax over score, which at temperature 1 over scores in `[0, 1]` leaves only `exp(1)/exp(0) = 2.7` between the best and the worst entry.

Measured over a four-candidate archive scoring 0.2 / 0.9 / 0.5 / 0.9:

| mode | distinct scores picked in 40 draws | worst agent picked |
|---|---|---|
| `best` | `{0.9}` | **0/40** |
| `performance` | `{0.2, 0.5, 0.9}` | 8/40 |
| `uniform` | `{0.2, 0.5, 0.9}` | 15/40 |

The page had the rule right in prose — *"selects by best mean score"* — and named a mode that does something else. That is this series' recurring shape: the description is accurate and the implementation is not.

### Why `best` goes in the shared seam

`Archive` gains a `best` mode rather than SICA getting a private policy, because a deterministic argmax over the archive is a **published rule** and belongs beside `performance`, `novelty` and the `uniform` ablation — and because the difference from `performance` is easy to miss, so having both named makes it checkable.

Ties go to the earlier entry, as `idxmax` does, so a later candidate has to *beat* the incumbent rather than merely equal it.

## The gate was checked before the run, not diagnosed after it

A self-edit analogue whose editable surface cannot express a solution is [Voyager](https://github.com/Birfy/agentdescent/pull/131)'s failure in another shape: three seeds of 0.000, no invalid proposals, against a target the world does not accept.

`test_the_gate_admits_a_prompt_that_can_clear_the_domain` compiles a policy that teaches integer cents and working-out and asserts the AST gate lets it through. A zero here would then be the algorithm's, not the harness's.

## Measured

Three seeds, 80 rollouts, `async_pipeline`, 8 workers, `--staleness full`:

| seed | test | validation | accepted | calls |
|---|---|---:|---:|---:|
| 0 | 0.000 → **0.562** | 0.000 → 0.812 | 3/80 | 599 |
| 1 | 0.000 → **0.188** | 0.000 → 0.625 | 1/80 | 1351 |
| 2 | 0.000 → **0.938** | 0.000 → 1.000 | 3/80 | 807 |

Mean **0.563**, all three seeds moving.

The call counts vary by more than 2× because `reflective=False` is a **fidelity** choice here — a model-synthesised merge of Python source would bypass the AST gate that makes executing it safe — so contested edits to the single policy slot are resolved by *ranking*, and ranking costs evaluations. The seed that accepted least spent most.

## Verification

CI. 7 tests in `tests/test_sica_upstream.py`, plus the existing `tests/test_selection.py` confirming the new mode does not disturb the seam's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)