### PR TITLE
docs: make the site findable by the searches people actually run

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install "mkdocs-material>=9.5"
+      # cairosvg loads libcairo at runtime; the social plugin needs it to
+      # render the per-page cards, and the build fails without it.
+      - run: sudo apt-get update && sudo apt-get install -y libcairo2
+      - run: pip install "mkdocs-material[imaging]>=9.5"
       - run: mkdocs build --clean --strict
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ venv/
 .DS_Store
 *.log
 site/
+# mkdocs-material's social-card cache; 12 MB of regenerable PNGs
+.cache/

--- a/docs/algo-absolute-zero.md
+++ b/docs/algo-absolute-zero.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of Absolute Zero zero-data self-play, where one model proposes and solves its own tasks graded for learnability. Inference analogue, three seeds.
+---
+
 # Absolute Zero — Zero-data self-play (single model)
 
 > **Self-play policy evolution.** One model proposes and solves its own tasks,

--- a/docs/algo-ace.md
+++ b/docs/algo-ace.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of ACE (Agentic Context Engineering): evolve a playbook of lessons instead of weights. Benchmark-faithful port with measured FiNER-139 results.
+---
+
 # ACE — Agentic Context Engineering
 
 > **Skill / context self-evolution.** Evolve a *playbook of lessons* (the model's

--- a/docs/algo-adas.md
+++ b/docs/algo-adas.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of ADAS (Meta Agent Search): evolve the agentic system itself. Benchmark-faithful port, and an honest account of why it reports no lift number.
+---
+
 # ADAS — Meta Agent Search
 
 > **Harness self-evolution.** Evolve the *agentic system itself* — the control

--- a/docs/algo-aflow.md
+++ b/docs/algo-aflow.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of AFlow agentic workflow search with soft mixed selection over top-k workflows. Mechanism microport, measured on GSM8K over three seeds.
+---
+
 # AFlow — Agentic workflow search
 
 > **Workflow self-evolution.** Search the space of code-expressed agentic

--- a/docs/algo-agent0.md
+++ b/docs/algo-agent0.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of Agent0 tool-integrated curriculum co-evolution, where a curriculum agent writes tasks at the executor's frontier. Inference analogue, three seeds.
+---
+
 # Agent0 — Tool-integrated curriculum co-evolution
 
 > **Curriculum/executor co-evolution.** A Curriculum agent writes tasks at the

--- a/docs/algo-dgm.md
+++ b/docs/algo-dgm.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of DGM (Darwin Godel Machine): a coding agent that edits its own codebase into an open-ended archive. Measured on vendored bugs under real pytest.
+---
+
 # DGM — Darwin Gödel Machine
 
 > **Harness self-evolution.** A coding agent that *edits its own codebase*,

--- a/docs/algo-era.md
+++ b/docs/algo-era.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of ERA, Google Research's empirical-software search with a flat-PUCT tree. Measured on its own Kaggle task: test RMSE 0.7297 to 0.5913.
+---
+
 # ERA — Empirical-software search (Flat UCB tree search)
 
 > **Program search, tree-shaped.** A Python solution to a scientific-computing

--- a/docs/algo-evoskill.md
+++ b/docs/algo-evoskill.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of EvoSkill automated skill discovery: learn reusable SKILL.md files from execution failures under a bounded top-K frontier. Measured on FinQA.
+---
+
 # EvoSkill — Automated Skill Discovery
 
 > **Skill-library self-evolution.** Discover reusable `SKILL.md` skills from

--- a/docs/algo-gepa.md
+++ b/docs/algo-gepa.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of GEPA (Reflective Prompt Evolution) with per-instance Pareto parent selection. Benchmark-faithful port, measured on HotpotQA against a serial control.
+---
+
 # GEPA — Reflective Prompt Evolution
 
 > **Skill / prompt self-evolution.** Evolve an instruction prompt with a genetic,

--- a/docs/algo-godel-agent.md
+++ b/docs/algo-godel-agent.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of Godel Agent recursive runtime self-modification, where the search rewrites its own search prompt. Self-edit analogue, measured on GSM-Hard.
+---
+
 # Gödel Agent — Recursive runtime self-modification
 
 > **Self-edit.** The artifact owns both its solve prompt and the

--- a/docs/algo-openevolve.md
+++ b/docs/algo-openevolve.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of OpenEvolve program evolution with MAP-Elites islands, where Python source is the genome and a sandboxed evaluator supplies reward.
+---
+
 # OpenEvolve — Program evolution
 
 > **Program self-evolution.** Python source is the genome: model calls mutate it,

--- a/docs/algo-promptbreeder.md
+++ b/docs/algo-promptbreeder.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of PromptBreeder genetic prompt self-evolution with binary tournaments. Mechanism microport with measured GSM8K results over three seeds.
+---
+
 # PromptBreeder — Prompt self-evolution (genetic)
 
 > **Prompt self-evolution.** Evolve a population of task-prompt + mutation-prompt

--- a/docs/algo-r-zero.md
+++ b/docs/algo-r-zero.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of R-Zero Challenger/Solver co-evolution with a GRPO-shaped acceptance rule. Inference analogue over self-play carts, measured over three seeds.
+---
+
 # R-Zero — Challenger/Solver co-evolution
 
 > **Co-evolution of two roles.** A Challenger writes questions at the Solver's

--- a/docs/algo-reflexion.md
+++ b/docs/algo-reflexion.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of Reflexion verbal reinforcement with bounded episodic memory. Mechanism microport on GSM-Hard, reported against that domain's noise floor.
+---
+
 # Reflexion — Verbal reinforcement / episodic memory
 
 > **Memory self-evolution.** Turn a failed trajectory into a verbal reflection,

--- a/docs/algo-self-refine.md
+++ b/docs/algo-self-refine.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of Self-Refine iterative feedback refinement: generate, self-critique, refine. Mechanism microport with measured GSM8K results and call costs.
+---
+
 # Self-Refine — Iterative feedback refinement
 
 > **Feedback-loop self-evolution.** One model generates, critiques its own

--- a/docs/algo-sica.md
+++ b/docs/algo-sica.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of SICA, the self-improving coding agent that edits its own Python source under an AST gate. Self-edit analogue with measured GSM-Hard results.
+---
+
 # SICA — Self-improving coding agent (real source edits)
 
 > **Self-edit.** An archive of agent iterations; the best performer edits its own

--- a/docs/algo-skillopt.md
+++ b/docs/algo-skillopt.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of SkillOpt (ReflACT) skill-document editing under a strict acceptance gate. Measured on a hard SearchQA subset: 3 of 43 edits accepted.
+---
+
 # SkillOpt — ReflACT
 
 > **Skill-document self-evolution.** Train a single markdown skill doc as the

--- a/docs/algo-skillweaver.md
+++ b/docs/algo-skillweaver.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of SkillWeaver web-agent API synthesis with a self-verifying reward model. Environment analogue over a settings site, measured over three seeds.
+---
+
 # SkillWeaver — Web agent API synthesis
 
 > **API-library self-evolution.** Propose, practise, verify and hone reusable

--- a/docs/algo-voyager.md
+++ b/docs/algo-voyager.md
@@ -1,3 +1,7 @@
+---
+description: A runnable reproduction of Voyager's embodied skill library with a self-verification critic and difficulty-weighted sampling. Environment analogue over a crafting world.
+---
+
 # Voyager — Embodied skill-library agent
 
 > **Skill-library self-evolution.** Grow a library of executable skills from a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,7 @@
+---
+description: How AgentDescent works: N workers propose diffs against ledger snapshots and a barrier-free aggregator merges them through a five-stage pipeline into a git-backed ledger.
+---
+
 # Architecture
 
 This document explains how AgentDescent's components fit together and how a diff

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,3 +1,7 @@
+---
+description: The concepts behind AgentDescent: the training-to-self-improvement analogy, why diffs do not add, bounded staleness, the aggregator, and governance by blast radius.
+---
+
 # Concepts
 
 The ideas behind AgentDescent, in the order you need them. This is the *why*; for

--- a/docs/evolution.md
+++ b/docs/evolution.md
@@ -1,3 +1,7 @@
+---
+description: Evolve any artifact with AgentDescent: describe what evolves with a Strategy and the rules of evolution with run, reward and propose.
+---
+
 # The `evolve` method
 
 `evolve()` is the **one entry point** to the framework. You describe *what

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+description: AgentDescent puts the deep-learning training stack on top of self-evolving LLM agents: diffs are the gradients, and the aggregator is the optimizer step.
+---
+
 # AgentDescent
 
 **Gradient descent — but the parameters are agents.** A parallel, asynchronous

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,3 +1,7 @@
+---
+description: The decision plane of AgentDescent: eight named policy slots covering selection, sampling, proposal, staleness, conflict, fusion, acceptance and promotion.
+---
+
 # Choosing policies — the decision plane
 
 *Module:* [`agentdescent.policies`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/policies.py)

--- a/docs/policy-guide.md
+++ b/docs/policy-guide.md
@@ -1,3 +1,7 @@
+---
+description: How to write a policy for AgentDescent: where each of the eight algorithm slots sits in a round, what it is handed, what it must return, and how to prove it ran.
+---
+
 # Using the policy slots — a systematic guide
 
 *Companion to:* [Choosing policies](policies.md) (the catalogue of what ships)

--- a/docs/quickstart-skill.md
+++ b/docs/quickstart-skill.md
@@ -1,3 +1,7 @@
+---
+description: Turn a dataset into an evolved skill in one evolve() call. A worked example on 40 HotpotQA items that raises held-out exact match from 0.167 to 0.583.
+---
+
 # Dataset → evolved skill
 
 There is one entry point, [`evolve`](evolution.md). Evolving a skill from a

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,3 +1,7 @@
+---
+description: Every empirical claim in AgentDescent with the setup that produced it, including the runs where there was nothing left to learn and the knobs that did not transfer.
+---
+
 # Measured results
 
 Every number here comes from a real run on the algorithm's own dataset with

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -1,3 +1,7 @@
+---
+description: Nineteen published self-evolution algorithms ported as runnable plug-ins on one runtime, each with a declared fidelity class and a measured before-and-after result.
+---
+
 # Self-evolution algorithms — nineteen ports
 
 AgentDescent is a *general* engine for parallel, merge-based evolution. To show

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,3 +1,7 @@
+---
+description: Strategies decide what evolves and how a proposal becomes a diff. The key space a strategy writes is what decides whether concurrent edits can fuse at all.
+---
+
 # Strategies — what evolves, and how a proposal becomes a diff
 
 *Modules:* [`agentdescent.strategies`](https://github.com/Birfy/agentdescent/blob/main/agentdescent/strategies.py)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,26 @@
 site_name: AgentDescent
-site_description: A parallel, self-evolving framework for accelerating RSI
+# Written for search, not for us: "RSI" is jargon nobody types into a search box,
+# and the phrases people do type -- self-evolving agents, an implementation of a
+# named method -- were in none of these pages' metadata.
+site_description: >-
+  A parallel, asynchronous framework for self-evolving LLM agents, with runnable
+  reproductions of nineteen published self-evolution algorithms.
+# Required for canonical URLs, an absolute-URL sitemap, and the social cards
+# below -- without it mkdocs emits neither, and the social plugin warns.
+site_url: https://birfy.github.io/agentdescent/
 repo_url: https://github.com/Birfy/agentdescent
 repo_name: Birfy/agentdescent
 docs_dir: docs
 site_dir: site
+
+plugins:
+  # `search` is listed explicitly because declaring any plugin replaces the
+  # default set, and dropping it silently removes the docs site's own search.
+  - search
+  # Renders an og:image per page, so a link shared anywhere shows the page title
+  # instead of a bare URL. Needs mkdocs-material[imaging]; the docs workflow
+  # installs it and the cairo library it loads at runtime.
+  - social
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]
-docs = ["mkdocs-material>=9.5"]
+docs = ["mkdocs-material[imaging]>=9.5"]   # [imaging] builds the social cards
 
 [project.urls]
 Homepage = "https://github.com/Birfy/agentdescent"


### PR DESCRIPTION
Nobody searches "AgentDescent". People do search **"GEPA implementation"**, **"Darwin Gödel Machine code"**, **"PromptBreeder reproduction"** — and this repository has a written, measured page for each of nineteen such methods that none of those searches can reach. The content was already there; only the metadata was missing.

This is the one distribution change that compounds: a forum post is a spike that sinks in a day, and search traffic arrives every day afterwards with the intent already formed.

## What was missing

| | before | after |
|---|---|---|
| pages with a meta description | **0 of 68** | 68 |
| pages with a canonical URL | **0** | 68 |
| sitemap entries | absolute URLs absent | 68 |
| shared link preview | a bare URL | per-page card with its title |

## The three changes

**Per-page descriptions, 29 of them** — nineteen method pages plus ten entry points. Written for the query rather than for us: the method's full name, the word a searcher uses for what they want (implementation, reproduction, code), the fidelity class, and the measured result where there is one. The other 39 pages fall back to `site_description`, which is rewritten for the same reason — *"a framework for accelerating RSI"* contains no phrase anyone types into a search box.

**`site_url`, which was never set.** That single omission cost more than the descriptions: without it mkdocs emits no `<link rel="canonical">` and no absolute-URL sitemap at all.

**Social cards** via the `social` plugin, so a link shared to X, Slack or WeChat arrives with its own title instead of as a bare URL.

## The bug this change could easily have shipped

`mkdocs.yml` had **no `plugins:` section**, and declaring any plugin replaces mkdocs' default set. Adding `social` alone would have silently removed the docs site's own **search box**. `search` is therefore listed explicitly, with a comment saying why.

## Build

The plugin needs `mkdocs-material[imaging]`, so the `docs` extra asks for it and the docs workflow installs it along with `libcairo2`, which `cairosvg` loads at runtime.

Verified rather than assumed: `mkdocs build --strict` is clean, 68 cards render, and the built HTML was checked to carry a description and a canonical URL on all 68 pages.

`.cache/` — 12 MB of regenerable social-card PNGs the plugin writes — is now git-ignored. It briefly landed in this branch's first push and was amended out.

Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwnGcfun6PmFdEPmytGeKd

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwnGcfun6PmFdEPmytGeKd)_