### PR TITLE
Make the project citable, and drop two claims about RQ4's data the repo does not support

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,29 @@
+{
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "mit",
+  "title": "AgentDescent: a parallel, asynchronous framework for self-evolving LLM agents",
+  "creators": [
+    {
+      "name": "Chen, Danyang"
+    }
+  ],
+  "description": "<p><strong>AgentDescent</strong> puts the distributed deep-learning training stack on top of agent self-evolution. The &quot;parameters&quot; are a library of evolvable artifacts (skills, prompts, harness modules, verifiers); the &quot;gradients&quot; are diffs carrying evidence cards; and the &quot;optimizer step&quot; is a merge decision. <em>N</em> workers propose diffs in parallel and a barrier-free asynchronous aggregator merges them into a shared, version-controlled artifact library.</p><p>The one place the analogy must break defines the system: <strong>gradients add and diffs do not</strong>, so aggregation is not averaging but conflict resolution, fusion, statistical acceptance and transactional commit. When an artifact is held in a single key every concurrent pair conflicts and merge-of-<em>N</em> degenerates into best-of-<em>N</em> selection at best-of-<em>N</em> validation cost. <em>Reflective merge</em> &mdash; a model asked to write the union of the contradicting proposals, gated by the same acceptance test as any other candidate &mdash; is what removes that degeneracy.</p><p>Nineteen published self-evolution algorithms (among them ACE, GEPA, ADAS, DGM, OpenEvolve, ERA, Voyager, Reflexion, PromptBreeder and AFlow) run as plug-ins over eight named policy slots, under serial, synchronous and barrier-free schedulers, without modifying the engine. The core engine has no required dependencies and needs only Python 3.9 or later.</p><p>Accompanying paper: <em>AgentDescent: Asynchronous Parallel Self-Evolution of LLM Agents by Merging Conflicting Edits</em>.</p>",
+  "keywords": [
+    "self-evolving agents",
+    "recursive self-improvement",
+    "LLM agents",
+    "parallel and asynchronous execution",
+    "diff aggregation",
+    "bounded staleness",
+    "prompt optimization",
+    "skill learning",
+    "evolutionary algorithms"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://birfy.github.io/agentdescent/",
+      "relation": "isDocumentedBy"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,48 @@
+# Consumed by GitHub's "Cite this repository" button.
+#
+# Zenodo ignores this file whenever `.zenodo.json` is present, which it is --
+# the two describe the same work for different consumers and are kept in sync
+# by hand. If you edit one, edit the other.
+#
+# No `version:`/`date-released:` here on purpose. `agentdescent/__init__.py` is
+# the only place the version lives (see the note in pyproject.toml, where a
+# duplicate drifted to 0.7.0 while every wheel said 0.2.0), and Zenodo takes
+# the version from the release tag. A copy here would be a third source.
+cff-version: 1.2.0
+message: >-
+  If you use AgentDescent, please cite the paper below. To cite the software
+  itself, use the archived release DOI from the repository's Zenodo record.
+title: AgentDescent
+type: software
+abstract: >-
+  A parallel, asynchronous framework for self-evolving LLM agents that puts the
+  distributed deep-learning training stack on top of agent self-improvement: the
+  parameters are a library of evolvable artifacts, the gradients are diffs
+  carrying evidence cards, and the optimizer step is a merge decision.
+authors:
+  - family-names: Chen
+    given-names: Danyang
+    # orcid: "https://orcid.org/0000-0000-0000-0000"   # add yours
+repository-code: "https://github.com/Birfy/agentdescent"
+url: "https://birfy.github.io/agentdescent/"
+license: MIT
+keywords:
+  - self-evolving agents
+  - recursive self-improvement
+  - LLM agents
+  - parallel and asynchronous execution
+  - diff aggregation
+  - bounded staleness
+  - prompt optimization
+  - skill learning
+preferred-citation:
+  type: article
+  title: >-
+    AgentDescent: Asynchronous Parallel Self-Evolution of LLM Agents by Merging
+    Conflicting Edits
+  authors:
+    - family-names: Chen
+      given-names: Danyang
+  year: 2026
+  url: "https://github.com/Birfy/agentdescent/blob/paper/paper/main.pdf"
+  # doi: "10.5281/zenodo.XXXXXXX"   # fill in once the paper record is minted

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 📄 **Paper:** [*AgentDescent: Asynchronous Parallel Self-Evolution of LLM Agents by Merging
 Conflicting Edits*](paper/main.pdf) — the design, the closed-form condition under which
 merging can fire at all, and a live-model evaluation with every generating script named.
-Source and per-result raw data are in [`paper/`](paper/) and [`bench/results/`](bench/results/).
+Source is in [`paper/`](paper/). Per-result raw data is in [`bench/results/`](bench/results/) for most results, including the reflective-merge ablation; the merge-versus-selection sweeps are re-measurable from the command the paper names rather than recomputable, because their per-run data was not retained.
 
 AgentDescent puts the deep-learning **training stack** on top of agents. The
 "parameters" are a **library of evolvable artifacts** (skills, prompts, harness

--- a/bench/baselines_run.py
+++ b/bench/baselines_run.py
@@ -22,9 +22,11 @@ when that split says so, and the fork arm *selects* on it -- so reporting it
 would be reporting a training score twice over. `test_eval` scores `ds.test`,
 which no gate in any arm ever sees.
 
-Cost is the reason the defaults are small. Three arms x three seeds is nine runs,
-and the fork arm is N runs by itself, so `--width 4 --seeds 0,1,2` is 33 runs of
-`--budget-rollouts` rollouts each. Print `--plan` first.
+Cost is the reason the defaults are small. Three arms x three seeds is nine
+*results*, but a fork arm is N runs by itself, so the run count is what
+`runs = len(seeds) * sum(width if a == "fork" else 1 for a in arms)` says below:
+`--width 4 --seeds 0,1,2` is 18 runs of `--budget-rollouts` rollouts each, not
+nine. Print `--plan` first.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Two commits. The first makes the project citable; the second removes two statements that a check could not confirm. They are unrelated in subject and are here in one PR by request.

---

## 1 — `CITATION.cff` and `.zenodo.json`

arXiv's endorsement policy changed on 2026-01-21: an institutional email address no longer earns automatic endorsement on its own. The paper is going to TechRxiv instead, which mints a DOI without gatekeeping; Zenodo archives the **code**. These are the two files those services and GitHub read.

They describe the same work for different consumers, and **Zenodo ignores `CITATION.cff` outright whenever `.zenodo.json` is present**, so the pair is kept in sync by hand and each file says so at the top.

| File | Read by | Drives |
|---|---|---|
| `.zenodo.json` | Zenodo | the archived **software** record a GitHub release creates |
| `CITATION.cff` | GitHub | the repository's own *Cite this repository* button |

`CITATION.cff`'s `preferred-citation` points at the **paper**, not the code.

**Neither file carries a version or a release date.** `agentdescent/__init__.py` is the only place the version lives, for the reason `pyproject.toml` records at the point where a duplicate drifted to `0.7.0` while every wheel said `0.2.0`. Zenodo takes the version from the release tag, and `.zenodo.json` *overrides* what Zenodo derives — so a pinned version there would silently relabel every future release `0.4.6`.

`CITATION.cff` validates against the official Citation File Format 1.2.0 schema, checked against the published schema rather than assumed; an invalid file renders as an error banner on the repository front page. `.zenodo.json` uses the lowercase licence identifier Zenodo's own example uses. Its only `related_identifiers` entry is the documentation site — Zenodo adds the GitHub relation itself, and a PyPI entry was drafted and dropped because `isIdenticalTo` is not true of a built distribution against an archived source snapshot.

Left for a human: the ORCID placeholder, and the paper DOI once TechRxiv mints it.

## 2 — Two claims about RQ4's data

The `main`-side half of a correction whose other half is on the `paper` branch.

**The runner's docstring contradicts the runner.** It says `--width 4 --seeds 0,1,2` is 33 runs. Twenty lines below, the code counts them:

```python
runs = len(seeds) * sum(width if a == "fork" else 1 for a in arms)
```

which is `3 * (1 + 4 + 1)` = **18**. The docstring now quotes that line instead of carrying a second, hand-maintained number beside the expression that computes it — which is how this one drifted in the first place. It also now separates *results* (nine) from *runs* (eighteen), the distinction the sentence was reaching for.

Eighteen is worth naming because the paper reported "eighteen control runs" for a configuration that ran six seeds at two widths, where the same formula gives 84. The likeliest origin of that number is this example, which is not what RQ4 ran. That sentence is fixed on the `paper` branch.

**The README promises raw data the repository does not have.** "Source and per-result raw data are in `paper/` and `bench/results/`" holds for most results and for the reflective-merge ablation, whose four-seed per-arm JSON does ship and against which every number in that section was checked. It does not hold for the merge-versus-selection sweeps: **no `bbh-keyed` run data exists in `bench/results/` on any ref in this repository's history** — `bbh-keyed` appears in the runner and in the paper, nowhere else. Those rows are re-measurable by re-running the named command, not recomputable, and the README now says so.

## Still open, not in this PR

`main`'s `paper/main.pdf` is stale — it predates the review pass on the `paper` branch, and the README's paper badge points at it. Syncing it is a separate decision, since the `paper` branch exists to keep the paper out of `main` and that separation was never completed.

## Testing

Full suite passes. `CITATION.cff` validated against the CFF 1.2.0 schema; `.zenodo.json` parsed and cross-checked against `CITATION.cff` for author, licence and URL agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwnGcfun6PmFdEPmytGeKd