### PR TITLE
One entry point: install policies through bind/configure, remove the one-call wrappers, and a guide to the policy slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **A wrapper around a default policy can now be installed through `Policies`
+  alone.** `DefaultConflict` and `DefaultFusion` take the verifier through an
+  optional `bind(verifier)` hook, `DefaultAcceptance` and `DefaultPromotion`
+  take their thresholds through `configure(config)` (or the pinned
+  `from_config(cfg)`), and the aggregator now offers both hooks to every
+  installed merge-side policy — previously only fusion was bound, so
+  `Policies(conflict=AdvantageConflict(DefaultConflict(...)))` type-checked,
+  installed, and died with `'NoneType' has no attribute 'cheap_eval'` on the
+  first contradiction that reached the inner rule; the repository's own tests
+  had to route it through an `aggregator_factory`. The wrappers
+  (`AdvantageConflict`, `AdvantageAcceptance`, `StableDistanceAcceptance`)
+  forward the hooks and default their `inner` to the shipped rule, so
+  `AdvantageAcceptance()` reads the run's `agg_config=` instead of a hand-copied
+  `DefaultAcceptance(0.5, 64, 4000)` that silently diverged from it. A default
+  used without being installed raises `PolicyUnboundError` naming the missing
+  piece. New: `agentdescent.aggregator.install_policy`,
+  `tests/test_policy_install.py`; docs on
+  [acceptance](docs/acceptance-policies.md) and
+  [conflict](docs/conflict-policies.md) policies.
+
 ## [0.4.6] — 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to AgentDescent are documented here. The format follows
 
 ## [Unreleased]
 
+### Added
+
+- **A systematic guide to the policy slots**, `docs/policy-guide.md`: where
+  each of the eight slots sits in a round, what it is handed and must return,
+  the five composition rules the engine enforces, the three ways to fill a
+  slot (shipped, wrap, replace), the per-slot contract with its one common
+  mistake, the `bind` / `configure` install hooks, how to prove a policy ran,
+  a recipe table, and the pitfalls in the order people meet them. Linked from
+  the policies catalogue and the nav.
+
 ### Fixed
 
 - **A wrapper around a default policy can now be installed through `Policies`

--- a/agentdescent/advantage.py
+++ b/agentdescent/advantage.py
@@ -135,7 +135,30 @@ class GroupAdvantage:
         return self._n.get(key, 0)
 
 
-class AdvantageAcceptance:
+class _ForwardsInstall:
+    """Forward the aggregator's install hooks to the wrapped rule.
+
+    A wrapper adds one term and defers to ``inner`` for everything else, so
+    whatever the engine hands over -- its verifier through ``bind``, its
+    thresholds through ``configure`` -- belongs to the inner rule, and the wrapper
+    passes it straight through. Without this a wrapper around a default rule
+    could only be installed by rebuilding the aggregator by hand.
+    """
+
+    inner: object
+
+    def bind(self, verifier) -> None:
+        fn = getattr(self.inner, "bind", None)
+        if callable(fn):
+            fn(verifier)
+
+    def configure(self, config) -> None:
+        fn = getattr(self.inner, "configure", None)
+        if callable(fn):
+            fn(config)
+
+
+class AdvantageAcceptance(_ForwardsInstall):
     """Shift the acceptance prior by how well a proposal did against its group.
 
     Wraps another :class:`~agentdescent.policies.AcceptancePolicy` rather than
@@ -152,12 +175,18 @@ class AdvantageAcceptance:
 
     Cards without an advantage are skipped, not counted as zero -- see
     :class:`GroupAdvantage`.
+
+    ``inner`` defaults to the shipped gate with the run's own thresholds: the
+    aggregator fills them in when the policy is installed, so
+    ``AdvantageAcceptance()`` and ``agg_config=`` cannot disagree.
     """
 
-    def __init__(self, inner, strength: float = 1.0) -> None:
+    def __init__(self, inner=None, strength: float = 1.0) -> None:
+        from .defaults import DefaultAcceptance
+
         if strength < 0:
             raise ValueError("strength must not be negative")
-        self.inner = inner
+        self.inner = inner if inner is not None else DefaultAcceptance()
         self.strength = strength
 
     def accept(self, ctx):
@@ -178,7 +207,7 @@ class AdvantageAcceptance:
         return self.inner.accept(_replace(ctx, prior=shifted))
 
 
-class AdvantageConflict:
+class AdvantageConflict(_ForwardsInstall):
     """Break a contradiction by group-relative advantage, not raw score.
 
     The default rule keeps whichever of two contradicting diffs scores better on
@@ -191,10 +220,17 @@ class AdvantageConflict:
     Falls through to the wrapped policy whenever either side has no advantage, or
     the two are within ``margin`` -- so it only fires where it has something the
     default does not.
+
+    ``inner`` defaults to :class:`~agentdescent.defaults.DefaultConflict`, which
+    needs the engine's verifier to score a tie. The aggregator hands it over
+    through ``bind`` when the policy is installed, so ``AdvantageConflict()`` is
+    enough on its own; nothing here has to see a verifier.
     """
 
-    def __init__(self, inner, margin: float = 0.5) -> None:
-        self.inner = inner
+    def __init__(self, inner=None, margin: float = 0.5) -> None:
+        from .defaults import DefaultConflict
+
+        self.inner = inner if inner is not None else DefaultConflict()
         self.margin = margin
 
     def resolve(self, artifact, cards):
@@ -340,7 +376,7 @@ def state_distance(a, b) -> float:
     return sum(1 for k in keys if a.get(k) != b.get(k)) / len(keys)
 
 
-class StableDistanceAcceptance:
+class StableDistanceAcceptance(_ForwardsInstall):
     """Penalise candidates that drift far from the confirmed branch.
 
     The KL-to-a-reference-policy analogy, with ``stable`` as the reference. It
@@ -358,12 +394,17 @@ class StableDistanceAcceptance:
     Wraps another policy, and does nothing at all when the context carries no
     stable distance -- so a run whose ledger has no `stable` branch yet behaves
     exactly as before.
+
+    ``inner`` defaults to the shipped gate with the run's own thresholds, filled
+    in by the aggregator when the policy is installed.
     """
 
-    def __init__(self, inner, strength: float = 0.1) -> None:
+    def __init__(self, inner=None, strength: float = 0.1) -> None:
+        from .defaults import DefaultAcceptance
+
         if strength < 0:
             raise ValueError("strength must not be negative")
-        self.inner = inner
+        self.inner = inner if inner is not None else DefaultAcceptance()
         self.strength = strength
 
     def accept(self, ctx):

--- a/agentdescent/aggregator.py
+++ b/agentdescent/aggregator.py
@@ -32,7 +32,7 @@ import time
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import (Callable, Deque, Dict, List, Optional, Protocol, Tuple,
+from typing import (Any, Callable, Deque, Dict, List, Optional, Protocol, Tuple,
                     Union, runtime_checkable)
 
 from .evolvable import (
@@ -447,6 +447,23 @@ def fuse_diffs(diffs: List[Diff]) -> Diff:
                 contract_breaking=breaking, author="aggregator")
 
 
+def install_policy(policy: Any, verifier: Any, config: "AggregatorConfig") -> None:
+    """Offer a policy the engine's verifier and config through its optional hooks.
+
+    ``bind(verifier)`` and ``configure(config)`` are both optional: a policy that
+    has neither is left alone. Wrappers such as
+    :class:`~agentdescent.advantage.AdvantageConflict` forward them to their
+    inner rule, which is what lets ``Policies(conflict=AdvantageConflict())``
+    work without the caller ever seeing a verifier. Public so a hand-built
+    aggregator, a factory, or a test can install a policy the same way."""
+    bind = getattr(policy, "bind", None)
+    if callable(bind):
+        bind(verifier)
+    configure = getattr(policy, "configure", None)
+    if callable(configure):
+        configure(config)
+
+
 class Aggregator:
     """Per-artifact optimizer step over the ledger."""
 
@@ -475,20 +492,23 @@ class Aggregator:
         self.config = config or AggregatorConfig()
         # The decisions, as objects. Swapping one is the point; the defaults are
         # the code that used to be inline here, moved rather than rewritten.
+        cfg = self.config
         self.conflict_policy = conflict or DefaultConflict(verifier)
         self.fusion_policy = fusion or DefaultFusion(
-            verifier, tournament=self.config.fusion_tournament)
-        # A fusion policy ranks candidates, so it needs the verifier -- and a
-        # caller building one cannot supply it, because the verifier is built
-        # inside the engine. Hand it over to any policy that asked by exposing
-        # `bind`; the shipped one takes it in its constructor and has none.
-        _bind = getattr(self.fusion_policy, "bind", None)
-        if callable(_bind):
-            _bind(verifier)
-        cfg = self.config
-        self.acceptance_policy = acceptance or DefaultAcceptance(
-            cfg.base_delta, cfg.anneal_half_life, cfg.accept_samples)
-        self.promotion_policy = promotion or DefaultPromotion(cfg.promote_after_k)
+            verifier, tournament=cfg.fusion_tournament)
+        self.acceptance_policy = acceptance or DefaultAcceptance.from_config(cfg)
+        self.promotion_policy = promotion or DefaultPromotion.from_config(cfg)
+        # Two things a policy may need are built in here and nowhere a caller
+        # can reach: the verifier (for anything that ranks) and the config (for
+        # anything that reads a threshold). So every installed policy is offered
+        # both, through two optional hooks -- `bind(verifier)` and
+        # `configure(config)` -- and a wrapper forwards them to whatever it
+        # wraps. Before this only fusion was bound, so
+        # `AdvantageConflict(DefaultConflict())` type-checked, installed, and
+        # died on the first contradiction that reached the inner rule.
+        for policy in (self.conflict_policy, self.fusion_policy,
+                       self.acceptance_policy, self.promotion_policy):
+            install_policy(policy, verifier, cfg)
         self.buffer = EvidenceBuffer()
         self._posteriors: Dict[str, BetaPosterior] = defaultdict(BetaPosterior)
         # dev-branch survival counter for EMA-style promotion.

--- a/agentdescent/defaults.py
+++ b/agentdescent/defaults.py
@@ -24,22 +24,45 @@ from typing import (
     TYPE_CHECKING, Dict, List, Optional, Sequence, Tuple,
 )
 
-from .evolvable import Diff, EvidenceCard, Evolvable
+from .evolvable import ContractError, Diff, EvidenceCard, Evolvable
 from .policies import (
     AcceptDecision, FusionTrial, MergeContext, Promotion, ProposalContext,
 )
 from .stats import annealed_delta, prob_improvement
 
 if TYPE_CHECKING:                                # pragma: no cover
-    from .aggregator import MergeReport
+    from .aggregator import AggregatorConfig, MergeReport
 
 __all__ = [
     "DefaultAcceptance",
     "DefaultConflict",
     "DefaultFusion",
     "DefaultPromotion",
+    "PolicyUnboundError",
     "SingleProposal",
 ]
+
+
+class PolicyUnboundError(ContractError, RuntimeError):
+    """A default policy was asked to decide before the engine handed it what it reads.
+
+    Every default here needs something only the engine has -- the verifier for
+    the two that rank, the `AggregatorConfig` for the two that read thresholds.
+    A caller building one by hand cannot supply those, so the constructors accept
+    ``None`` and the aggregator fills them in through :meth:`bind` /
+    :meth:`configure` when the policy is installed. This is what a policy raises
+    if it is used *without* having been installed -- naming the missing piece,
+    rather than dying on ``'NoneType' has no attribute 'cheap_eval'`` in the
+    middle of the first contradiction.
+    """
+
+
+def _unbound(policy: object, what: str, hook: str) -> PolicyUnboundError:
+    name = type(policy).__name__
+    return PolicyUnboundError(
+        f"{name} has no {what}: it was used before the aggregator installed it. "
+        f"Pass it through Policies(...) so the engine calls {name}.{hook}(), or "
+        f"call {hook}() yourself when driving the policy by hand.")
 
 
 class SingleProposal:
@@ -58,10 +81,22 @@ class SingleProposal:
 
 
 class DefaultConflict:
-    """Drop contradicting diffs, keeping whichever scores better (PCGrad-style)."""
+    """Drop contradicting diffs, keeping whichever scores better (PCGrad-style).
 
-    def __init__(self, verifier) -> None:
+    ``verifier`` is normally left unset: the engine constructs it, so a caller
+    has no way to pass one in. :class:`~agentdescent.aggregator.Aggregator` calls
+    :meth:`bind` on every conflict policy that has it -- which is what lets a
+    wrapper such as :class:`~agentdescent.advantage.AdvantageConflict` carry
+    this rule as its fallback through ``Policies(conflict=...)``.
+    """
+
+    def __init__(self, verifier=None) -> None:
         self.verifier = verifier
+
+    def bind(self, verifier) -> None:
+        """Receive the engine's verifier, if the caller did not supply one."""
+        if self.verifier is None:
+            self.verifier = verifier
 
     def resolve(self, artifact: Evolvable,
                 cards: Sequence[EvidenceCard]) -> Tuple[List[EvidenceCard], int]:
@@ -81,6 +116,8 @@ class DefaultConflict:
                             if diffs_contradict(survivor.diff, k.diff)), None)
                 if idx is None:
                     break
+                if self.verifier is None:
+                    raise _unbound(self, "verifier", "bind")
                 # project out the worse of the two on the held-out subset.
                 d_score = self.verifier.cheap_eval(artifact.apply(survivor.diff))
                 k_score = self.verifier.cheap_eval(artifact.apply(kept[idx].diff))
@@ -138,7 +175,9 @@ class DefaultFusion:
     is where a choice is unavoidable.
     """
 
-    def __init__(self, verifier, tournament: bool = False) -> None:
+    def __init__(self, verifier=None, tournament: bool = False) -> None:
+        #: Left unset by a caller; the aggregator fills it in through
+        #: :meth:`bind` when the policy is installed.
         self.verifier = verifier
         #: Rank candidates against each other before putting one forward. Off by
         #: default; see the class docstring for the cost/benefit that decides it.
@@ -147,12 +186,19 @@ class DefaultFusion:
         #: by the engine when it assembles the result.
         self.trials: List[FusionTrial] = []
 
+    def bind(self, verifier) -> None:
+        """Receive the engine's verifier, if the caller did not supply one."""
+        if self.verifier is None:
+            self.verifier = verifier
+
     def select(self, artifact: Evolvable,
                diffs: List[Diff]) -> Tuple[Diff, Evolvable, bool]:
         union, reason = self._union_of(diffs)
 
         if not self.tournament:
             return self._commit_union(artifact, diffs, union, reason)
+        if self.verifier is None:
+            raise _unbound(self, "verifier", "bind")
 
         # Score once and keep the numbers. `max(..., key=cheap_eval)` recomputed
         # them and threw them away, which is why the question below had no data
@@ -271,18 +317,43 @@ class DefaultAcceptance:
       posterior either way produced lines like `P(delta>0)=0.97 <= 0.50` when the
       regression guard was the real cause -- self-contradictory to anyone reading
       `outcomes()` to find out why nothing committed, which is its one job.
+
+    The three thresholds are the aggregator's -- ``base_delta``,
+    ``anneal_half_life`` and ``accept_samples`` on
+    :class:`~agentdescent.aggregator.AggregatorConfig`. Leave them ``None`` and
+    the aggregator fills them from its config through :meth:`configure` when the
+    policy is installed, so a wrapper's inner rule and the run's ``agg_config=``
+    cannot disagree. Pass a value to pin it; a pinned value is never overwritten.
     """
 
-    def __init__(self, base_delta: float, anneal_half_life: int,
-                 accept_samples: int) -> None:
+    def __init__(self, base_delta: Optional[float] = None,
+                 anneal_half_life: Optional[int] = None,
+                 accept_samples: Optional[int] = None) -> None:
         self.base_delta = base_delta
         self.anneal_half_life = anneal_half_life
         self.accept_samples = accept_samples
+
+    @classmethod
+    def from_config(cls, config: "AggregatorConfig") -> "DefaultAcceptance":
+        """The rule the aggregator would build for ``config``, pinned."""
+        return cls(config.base_delta, config.anneal_half_life, config.accept_samples)
+
+    def configure(self, config: "AggregatorConfig") -> None:
+        """Fill every threshold the caller left unset from the run's config."""
+        if self.base_delta is None:
+            self.base_delta = config.base_delta
+        if self.anneal_half_life is None:
+            self.anneal_half_life = config.anneal_half_life
+        if self.accept_samples is None:
+            self.accept_samples = config.accept_samples
 
     def accept(self, ctx: MergeContext) -> AcceptDecision:
         from .evolvable import stable_hash
         from .stats import BetaPosterior
 
+        if (self.base_delta is None or self.anneal_half_life is None
+                or self.accept_samples is None):
+            raise _unbound(self, "thresholds", "configure")
         prior = ctx.prior if ctx.prior is not None else BetaPosterior()
         base_s, base_f = ctx.base_counts
         cand_s, cand_f = ctx.cand_counts
@@ -338,9 +409,20 @@ class DefaultPromotion:
     looked at would mean a quiet artifact never promotes.
     """
 
-    def __init__(self, promote_after_k: int) -> None:
+    def __init__(self, promote_after_k: Optional[int] = None) -> None:
+        #: ``None`` until :meth:`configure` fills it from the run's config.
         self.promote_after_k = promote_after_k
         self._survival: Dict[str, int] = defaultdict(int)
+
+    @classmethod
+    def from_config(cls, config: "AggregatorConfig") -> "DefaultPromotion":
+        """The rule the aggregator would build for ``config``, pinned."""
+        return cls(config.promote_after_k)
+
+    def configure(self, config: "AggregatorConfig") -> None:
+        """Fill ``promote_after_k`` from the run's config if the caller left it unset."""
+        if self.promote_after_k is None:
+            self.promote_after_k = config.promote_after_k
 
     @property
     def survival(self) -> Dict[str, int]:
@@ -348,6 +430,8 @@ class DefaultPromotion:
         return self._survival
 
     def observe(self, reports: Sequence["MergeReport"]) -> Sequence[Promotion]:
+        if self.promote_after_k is None:
+            raise _unbound(self, "promote_after_k", "configure")
         by_id = {r.artifact_id: r for r in reports}
         out: List[Promotion] = []
         for aid in set(self._survival) | set(by_id):

--- a/docs/acceptance-policies.md
+++ b/docs/acceptance-policies.md
@@ -24,8 +24,31 @@ cap diff size before cards ever reach the gate.
 
 ```python
 evolve(tasks, reward, agent=agent, policies=Policies(
-    acceptance=AdvantageAcceptance(DefaultAcceptance(0.5, 64, 4000))))
+    acceptance=AdvantageAcceptance()))          # wraps the shipped gate
 ```
+
+`AdvantageAcceptance()` and `StableDistanceAcceptance()` wrap the shipped
+`DefaultAcceptance` when given no `inner`. Its three thresholds
+(`base_delta`, `anneal_half_life`, `accept_samples`) are left unset and the
+aggregator fills them from the run's `AggregatorConfig` when the policy is
+installed — so the wrapped gate and `agg_config=` cannot disagree, which they
+silently could when the example above read
+`DefaultAcceptance(0.5, 64, 4000)`. Pass a value to pin one:
+`AdvantageAcceptance(DefaultAcceptance(base_delta=0.3))` keeps `0.3` and takes
+the other two from the run. `DefaultAcceptance.from_config(cfg)` is the fully
+pinned form.
+
+## Installing a policy: the two optional hooks
+
+A policy may need two things only the engine has: the verifier, for anything
+that ranks, and the aggregator's config, for anything that reads a threshold.
+When a policy is installed the aggregator offers both through two *optional*
+methods — `bind(verifier)` and `configure(config)` — and every shipped wrapper
+forwards them to its `inner` rule. A policy with neither is left alone. A
+shipped default used **without** having been installed (driven by hand, outside
+`evolve()`) raises `PolicyUnboundError` naming the missing piece rather than
+failing on a `None` in the middle of a merge; call the hook yourself, or use
+`install_policy(policy, verifier, config)` from `agentdescent.aggregator`.
 
 ## What the default knows that a replacement must be told
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1385,11 +1385,11 @@ AdaptiveTrustRegion(
 |---|---|
 | `observe(outcome: str) -> TrustRegion` | Record one merge outcome and return the region for the next merge. |
 
-### `AdvantageAcceptance(inner, strength: float = 1.0) -> None`
+### `AdvantageAcceptance(inner = None, strength: float = 1.0) -> None`
 
 Shift the acceptance prior by how well a proposal did against its group.
 
-### `AdvantageConflict(inner, margin: float = 0.5) -> None`
+### `AdvantageConflict(inner = None, margin: float = 0.5) -> None`
 
 Break a contradiction by group-relative advantage, not raw score.
 
@@ -1402,7 +1402,7 @@ Standardise a rollout's reward against the group it belongs to.
 | `key(base_version: int, cluster: str = '') -> str` | The group a rollout belongs to. Same base, same cluster. |
 | `observe(key: str, reward: float) -> Optional[float]` | Record a reward and return its advantage, or `None` if unknown yet. |
 
-### `StableDistanceAcceptance(inner, strength: float = 0.1) -> None`
+### `StableDistanceAcceptance(inner = None, strength: float = 0.1) -> None`
 
 Penalise candidates that drift far from the confirmed branch.
 

--- a/docs/conflict-policies.md
+++ b/docs/conflict-policies.md
@@ -19,3 +19,21 @@ here decides what fusion ever gets to see.
 
 Use `reflective_merge(completion)` to install the `KeepContradictions` +
 `ReflectiveFusion` pair correctly — see [fusion policies](fusion-policies.md).
+
+```python
+from agentdescent import Policies, evolve
+from agentdescent.advantage import AdvantageConflict
+
+evolve(tasks, reward, agent=agent, policies=Policies(
+    conflict=AdvantageConflict(margin=0.5)))    # falls back to DefaultConflict
+```
+
+`AdvantageConflict()` wraps `DefaultConflict` when given no `inner`. That rule
+scores a tie on the verifier, which is built inside the engine and which a
+caller cannot supply — so the aggregator hands it over through the policy's
+optional `bind(verifier)` hook when the policy is installed, and the wrapper
+forwards it. Nothing here has to see a verifier. Before this only fusion was
+bound, and a wrapped default conflict rule could be installed only from inside
+an `aggregator_factory`. See
+[acceptance policies](acceptance-policies.md#installing-a-policy-the-two-optional-hooks)
+for the hooks themselves.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -3,7 +3,9 @@
 *Module:* [`agentdescent.policies`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/policies.py)
 
 Every decision `evolve()` makes is an object you can swap, and they all travel
-in one argument:
+in one argument. This page is the catalogue; [the guide](policy-guide.md)
+is the how — where each slot sits, what it is handed, how they compose, and
+how to prove one ran.
 
 ```python
 from agentdescent import Policies, evolve

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -26,6 +26,14 @@ on anything else — a custom acceptance rule either runs or refuses loudly.
 **`None` means today's behaviour**: `Policies()` and passing nothing are the
 same run, so adding a policy never changes an existing measurement.
 
+Each field is independent: swap one and the other seven stay at their defaults.
+The one deliberate pair is `conflict` + `fusion` for model merging, which is why
+`reflective_merge()` returns both. A wrapper that defers to a shipped default —
+`AdvantageConflict()`, `AdvantageAcceptance()` — needs nothing from you: the
+aggregator hands the engine's verifier and config to any policy exposing the
+optional `bind(verifier)` / `configure(config)` hooks
+([details](acceptance-policies.md#installing-a-policy-the-two-optional-hooks)).
+
 ## Which seam is my mechanism?
 
 An algorithm's distinctive mechanism lives in exactly one of three layers:

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -1,0 +1,341 @@
+# Using the policy slots — a systematic guide
+
+*Companion to:* [Choosing policies](policies.md) (the catalogue of what ships)
+· [The aggregator](aggregator.md) (the pipeline the slots sit in)
+
+[`policies.md`](policies.md) lists the slots and what fills them. This page
+is the *how*: where each slot sits in a round, what it is handed and what it
+must give back, how slots compose, the three ways to fill one, how to write
+one that the engine will actually honour, and how to prove it ran. Read it
+once before writing a policy; come back to §4 while writing one.
+
+## 1. Where each slot sits
+
+One round of `evolve()` is a loop of rollouts feeding one merge. The eight
+algorithm slots sit at fixed points of that loop, and nothing else in the
+engine is a decision you can swap — everything between the boxes is
+machinery.
+
+```mermaid
+flowchart TD
+    S[selection<br/>which head each worker starts from] --> T[task_sampler<br/>which task the rollout spends]
+    T --> R[rollout: run + reward]
+    R --> P[proposal<br/>evidence into a proposal]
+    P --> D[strategy.to_diff -> EvidenceCard]
+    D --> A0[trust region]
+    A0 --> A1[staleness<br/>keep / rebase / discard a lagging card]
+    A1 --> A2[conflict<br/>which of the contradicting diffs survive]
+    A2 --> A3[fusion<br/>one candidate out of the survivors]
+    A3 --> M[measure on held-out, oracle audit]
+    M --> A4[acceptance<br/>commit the candidate or refuse it]
+    A4 --> C[commit to dev]
+    C --> A5[promotion<br/>has dev earned stable?]
+    A5 --> S
+```
+
+| Slot | Runs | Is handed | Must return | Default |
+|---|---|---|---|---|
+| `selection` | once per merge, before the next batch | `SelectionContext` (head, every candidate, round, `n_workers`) | up to `n` `Candidate`s; repeats mean "put more workers here" | `SingleHead` |
+| `task_sampler` | once per rollout | the worker's task ids, the round index | one id from those ids; later told the score | `RoundRobin` |
+| `proposal` | once per rollout, after reward | `ProposalContext` (rendered artifact, task, output, reward) | zero or one proposal string | the actor's `propose` |
+| `staleness` | once per card at merge | `eta` (versions behind), `alpha` (tolerance), `contract_breaking` | a `StaleAction` | `Guarded` |
+| `conflict` | once per merge | the artifact, the surviving cards | `(kept_cards, dropped_count)` | `DefaultConflict` |
+| `fusion` | once per merge | the artifact, the kept diffs | `(chosen_diff, candidate_artifact, fused: bool)` | `DefaultFusion` |
+| `acceptance` | once per candidate | `MergeContext` (both measurements, prior, distance to stable) | `AcceptDecision` | `DefaultAcceptance` |
+| `promotion` | once per `step()`, after every artifact's report | this step's `MergeReport`s | `Promotion`s for `stable` | `DefaultPromotion` |
+
+Three points on the diagram are worth fixing in mind. **Conflict runs before
+fusion**, so a fusion policy only ever sees what the conflict policy let
+through — that is why model merging is a pair of slots, not one. **Acceptance
+runs after measurement**, so it never measures anything; it reads numbers. And
+**promotion sees reports, not artifacts**: it decides from what happened this
+step, and artifacts nobody touched still age (see §4).
+
+## 2. How slots compose
+
+Five rules, and every one of them is enforced rather than documented.
+
+1. **Empty means today.** Each field is `None` by default and `None` is the
+   shipped behaviour, so `Policies()` and passing nothing are the same run,
+   and filling one slot leaves the other seven untouched. Fill exactly the
+   slots your mechanism is about.
+2. **One pair.** `conflict` and `fusion` are the only two that must agree:
+   `ReflectiveFusion` merges contradictions, and the default conflict rule
+   throws contradictions away one step earlier. `reflective_merge(completion)`
+   returns both so the half-installed version is not available to you. Every
+   other combination is orthogonal.
+3. **One seat, one occupant.** `selection` installs the population aggregator
+   and `aggregator_factory` replaces the aggregator, so passing both raises.
+   A factory-built aggregator also does not see `conflict`, `fusion`,
+   `acceptance` or `promotion` from the bundle — pass those into your
+   aggregator's constructor and drop them from the bundle; the engine warns
+   if you leave them in ([the factory exit](aggregator-factory.md)).
+4. **Nothing is silently ignored.** Each driver declares the fields it
+   honours and `Policies.require_supported` raises on the rest. Today that
+   means `sandbox_provider` is refused everywhere and `executor` is refused
+   by `async_evolve()` — a policy that installs but does not run is the one
+   failure a caller cannot detect, so it is made impossible.
+5. **The old keyword arguments are shortcuts.** `task_sampler=`,
+   `staleness_policy=` and `aggregator_factory=` on `evolve()` fold into the
+   bundle, and an explicit argument beats a bundle default. Use one spelling
+   per call site.
+
+## 3. Three ways to fill a slot
+
+**Pick a shipped implementation.** The tables on each slot's page. Nothing
+to write:
+
+```python
+from agentdescent import Policies, evolve
+from agentdescent.selection import Beam
+from agentdescent.sampling import DifficultyWeighted
+
+evolve(tasks, reward, agent=agent,
+       policies=Policies(selection=Beam(4), task_sampler=DifficultyWeighted()))
+```
+
+**Wrap the default.** When your idea is *one extra term* on a decision the
+shipped rule already makes well, wrap it rather than replacing it — the
+regression guard, the seeded Beta draw and the reset semantics all have a
+history, and a replacement is how a codebase forgets what it paid to learn.
+The shipped wrappers (`AdvantageAcceptance`, `StableDistanceAcceptance`,
+`AdvantageConflict`) default their `inner` to the shipped rule and forward the
+install hooks (§5), so they need nothing from you:
+
+```python
+from agentdescent.advantage import AdvantageAcceptance, AdvantageConflict
+
+evolve(tasks, reward, agent=agent, policies=Policies(
+    acceptance=AdvantageAcceptance(strength=1.0),   # shipped gate + a prior shift
+    conflict=AdvantageConflict(margin=0.5),         # shipped rule + a tie-break
+))
+```
+
+Writing your own wrapper is the same shape: hold `inner`, add the term,
+defer for everything else, and forward `bind` / `configure` (copy the
+five-line pattern from `agentdescent.advantage`).
+
+**Replace it.** When the decision *rule* is different — a strict-improvement
+gate, a curriculum sampler, a tree-search selection — write an object with
+the slot's method (§4) and pass it. The contracts are `typing.Protocol`s, so
+there is nothing to inherit from; the method name and signature are the
+whole contract, and `tests/test_policy_contract.py` re-derives them from the
+engine's call sites so they cannot drift from what actually runs.
+
+Which of the three: shipped if it exists; wrap if the default's guards should
+survive; replace if they should not. When the mechanism needs *state the
+pipeline does not keep* — an archive, per-instance score rows, a pool with its
+own admission rule — none of the three fits, and the
+[`aggregator_factory`](aggregator-factory.md) exit is the answer.
+
+## 4. Writing a policy: the contract for each slot
+
+Everything below is what the engine actually calls; the module docstring of
+`agentdescent/policies.py` explains why the contracts were written from the
+call sites rather than the docs. Each entry names the method, what it may
+rely on, and the one thing that goes wrong most.
+
+### `task_sampler` — `pick(keys, round_index) -> str`, `record(task_id, score)`
+
+Return one id from `keys`; never mutate `keys`. `record` arrives after the
+rollout with the reward in `[0, 1]`, and is your only learning signal. Under
+data parallelism `keys` is *this worker's shard*, so a sampler that assumes
+it sees every task will mis-weight. Page: [task sampling](sampling.md).
+
+### `selection` — `select(ctx, n) -> Sequence[Candidate]`
+
+`ctx.head` is what the engine would have used with no policy; return
+`[ctx.head] * n` when you have no reason to do otherwise. Return fewer than
+`n` and the engine assigns round-robin; return repeats to weight a point.
+`Candidate.score is None` means *unmeasured*, not zero — ranking it last is
+how a fresh branch never gets tried. Declaring any policy other than
+`SingleHead` installs the population layer that keeps an archive of committed
+heads for you; you do not build it. Page: [candidate selection](selection.md).
+
+### `proposal` — `propose(ctx) -> Sequence[str]`
+
+Zero or one string. Returning `[]` skips the rollout's proposal cleanly.
+Returning two or more raises `ProposalContractError` rather than keeping the
+first: the engine turns one proposal into one diff, and truncating would make
+a k-sampling algorithm look like it ran. `ctx.history` and `ctx.k` exist for
+the day batched rollouts land; today they are empty and `1`. Page:
+[proposal policies](proposal-policies.md).
+
+### `staleness` — `decide(eta, alpha, contract_breaking) -> StaleAction`
+
+Declare a `name`. `ACCEPT` takes the diff as-is (rebased mechanically when
+`eta > 0`), `REBASE` rebases and cheaply re-verifies, `DISCARD` settles the
+card's evidence back to the pool. `alpha` is already the tolerance for this
+artifact's governance layer; you decide, the aggregator executes. Page:
+[staleness policies](staleness.md).
+
+### `conflict` — `resolve(artifact, cards) -> (kept, dropped)`
+
+Two diffs contradict when they write one key with different values. Keep
+going after a win: a card that displaces one survivor may contradict another,
+and stopping at the first left mutually contradicting cards for fusion to
+choke on. `dropped` is a count, reported as `conflicts_dropped`. **Keep at
+least one card**: the fusion step is handed whatever you kept and indexes into
+it, so a policy that empties the batch fails there, not here — drop losers,
+never the whole round. To *score* a tie you need the verifier's `cheap_eval`
+— which you cannot construct, so take it through `bind` (§5). Page:
+[conflict policies](conflict-policies.md).
+
+### `fusion` — `select(artifact, diffs) -> (diff, candidate, fused)`
+
+Given the kept diffs, return the one diff that goes to the gate, the artifact
+with it applied, and whether it is a union. `fuse_diffs` in
+`agentdescent.aggregator` builds a union for you; contradictions must be gone
+by now or the union is ill-defined. Optionally keep a `trials` list of
+`FusionTrial`s and the engine carries it onto `result.fusion_trials` — leave
+it out and `fusion_stats()` reports "not instrumented" rather than "never
+won". Ranking needs the verifier: `bind`. Page:
+[fusion policies](fusion-policies.md).
+
+### `acceptance` — `accept(ctx: MergeContext) -> AcceptDecision`
+
+The one contract with a rule that has already been broken once, so it is the
+one to read twice. **Decide from `base_counts` / `cand_counts`** — the full
+held-out measurement as `(successes, failures)` — **never from `base_cheap` /
+`cand_cheap`**, which are a sub-sample meant for ranking. `ctx.prior` is the
+artifact's running posterior; do not mutate it, return a new one through
+`dataclasses.replace` as the wrappers do. `category` on a refusal must be a
+`MergeOutcome` value (`"below-threshold"` is the ordinary one) — it is what
+`result.outcomes()` reports and the aggregator converts it with
+`MergeOutcome(...)`, so a made-up string raises. Carry `p_improve` and
+`observed_delta` out: the draw is sampled, so recomputing gives a different
+number than the one that decided, and a refused candidate's `observed_delta`
+is folded back into the prior. Page: [acceptance policies](acceptance-policies.md).
+
+### `promotion` — `observe(reports) -> Sequence[Promotion]`
+
+Called once per `step()` with every artifact's report for that step. Any id
+you return is copied from `dev` onto `stable`. Two things the default does
+that a replacement must decide about: a commit and an oracle rejection both
+*reset* an artifact's survival clock, and an artifact absent from this step's
+reports still *ages* — not being touched is the ordinary way to survive a
+round. An optional `survival` mapping is picked up for diagnostics. Page:
+[promotion policies](promotion-policies.md).
+
+## 5. Installing: what the engine hands your policy
+
+Two things a policy may need are built inside the engine and cannot be
+constructed by a caller: the **verifier** (for anything that ranks) and the
+**`AggregatorConfig`** (for anything that reads a threshold). When the
+aggregator installs a merge-side policy it offers both, through two optional
+methods:
+
+| Hook | Offered to | Use it for |
+|---|---|---|
+| `bind(verifier)` | conflict, fusion, acceptance, promotion | `verifier.cheap_eval(...)` to rank, `eval_counts(...)` to measure |
+| `configure(config)` | the same four | `base_delta`, `promote_after_k`, `trust_region_*` — the run's numbers, not a copy |
+
+Neither is required; a policy with neither is left alone. A wrapper forwards
+both to its `inner`. A shipped default that is *driven by hand* without ever
+being installed raises `PolicyUnboundError` naming the missing piece; in a
+test, `install_policy(policy, verifier, config)` from
+`agentdescent.aggregator` does what the aggregator would.
+
+Two consequences worth stating. Values you pass explicitly are never
+overwritten — `DefaultAcceptance(base_delta=0.3)` keeps `0.3` and takes the
+other two thresholds from the run. And a policy is installed *once per
+aggregator*, so a policy object carries state across every merge of the run;
+build a fresh one per `evolve()` call rather than sharing an instance across
+runs.
+
+## 6. Proving the policy ran
+
+A policy that installs and is never consulted is indistinguishable from one
+that works, so the first test of any new policy is a counter. This is
+runnable as written — no credentials, one second:
+
+```python
+from agentdescent import AppendRules, Policies, Task, evolve
+from agentdescent.policies import AcceptDecision
+
+tasks = [Task(id=f"t{i}", prompt="q", meta={"gold": f"t{i}"}) for i in range(8)]
+reward = lambda task, output: 1.0 if output == task.meta["gold"] else 0.0
+run = lambda rendered, task: task.meta["gold"] if task.id in rendered else "?"
+propose = lambda rendered, task, output, score: task.id
+
+
+class RefuseEverything:
+    calls = 0
+
+    def accept(self, ctx):
+        RefuseEverything.calls += 1
+        return AcceptDecision(False, "below-threshold", "refused for the demo",
+                              p_improve=0.0,
+                              observed_delta=ctx.rate(ctx.cand_counts) - ctx.rate(ctx.base_counts))
+
+
+result = evolve(tasks, reward, run=run, propose=propose, strategy=AppendRules(),
+                rounds=3, n_workers=2, held_out_frac=0.5, seed=0,
+                policies=Policies(acceptance=RefuseEverything()))
+
+assert RefuseEverything.calls > 0, "the gate was never consulted"
+assert result.outcomes() == {"below-threshold": RefuseEverything.calls}
+```
+
+Then the three checks that catch what a counter cannot:
+
+- **`result.outcomes()`** is the vocabulary of what happened at the gate.
+  `committed`, `below-threshold`, `all-stale`, `oversized`,
+  `oracle-rejected`, `cas-conflict` — each names a different stage, so a
+  policy at one stage shows up under one key: a staleness policy that
+  discards shows as `all-stale`, a gate that refuses as `below-threshold`,
+  and a conflict policy only ever moves `conflicts_dropped` on the reports.
+- **A paired baseline run.** Same tasks, same `seed`, `Policies()` — then
+  diff `result.history`. The empty bundle *is* the default run, so any
+  difference is your policy. `tests/test_policy_contract.py` uses exactly this
+  to prove the seams are load-bearing.
+- **`result.fusion_stats()`** for a fusion policy, and the `trials` list it
+  summarises; for a selection policy, the `population-select` key in
+  `outcomes()` says the population layer was installed at all.
+
+## 7. Recipes
+
+| I want to… | Slot | Start from |
+|---|---|---|
+| spend rollouts where the reward is informative | `task_sampler` | `DifficultyWeighted()` |
+| keep several heads and pick the best | `selection` | `Beam(k)`, `ParetoFrontier`, `Archive`, `MCTS` |
+| propose only when a rollout was bad | `proposal` | write one: return `[]` above a reward threshold |
+| tolerate or reject lagging workers | `staleness` | `get_policy("full" / "guarded" / "reflective")` |
+| break ties by group-relative advantage | `conflict` | `AdvantageConflict()` |
+| merge contradicting text with a model | `conflict` + `fusion` | `**reflective_merge(completion)` |
+| rank singles against their union first | `fusion` | `DefaultFusion(tournament=True)` |
+| raise or lower the commit bar | `acceptance` | `agg_config=AggregatorConfig(base_delta=…)` — not a policy |
+| add a term to the shipped gate | `acceptance` | `AdvantageAcceptance()`, `StableDistanceAcceptance()` |
+| commit only strict full-held-out improvement | `acceptance` | replace: `examples/skillopt` `StrictImprovement` |
+| never reach `stable`, or reach it on a schedule | `promotion` | replace: `observe` returning `[]` or your rule |
+| a pool with its own admission rule | none | [`aggregator_factory`](aggregator-factory.md) |
+
+The `acceptance` row that says "not a policy" is the general rule: a
+*threshold* is a config field, a *rule* is a policy. Change numbers in
+`AggregatorConfig`; change decisions in `Policies`.
+
+## 8. Pitfalls, in the order people meet them
+
+1. **Passing the thresholds by hand.** `AdvantageAcceptance(DefaultAcceptance(0.5, 64, 4000))`
+   works and silently disagrees with `agg_config=` the day one changes. Leave
+   `inner` unset, or use `DefaultAcceptance.from_config(cfg)` when you mean to pin it.
+2. **Reading the cheap layer to decide.** `base_cheap` / `cand_cheap` rank;
+   `base_counts` / `cand_counts` decide. The field names are different on
+   purpose.
+3. **A category outside `MergeOutcome`.** `AcceptDecision(False, "nope")`
+   raises at the aggregator. Use `"below-threshold"` unless you are reporting
+   one of the other named stages.
+4. **Installing `ReflectiveFusion` alone.** It is handed one diff and
+   correctly declines. Install the pair.
+5. **A selection policy and a factory.** Refused together. The factory does
+   its own selecting, or the policy runs on the shipped pipeline; choose.
+6. **Merge-side policies alongside a factory.** Warned, then ignored. Pass
+   them into your aggregator's constructor instead.
+7. **`executor` on `async_evolve()`.** Refused rather than dropped; the
+   barrier-free loop has no executor seam yet.
+8. **Sharing one policy instance across runs.** It keeps per-run state
+   (survival counters, posteriors it shifted, trials). One instance per call.
+9. **Returning two proposals.** `ProposalContractError`, not truncation.
+10. **A `DefaultConflict` driven by hand in a test.** `PolicyUnboundError` on
+    the first contradiction: call `bind(verifier)` or `install_policy(...)`
+    first. The aggregator does this for you in a real run.

--- a/docs/promotion-policies.md
+++ b/docs/promotion-policies.md
@@ -10,7 +10,7 @@ reads, and promotion is the EMA-style confirmation between them.
 
 | Policy | Rule | Reach for it when |
 |---|---|---|
-| `DefaultPromotion(promote_after_k)` | promote after K regression-free rounds on dev; the counter resets on any regression | the default; read its docstring before replacing it — the reset semantics are the part everyone gets wrong |
+| `DefaultPromotion(promote_after_k=None)` — `None` takes the run's `AggregatorConfig.promote_after_k` | promote after K regression-free rounds on dev; the counter resets on any regression | the default; read its docstring before replacing it — the reset semantics are the part everyone gets wrong |
 
 A clean run also promotes on `finalize()`: `target_reward` can fire on the
 very commit that reaches it, and the artifact the run was *for* must reach the

--- a/examples/r_zero/r_zero_challenger_solver.py
+++ b/examples/r_zero/r_zero_challenger_solver.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from typing import Optional
 
 from agentdescent.advantage import AdvantageAcceptance
-from agentdescent.defaults import DefaultAcceptance
 from agentdescent.evolution import Task
 from agentdescent.policies import Policies
 from agentdescent.sampling import DifficultyWeighted
@@ -139,7 +138,7 @@ def build(seed: int) -> MethodPolicy:
         proposal_calls_per_candidate=2,
         engine=Policies(
             task_sampler=DifficultyWeighted(),
-            acceptance=AdvantageAcceptance(DefaultAcceptance(0.5, 64, 4000)),
+            acceptance=AdvantageAcceptance(),   # wraps the run's own gate
         ),
         reflective=True,
     )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - Duration-aware scheduling: duration-scheduling.md
   - The decision plane (policies):
     - Choosing policies: policies.md
+    - Using the slots — a guide: policy-guide.md
     - Task sampling: sampling.md
     - Candidate selection: selection.md
     - Proposal policies: proposal-policies.md

--- a/tests/test_policy_install.py
+++ b/tests/test_policy_install.py
@@ -1,0 +1,183 @@
+"""A wrapper around a default rule must be installable through ``Policies`` alone.
+
+Two of the four merge-side defaults need something only the engine has -- the
+verifier, for the rules that rank -- and the other two read thresholds off the
+aggregator's config. Before this the aggregator handed the verifier to *fusion*
+and to nothing else, so ``AdvantageConflict(DefaultConflict(verifier))`` could
+only be written from inside an ``aggregator_factory`` (which is what
+``tests/test_advantage.py`` did), and the acceptance wrapper's inner gate had to
+copy three numbers out of ``AggregatorConfig`` by hand -- silently diverging the
+moment ``agg_config=`` changed one of them.
+
+Now every installed policy is offered ``bind(verifier)`` and
+``configure(config)``, wrappers forward both, and a default used *without*
+being installed says so instead of dying on a ``NoneType``.
+"""
+
+import pytest
+
+from agentdescent import Policies, SingleSlot, Task, evolve
+from agentdescent.advantage import (
+    AdvantageAcceptance, AdvantageConflict, StableDistanceAcceptance,
+)
+from agentdescent.aggregator import Aggregator, AggregatorConfig, install_policy
+from agentdescent.defaults import (
+    DefaultAcceptance, DefaultConflict, DefaultFusion, DefaultPromotion,
+    PolicyUnboundError,
+)
+from agentdescent.evolvable import Diff
+from agentdescent.ledger import Ledger
+from agentdescent.scheduler import AuditScheduler
+from agentdescent.verifier import ThreeLayerVerifier, VerifierBudget
+
+
+def _verifier():
+    return ThreeLayerVerifier(eval_fn=lambda a, ts: 1.0, held_out=[1, 2, 3],
+                              budget=VerifierBudget(oracle_calls_remaining=5))
+
+
+def _card(value, advantage=None):
+    c = type("C", (), {})()
+    c.diff = Diff(diff_id=f"d{value}", target="a", ops={"k": value})
+    c.advantage = advantage
+    return c
+
+
+# -- a contradiction reaching the inner rule, through Policies alone ----------
+
+
+def _contradicting_run(**kw):
+    """Three workers rewrite one slot with three different values every round,
+    so every merge carries contradictions and none of the cards has an
+    advantage (the group is too small) -- the exact path that used to die."""
+    tasks = [Task(id=str(i), prompt="q", meta={"gold": f"g{i % 3}"})
+             for i in range(12)]
+    return evolve(tasks, lambda t, o: 1.0 if o == t.meta["gold"] else 0.0,
+                  run=lambda rendered, t: rendered.strip().split()[-1],
+                  propose=lambda rendered, t, o, s: t.meta["gold"],
+                  strategy=SingleSlot(initial_value="g0"), rounds=3, n_workers=3,
+                  max_concurrency=1, held_out_frac=0.5, seed=0, **kw)
+
+
+def test_a_wrapped_default_conflict_rule_installs_through_policies():
+    seen = []
+
+    class Watching(AdvantageConflict):
+        def resolve(self, artifact, cards):
+            seen.append(len(cards))
+            return super().resolve(artifact, cards)
+
+    policy = Watching()
+    r = _contradicting_run(policies=Policies(conflict=policy))
+    assert r.error is None
+    assert max(seen) >= 2, "the run never produced a contradiction to resolve"
+    assert policy.inner.verifier is not None, "the inner rule was never bound"
+
+
+def test_the_bare_default_conflict_rule_installs_through_policies():
+    policy = DefaultConflict()
+    r = _contradicting_run(policies=Policies(conflict=policy))
+    assert r.error is None and policy.verifier is not None
+
+
+# -- thresholds come from the run's config, not from a hand copy --------------
+
+
+def test_a_wrapped_default_gate_takes_the_runs_thresholds():
+    policy = AdvantageAcceptance()
+    _contradicting_run(policies=Policies(acceptance=policy),
+                       agg_config=AggregatorConfig(base_delta=0.9, anneal_half_life=7,
+                                                   accept_samples=123))
+    inner = policy.inner
+    assert (inner.base_delta, inner.anneal_half_life, inner.accept_samples) == (0.9, 7, 123)
+
+
+def test_a_pinned_threshold_is_not_overwritten_by_configure():
+    gate = DefaultAcceptance(base_delta=0.25)
+    gate.configure(AggregatorConfig(base_delta=0.9, anneal_half_life=7, accept_samples=123))
+    assert (gate.base_delta, gate.anneal_half_life, gate.accept_samples) == (0.25, 7, 123)
+
+
+def test_from_config_is_the_rule_the_aggregator_builds():
+    cfg = AggregatorConfig(base_delta=0.4, anneal_half_life=9, accept_samples=50,
+                           promote_after_k=5)
+    gate = DefaultAcceptance.from_config(cfg)
+    assert (gate.base_delta, gate.anneal_half_life, gate.accept_samples) == (0.4, 9, 50)
+    assert DefaultPromotion.from_config(cfg).promote_after_k == 5
+
+
+def test_stable_distance_wrapper_forwards_configure():
+    policy = StableDistanceAcceptance()
+    install_policy(policy, _verifier(), AggregatorConfig(base_delta=0.33))
+    assert policy.inner.base_delta == 0.33
+
+
+# -- an uninstalled default names what it is missing --------------------------
+
+
+def test_an_unbound_conflict_rule_says_so_on_the_first_contradiction():
+    with pytest.raises(PolicyUnboundError, match="DefaultConflict.*bind"):
+        DefaultConflict().resolve(None, [_card("x"), _card("y")])
+
+
+def test_an_unbound_conflict_rule_is_fine_without_contradictions():
+    kept, dropped = DefaultConflict().resolve(None, [_card("x")])
+    assert len(kept) == 1 and dropped == 0
+
+
+def test_a_wrapper_around_an_unbound_rule_reports_the_inner_rule():
+    with pytest.raises(PolicyUnboundError, match="DefaultConflict"):
+        AdvantageConflict().resolve(None, [_card("x"), _card("y")])
+
+
+def test_an_unconfigured_gate_says_so():
+    from agentdescent.policies import MergeContext
+    ctx = MergeContext(artifact=None, candidate=None, cards=(),
+                       base_counts=(1.0, 1.0), cand_counts=(2.0, 0.0))
+    with pytest.raises(PolicyUnboundError, match="DefaultAcceptance.*configure"):
+        DefaultAcceptance().accept(ctx)
+
+
+def test_an_unconfigured_promotion_rule_says_so():
+    with pytest.raises(PolicyUnboundError, match="DefaultPromotion.*configure"):
+        DefaultPromotion().observe([])
+
+
+def test_an_unbound_tournament_says_so():
+    art = type("A", (), {"apply": lambda self, d: self})()
+    with pytest.raises(PolicyUnboundError, match="DefaultFusion.*bind"):
+        DefaultFusion(tournament=True).select(art, [_card("x").diff, _card("y").diff])
+
+
+# -- the aggregator installs all four, and a bound value stays bound ----------
+
+
+def test_the_aggregator_installs_every_merge_side_policy(tmp_path):
+    verifier = _verifier()
+    conflict, fusion = AdvantageConflict(), DefaultFusion()
+    acceptance, promotion = StableDistanceAcceptance(), DefaultPromotion()
+    cfg = AggregatorConfig(base_delta=0.6, promote_after_k=4)
+    ledger = Ledger(str(tmp_path / "repo"), serialize=lambda a: {"state": {}},
+                    deserialize=lambda aid, v, d: None)
+    Aggregator(ledger, verifier, AuditScheduler(), cfg,
+               conflict=conflict, fusion=fusion, acceptance=acceptance,
+               promotion=promotion)
+    assert conflict.inner.verifier is verifier
+    assert fusion.verifier is verifier
+    assert acceptance.inner.base_delta == 0.6
+    assert promotion.promote_after_k == 4
+
+
+def test_a_caller_supplied_verifier_is_kept_over_the_engines():
+    mine, engines = _verifier(), _verifier()
+    policy = DefaultConflict(mine)
+    install_policy(policy, engines, AggregatorConfig())
+    assert policy.verifier is mine
+
+
+def test_a_policy_without_hooks_is_left_alone():
+    class Bare:
+        def resolve(self, artifact, cards):
+            return list(cards), 0
+
+    install_policy(Bare(), _verifier(), AggregatorConfig())     # no error, no effect


### PR DESCRIPTION
## Summary

Three commits, one theme: `evolve()` is the single entry point, and everything it takes is an independent, self-contained piece.

### 1. Fixed: a wrapper around a default policy could not be installed through `Policies`

An audit of how independently the `Policies` slots can be swapped. All eight algorithm slots already work alone (verified by swapping each one in with a counter, on both `evolve()` and `async_evolve()`), but two couplings made *wrapping a default rule* impossible through the bundle:

- `DefaultConflict` needs the engine's verifier to score a tie, and the aggregator handed the verifier to **fusion only**. So `Policies(conflict=AdvantageConflict(DefaultConflict(...)))` type-checked, installed, and died with `'NoneType' has no attribute 'cheap_eval'` on the first contradiction that reached the inner rule. The repository's own tests routed it through an `aggregator_factory` to attach the verifier by hand.
- The acceptance wrappers had the mirror problem: their inner gate copied three thresholds out of `AggregatorConfig` by hand (`DefaultAcceptance(0.5, 64, 4000)`), which silently diverged from `agg_config=`.

Changes: `DefaultConflict` / `DefaultFusion` take the verifier through an optional `bind(verifier)`; `DefaultAcceptance` / `DefaultPromotion` take their thresholds through `configure(config)`, with `from_config(cfg)` as the pinned form. `Aggregator` offers both hooks to every installed merge-side policy through the new public `install_policy()`. The wrappers (`AdvantageConflict`, `AdvantageAcceptance`, `StableDistanceAcceptance`) forward them and default their `inner` to the shipped rule. A default used *without* being installed raises `PolicyUnboundError` naming the missing piece.

### 2. Added: `docs/policy-guide.md`

A systematic how-to, companion to the `policies.md` catalogue: where each slot sits in a round (diagram + table), the five composition rules the engine enforces, the three ways to fill a slot (shipped / wrap / replace), the per-slot contract written from the engine's call sites, the install hooks, how to prove a policy ran (runnable example), a recipe table, and a pitfall list. Writing it surfaced one undocumented contract, now stated: a conflict policy must keep at least one card, because the fusion step indexes into what it kept.

### 3. Removed: the one-call wrappers

`evolve_skill`, `evolve_skill_dir`, `evolve_agent_dir` and `evolve_agent_code` (modules `skill.py`, `skilldir.py`) are gone. Each was thirty lines of wiring plus defaults, and a second signature to learn, document and keep in step with `evolve()`. `async_evolve` stays.

What they assembled is now public building blocks handed straight to `evolve()`:
- `rewards.SCORERS` / `scorer()` — a dataset's reward by name or callable (moved from `skill.py`)
- `runners.gated_reward()` — a failed `code_runner` gate scores 0
- `governance.SKILL_BLAST_RADIUS` / `HARNESS_BLAST_RADIUS` — the layer

The rest (`tasks_from`, `SingleSlot`, `reflector`, `load_tree`, `FileTree`, `tree_runner`, `code_runner`, `tree_reflector`) was already public. The two defaults the wrappers set for a real-agent workload (`self_verify=False`, `cheap_eval_tasks=4`) are now passed explicitly and every doc block shows the full call. Callers rewritten: the directory example, the directory and dataset tests, README, index, install, both quickstarts, the directory reference, modules, results, the design record (annotated), `api.md` regenerated.

## Test plan

- [x] New `tests/test_policy_install.py` (15 tests): a contradiction-driven `evolve()` run through `AdvantageConflict()` installed via `Policies` alone; thresholds from `agg_config=`; pinned values kept; every unbound default raises `PolicyUnboundError`; the aggregator installs all four.
- [x] `tests/test_evolve_skill.py` → `tests/test_dataset_to_skill.py`: the dataset path through `evolve()` with `tasks_from` / `scorer` / `SingleSlot` / `reflector`; scorer tests kept.
- [x] `tests/test_dir_evolution.py` and `tests/test_skill_dir_example.py` run the same scenarios through explicit `evolve()` wiring.
- [x] Full `pytest -q` passes.
- [x] The guide's example executes as written; docs link / import / API-reference tests pass.
- [ ] `mkdocs build --strict` not run locally (mkdocs not installed in the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DohTDxpCZDbBwvfWNMfDc7