### PR TITLE
Deploy the docs on a push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,11 @@
 name: docs
 
-# On every push: build + strict-validate the MkDocs site (always green).
-# Deploy to GitHub Pages runs only on a manual trigger, so pushes never fail
-# just because Pages is off. To publish: enable Pages (Settings -> Pages ->
-# Source: "GitHub Actions"; needs a public repo or a plan that supports Pages on
-# private repos), then run this workflow from the Actions tab ("Run workflow").
+# Every push to main builds, strict-validates and deploys the MkDocs site.
+# Deploy used to be manual-only, so that a push could not fail on a repository
+# where Pages was off. Pages is on now, and the guard had outlived it: the site
+# went stale silently, and README links to pages that only existed in the
+# source tree returned 404 -- which is worse than the red run it was avoiding.
+# `workflow_dispatch` is kept for re-publishing without a commit.
 
 on:
   push:
@@ -39,9 +40,9 @@ jobs:
 
   deploy:
     needs: build
-    # only deploy on a manual run, so normal pushes stay green even when Pages
-    # is not enabled on the repo.
-    if: github.event_name == 'workflow_dispatch'
+    # A push to main, or a manual re-publish. Anything else -- a PR build --
+    # validates and stops, because a fork's build must never reach Pages.
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
The last five `docs` runs were pushes. All green, none of them published: the
`deploy` job is gated on `workflow_dispatch`, a guard added so a push could not
fail on a repository where Pages was off.

Pages is on now (`source: workflow`), and the guard had inverted. The site
serves an old build, and the README's own links return 404 against it:

| link | live site |
|---|---|
| `birfy.github.io/agentdescent/plugins/` | **404** |
| `birfy.github.io/agentdescent/testing-guide/` | **404** |

Both pages have been in the source tree for weeks. A stale site that returns
200 on its front page is worse than the red run the guard was avoiding, because
nothing announces it.

`workflow_dispatch` is kept so the site can be re-published without a commit.
The condition becomes `workflow_dispatch || ref == refs/heads/main` rather than
dropping the `if`, so pull requests still build and strict-validate while a
fork's build can never reach Pages.

A manual deploy has already been triggered to fix the current 404s; this is so
it does not happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)