### PR TITLE
feat(selection): GEPA's and DGM's published rules, shipped and pinned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`ParetoFrontier(mode="win_frequency")` — GEPA's Algorithm 2, shipped.**
+  Per-instance winners → dominance pruning → a draw weighted by how many
+  instances each survivor still wins, as
+  `agentdescent.selection.pareto_win_frequency`. GEPA kept its own copy for a
+  stated reason ("the shipped policy walks the frontier round-robin, GEPA
+  samples it weighted by unique wins — close enough to look right and wrong
+  enough to change a measured run"), and the reason was correct. The port now
+  uses the shipped mode.
+- **`Archive(sampling="sigmoid_novelty")` — DGM's `choose_selfimproves`,
+  shipped**, as `agentdescent.selection.sigmoid_novelty_weights`. Same story:
+  `novelty` is a temperature-1 softmax, DGM's is `sigmoid(10·(s−0.5))`, and a
+  sigmoid at gain 10 is nearly a step where the softmax is nearly flat — they
+  disagree most exactly where an archive spends its time. `examples/dgm` and
+  `examples/adas` each carried a byte-identical copy of the formula; there is
+  one now. ADAS keeps a function rather than the policy because it uses the same
+  weights for a different draw: five entries without replacement to condition
+  the meta-agent, against DGM's one parent.
+- **`rng=` on `ParetoFrontier` and `Archive`.** A port migrating off a
+  hand-written rule has to keep drawing from *its* rng in *its* order; a policy
+  that re-seeded per call would agree on the distribution and disagree with
+  every number the port has published. `seed=` still builds a fresh stream.
+- **`tests/test_port_selection_equivalence.py`.** What makes "we did not change
+  the upstream selection rule" a claim a test can check rather than a sentence a
+  reader has to trust: the shipped mode and the rule it replaced are stepped
+  through **one shared rng in lockstep**, 200 consecutive draws, and the
+  frontier is compared against GEPA's own implementation rather than a
+  transcription of it.
+
+### Fixed
+
+- **`ParetoFrontier(mode="per_instance")` claimed to be GEPA and is not.** It is
+  plain Pareto walked round-robin: it keeps candidates that are best at nothing,
+  and it does not weight the draw. `docs/port-fidelity.md` recorded GEPA as
+  using it, which was wrong twice over — the port did not use the shipped policy
+  at all. The mode keeps its behaviour and loses the claim; `win_frequency` is
+  what the name meant. The same entry recorded DGM as `sampling="novelty"`,
+  which was the softmax it specifically did not use.
+
 ### Changed
 
 - **`Policies(selection=…)` now takes effect, from either driver.** The

--- a/agentdescent/selection.py
+++ b/agentdescent/selection.py
@@ -56,7 +56,8 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from typing import (
-    Dict, List, Mapping, Optional, Protocol, Sequence, runtime_checkable,
+    Dict, List, Mapping, Optional, Protocol, Sequence, Set, Tuple,
+    runtime_checkable,
 )
 
 from .evolvable import ContractError
@@ -72,6 +73,8 @@ __all__ = [
     "SelectionPolicy",
     "SingleHead",
     "pareto_front",
+    "pareto_win_frequency",
+    "sigmoid_novelty_weights",
 ]
 
 
@@ -188,6 +191,72 @@ class Beam(SingleHead):
         return [beam[i % len(beam)] for i in range(n)]
 
 
+def pareto_win_frequency(
+        scores: Sequence[Sequence[float]]) -> Tuple[Set[int], Dict[int, int]]:
+    """GEPA Algorithm 2, steps 1-4: the frontier and how often each member wins.
+
+    ``scores[c][i]`` is candidate ``c``'s score on Pareto instance ``i``.
+
+    1. per-instance best; 2. union of the candidates that tie it; 3. drop any
+    candidate strictly dominated by another survivor; 4. count, for each
+    survivor, how many instances it still ties the best on.
+
+    This is **not** :func:`pareto_front`, and the difference is the point.
+    `pareto_front` keeps everything nothing else dominates; this keeps only what
+    ties the best on at least one instance, then prunes. A candidate that is
+    merely un-dominated -- never the best anywhere -- is on the first and not on
+    the second. Two published rules, two functions, so a run can say which it
+    used.
+    """
+    if not scores or not scores[0]:
+        return set(), {}
+    n_cand, n_inst = len(scores), len(scores[0])
+    # 1 + 2: candidates that tie the best score on at least one instance.
+    best = [max(scores[c][i] for c in range(n_cand)) for i in range(n_inst)]
+    pstar = [{c for c in range(n_cand) if scores[c][i] == best[i]}
+             for i in range(n_inst)]
+    kept: Set[int] = set().union(*pstar) if pstar else set()
+    # 3: iteratively remove any candidate strictly dominated by another in the
+    # surviving set -- not by any candidate, which would prune against rows that
+    # are themselves already out.
+    changed = True
+    while changed:
+        changed = False
+        for b in list(kept):
+            if any(a != b
+                   and all(x >= y for x, y in zip(scores[a], scores[b]))
+                   and any(x > y for x, y in zip(scores[a], scores[b]))
+                   for a in kept):
+                kept.discard(b)
+                changed = True
+                break
+    # 4: frequency over the pruned per-instance frontier.
+    freq: Dict[int, int] = {c: 0 for c in kept}
+    for winners in pstar:
+        for c in (winners & kept):
+            freq[c] += 1
+    return kept, freq
+
+
+def sigmoid_novelty_weights(scores: Sequence[float],
+                            children: Sequence[int]) -> List[float]:
+    """DGM's ``score_child_prop``: ``sigmoid(10*(s-0.5)) * 1/(1+children)``.
+
+    Favour high performers, discount parents already explored. Normalised, and
+    an all-zero raw vector divides by 1 rather than by 0 -- the degenerate case
+    an archive of untouched zero-scorers actually reaches.
+
+    Here rather than in a port because it was in *two*: `examples/dgm` and
+    `examples/adas` each carried a byte-identical copy, one selecting a parent
+    and one choosing what to show the meta-agent. Two copies of a published
+    formula is how the two quietly stop being the same formula.
+    """
+    raw = [(1.0 / (1.0 + math.exp(-10.0 * (s - 0.5)))) * (1.0 / (1.0 + c))
+           for s, c in zip(scores, children)]
+    total = sum(raw) or 1.0
+    return [r / total for r in raw]
+
+
 def pareto_front(candidates: Sequence[Candidate], *,
                  tasks: Sequence[str]) -> List[Candidate]:
     """Candidates no other candidate beats on every task and betters on one.
@@ -210,37 +279,87 @@ def pareto_front(candidates: Sequence[Candidate], *,
 
 
 class ParetoFrontier(SingleHead):
-    """GEPA's and EvoSkill's selection rules, as one class and one argument.
+    """Three published frontier rules, as one class and one argument.
 
-    They are genuinely different rules and the repository has documented the
-    difference in prose for a while:
-
+    ``win_frequency``
+        **GEPA's Algorithm 2**, exactly: the per-instance winners, pruned of
+        anything a survivor dominates, sampled in proportion to how many
+        instances each survivor still wins. One draw per call, repeated for
+        every worker, because Algorithm 2 selects *a* parent per iteration.
+        Needs ``Candidate.per_task`` and an rng.
     ``per_instance``
-        GEPA. A candidate survives when no other dominates it across the
-        held-out instances, so a candidate that is best on a single hard task
-        stays in. Needs ``Candidate.per_task``.
+        Plain Pareto: a candidate survives when nothing else dominates it, and
+        the survivors are walked round-robin. Close to GEPA and not GEPA -- it
+        keeps candidates that are best at nothing, and it does not weight the
+        draw. This is the mode the class shipped with under GEPA's name; the
+        name was wrong and `win_frequency` is what that name meant.
     ``topk_aggregate``
         EvoSkill's released code. Rank by the aggregate score and keep the top
-        ``k``. Cheaper, and it discards the specialist the first mode keeps.
+        ``k``. Cheaper, and it discards the specialist the other two keep.
 
-    Making this an argument is the point: a fidelity difference that lives in two
-    hand-written implementations drifts, and a reader cannot tell which one a run
-    used.
+    Making this an argument is the point: a fidelity difference that lives in
+    hand-written per-port implementations drifts, and a reader of a result
+    cannot tell which rule produced it.
     """
 
-    MODES = ("per_instance", "topk_aggregate")
+    MODES = ("win_frequency", "per_instance", "topk_aggregate")
 
-    def __init__(self, mode: str = "per_instance", k: int = 5) -> None:
+    def __init__(self, mode: str = "per_instance", k: int = 5,
+                 seed: int = 0, rng: Optional["random.Random"] = None) -> None:
         if mode not in self.MODES:
             raise ValueError(f"mode must be one of {self.MODES}, not {mode!r}")
         self.mode = mode
         self.k = k
+        self.seed = seed
+        #: Passed in when the caller owns the stream. A port migrating off a
+        #: hand-written rule has to keep drawing from *its* rng in *its* order,
+        #: or a seeded run picks different parents and every measured number it
+        #: published moves. A fresh `Random(seed)` otherwise.
+        self.rng = rng
+
+    def _draw(self, ctx: SelectionContext):
+        import random
+
+        if self.rng is not None:
+            return self.rng
+        return random.Random(self.seed * 1_000_003 + ctx.round)
+
+    def _win_frequency(self, ctx: SelectionContext, n: int) -> Sequence[Candidate]:
+        """Algorithm 2 step 5: one draw, weighted by win frequency.
+
+        One `rng.choices(..., k=1)` for the whole batch, not `k=n`: Algorithm 2
+        selects a parent per iteration and every worker mutates it. Drawing per
+        worker would consume the stream differently and pick different parents
+        on a seeded re-run of an already-published number.
+        """
+        candidates = list(ctx.candidates)
+        tasks = sorted({t for c in candidates for t in c.per_task})
+        if not tasks:
+            raise ValueError(
+                "ParetoFrontier(mode='win_frequency') is GEPA Algorithm 2 and "
+                "needs Candidate.per_task scores; none were provided. Use "
+                "mode='topk_aggregate' if aggregate ranking is what you want.")
+        rows = [[c.per_task.get(t, 0.0) for t in tasks] for c in candidates]
+        kept, freq = pareto_win_frequency(rows)
+        pool = [c for c in sorted(kept) if freq[c] > 0]
+        if not pool:
+            # Degenerate -- every row identical, so nothing uniquely wins.
+            # Best aggregate, which is where upstream lands too, and no draw:
+            # spending a random number here would desynchronise the stream
+            # against a run that had one more candidate.
+            best = max(range(len(rows)), key=lambda c: sum(rows[c]))
+            return [candidates[best]] * n
+        chosen = self._draw(ctx).choices(pool, weights=[freq[c] for c in pool],
+                                         k=1)[0]
+        return [candidates[chosen]] * n
 
     def select(self, ctx: SelectionContext, n: int) -> Sequence[Candidate]:
         if len(ctx.candidates) <= 1:
             return super().select(ctx, n)
         if self.mode == "topk_aggregate":
             return Beam(self.k).select(ctx, n)
+        if self.mode == "win_frequency":
+            return self._win_frequency(ctx, n)
         tasks = sorted({t for c in ctx.candidates for t in c.per_task})
         if not tasks:
             # Refused rather than silently degraded to aggregate ranking: that
@@ -273,14 +392,24 @@ class Archive(SingleHead):
     configured as "performance" picks the worst entry roughly a quarter of the
     time where SICA would never pick it.
 
+    ``'sigmoid_novelty'`` is **DGM's** ``choose_selfimproves`` exactly:
+    :func:`sigmoid_novelty_weights`, i.e. ``sigmoid(10*(s-0.5)) / (1+selected)``.
+    The shape is `'novelty'`'s and the numbers are not -- a sigmoid at gain 10
+    is nearly a step at 0.5, where a temperature-1 softmax is nearly flat, so
+    the two disagree most exactly where an archive spends its time. It is a
+    separate mode rather than a tuning of `'novelty'` for that reason.
+
     Deterministic given ``seed``: an archive that samples differently on a
-    re-run makes a seeded comparison meaningless.
+    re-run makes a seeded comparison meaningless. Pass ``rng`` instead when the
+    caller owns the stream -- a port migrating off a hand-written rule has to
+    keep drawing from *its* rng in *its* order, or every measured number it
+    published moves.
     """
 
-    MODES = ("performance", "novelty", "uniform", "best")
+    MODES = ("performance", "novelty", "sigmoid_novelty", "uniform", "best")
 
     def __init__(self, sampling: str = "novelty", temperature: float = 1.0,
-                 seed: int = 0) -> None:
+                 seed: int = 0, rng: Optional["random.Random"] = None) -> None:
         if sampling not in self.MODES:
             raise ValueError(f"sampling must be one of {self.MODES}, not {sampling!r}")
         if temperature <= 0:
@@ -288,6 +417,7 @@ class Archive(SingleHead):
         self.sampling = sampling
         self.temperature = temperature
         self.seed = seed
+        self.rng = rng
 
     def _weight(self, c: Candidate) -> float:
         if self.sampling == "uniform":
@@ -309,11 +439,19 @@ class Archive(SingleHead):
             best = max(ctx.candidates,
                        key=lambda c: (0.0 if c.score is None else c.score))
             return [best] * n
+        pool = list(ctx.candidates)
+        if self.sampling == "sigmoid_novelty":
+            # An unscored candidate is a zero here, not the mean: DGM's archive
+            # holds evaluated agents, and inventing 0.5 for one would place it
+            # exactly on the sigmoid's steepest point.
+            weights = sigmoid_novelty_weights(
+                [0.0 if c.score is None else c.score for c in pool],
+                [c.selected for c in pool])
+        else:
+            weights = [self._weight(c) for c in pool]
         # An int, not a tuple: tuple seeding is deprecated from 3.9 and would
         # eventually start raising in the middle of a long run.
-        rng = random.Random(self.seed * 1_000_003 + ctx.round)
-        pool = list(ctx.candidates)
-        weights = [self._weight(c) for c in pool]
+        rng = self.rng or random.Random(self.seed * 1_000_003 + ctx.round)
         return rng.choices(pool, weights=weights, k=n)
 
 

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -58,7 +58,7 @@ In [`examples/adas/adas_meta_agent_search.py`](https://github.com/Birfy/agentdes
 | **`MetaSearchAggregator`** | `aggregator_factory=` | ADAS's keep-all archive with bootstrap-CI fitness |
 | `make_propose(...)` | `propose=` | the meta-agent, conditioned on the whole archive (+ two Reflexion rounds) |
 | **`Interpreter`** + **`seed_archive`** | (agent substrate) | the safe control-flow DSL (`cot`/`cot_sc`/`reflexion`/`debate`/`step_back`/`role_assignment`/`ensemble`) and the seven MGSM seeds |
-| **`dgm_parent_weights`** | `--select dgm` | DGM's sigmoid×novelty rule as an alternative archive-conditioning strategy |
+| **`dgm_parent_weights`** | `--select dgm` | DGM's sigmoid×novelty rule as an alternative archive-conditioning strategy. Shared with `examples/dgm` as [`sigmoid_novelty_weights`](selection.md) — same formula, different draw: ADAS samples five entries without replacement to condition the meta-agent, DGM samples one parent |
 
 ## Measured results — GPQA Diamond
 

--- a/docs/algo-dgm.md
+++ b/docs/algo-dgm.md
@@ -54,10 +54,10 @@ In [`examples/dgm/dgm_self_improve.py`](https://github.com/Birfy/agentdescent/bl
 
 | Plug-in | `evolve()` slot | What it does |
 |---|---|---|
-| `DGMParentSelection` | selection ([seam](selection.md)) | `sigmoid(10·(s−0.5)) × 1/(1+children)` parent sampling; default of `DGMArchiveAggregator` |
+| shipped `Archive(sampling="sigmoid_novelty")` | selection ([seam](selection.md)) | `sigmoid(10·(s−0.5)) × 1/(1+children)` parent sampling; default of `DGMArchiveAggregator`, with the aggregator's own rng |
 | **`HarnessStrategy`** | `strategy=` | a proposed capability becomes a `Diff` on the harness capability set |
 | **`DGMArchiveAggregator`** | `aggregator_factory=` | keep-all archive + staged eval (10→50→140) + sigmoid×novelty parent selection; sets the sampled parent as the dev head |
-| **`dgm_parent_weights` / `choose_selfimproves`** | (selection) | the exact DGM rule `p_i ∝ sigmoid(10·(score−0.5)) · 1/(1+children_i)` |
+| **`dgm_parent_weights` / `choose_selfimproves`** | (selection) | the exact DGM rule `p_i ∝ sigmoid(10·(score−0.5)) · 1/(1+children_i)`. The formula is now [`agentdescent.selection.sigmoid_novelty_weights`](selection.md); `examples/adas` carried a byte-identical copy until it was shared |
 | `propose` + `make_surrogate_evaluator` | `propose=` / objective | add the most-needed capability; the transparent surrogate objective (swap in a real Docker harness via `evaluate_fn`) |
 
 ## Measured results — vendored bugs (`--objective real`)

--- a/docs/algo-gepa.md
+++ b/docs/algo-gepa.md
@@ -58,10 +58,10 @@ In [`examples/gepa/gepa_prompt_evolution.py`](https://github.com/Birfy/agentdesc
 
 | Plug-in | `evolve()` slot | What it does |
 |---|---|---|
-| `ParetoWinFrequency` | selection ([seam](selection.md)) | Algorithm-2 frontier sampling as a named policy; `ParetoAggregator` delegates to it |
+| shipped `ParetoFrontier(mode="win_frequency")` | selection ([seam](selection.md)) | Algorithm-2 frontier sampling; `ParetoAggregator` passes its own rng so the stream is unchanged |
 | **`InstructionSlot`** | `strategy=` | a single evolvable instruction module; each proposal replaces it (content-addressed) |
 | **`ParetoAggregator`** / `pareto_aggregator_factory` | `aggregator_factory=` | GEPA's per-instance Pareto candidate selection; commits the sampled Pareto parent as the dev head |
-| **`pareto_frontier` / `pareto_select`** | (pure, unit-tested) | Algorithm 2: per-instance best → union of winners → dominance pruning → frequency-weighted sampling |
+| **`pareto_frontier` / `pareto_select`** | (pure, unit-tested) | Algorithm 2: per-instance best → union of winners → dominance pruning → frequency-weighted sampling. `pareto_frontier` is now [`agentdescent.selection.pareto_win_frequency`](selection.md) under this name |
 | `gepa_agent()` | `agent=` | Generator + reflective-mutation actor (rewrites the instruction from trace + NL feedback) |
 
 ## Measured results — HotpotQA

--- a/docs/api.md
+++ b/docs/api.md
@@ -1176,9 +1176,18 @@ Chooses the next task id for a worker, and learns from the outcome.
 
 Which candidate the next batch of workers starts from. &nbsp;·&nbsp; `agentdescent.selection` &nbsp;·&nbsp; [guide](selection.md)
 
-### `Archive(sampling: str = 'novelty', temperature: float = 1.0, seed: int = 0) -> None`
+### `Archive(...)`
 
 DGM's and ADAS's archive sampling: performance, tempered by novelty.
+
+```python
+Archive(
+    sampling: str = 'novelty',
+    temperature: float = 1.0,
+    seed: int = 0,
+    rng: Optional['random.Random'] = None
+) -> None
+```
 
 ### `Beam(k: int = 1) -> None`
 
@@ -1208,9 +1217,18 @@ UCT over the candidate tree: one evolve step is one rollout.
 
 A policy named a starting point the ledger cannot hold yet.
 
-### `ParetoFrontier(mode: str = 'per_instance', k: int = 5) -> None`
+### `ParetoFrontier(...)`
 
-GEPA's and EvoSkill's selection rules, as one class and one argument.
+Three published frontier rules, as one class and one argument.
+
+```python
+ParetoFrontier(
+    mode: str = 'per_instance',
+    k: int = 5,
+    seed: int = 0,
+    rng: Optional['random.Random'] = None
+) -> None
+```
 
 ### `SelectionContext(...)`
 

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -109,9 +109,15 @@ column of each section below says exactly where to look.
   `--workers` is the minibatch size. The Pareto set is the held-out split.
 * **Departures**: one module rather than many. Recorded because "GEPA on
   HotpotQA" without it would imply the multi-module search ran.
-* **Selection rule lives in**: `ParetoWinFrequency` — GEPA's Algorithm-2 sampling as a named `SelectionPolicy` ([selection](selection.md)); `ParetoAggregator` delegates to it
-  `examples/gepa/gepa_prompt_evolution.py` — per-instance domination, the
-  `per_instance` mode of [`ParetoFrontier`](selection.md).
+* **Selection rule lives in**: the engine —
+  [`ParetoFrontier(mode="win_frequency")`](selection.md), Algorithm 2 exactly:
+  per-instance winners → dominance pruning → a draw weighted by unique wins.
+  `ParetoAggregator` passes its own rng so the stream is unchanged.
+  This entry used to say `per_instance`, and that was wrong twice over: the port
+  did not use the shipped policy at all (it kept `ParetoWinFrequency` locally),
+  and `per_instance` is plain Pareto walked round-robin — it keeps candidates
+  that are best at nothing and it does not weight the draw. Two different rules
+  under one name is exactly what a fidelity record exists to stop.
 * **Details**: [algo-gepa.md](algo-gepa.md)
 
 ## EvoSkill — Automated Skill Discovery
@@ -235,9 +241,13 @@ column of each section below says exactly where to look.
   archived child 0.906, and an earlier run archived children at 0.875 and 0.500
   -- the worse one kept, which is what `keep-all` is for and what the surrogate
   cannot produce. See [algo-dgm.md](algo-dgm.md#measured-results-vendored-bugs-objective-real).
-* **Selection rule lives in**: `DGMParentSelection` — `sigmoid(10·(s−0.5)) × 1/(1+children)` as a named `SelectionPolicy` over the archive
-  `examples/dgm/dgm_self_improve.py` — [`Archive`](selection.md) with
-  `sampling="novelty"`.
+* **Selection rule lives in**: the engine —
+  [`Archive(sampling="sigmoid_novelty")`](selection.md), i.e.
+  `sigmoid(10·(s−0.5)) × 1/(1+children)`, with the aggregator's own rng.
+  This entry used to say `sampling="novelty"`, and that was wrong: `novelty` is
+  a temperature-1 softmax, and a sigmoid at gain 10 is nearly a step at 0.5 —
+  they disagree most exactly where an archive spends its time, which is why the
+  port kept a local class rather than using the shipped one.
 * **Details**: [algo-dgm.md](algo-dgm.md)
 
 ## OpenEvolve — Program Evolution (AlphaEvolve)

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -62,8 +62,8 @@ evolve(tasks, reward, agent=agent,
 |---|---|---|
 | `SingleHead()` | today's engine | the default; every worker starts from the head |
 | `Beam(k)` | classic beam search | `Beam(1)` computes `SingleHead`'s answer by another route, and the tests assert they agree |
-| `ParetoFrontier(mode=...)` | GEPA / EvoSkill | `per_instance` and `topk_aggregate` — the fidelity difference as a parameter |
-| `Archive(sampling=...)` | DGM / ADAS | `performance`, `novelty` (performance ÷ `1 + selected`), `uniform` as the ablation |
+| `ParetoFrontier(mode=...)` | GEPA / EvoSkill | `win_frequency` is GEPA's Algorithm 2 exactly; `per_instance` is plain Pareto walked round-robin; `topk_aggregate` is EvoSkill's — three published rules, one argument |
+| `Archive(sampling=...)` | DGM / ADAS / SICA | `sigmoid_novelty` is DGM's `choose_selfimproves`; `performance`, `novelty` (softmax ÷ `1 + selected`), `best` (SICA's `idxmax`), `uniform` as the ablation |
 | `MCTS(exploration=...)` | tree search | UCT over the candidate tree; one evolve step is one rollout, value is held-out reward, backup runs up `Candidate.parent` |
 
 Three details that are decisions rather than defaults:
@@ -72,12 +72,21 @@ Three details that are decisions rather than defaults:
 *unmeasured*. Ranking it as the worst is how a beam collapses onto a single line
 of descent and stops being a beam, and how an archive stops exploring.
 
-**`per_instance` Pareto refuses to fall back.** Given candidates with no
-`per_task` scores it raises rather than quietly ranking on the aggregate — which
-would be running *EvoSkill's* rule and reporting it under GEPA's name.
+**Per-instance Pareto refuses to fall back.** Given candidates with no
+`per_task` scores, `win_frequency` and `per_instance` raise rather than quietly
+ranking on the aggregate — which would be running *EvoSkill's* rule and
+reporting it under GEPA's name.
+
+**`per_instance` is not GEPA, and used to claim it was.** Plain Pareto keeps
+every candidate nothing dominates, including ones that are best at nothing, and
+walks them round-robin. Algorithm 2 admits only the per-instance winners and
+draws in proportion to how many instances each still wins. `win_frequency` is
+what the old name meant.
 
 **`Archive` is deterministic given its seed.** An archive that samples differently
-on a re-run makes a seeded comparison meaningless.
+on a re-run makes a seeded comparison meaningless. Pass `rng=` instead when the
+caller owns the stream: a port migrating off a hand-written rule has to keep
+drawing from *its* rng in *its* order, or every number it published moves.
 
 ## How a policy takes effect: serialised heads
 
@@ -160,14 +169,30 @@ equivalent policy — the two cannot disagree about who wins.
 
 ## Legacy-port policies
 
-The mechanism-heavy ports express their parent rules as policy classes at this
-seam (local where the upstream rule differs from a shipped policy — the
-difference is always documented on the class):
+The mechanism-heavy ports express their parent rules at this seam. Two of them
+used to keep a *local* class because the shipped policy could not express the
+published rule; both said so on the class, in the same words — "close enough to
+look right and wrong enough to change a measured run". Those two rules are now
+shipped modes, so the difference a result carries is an argument rather than a
+file a reader has to find:
 
-| Policy | Rule | Port |
+| Port | Rule | Now |
 |---|---|---|
-| `DGMParentSelection` | `sigmoid(10·(s−0.5)) × 1/(1+children)` sampling | [DGM](algo-dgm.md) |
-| `ParetoWinFrequency` | per-instance Pareto frontier, sampled by unique wins | [GEPA](algo-gepa.md) |
-| `FrontierBest` | best member of the bounded top-K frontier | [EvoSkill](algo-evoskill.md) |
-| shipped `Beam(1)` | best of the keep-all archive (exact match, no subclass) | [ADAS](algo-adas.md) |
-| `EpsilonGreedy` | exploit best with probability ε, else uniform | [OpenEvolve](algo-openevolve.md) |
+| [GEPA](algo-gepa.md) | per-instance frontier, sampled by unique wins | `ParetoFrontier(mode="win_frequency")` |
+| [DGM](algo-dgm.md) | `sigmoid(10·(s−0.5)) × 1/(1+children)` sampling | `Archive(sampling="sigmoid_novelty")` |
+| [ADAS](algo-adas.md) | best of the keep-all archive | shipped `Beam(1)` (always was) |
+| [EvoSkill](algo-evoskill.md) | best member of the bounded top-K frontier | `FrontierBest`, local |
+| [OpenEvolve](algo-openevolve.md) | exploit best with probability ε, else uniform | `EpsilonGreedy`, local |
+
+Migrating a rule must not move a number, and "must not" is checked rather than
+intended: `tests/test_port_selection_equivalence.py` steps the shipped mode and
+the rule it replaced through **one shared rng in lockstep**, 200 consecutive
+draws, rather than comparing their distributions. A policy that drew the right
+parent from the wrong stream offset would pass a distribution test and change
+every seeded run.
+
+ADAS is the reason `sigmoid_novelty_weights` is a function and not only a
+sampling mode: ADAS uses the same weights for a different *draw* — up to five
+archive entries without replacement, to condition the meta-agent, rather than
+one parent. Shared formula, unshared draw. It had a byte-identical copy of the
+formula until this landed.

--- a/examples/adas/adas_meta_agent_search.py
+++ b/examples/adas/adas_meta_agent_search.py
@@ -60,6 +60,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from agentdescent.selection import sigmoid_novelty_weights
 from agentdescent.staleness import get_policy
 from examples._common import (add_standard_args, completion_for, confirm,
                               is_openai_compatible, worker_count,
@@ -322,18 +323,18 @@ def bootstrap_ci(correct: List[float], n_resamples: int = 2000, seed: int = 0
     return mean, lo, hi
 
 
-def dgm_parent_weights(scores: List[float], children: List[int]) -> List[float]:
-    """Darwin Godel Machine parent-selection weights (DGM_outer.py `score_child_prop`).
-
-    ``p_i proportional to sigmoid(10*(score-0.5)) * 1/(1+children_i)``: favour
-    high performers, discount already-explored parents (open-ended novelty)."""
-    raw = []
-    for s, c in zip(scores, children):
-        sig = 1.0 / (1.0 + math.exp(-10.0 * (s - 0.5)))
-        nov = 1.0 / (1.0 + c)
-        raw.append(sig * nov)
-    total = sum(raw) or 1.0
-    return [r / total for r in raw]
+#: Darwin Godel Machine weights (``DGM_outer.py:score_child_prop``):
+#: ``p_i proportional to sigmoid(10*(score-0.5)) * 1/(1+children_i)`` -- favour
+#: high performers, discount already-explored parents. Now shipped as
+#: :func:`agentdescent.selection.sigmoid_novelty_weights`, because this file and
+#: `examples/dgm` each carried a byte-identical copy.
+#:
+#: ADAS uses the weights for a different *draw*: `examples/dgm` samples one
+#: parent, ADAS samples up to five archive entries without replacement to
+#: condition the meta-agent. Sharing the formula and not the draw is the whole
+#: distinction, and it is why this stays a function here rather than becoming
+#: `Archive('sigmoid_novelty')`.
+dgm_parent_weights = sigmoid_novelty_weights
 
 
 # ===========================================================================

--- a/examples/dgm/dgm_self_improve.py
+++ b/examples/dgm/dgm_self_improve.py
@@ -67,6 +67,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, Task, evolve
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from agentdescent.selection import Archive, sigmoid_novelty_weights
 from agentdescent.staleness import get_policy
 from examples._common import (add_standard_args, completion_for, confirm,
                               worker_count,
@@ -92,15 +93,11 @@ CAPABILITY_POOL = [
 # ===========================================================================
 
 
-def dgm_parent_weights(scores: List[float], children: List[int]) -> List[float]:
-    """``p_i proportional to sigmoid(10*(score-0.5)) * 1/(1+children_i)``."""
-    raw = []
-    for s, c in zip(scores, children):
-        sig = 1.0 / (1.0 + math.exp(-10.0 * (s - 0.5)))
-        nov = 1.0 / (1.0 + c)
-        raw.append(sig * nov)
-    total = sum(raw) or 1.0
-    return [r / total for r in raw]
+#: ``p_i proportional to sigmoid(10*(score-0.5)) * 1/(1+children_i)``, now
+#: shipped as :func:`agentdescent.selection.sigmoid_novelty_weights`. It was
+#: written out here *and* byte-identically in `examples/adas`, which is how two
+#: copies of a published formula quietly stop being the same formula.
+dgm_parent_weights = sigmoid_novelty_weights
 
 
 def choose_selfimproves(archive: List["Agent"], k: int,
@@ -110,34 +107,6 @@ def choose_selfimproves(archive: List["Agent"], k: int,
     children = [a.children for a in archive]
     weights = dgm_parent_weights(scores, children)
     return rng.choices(range(len(archive)), weights=weights, k=k)
-
-
-class DGMParentSelection:
-    """`choose_selfimproves` at the standard selection seam.
-
-    A :class:`~agentdescent.selection.SelectionPolicy` over `Candidate` records:
-    ``score`` carries the staged-eval score and ``selected`` carries DGM's
-    children-explored count, so `dgm_parent_weights` reads them unchanged and
-    the single ``rng.choices`` call keeps the exact random-consumption order of
-    the inline rule it replaces -- a seeded run picks identical parents.
-
-    Local rather than shipped on purpose: `Archive('novelty')` divides by
-    ``1+selected`` but scores with a temperature softmax, not DGM's
-    ``sigmoid(10*(s-0.5))`` -- close enough to look right and wrong enough to
-    change a measured run.
-    """
-
-    def __init__(self, rng: random.Random) -> None:
-        self.rng = rng
-
-    def select(self, ctx, n: int):
-        candidates = list(ctx.candidates)
-        if len(candidates) <= 1:
-            return [ctx.head] * n
-        weights = dgm_parent_weights(
-            [c.score or 0.0 for c in candidates],
-            [c.selected for c in candidates])
-        return self.rng.choices(candidates, weights=weights, k=n)
 
 
 # ===========================================================================
@@ -319,11 +288,16 @@ class DGMArchiveAggregator(AggregatorProtocol):
 
     def __init__(self, ledger: Ledger, verifier, ctx: DGMContext,
                  artifact_id: str = "coding_agent",
-                 selection: Optional[DGMParentSelection] = None):
+                 selection: Optional[Archive] = None):
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
-        self.selection = selection or DGMParentSelection(ctx.rng)
+        # `choose_selfimproves` at the shipped seam. `rng=` rather than
+        # `seed=` because this aggregator owns the stream: a policy that
+        # re-seeded per call would sample the same distribution and pick
+        # different parents than every number this port has published.
+        self.selection = selection or Archive(
+            sampling="sigmoid_novelty", rng=ctx.rng)
         self.aid = artifact_id
         self.cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread

--- a/examples/dgm/real_objective.py
+++ b/examples/dgm/real_objective.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
 
 from agentdescent.filetree import parse_tree
+from agentdescent.selection import Archive
 from agentdescent.treestrategy import FileTree as _FileTree
 
 TASKS_DIR = pathlib.Path(__file__).resolve().parent / "tasks"
@@ -479,7 +480,7 @@ class SourceArchiveAggregator:
 
     * keep-all append (stepping stones stay, and under a real objective they can
       genuinely be worse -- which is the point);
-    * `DGMParentSelection`, i.e. `sigmoid(10*(s-0.5)) / (1+children)`, at the
+    * `Archive('sigmoid_novelty')`, i.e. `sigmoid(10*(s-0.5)) / (1+children)`, at the
       standard selection seam;
     * `staged_evaluate`'s small -> medium ladder with `test_more_threshold=0.4`.
     """
@@ -488,13 +489,13 @@ class SourceArchiveAggregator:
                  selection=None) -> None:
         import threading
 
-        from examples.dgm.dgm_self_improve import DGMParentSelection
 
         self.ledger = ledger
         self.verifier = verifier
         self.ctx = ctx
         self.aid = artifact_id
-        self.selection = selection or DGMParentSelection(ctx.rng)
+        self.selection = selection or Archive(
+            sampling="sigmoid_novelty", rng=ctx.rng)
         self.cards: List = []
         self._lock = threading.Lock()
         self.head_index = 0

--- a/examples/gepa/gepa_prompt_evolution.py
+++ b/examples/gepa/gepa_prompt_evolution.py
@@ -55,6 +55,7 @@ from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.evolution import EvolvingArtifact, LLMAgent, Task, evolve, rule_id
 from agentdescent.governance import classify
 from agentdescent.ledger import CASConflict, Ledger
+from agentdescent.selection import ParetoFrontier, pareto_win_frequency
 from examples._common import (add_standard_args, completion_for, confirm,
                               score_tasks, worker_count,
                               budget_kwargs, capped_val, report_engine)
@@ -122,81 +123,31 @@ def gepa_agent(complete) -> LLMAgent:
 # ===========================================================================
 
 
-def _dominates(a: Sequence[float], b: Sequence[float]) -> bool:
-    """Row a Pareto-dominates row b: >= on every instance, > on at least one."""
-    ge = all(x >= y for x, y in zip(a, b))
-    gt = any(x > y for x, y in zip(a, b))
-    return ge and gt
-
-
-def pareto_frontier(scores: List[List[float]]) -> Tuple[Set[int], Dict[int, int]]:
-    """Return (kept candidates, win-frequency) per GEPA Algorithm 2, steps 1-4.
-
-    ``scores[c][i]`` = candidate c's score on Pareto instance i. Steps:
-    1. per-instance best; 2. union of instance-winners; 3. drop strictly
-    dominated candidates; 4. frequency = #instances each survivor still wins."""
-    if not scores or not scores[0]:
-        return set(), {}
-    n_cand, n_inst = len(scores), len(scores[0])
-    # 1 + 2: candidates that tie the best score on at least one instance.
-    best = [max(scores[c][i] for c in range(n_cand)) for i in range(n_inst)]
-    pstar = [set(c for c in range(n_cand) if scores[c][i] == best[i])
-             for i in range(n_inst)]
-    C: Set[int] = set().union(*pstar) if pstar else set()
-    # 3: iteratively remove any candidate strictly dominated by another in C.
-    kept = set(C)
-    changed = True
-    while changed:
-        changed = False
-        for b in list(kept):
-            if any(a != b and _dominates(scores[a], scores[b]) for a in kept):
-                kept.discard(b)
-                changed = True
-                break
-    # 4: frequency over the pruned per-instance frontier.
-    freq: Dict[int, int] = {c: 0 for c in kept}
-    for s in pstar:
-        for c in (s & kept):
-            freq[c] += 1
-    return kept, freq
+#: Algorithm 2 steps 1-4, now shipped as
+#: :func:`agentdescent.selection.pareto_win_frequency`. Kept under this name
+#: because it is what the paper's step numbering calls it and what this port's
+#: tests reach for; the implementation moved so that a *run* can name the rule
+#: it used (``ParetoFrontier(mode='win_frequency')``) instead of a reader
+#: having to find this file.
+pareto_frontier = pareto_win_frequency
 
 
 def pareto_select(scores: List[List[float]], rng: random.Random) -> int:
-    """Sample a parent index ~ its Pareto win-frequency (Algorithm 2, step 5)."""
-    kept, freq = pareto_frontier(scores)
+    """Sample a parent index ~ its Pareto win-frequency (Algorithm 2, step 5).
+
+    The index form, for the tests and for anyone reading the algorithm rather
+    than driving the engine. The engine drives
+    :class:`~agentdescent.selection.ParetoFrontier` with ``mode='win_frequency'``,
+    which is this function over `Candidate` rows and draws from the same rng in
+    the same order -- `tests/test_port_selection_equivalence.py` steps the two
+    in lockstep rather than comparing their distributions.
+    """
+    kept, freq = pareto_win_frequency(scores)
     cands = [c for c in sorted(kept) if freq[c] > 0]
     if not cands:  # degenerate: fall back to best average
         return max(range(len(scores)), key=lambda c: sum(scores[c]))
     weights = [freq[c] for c in cands]
     return rng.choices(cands, weights=weights, k=1)[0]
-
-
-class ParetoWinFrequency:
-    """GEPA's Algorithm-2 sampling at the standard selection seam.
-
-    A :class:`~agentdescent.selection.SelectionPolicy` whose candidates carry
-    their per-instance rows in ``Candidate.per_task``; ``select`` rebuilds the
-    aligned score matrix and defers to :func:`pareto_select`, so the rng call
-    order -- and therefore every seeded run -- is identical to the inline rule
-    it replaces.
-
-    Local rather than the shipped ``ParetoFrontier`` on purpose: the shipped
-    policy walks the frontier round-robin, GEPA samples it weighted by how many
-    instances a candidate *uniquely* wins. Same frontier, different draw --
-    close enough to look right and wrong enough to change a measured run.
-    """
-
-    def __init__(self, rng: random.Random) -> None:
-        self.rng = rng
-
-    def select(self, ctx, n: int):
-        candidates = list(ctx.candidates)
-        if len(candidates) <= 1:
-            return [ctx.head] * n
-        tasks = sorted({t for c in candidates for t in c.per_task})
-        scores = [[c.per_task.get(t, 0.0) for t in tasks] for c in candidates]
-        k = pareto_select(scores, self.rng)
-        return [candidates[k]] * n
 
 
 # ===========================================================================
@@ -225,7 +176,7 @@ class ParetoAggregator(AggregatorProtocol):
     def __init__(self, ledger: Ledger, verifier, audit, config, policy,
                  artifact_id: str = "gepa_prompt", seed: int = 0,
                  eval_concurrency: int = 8, merge_round=None,
-                 selection: Optional["ParetoWinFrequency"] = None):
+                 selection: Optional["ParetoFrontier"] = None):
         self.ledger = ledger
         self.eval_concurrency = eval_concurrency
         #: Optional :class:`~agentdescent.policies.FusionPolicy`. When set, the
@@ -247,7 +198,12 @@ class ParetoAggregator(AggregatorProtocol):
         self.verifier = verifier
         self.artifact_id = artifact_id
         self.rng = random.Random(seed)
-        self.selection = selection or ParetoWinFrequency(self.rng)
+        # Algorithm 2 at the shipped seam. `rng=` rather than `seed=` because
+        # this aggregator owns the stream and spends it elsewhere too: a
+        # policy that re-seeded per call would agree on the distribution and
+        # disagree with every number this port has published.
+        self.selection = selection or ParetoFrontier(
+            mode="win_frequency", rng=self.rng)
         self._cards: List[EvidenceCard] = []
         self._lock = threading.Lock()   # ingest: workers; step: one thread
         # pool: list of (state_dict, per_instance_scores, avg). Parallel lists so

--- a/tests/test_port_selection_equivalence.py
+++ b/tests/test_port_selection_equivalence.py
@@ -1,0 +1,227 @@
+"""The ports' published selection rules, now shipped -- and provably the same.
+
+Two ports kept a hand-written selection rule rather than using the shipped
+policy, each for a stated reason: GEPA samples its frontier by win frequency
+where `ParetoFrontier` walked it round-robin, and DGM weights by
+``sigmoid(10*(s-0.5))`` where `Archive('novelty')` uses a temperature softmax.
+Both comments said the same thing -- "close enough to look right and wrong
+enough to change a measured run".
+
+The fix is not to pick one. It is to make the shipped policy able to express the
+published rule, so the fidelity difference is an argument a result can record
+instead of a class a reader has to find. These tests are what makes that
+claimable: they compare the shipped mode against the rule it replaces, on the
+same seeded rng, and a mismatch anywhere is a port whose measured numbers moved.
+
+The rng is the part that is easy to get wrong and impossible to see. Both ports
+draw from a *shared, stateful* `random.Random` that their aggregator owns, and
+both spend exactly one `choices` call per selection. A shipped policy that
+re-seeded per call, or drew ``k=n`` where upstream draws ``k=1``, would agree on
+the distribution and disagree on every actual run.
+"""
+
+import math
+import random
+
+import pytest
+
+from agentdescent.selection import (
+    Archive, Candidate, ParetoFrontier, SelectionContext,
+    pareto_win_frequency, sigmoid_novelty_weights,
+)
+
+
+def _cand(version, score=None, per_task=None, selected=0):
+    return Candidate(artifact_id="a", version=version, score=score,
+                     state={"k": f"v{version}"}, per_task=per_task or {},
+                     selected=selected)
+
+
+# -- GEPA: Algorithm 2 --------------------------------------------------------
+
+
+ROWS = [
+    [0.9, 0.1, 0.4],     # a specialist: wins instance 0
+    [0.3, 0.9, 0.5],     # a specialist: wins instance 1
+    [0.4, 0.4, 0.9],     # a specialist: wins instance 2
+    [0.2, 0.2, 0.2],     # dominated by everything, wins nothing
+    [0.9, 0.9, 0.9],     # wins all three
+]
+TASKS = ["t0", "t1", "t2"]
+
+
+def _ctx_from_rows(rows):
+    cands = tuple(_cand(i, score=sum(r) / len(r),
+                        per_task=dict(zip(TASKS, r)))
+                  for i, r in enumerate(rows))
+    return SelectionContext(head=cands[0], candidates=cands, n_workers=4)
+
+
+@pytest.mark.parametrize("rows", [
+    ROWS,
+    [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+    [[1.0, 0.0], [0.0, 1.0]],
+    [[0.5, 0.5], [0.5, 0.5]],                 # identical rows: both win both
+    [[0.2, 0.2], [0.9, 0.9], [0.9, 0.9]],     # a tie at the top
+    [[0.0]],
+])
+def test_the_shipped_frontier_is_the_ports_frontier(rows):
+    """Against GEPA's own implementation, not against a transcription of it."""
+    from examples.gepa.gepa_prompt_evolution import pareto_frontier
+
+    assert pareto_win_frequency(rows) == pareto_frontier(rows)
+
+
+def test_the_frontier_is_the_instance_winners_not_the_undominated_set():
+    """`pareto_win_frequency` and `pareto_front` are different sets, on purpose.
+
+    ``[0.5, 0.5]`` is dominated by neither specialist -- so plain Pareto keeps
+    it -- and ties the best on nothing, so Algorithm 2 never admits it. A class
+    that ran one under the other's name would develop a candidate GEPA would
+    not, which is the whole reason the port kept its own copy.
+    """
+    rows = [[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]]
+    kept, freq = pareto_win_frequency(rows)
+    assert kept == {0, 1} and freq == {0: 1, 1: 1}
+
+    cands = tuple(_cand(i, per_task=dict(zip(["t0", "t1"], r)))
+                  for i, r in enumerate(rows))
+    from agentdescent.selection import pareto_front
+    plain = pareto_front(cands, tasks=["t0", "t1"])
+    assert {c.version for c in plain} == {0, 1, 2}
+
+
+def test_a_dominated_row_is_pruned_and_every_survivor_carries_weight():
+    kept, freq = pareto_win_frequency(ROWS)
+    assert 3 not in kept, "a strictly dominated row must be pruned"
+    assert all(freq[c] > 0 for c in kept), "a survivor with no win has no weight"
+
+
+def _gepa_reference(rows, rng):
+    """GEPA's inline rule, transcribed: frontier, then one weighted draw."""
+    kept, freq = pareto_win_frequency(rows)
+    cands = [c for c in sorted(kept) if freq[c] > 0]
+    if not cands:
+        return max(range(len(rows)), key=lambda c: sum(rows[c]))
+    return rng.choices(cands, weights=[freq[c] for c in cands], k=1)[0]
+
+
+def test_shipped_win_frequency_draws_what_the_port_drew():
+    """Same rng object, same call order, same parent -- 200 consecutive draws.
+
+    One shared stream stepped in lockstep, not two streams compared by
+    distribution: a policy that drew the right parent from the wrong offset
+    would pass a distribution test and change every seeded run.
+    """
+    rows = [[0.9, 0.1], [0.1, 0.9], [0.5, 0.5]]
+    ctx = _ctx_from_rows(rows)
+    theirs, ours = random.Random(7), random.Random(7)
+    policy = ParetoFrontier(mode="win_frequency", rng=ours)
+    for _ in range(200):
+        expected = _gepa_reference(rows, theirs)
+        got = policy.select(ctx, 4)
+        assert [c.version for c in got] == [expected] * 4
+
+
+def test_win_frequency_spends_one_draw_per_batch_not_one_per_worker():
+    """Algorithm 2 selects *a* parent per iteration; every worker mutates it.
+
+    Drawing per worker would consume `n` numbers where upstream consumes one,
+    so the streams diverge from the second selection onwards even though the
+    first parent matches.
+    """
+    ctx = _ctx_from_rows([[0.9, 0.1], [0.1, 0.9]])
+    rng = random.Random(3)
+    ParetoFrontier(mode="win_frequency", rng=rng).select(ctx, 8)
+    spent = random.Random(3)
+    spent.choices([0, 1], weights=[1, 1], k=1)
+    assert rng.random() == spent.random(), "more than one draw was consumed"
+
+
+def test_win_frequency_needs_per_task_rows():
+    ctx = SelectionContext(head=_cand(1, 0.5), candidates=(_cand(1, 0.5), _cand(2, 0.6)))
+    with pytest.raises(ValueError, match="Algorithm 2"):
+        ParetoFrontier(mode="win_frequency").select(ctx, 1)
+
+
+def test_identical_rows_all_survive_with_equal_weight():
+    """Not the degenerate case, which is the easy thing to assume.
+
+    Two identical rows tie the best on every instance, so both are instance
+    winners and neither strictly dominates the other: the frontier is both, at
+    equal weight, and the draw is a coin flip. The aggregate fallback is for a
+    matrix with no instances at all, which `select` rejects before reaching it.
+    """
+    kept, freq = pareto_win_frequency([[0.5, 0.5], [0.5, 0.5]])
+    assert kept == {0, 1} and freq == {0: 2, 1: 2}
+
+
+# -- DGM: choose_selfimproves -------------------------------------------------
+
+
+def _dgm_reference_weights(scores, children):
+    """DGM's inline formula, transcribed from `DGM_outer.py:score_child_prop`."""
+    raw = []
+    for s, c in zip(scores, children):
+        raw.append((1.0 / (1.0 + math.exp(-10.0 * (s - 0.5)))) * (1.0 / (1.0 + c)))
+    total = sum(raw) or 1.0
+    return [r / total for r in raw]
+
+
+@pytest.mark.parametrize("scores,children", [
+    ([0.9, 0.5, 0.1], [0, 0, 0]),
+    ([0.9, 0.9], [0, 5]),
+    ([0.0, 0.0], [0, 0]),            # the all-zero vector: divide by 1, not 0
+    ([1.0], [0]),
+    ([0.5, 0.5, 0.5], [3, 1, 0]),
+])
+def test_shipped_weights_are_the_ports_weights(scores, children):
+    assert sigmoid_novelty_weights(scores, children) == \
+           _dgm_reference_weights(scores, children)
+
+
+def test_sigmoid_novelty_draws_what_the_port_drew():
+    """Same rng object, same single `choices(..., k=n)` call, same parents."""
+    pool = [_cand(0, 0.9, selected=0), _cand(1, 0.5, selected=2),
+            _cand(2, 0.1, selected=0), _cand(3, 0.7, selected=1)]
+    ctx = SelectionContext(head=pool[0], candidates=tuple(pool), n_workers=3)
+    theirs, ours = random.Random(5), random.Random(5)
+    policy = Archive(sampling="sigmoid_novelty", rng=ours)
+    weights = _dgm_reference_weights([c.score for c in pool],
+                                     [c.selected for c in pool])
+    for _ in range(200):
+        expected = [c.version for c in theirs.choices(pool, weights=weights, k=3)]
+        assert [c.version for c in policy.select(ctx, 3)] == expected
+
+
+def test_sigmoid_novelty_is_not_novelty():
+    """If the two agreed, the port would have had no reason to hand-write one.
+
+    A sigmoid at gain 10 is nearly a step at 0.5; a temperature-1 softmax over
+    [0, 1] spans a factor of e. They disagree most where an archive lives.
+    """
+    pool = [_cand(0, 0.9), _cand(1, 0.1)]
+    ctx = SelectionContext(head=pool[0], candidates=tuple(pool))
+    dgm = Archive(sampling="sigmoid_novelty", rng=random.Random(0))
+    soft = Archive(sampling="novelty", rng=random.Random(0))
+    dgm_picks = [dgm.select(ctx, 1)[0].version for _ in range(400)]
+    soft_picks = [soft.select(ctx, 1)[0].version for _ in range(400)]
+    # DGM's sigmoid nearly excludes the 0.1 candidate; the softmax does not.
+    assert dgm_picks.count(1) < soft_picks.count(1) / 2
+
+
+def test_an_unscored_candidate_is_zero_here_not_the_archive_mean():
+    """`novelty` gives an unscored candidate 0.5; `sigmoid_novelty` gives it 0.
+
+    0.5 is the sigmoid's inflection point, so borrowing the other mode's
+    convention would place an unevaluated agent at exactly the median weight --
+    the most favourable spot on the curve, for a candidate nothing is known
+    about.
+    """
+    pool = [_cand(0, 1.0), _cand(1, None)]
+    ctx = SelectionContext(head=pool[0], candidates=tuple(pool))
+    weights = sigmoid_novelty_weights([1.0, 0.0], [0, 0])
+    rng, mirror = random.Random(2), random.Random(2)
+    got = Archive(sampling="sigmoid_novelty", rng=rng).select(ctx, 5)
+    expected = mirror.choices(pool, weights=weights, k=5)
+    assert [c.version for c in got] == [c.version for c in expected]


### PR DESCRIPTION
Step C of #75 — the part whose value does not depend on any measurement.

## What was actually wrong

Two ports kept a hand-written selection rule, and each said why on the class, in the same words: *"close enough to look right and wrong enough to change a measured run"*. Both were right.

| Port | Its rule | Nearest shipped policy | Why not that one |
|---|---|---|---|
| GEPA | Algorithm 2: per-instance winners, sampled by unique wins | `ParetoFrontier(per_instance)` | plain Pareto, walked round-robin — keeps candidates that are best at nothing, and does not weight the draw |
| DGM | `sigmoid(10·(s−0.5)) / (1+children)` | `Archive("novelty")` | temperature-1 softmax; a sigmoid at gain 10 is nearly a step exactly where the softmax is nearly flat — i.e. where an archive spends its time |

So the fix is not to adopt the near-miss. It is to make the shipped policy express the published rule, which turns a fidelity difference from *a class a reader has to find* into *an argument a result can record*:

```python
ParetoFrontier(mode="win_frequency")    # GEPA Algorithm 2
Archive(sampling="sigmoid_novelty")     # DGM choose_selfimproves
```

Both gain `rng=`. A port migrating off its own rule has to keep drawing from **its** stream in **its** order — `seed=` still builds a fresh one.

## One real duplication removed

`dgm_parent_weights` was written out **byte-identically** in `examples/dgm` and `examples/adas`. It is `sigmoid_novelty_weights` once now. ADAS keeps a function rather than the policy because it shares the formula and not the draw: five archive entries without replacement to condition the meta-agent, against DGM's one parent.

## How equivalence is pinned

`tests/test_port_selection_equivalence.py` (20 tests) is what makes "we did not change the upstream selection rule" checkable instead of readable. The rng is the part that is easy to get wrong and impossible to see, so the tests do not compare distributions:

- the shipped mode and the rule it replaced are stepped through **one shared rng in lockstep**, 200 consecutive draws
- the frontier is compared against **GEPA's own `pareto_frontier`**, not against a transcription of it
- one test pins that `win_frequency` spends **one draw per batch, not one per worker** — `k=n` would match on the first selection and diverge from the second

A policy that drew the right parent from the wrong stream offset passes a distribution test and changes every seeded run. That is the failure this file exists for.

## Two fidelity records were wrong

`docs/port-fidelity.md` recorded GEPA as using `ParetoFrontier(per_instance)` — wrong twice over: the port used no shipped policy at all, and `per_instance` is not Algorithm 2. The same page recorded DGM as `sampling="novelty"`, the softmax it specifically did not use.

`per_instance` keeps its behaviour and loses its claim to be GEPA. `win_frequency` is what that name meant.

## Tests

Full suite green (exit 0, 100%), `mkdocs build --strict` clean.

## On the rest of #75

While scoping this I checked what the serialised population layer actually expresses, and it is worth recording:

```
Beam(1)                n=1 -> [2]      n=4 -> [2, 2, 2, 2]
Beam(4)                n=1 -> [2]      n=4 -> [2, 3, 4, 1]
Pareto(per_instance)   n=1 -> [1]      n=4 -> [1, 2, 3, 1]
Archive(novelty)       n=1 -> [2]      n=4 -> [2, 2, 1, 4]
MCTS()                 n=1 -> [1]      n=4 -> [1, 2, 3, 4]
```

The layer asks `select(ctx, 1)`. `Archive` and `MCTS` carry state that rotates them across steps, so they express fine. `Beam(k)` does not — `Beam(4)` and `Beam(1)` give the same answer, so the width is inert — and `ParetoFrontier` is pinned to the oldest front member. Neither is reachable from anything in this repo today (no port uses either), which is why it is recorded here rather than fixed here. It becomes reachable the moment a user follows the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)