### PR TITLE
fix(selection): a declared Beam(4) was Beam(1), and Pareto never moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **A declared `Beam(k)` was `Beam(1)`, and `ParetoFrontier` never left the
+  candidate it was handed first.** `PopulationAggregator` asks for one starting
+  point per merge — the ledger holds one live head — and built its
+  `SelectionContext` without `round=`, leaving it at 0 for every call. `MCTS` and
+  `Archive` rotate on state they read per candidate (`selected`), so they
+  coped; `Beam` and `ParetoFrontier` rank a pool and have nothing per-candidate
+  to read, so they returned the same entry forever. Measured over eight
+  selections against a growing archive:
+
+  ```
+  before                                  after
+  Beam(4)               [3,3,3,3,...]     [3,2,1,0,3,2,1,0]
+  Pareto(per_instance)  [0,0,0,0,...]     [0,3,0,3,0,3,0,3]
+  Archive(novelty)      [2,2,2,1,2,2,2,2] [2,2,1,1,3,3,1,0]
+  ```
+
+  `ParetoFrontier` was the worse of the two: the front is built in archive
+  order, so `front[0]` is the earliest admitted non-dominated candidate —
+  usually the seed — and a run could watch far higher scorers arrive and keep
+  expanding the seed, the exact opposite of what keeping a specialist is for.
+
+  The layer now counts its selections and passes one, and `Beam` /
+  `ParetoFrontier` offset their round-robin by it, so the walk is continuous
+  across calls rather than restarted at the best member. `Archive`'s seeded rng
+  was also rebuilding an identical `Random` every call for the same reason.
+
+  **No published number moves**, and it is pinned rather than asserted: at
+  `round == 0` the new expression is the old one (`(0 + i) % len == i % len`)
+  and a test compares the concrete answers. Every configuration this repository
+  runs is unaffected for a separate reason each — SICA's `Archive('best')` never
+  draws, DGM and GEPA pass their own rng so `ctx.round` is unread, AFlow and
+  PromptBreeder hold their own stateful rng, and ADAS and EvoSkill use `Beam(1)`
+  whose single slot cannot rotate. The one configuration that changes is
+  `Archive(sampling='novelty'|'performance'|'uniform', seed=N)` under the
+  population layer, which nothing here uses and which was drawing the same
+  random number every step.
+
 ### Added
 
 - **`ParetoFrontier(mode="win_frequency")` — GEPA's Algorithm 2, shipped.**

--- a/agentdescent/population.py
+++ b/agentdescent/population.py
@@ -69,6 +69,10 @@ class PopulationAggregator(Aggregator):
         self._archive: List[Dict[str, object]] = []
         self._seen: Set[str] = set()
         self._archive_lock = threading.Lock()
+        #: Selections made, i.e. the ``round`` handed to the policy. Not under
+        #: the archive lock: `step()` is the merger's, one thread, while the
+        #: lock guards the archive against the workers that `ingest`.
+        self._selections = 0
 
     # -- the archive ---------------------------------------------------------
 
@@ -182,8 +186,23 @@ class PopulationAggregator(Aggregator):
         # point no matter how many workers are under it. This is the seam that
         # widens when the ledger can hold several -- the policy is already
         # written to answer for ``n``.
+        #
+        # ``round`` is *which selection this is*, not the engine's round, and it
+        # is counted here because only this method knows: `step()` also runs on
+        # sweeps that never reach a choice (fewer than two candidates), and
+        # counting those would have a beam skip slots it never expanded.
+        #
+        # It used to be left at its default of 0, and that single omission is
+        # what made width inert. A policy asked for one starting point can only
+        # rotate on something that changes between calls; the archive and the
+        # `selected` counts are two such things, and `MCTS` and `Archive` read
+        # them -- but `Beam` and `ParetoFrontier` rank a pool and have no
+        # per-candidate state to read, so with a constant round they returned
+        # the same entry forever. `Beam(4)` was `Beam(1)`, and `ParetoFrontier`
+        # sat on whichever front member was admitted first, usually the seed.
         ctx = SelectionContext(head=head_candidate, candidates=tuple(candidates),
-                               n_workers=1)
+                               round=self._selections, n_workers=1)
+        self._selections += 1
         chosen = list(self.selection.select(ctx, 1))
         if not chosen:
             return reports

--- a/agentdescent/selection.py
+++ b/agentdescent/selection.py
@@ -171,6 +171,18 @@ class Beam(SingleHead):
     has not been measured, and ranking it as the worst is how a freshly created
     branch is never explored -- the classic way a beam collapses to a single line
     of descent.
+
+    The walk over the beam is **continuous across calls**, offset by
+    ``ctx.round``, not restarted at the best member each time. That is what makes
+    ``k`` mean anything where a caller asks for one starting point at a time: the
+    engine's ledger holds one live head, so the population layer asks for one per
+    merge, and a beam that answered "the best" every time was `Beam(1)` under
+    another name. Rotating expands each of the ``k`` in turn instead -- serial
+    where textbook beam search is parallel, and the same frontier.
+
+    At ``ctx.round == 0`` this is exactly the old per-call round-robin, which is
+    what makes the change checkable: `tests/test_selection.py` pins that every
+    policy's answer at round 0 is the answer it gave before.
     """
 
     def __init__(self, k: int = 1) -> None:
@@ -188,7 +200,7 @@ class Beam(SingleHead):
                         key=lambda c: (c.score is None, c.score or 0.0),
                         reverse=True)
         beam = ranked[:self.k] or [ctx.head]
-        return [beam[i % len(beam)] for i in range(n)]
+        return [beam[(ctx.round + i) % len(beam)] for i in range(n)]
 
 
 def pareto_win_frequency(
@@ -370,7 +382,7 @@ class ParetoFrontier(SingleHead):
                 "scores and none were provided; use mode='topk_aggregate' if "
                 "aggregate ranking is what you want")
         front = pareto_front(ctx.candidates, tasks=tasks) or [ctx.head]
-        return [front[i % len(front)] for i in range(n)]
+        return [front[(ctx.round + i) % len(front)] for i in range(n)]
 
 
 class Archive(SingleHead):

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -61,7 +61,7 @@ evolve(tasks, reward, agent=agent,
 | policy | corresponds to | note |
 |---|---|---|
 | `SingleHead()` | today's engine | the default; every worker starts from the head |
-| `Beam(k)` | classic beam search | `Beam(1)` computes `SingleHead`'s answer by another route, and the tests assert they agree |
+| `Beam(k)` | classic beam search | the walk over the `k` best is continuous across calls, so asking one at a time expands each in turn; `Beam(1)` computes `SingleHead`'s answer by another route, and the tests assert they agree |
 | `ParetoFrontier(mode=...)` | GEPA / EvoSkill | `win_frequency` is GEPA's Algorithm 2 exactly; `per_instance` is plain Pareto walked round-robin; `topk_aggregate` is EvoSkill's — three published rules, one argument |
 | `Archive(sampling=...)` | DGM / ADAS / SICA | `sigmoid_novelty` is DGM's `choose_selfimproves`; `performance`, `novelty` (softmax ÷ `1 + selected`), `best` (SICA's `idxmax`), `uniform` as the ablation |
 | `MCTS(exploration=...)` | tree search | UCT over the candidate tree; one evolve step is one rollout, value is held-out reward, backup runs up `Candidate.parent` |
@@ -82,6 +82,18 @@ every candidate nothing dominates, including ones that are best at nothing, and
 walks them round-robin. Algorithm 2 admits only the per-instance winners and
 draws in proportion to how many instances each still wins. `win_frequency` is
 what the old name meant.
+
+**The walk over a pool is continuous, not restarted.** `Beam` and
+`ParetoFrontier` offset their round-robin by `SelectionContext.round`. It
+matters because the population layer asks for **one** starting point per merge —
+the ledger holds one live head — and a policy that answered "the best" every
+time made `k` inert: `Beam(4)` was `Beam(1)`, and `ParetoFrontier` sat on
+whichever front member was admitted first, usually the seed, while candidates
+scoring far higher arrived and were never expanded. Rotating expands each slot
+in turn: serial where textbook beam search is parallel, same frontier. At
+`round == 0` it is exactly the old per-call round-robin, which is what makes the
+change checkable — the tests pin that every policy's round-0 answer is the
+answer it gave before.
 
 **`Archive` is deterministic given its seed.** An archive that samples differently
 on a re-run makes a seeded comparison meaningless. Pass `rng=` instead when the

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -30,9 +30,10 @@ def _c(version, score=None, per_task=None, selected=0, parent=None):
                      per_task=per_task or {}, selected=selected, parent=parent)
 
 
-def _ctx(*candidates, head=None, n=4):
+def _ctx(*candidates, head=None, n=4, round=0):
     head = head or candidates[0]
-    return SelectionContext(head=head, candidates=candidates, n_workers=n)
+    return SelectionContext(head=head, candidates=candidates, round=round,
+                            n_workers=n)
 
 
 # -- the default is the status quo ------------------------------------------
@@ -324,3 +325,93 @@ def test_mcts_spreads_a_batch_across_distinct_arms():
                _c(3, 0.7, selected=5), n=3)
     chosen = MCTS().select(ctx, 3)
     assert len({c.version for c in chosen}) == 3
+
+
+# -- the walk over the pool, and the promise that round 0 did not move -------
+
+
+def test_round_zero_answers_exactly_what_it_answered_before():
+    """The guard on the whole change: at ``round == 0`` nothing moved.
+
+    `Beam` and `ParetoFrontier` walk their pool offset by `ctx.round` now,
+    where they used to restart at the best member on every call. The two are
+    the same expression when the offset is zero -- ``(0 + i) % len == i % len``
+    -- and this pins that rather than trusting the algebra, because every
+    number this repository has published was produced with the round the
+    population layer used to pass, which was zero.
+    """
+    pool = (_c(1, 0.4, {"t0": 0.9, "t1": 0.1}), _c(2, 0.8, {"t0": 0.8, "t1": 0.8}),
+            _c(3, 0.6, {"t0": 0.2, "t1": 0.9}), _c(4, 0.5, {"t0": 0.5, "t1": 0.5}))
+    ctx = _ctx(*pool, round=0)
+    # Beam: ranked best-first, taken from the top.
+    assert [c.version for c in Beam(4).select(ctx, 1)] == [2]
+    assert [c.version for c in Beam(4).select(ctx, 4)] == [2, 3, 4, 1]
+    assert [c.version for c in Beam(1).select(ctx, 4)] == [2, 2, 2, 2]
+    # ParetoFrontier: the front in archive order, taken from the front.
+    front = [c.version for c in pareto_front(pool, tasks=["t0", "t1"])]
+    assert [c.version for c in ParetoFrontier("per_instance").select(ctx, 1)] == front[:1]
+    assert [c.version for c in ParetoFrontier("per_instance").select(ctx, 3)] == \
+           [front[i % len(front)] for i in range(3)]
+
+
+def test_beam_of_one_is_single_head_at_every_round():
+    """A width-one beam has one slot, so rotating it cannot go anywhere.
+
+    ADAS and EvoSkill both use `Beam(1)` inside their own aggregators; if the
+    offset reached them their published numbers would move.
+    """
+    pool = (_c(1, 0.9), _c(2, 0.5), _c(3, 0.7))
+    for r in range(6):
+        ctx = _ctx(*pool, round=r)
+        assert list(Beam(1).select(ctx, 4)) == list(SingleHead().select(ctx, 4))
+
+
+def test_a_beam_expands_every_slot_when_asked_one_at_a_time():
+    """The defect, as the population layer actually meets it.
+
+    The layer asks for one starting point per merge, because the ledger holds
+    one live head. Asked that way with a constant round, `Beam(4)` answered
+    with the best candidate every time -- identical to `Beam(1)`, so the width
+    was inert and nothing said so.
+    """
+    pool = (_c(1, 0.4), _c(2, 0.8), _c(3, 0.6), _c(4, 0.5))
+    picks = [Beam(4).select(_ctx(*pool, round=r), 1)[0].version for r in range(8)]
+    assert set(picks) == {1, 2, 3, 4}, f"the beam never left its best slot: {picks}"
+    assert picks[:4] == picks[4:], "the walk should be a cycle over the beam"
+
+
+def test_the_frontier_is_walked_not_pinned_to_its_oldest_member():
+    """`ParetoFrontier` sat on `front[0]` forever, which is worse than best-first.
+
+    The front is built in archive order, so `front[0]` is the earliest admitted
+    non-dominated candidate -- usually the seed. A run could watch candidates
+    scoring far higher arrive and keep expanding the seed, which is the exact
+    opposite of what keeping a specialist is for.
+    """
+    pool = (_c(1, 0.30, {"t0": 0.95, "t1": 0.05}),      # the seed: a specialist
+            _c(2, 0.50, {"t0": 0.50, "t1": 0.50}),
+            _c(3, 0.80, {"t0": 0.75, "t1": 0.85}))
+    front = {c.version for c in pareto_front(pool, tasks=["t0", "t1"])}
+    picks = {ParetoFrontier("per_instance").select(_ctx(*pool, round=r), 1)[0].version
+             for r in range(8)}
+    assert picks == front, f"expanded {picks}, front is {front}"
+
+
+def test_the_population_layer_hands_the_policy_a_moving_round():
+    """The root cause: the layer never set `round`, so it was 0 for every call.
+
+    Counted per *selection* rather than per `step()`: a sweep with fewer than
+    two candidates makes no choice, and counting it would have the beam skip a
+    slot it never expanded.
+    """
+    seen = []
+
+    class Recording(Beam):
+        def select(self, ctx, n):
+            seen.append(ctx.round)
+            return super().select(ctx, n)
+
+    result = _run(policies=Policies(selection=Recording(3)))
+    assert result.error is None
+    assert seen, "the layer never asked"
+    assert seen == list(range(len(seen))), f"rounds were not consecutive: {seen}"


### PR DESCRIPTION
Closes the last two defects recorded in #148 for #75.

## The defect

`PopulationAggregator` asks the policy for **one** starting point per merge — the ledger holds one live head — and built its `SelectionContext` without `round=`, leaving it at 0 for every call.

A policy asked for one candidate can only rotate on something that changes between calls. `MCTS` and `Archive` read per-candidate state (`selected`) and coped. `Beam` and `ParetoFrontier` rank a pool and have nothing per-candidate to read.

Eight selections against a growing archive:

```
                        before               after
Beam(4)                 [3,3,3,3,...]        [3,2,1,0,3,2,1,0]
Pareto(per_instance)    [0,0,0,0,...]        [0,3,0,3,0,3,0,3]
Archive(novelty,seed=1) [2,2,2,1,2,2,2,2]    [2,2,1,1,3,3,1,0]
MCTS()                  [0,1,2,3,3,2,1,0]    unchanged
```

`Beam(4)` and `Beam(1)` were the same run and nothing said so. `ParetoFrontier` was the worse of the two: the front is built in archive order, so `front[0]` is the earliest admitted non-dominated candidate — usually the seed — and a run could watch candidates scoring far higher arrive while it kept expanding the seed. That is the opposite of what keeping a specialist is for.

`Archive`'s seeded rng was the same root cause in different clothes: `Random(seed*1_000_003 + ctx.round)` with a constant round rebuilds an identical `Random` every call, so one random number was being applied to shifting weights. That is not sampling.

## The change

Three edits.

1. The layer counts its selections and passes one as `round` — counted per *selection*, not per `step()`, because a sweep with fewer than two candidates makes no choice and counting it would have the beam skip a slot it never expanded.
2. `Beam` offsets its round-robin by `ctx.round`, so the walk is continuous across calls instead of restarting at the best member. Serial where textbook beam search is parallel; same frontier.
3. `ParetoFrontier(per_instance)` likewise. `win_frequency` is untouched — it is a weighted draw and already varies, and GEPA passes its own rng.

`Archive('best')` (SICA's `idxmax`) and `MCTS` are untouched by design.

## Why no published number moves

Pinned, not argued.

**Algebraically** at `round == 0` the new expression is the old one: `(0 + i) % len == i % len`. Every number this repository has published was produced with the round the layer used to pass, which was zero. `test_round_zero_answers_exactly_what_it_answered_before` compares the concrete answers rather than trusting that algebra.

**Per configuration**, each is unaffected for its own reason:

| configuration | why unaffected |
|---|---|
| default (no policy) | no population layer |
| SICA `Archive("best")` | never draws, never reads `round` |
| DGM `Archive("sigmoid_novelty", rng=…)` | own rng, so `ctx.round` is unread |
| GEPA `ParetoFrontier("win_frequency", rng=…)` | same |
| AFlow `SoftMixed` / PromptBreeder `BinaryTournament` | own stateful rng |
| ADAS / EvoSkill `Beam(1)` | one slot; `(r + i) % 1 == 0` |

`test_beam_of_one_is_single_head_at_every_round` pins that last row across six rounds, since it is the one that would silently move ADAS's and EvoSkill's published numbers.

**The one configuration that changes**: `Archive(sampling="novelty" | "performance" | "uniform", seed=N)` under the population layer. Nothing in this repository uses it, and what it did before was draw the same random number every step.

## Tests

Five new in `tests/test_selection.py` (34 total): the round-0 guard, `Beam(1)` invariance across rounds, beam slot coverage, frontier coverage, and one that pins the root cause — the layer hands the policy consecutive rounds starting at 0.

Full suite green (exit 0, 100%), `mkdocs build --strict` clean.

## On the rest of #75

#73 is closed as not planned, which retires the gate I had put on multi-lineage — and that gate was wrong anyway: #73's matrix compares schedulers for one algorithm, so it never measured search breadth, and the experiment that would have needs the implementation to exist first. Multi-lineage remains unbuilt, now on its own merits rather than pending data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)