### PR TITLE
feat(async): resync the workers when a sweep commits

### DIFF
--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -69,6 +69,7 @@ def async_evolve(
     artifact_id: str = "artifact",
     n_workers: int = 4,
     async_ratio: int = 3,
+    resync_on_commit: bool = False,
     max_seconds: float = 20.0,
     max_iters: Optional[int] = None,
     max_calls: Optional[int] = None,
@@ -134,6 +135,26 @@ def async_evolve(
         drifts more than this far ahead, **and** it stops producing while more
         than this many cards sit un-merged. The second bound matters at cold
         start, before any commit has moved head.
+    resync_on_commit:
+        Refresh every worker as soon as a sweep commits, whatever the ratio.
+
+        This does **not** remove staleness where a real workload gets it. A
+        worker snapshots, then spends the rollout in ``run``, then pushes; a
+        commit landing anywhere in that window makes the card stale no matter
+        what the top of the loop does. What it removes is the other source:
+        *starting* a rollout against a snapshot a finished sweep has already
+        superseded. The two coincide only when rollouts are short relative to
+        sweep cadence -- as they are in this repo's synthetic tests, where
+        turning this on does collapse η to 0 -- which is why it is opt-in
+        rather than the default.
+
+        Turn it on when the artifact's *content* is what workers reason from,
+        so an out-of-date copy makes the work void rather than merely stale.
+        Evolving a skill library from empty is the case that motivated it: the
+        lag budget fires at ``head_v - base_v > async_ratio``, so with the
+        default 3 the first three commits leave every worker still proposing
+        against no library at all, re-deriving what head already has for the
+        merger to discard.
     max_seconds:
         Wall-clock budget for the **production phase only**. Two things still
         happen after it, so budget for them: a bounded shutdown
@@ -374,6 +395,10 @@ def async_evolve(
     # Backpressure: bumped when the pipeline stalls (evidence keeps arriving and
     # nothing commits), which forces every worker to resync regardless of the ratio.
     epoch = [0]
+    #: Bumped on every commit when ``resync_on_commit``. Separate from `epoch`
+    #: because that one feeds `forced_refreshes`, which the docs define as quiet
+    #: on a healthy run -- and a commit is the pipeline working, not a fault.
+    commit_epoch = [0]
     forced_refreshes = [0]
     stragglers = [0]
     estimator = duration_estimator
@@ -478,6 +503,7 @@ def async_evolve(
         by_shard_id = {t.id: t for t in shard}
         i = 0
         local_epoch = epoch[0]
+        local_commit = commit_epoch[0]
         consecutive = 0            # consecutive backend failures for this worker
         warned = False
         while not stop.is_set():
@@ -515,11 +541,13 @@ def async_evolve(
             # never triggers a refresh either. It existed only in the reference
             # runtime, which is not the one a real workload reaches.
             forced = epoch[0] != local_epoch
-            if head_v - base_v > async_ratio or forced:
+            committed_since = commit_epoch[0] != local_commit
+            if head_v - base_v > async_ratio or forced or committed_since:
                 snap = eng.ledger.snapshot(Ledger.DEV)
                 base_v = snap.version.get(eng.artifact_id, 0)
                 artifact = snap.get(eng.artifact_id)
                 local_epoch = epoch[0]
+                local_commit = commit_epoch[0]
                 # Only the *forced* half is counted. Refreshing on one's own lag
                 # budget is what an async worker does all run long -- counting it
                 # made `forced_refreshes` non-zero on every healthy run, while the
@@ -778,6 +806,22 @@ def async_evolve(
         # staleness gate MUST land here with committed=0: those discards are the
         # livelock's signature, and this counter is the only thing that breaks it.
         stall.note_sweep(committed)
+        # A commit changes what the artifact *is*, so a worker about to start a
+        # rollout on the pre-merge snapshot is working from a version that no
+        # longer exists. The lag budget does not catch that on its own -- it
+        # fires at ``head_v - base_v > async_ratio``, so with the default 3 the
+        # first three commits leave the whole fleet on its start-of-run
+        # snapshot, which on a run that starts from an empty artifact means
+        # every worker keeps re-deriving what head already has.
+        #
+        # This does not make cards fresh: the snapshot is taken before `run` and
+        # the card is pushed after it, so a commit during a long rollout still
+        # arrives stale, which is where staleness comes from on any workload
+        # whose rollouts outlast a sweep. It is opt-in because on *short*
+        # rollouts the two windows collapse into one and η goes to 0, and this
+        # module exists to let η be non-zero.
+        if resync_on_commit and committed:
+            commit_epoch[0] += 1
         if stall.should_force_refresh():
             epoch[0] += 1                      # every worker resyncs on its next loop
             stall.force()

--- a/agentdescent/async_evolve.py
+++ b/agentdescent/async_evolve.py
@@ -69,7 +69,7 @@ def async_evolve(
     artifact_id: str = "artifact",
     n_workers: int = 4,
     async_ratio: int = 3,
-    resync_on_commit: bool = False,
+    resync_on_commit: bool = True,
     max_seconds: float = 20.0,
     max_iters: Optional[int] = None,
     max_calls: Optional[int] = None,
@@ -137,6 +137,9 @@ def async_evolve(
         start, before any commit has moved head.
     resync_on_commit:
         Refresh every worker as soon as a sweep commits, whatever the ratio.
+        On by default: a worker that starts a rollout against a version a
+        finished sweep has already replaced is doing work the merger will
+        discard, and no workload wants that.
 
         This does **not** remove staleness where a real workload gets it. A
         worker snapshots, then spends the rollout in ``run``, then pushes; a
@@ -144,9 +147,12 @@ def async_evolve(
         what the top of the loop does. What it removes is the other source:
         *starting* a rollout against a snapshot a finished sweep has already
         superseded. The two coincide only when rollouts are short relative to
-        sweep cadence -- as they are in this repo's synthetic tests, where
-        turning this on does collapse η to 0 -- which is why it is opt-in
-        rather than the default.
+        sweep cadence -- as they are in this repo's synthetic tests and bench
+        workloads, where a rollout is a dictionary lookup and turning this on
+        does collapse η to 0. Those are the cases that need ``False``: anything
+        measuring what the lag budget alone does has to switch this off, or the
+        budget is no longer the only resync trigger and the measurement is of
+        something else.
 
         Turn it on when the artifact's *content* is what workers reason from,
         so an out-of-date copy makes the work void rather than merely stale.
@@ -817,9 +823,10 @@ def async_evolve(
         # This does not make cards fresh: the snapshot is taken before `run` and
         # the card is pushed after it, so a commit during a long rollout still
         # arrives stale, which is where staleness comes from on any workload
-        # whose rollouts outlast a sweep. It is opt-in because on *short*
-        # rollouts the two windows collapse into one and η goes to 0, and this
-        # module exists to let η be non-zero.
+        # whose rollouts outlast a sweep -- the module's premise survives. It
+        # stays switchable because on *short* rollouts the two windows collapse
+        # into one and η goes to 0, so anything measuring the lag budget in
+        # isolation has to turn it off.
         if resync_on_commit and committed:
             commit_epoch[0] += 1
         if stall.should_force_refresh():

--- a/agentdescent/async_runtime.py
+++ b/agentdescent/async_runtime.py
@@ -46,6 +46,11 @@ from .staleness import StalenessPolicy
 class AsyncConfig:
     n_workers: int = 6
     async_ratio: int = 3          # ROLL Flash global lag budget (max head drift)
+    #: Resync every worker the moment a sweep commits. Mirrors the engine's
+    #: default. Switch off to study the lag budget in isolation: this domain's
+    #: rollout is a dictionary lookup, so with it on a worker is never more than
+    #: one lookup behind head and eta never leaves 0.
+    resync_on_commit: bool = True
     noise: float = 0.15
     target_accuracy: float = 0.98
     max_seconds: float = 20.0     # wall-clock safety bound
@@ -184,6 +189,7 @@ class AsyncAgentDescent:
             artifact_id=self.skill_id,
             n_workers=self.cfg.n_workers,
             async_ratio=self.cfg.async_ratio,
+            resync_on_commit=self.cfg.resync_on_commit,
             max_seconds=self.cfg.max_seconds,
             target_reward=self.cfg.target_accuracy,
             held_out_frac=cluster_split_frac(self._train_tasks, self._held_tasks),

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -2080,7 +2080,7 @@ def evolve(
     eval_concurrency: int = 8,
     asynchronous: bool = False,
     async_ratio: int = 3,
-    resync_on_commit: bool = False,
+    resync_on_commit: bool = True,
     pipelined_gate: bool = False,
     gate_workers: int = 2,
     max_seconds: Optional[float] = None,

--- a/agentdescent/evolution.py
+++ b/agentdescent/evolution.py
@@ -2080,6 +2080,7 @@ def evolve(
     eval_concurrency: int = 8,
     asynchronous: bool = False,
     async_ratio: int = 3,
+    resync_on_commit: bool = False,
     pipelined_gate: bool = False,
     gate_workers: int = 2,
     max_seconds: Optional[float] = None,
@@ -2251,6 +2252,12 @@ def evolve(
         :func:`~agentdescent.async_evolve.async_evolve`, which implements it.
         Warns and does nothing on the synchronous path, where the round barrier
         idles every worker for the whole merge regardless.
+    resync_on_commit:
+        Asynchronous path only. Refresh every worker's snapshot as soon as a
+        sweep commits, so no one *starts* a rollout against a superseded
+        artifact. See :func:`~agentdescent.async_evolve.async_evolve`, which
+        documents what it does and does not fix -- a commit landing mid-rollout
+        still produces a stale card.
     asynchronous, async_ratio:
         Delegate to :func:`~agentdescent.async_evolve.async_evolve` -- no round
         barrier, with ``async_ratio`` as the staleness lag budget.
@@ -2429,6 +2436,7 @@ def evolve(
             tasks, reward, agent=agent, run=run, propose=propose, strategy=strategy,
             initial_state=initial_state, blast_radius=blast_radius, artifact_id=artifact_id,
             n_workers=n_workers, async_ratio=async_ratio,
+            resync_on_commit=resync_on_commit,
             max_seconds=20.0 if max_seconds is None else max_seconds,
             max_iters=(max_rollouts if max_rollouts is not None
                        else rounds * max(1, n_workers)),

--- a/bench/harness.py
+++ b/bench/harness.py
@@ -64,6 +64,12 @@ class Config:
     #: value tuned for one workload is not a value at all for another -- which is
     #: why it is a dimension of the matrix rather than a constant in it.
     async_ratio: int = 3
+    #: Off across this matrix, unlike the engine default. Every async row here
+    #: exists to measure what the lag budget alone does, and a rollout in this
+    #: workload is a dictionary lookup -- with commit-resync on, a worker is
+    #: never more than one lookup behind head, eta never leaves 0 and the
+    #: `async_ratio` column stops varying anything.
+    resync_on_commit: bool = False
     staleness: str = "guarded"
 
     def as_row(self) -> Dict[str, Any]:

--- a/bench/run.py
+++ b/bench/run.py
@@ -108,6 +108,7 @@ def workload(config: Config, seed: int) -> EvolutionResult:
         max_concurrency=config.n_workers,
         eval_concurrency=config.eval_concurrency,
         asynchronous=config.asynchronous, async_ratio=config.async_ratio,
+        resync_on_commit=config.resync_on_commit,
         staleness_policy=get_policy(config.staleness),
         held_out_frac=0.4, seed=seed, max_seconds=60.0)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,6 +214,7 @@ evolve(
     eval_concurrency: int = 8,
     asynchronous: bool = False,
     async_ratio: int = 3,
+    resync_on_commit: bool = False,
     pipelined_gate: bool = False,
     gate_workers: int = 2,
     max_seconds: Optional[float] = None,
@@ -262,6 +263,7 @@ evolve(
 | `eval_concurrency` | `int` | `8` | How many held-out tasks to score at once. Every gate goes through this -- each round's measurement and, far more often, the aggregator's per-candidate comparisons -- so it is the merge half of the run's parallelism, independent of `n_workers`. `1` restores the old sequential behaviour. |
 | `asynchronous` | `bool` | `False` | Delegate to `async_evolve` -- no round barrier, with `async_ratio` as the staleness lag budget. |
 | `async_ratio` | `int` | `3` | As `asynchronous`. |
+| `resync_on_commit` | `bool` | `False` | Asynchronous path only. Refresh every worker's snapshot as soon as a sweep commits, so no one *starts* a rollout against a superseded artifact. See `async_evolve`, which documents what it does and does not fix -- a commit landing mid-rollout still produces a stale card. |
 | `pipelined_gate` | `bool` | `False` | Under `asynchronous=True`, run a merge's **measurement** phase on its own threads instead of on the merger, so the merger goes back to draining while the gate runs. Off by default; documented in full on `async_evolve`, which implements it. Warns and does nothing on the synchronous path, where the round barrier idles every worker for the whole merge regardless. |
 | `gate_workers` | `int` | `2` | As `pipelined_gate`. |
 | `max_seconds` | `Optional[float]` | `None` | Wall-clock budget. `None` (default) means unbounded; the async path uses `20.0` when unset. |
@@ -1540,6 +1542,7 @@ async_evolve(
     artifact_id: str = 'artifact',
     n_workers: int = 4,
     async_ratio: int = 3,
+    resync_on_commit: bool = False,
     max_seconds: float = 20.0,
     max_iters: Optional[int] = None,
     max_calls: Optional[int] = None,
@@ -1586,6 +1589,7 @@ async_evolve(
 | `artifact_id` | `str` | `'artifact'` | As `tasks`. |
 | `n_workers` | `int` | `4` | Producer threads (`>= 1`). The train tasks are sharded round-robin across them; a worker with an empty shard is not started. |
 | `async_ratio` | `int` | `3` | The lag budget, in two senses: a worker refreshes its snapshot once head drifts more than this far ahead, **and** it stops producing while more than this many cards sit un-merged. The second bound matters at cold start, before any commit has moved head. |
+| `resync_on_commit` | `bool` | `False` | Refresh every worker as soon as a sweep commits, whatever the ratio. This does **not** remove staleness where a real workload gets it. A worker snapshots, then spends the rollout in `run`, then pushes; a commit landing anywhere in that window makes the card stale no matter what the top of the loop does. What it removes is the other source: *starting* a rollout against a snapshot a finished sweep has already superseded. The two coincide only when rollouts are short relative to sweep cadence -- as they are in this repo's synthetic tests, where turning this on does collapse η to 0 -- which is why it is opt-in rather than the default. Turn it on when the artifact's *content* is what workers reason from, so an out-of-date copy makes the work void rather than merely stale. Evolving a skill library from empty is the case that motivated it: the lag budget fires at `head_v - base_v > async_ratio`, so with the default 3 the first three commits leave every worker still proposing against no library at all, re-deriving what head already has for the merger to discard. |
 | `max_seconds` | `float` | `20.0` | Wall-clock budget for the **production phase only**. Two things still happen after it, so budget for them: a bounded shutdown (`shutdown_grace`, since an in-flight rollout cannot be cancelled) and **one held-out scoring pass** to compute `final_reward`. That pass is memoised per (artifact, task), so it is free when the final head was already scored by a sweep and costs a full held-out sweep of the backend when it was not -- which is exactly the case when the budget was too short for any sweep to finish. |
 | `max_iters` | `Optional[int]` | `None` | Stop after this many worker rollouts in total (a budget, not a barrier). |
 | `max_calls` | `Optional[int]` | `None` | Stop after this many actor invocations (`run` + `propose`) in total. The second half of an equal-budget comparison: two configurations matched on rollouts still differ in model spend whenever one of them asks for more proposals per rollout, and the cheaper unit is the one a reader assumes was held fixed. Both bounds are checked as each rollout lands, so a run overshoots only by what was already in flight. |

--- a/docs/api.md
+++ b/docs/api.md
@@ -214,7 +214,7 @@ evolve(
     eval_concurrency: int = 8,
     asynchronous: bool = False,
     async_ratio: int = 3,
-    resync_on_commit: bool = False,
+    resync_on_commit: bool = True,
     pipelined_gate: bool = False,
     gate_workers: int = 2,
     max_seconds: Optional[float] = None,
@@ -263,7 +263,7 @@ evolve(
 | `eval_concurrency` | `int` | `8` | How many held-out tasks to score at once. Every gate goes through this -- each round's measurement and, far more often, the aggregator's per-candidate comparisons -- so it is the merge half of the run's parallelism, independent of `n_workers`. `1` restores the old sequential behaviour. |
 | `asynchronous` | `bool` | `False` | Delegate to `async_evolve` -- no round barrier, with `async_ratio` as the staleness lag budget. |
 | `async_ratio` | `int` | `3` | As `asynchronous`. |
-| `resync_on_commit` | `bool` | `False` | Asynchronous path only. Refresh every worker's snapshot as soon as a sweep commits, so no one *starts* a rollout against a superseded artifact. See `async_evolve`, which documents what it does and does not fix -- a commit landing mid-rollout still produces a stale card. |
+| `resync_on_commit` | `bool` | `True` | Asynchronous path only. Refresh every worker's snapshot as soon as a sweep commits, so no one *starts* a rollout against a superseded artifact. See `async_evolve`, which documents what it does and does not fix -- a commit landing mid-rollout still produces a stale card. |
 | `pipelined_gate` | `bool` | `False` | Under `asynchronous=True`, run a merge's **measurement** phase on its own threads instead of on the merger, so the merger goes back to draining while the gate runs. Off by default; documented in full on `async_evolve`, which implements it. Warns and does nothing on the synchronous path, where the round barrier idles every worker for the whole merge regardless. |
 | `gate_workers` | `int` | `2` | As `pipelined_gate`. |
 | `max_seconds` | `Optional[float]` | `None` | Wall-clock budget. `None` (default) means unbounded; the async path uses `20.0` when unset. |
@@ -1542,7 +1542,7 @@ async_evolve(
     artifact_id: str = 'artifact',
     n_workers: int = 4,
     async_ratio: int = 3,
-    resync_on_commit: bool = False,
+    resync_on_commit: bool = True,
     max_seconds: float = 20.0,
     max_iters: Optional[int] = None,
     max_calls: Optional[int] = None,
@@ -1589,7 +1589,7 @@ async_evolve(
 | `artifact_id` | `str` | `'artifact'` | As `tasks`. |
 | `n_workers` | `int` | `4` | Producer threads (`>= 1`). The train tasks are sharded round-robin across them; a worker with an empty shard is not started. |
 | `async_ratio` | `int` | `3` | The lag budget, in two senses: a worker refreshes its snapshot once head drifts more than this far ahead, **and** it stops producing while more than this many cards sit un-merged. The second bound matters at cold start, before any commit has moved head. |
-| `resync_on_commit` | `bool` | `False` | Refresh every worker as soon as a sweep commits, whatever the ratio. This does **not** remove staleness where a real workload gets it. A worker snapshots, then spends the rollout in `run`, then pushes; a commit landing anywhere in that window makes the card stale no matter what the top of the loop does. What it removes is the other source: *starting* a rollout against a snapshot a finished sweep has already superseded. The two coincide only when rollouts are short relative to sweep cadence -- as they are in this repo's synthetic tests, where turning this on does collapse η to 0 -- which is why it is opt-in rather than the default. Turn it on when the artifact's *content* is what workers reason from, so an out-of-date copy makes the work void rather than merely stale. Evolving a skill library from empty is the case that motivated it: the lag budget fires at `head_v - base_v > async_ratio`, so with the default 3 the first three commits leave every worker still proposing against no library at all, re-deriving what head already has for the merger to discard. |
+| `resync_on_commit` | `bool` | `True` | Refresh every worker as soon as a sweep commits, whatever the ratio. On by default: a worker that starts a rollout against a version a finished sweep has already replaced is doing work the merger will discard, and no workload wants that. This does **not** remove staleness where a real workload gets it. A worker snapshots, then spends the rollout in `run`, then pushes; a commit landing anywhere in that window makes the card stale no matter what the top of the loop does. What it removes is the other source: *starting* a rollout against a snapshot a finished sweep has already superseded. The two coincide only when rollouts are short relative to sweep cadence -- as they are in this repo's synthetic tests and bench workloads, where a rollout is a dictionary lookup and turning this on does collapse η to 0. Those are the cases that need `False`: anything measuring what the lag budget alone does has to switch this off, or the budget is no longer the only resync trigger and the measurement is of something else. Turn it on when the artifact's *content* is what workers reason from, so an out-of-date copy makes the work void rather than merely stale. Evolving a skill library from empty is the case that motivated it: the lag budget fires at `head_v - base_v > async_ratio`, so with the default 3 the first three commits leave every worker still proposing against no library at all, re-deriving what head already has for the merger to discard. |
 | `max_seconds` | `float` | `20.0` | Wall-clock budget for the **production phase only**. Two things still happen after it, so budget for them: a bounded shutdown (`shutdown_grace`, since an in-flight rollout cannot be cancelled) and **one held-out scoring pass** to compute `final_reward`. That pass is memoised per (artifact, task), so it is free when the final head was already scored by a sweep and costs a full held-out sweep of the backend when it was not -- which is exactly the case when the budget was too short for any sweep to finish. |
 | `max_iters` | `Optional[int]` | `None` | Stop after this many worker rollouts in total (a budget, not a barrier). |
 | `max_calls` | `Optional[int]` | `None` | Stop after this many actor invocations (`run` + `propose`) in total. The second half of an equal-budget comparison: two configurations matched on rollouts still differ in model spend whenever one of them asks for more proposals per rollout, and the cheaper unit is the one a reader assumes was held fixed. Both bounds are checked as each rollout lands, so a run overshoots only by what was already in flight. |
@@ -1655,6 +1655,7 @@ AsyncAgentDescent(
 AsyncConfig(
     n_workers: int = 6,
     async_ratio: int = 3,
+    resync_on_commit: bool = True,
     noise: float = 0.15,
     target_accuracy: float = 0.98,
     max_seconds: float = 20.0,

--- a/docs/efficiency.md
+++ b/docs/efficiency.md
@@ -297,9 +297,18 @@ configuration. Quality is scored on a split `evolve()`'s gate never saw.
 | sync-1 | 3 | 2/3 | 1.22 / 1.26 / 1.29 | 21 / 22 / 22 | 0.793 / 0.862 / 0.897 | 0% |
 | sync-4 | 3 | 3/3 | 0.46 / 0.52 / 0.71 | 24 / 24 / 40 | 0.862 / 1.000 / 1.000 | 0% |
 | sync-8 | 3 | 3/3 | 0.25 / 0.25 / 0.41 | 24 / 24 / 40 | 0.931 / 1.000 / 1.000 | 0% |
-| async-4 (lag 3, the default) | 3 | **0/3** | — | — | 0.310 / 0.345 / 0.379 | **93%** |
+| async-4 (lag 3, no commit-resync) | 3 | **0/3** | — | — | 0.310 / 0.345 / 0.379 | **93%** |
 | async-4 (lag 1) | 3 | 3/3 | 0.56 / 0.74 / 0.93 | 31 / 35 / 123 | 0.897 / 0.931 / 1.000 | 25% |
 | async-4 (lag 0) | 3 | 3/3 | 0.59 / 0.66 / 0.75 | 25 / 28 / 46 | 0.828 / 0.897 / 0.931 | 0% |
+
+!!! note "Every async row here runs with `resync_on_commit=False`, which is no longer the default"
+    The engine now resyncs a worker the moment a sweep commits, so nobody starts
+    a rollout against a version that has already been replaced. This matrix
+    pins it off, because a rollout in this workload is a dictionary lookup: with
+    it on, a worker is never more than one lookup behind head, `eta` never
+    leaves 0 and the `async_ratio` column stops varying anything. These rows are
+    what the lag budget does in isolation, which is what they were measuring all
+    along -- they are no longer a picture of the default configuration.
 
 !!! warning "The `stale%` column was understated, and this is the corrected run"
     It read **86%** and **10%** for the two async rows. The async path ran its own

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -14,10 +14,12 @@ from agentdescent.domains.router import make_task_universe
 from agentdescent.staleness import get_policy
 
 
-def _run(policy_name, async_ratio=4, seconds=15.0, noise=0.12, seed=1):
+def _run(policy_name, async_ratio=4, seconds=15.0, noise=0.12, seed=1,
+         resync_on_commit=True):
     universe = make_task_universe(seed=7)
     cfg = AsyncConfig(n_workers=6, async_ratio=async_ratio, noise=noise,
-                      target_accuracy=0.95, max_seconds=seconds, seed=seed)
+                      target_accuracy=0.95, max_seconds=seconds, seed=seed,
+                      resync_on_commit=resync_on_commit)
     with tempfile.TemporaryDirectory() as repo:
         sys = AsyncAgentDescent(repo, universe, config=cfg,
                              staleness_policy=get_policy(policy_name))
@@ -48,8 +50,13 @@ def test_guarded_discards_more_than_reflective():
     laptop and fails on a loaded CI runner (it did: 0.83 on Python 3.9). The
     relational invariants hold regardless of machine speed.
     """
-    g = _run("guarded", async_ratio=4, seconds=12.0, seed=3)
-    r = _run("reflective", async_ratio=4, seconds=12.0, seed=3)
+    # `resync_on_commit=False`: this compares what two staleness *policies* do
+    # with stale work, so the lag budget has to be the only resync trigger. With
+    # the default on, a commit resyncs every worker and -- rollouts here being
+    # dictionary lookups -- nothing is ever stale for either policy to act on,
+    # so both counters read 0 and the comparison has no content.
+    g = _run("guarded", async_ratio=4, seconds=12.0, seed=3, resync_on_commit=False)
+    r = _run("reflective", async_ratio=4, seconds=12.0, seed=3, resync_on_commit=False)
 
     assert g.discarded_stale > r.discarded_stale   # the claim under test
     # ...and as a *rate*, which is what "wastes less work" actually means.


### PR DESCRIPTION
## What

Adds `resync_on_commit` (**default `True`**) to `async_evolve` / `evolve`: a committed sweep refreshes every worker's snapshot immediately, whatever the lag budget says.

## Why

A worker snapshots the ledger, rolls out, proposes, pushes — and refreshes that snapshot only once head drifts past `async_ratio` versions. With the default `3`, the first three commits of a run leave the entire fleet on the snapshot it took at startup.

When the artifact is a rule set, that is mild staleness. When the artifact's **content is what the worker reasons from**, it means the fleet is proposing against an artifact that no longer exists — on a run starting from empty, against no artifact at all.

Observed on BiomniBench-DA (evolving a Claude Code skill library from empty):

- two hours after a ten-skill merge, five in-flight train rollouts still mounted **zero** skills
- the next sweep's six cards were rejected for re-deriving skills already committed

## Why this can be the default

It does not remove staleness where a real workload gets it. The snapshot is taken before `run` and the card is pushed after, so a commit landing during a 30–90 minute rollout still produces a stale card. The module's premise is intact. What this removes is the other source: **starting** a rollout against a version a finished sweep has already superseded, which no workload wants.

## Where it has to be off

Only where a rollout is a dictionary lookup, so the resync window and the rollout window collapse into one and `eta` never leaves 0:

- `tests/test_async.py::test_guarded_discards_more_than_reflective` — compares what two staleness *policies* do with stale work, so stale work has to exist. Pinned off at the call site.
- `bench/harness.py` — pinned off across the matrix. Every async row there exists to vary `async_ratio`; with commit-resync on, that column varies nothing.

`docs/efficiency.md` published a row labelled *"lag 3, the default"*. That is no longer the default, so the label now reads *"no commit-resync"* and a note states what the rows measure. **The numbers are untouched** — they are still true of what was run; only the claim that it described the default stopped being true. The matrix was not re-run.

## Implementation note

The trigger is its own counter, not `epoch`. `epoch` drives `forced_refreshes`, which `docs/async.md`, `docs/staleness.md` and `concepts.md` all define as quiet on a healthy run. A commit is the pipeline working, not a fault — routing it through `epoch` would make that diagnostic non-zero on every healthy run, the mistake the note at the resync site already warns against.

`AsyncConfig.resync_on_commit` mirrors the engine default so the reference runtime does not silently diverge.

## Test plan

- [x] `test_guarded_discards_more_than_reflective`, `test_the_lag_budget_is_what_made_the_async_row_look_broken` — both pass
- [x] `tests/test_api_reference.py` — new parameter reaches `docs/api.md` (regenerated via `python -m tools.gen_api_docs`)
- [ ] full suite — kept OOM-killing locally (exit 137); relying on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)