### PR TITLE
Two failures where a missing piece produced a confident wrong answer

### DIFF
--- a/examples/openevolve/_openevolve_support.py
+++ b/examples/openevolve/_openevolve_support.py
@@ -258,6 +258,33 @@ def sandbox_command(
         "or run on macOS where sandbox-exec ships with the system")
 
 
+def _sandbox_interpreter() -> str:
+    """The interpreter to exec *inside* the sandbox, with symlinks resolved.
+
+    The sandbox binds ``/usr`` read-only and deliberately does not bind
+    ``/etc``. On Debian and Ubuntu ``/usr/bin/python3`` is a symlink into
+    ``/etc/alternatives/``, so inside the sandbox it dangles and bwrap fails
+    with ``execvp /usr/bin/python3: No such file or directory`` -- before any
+    candidate runs, and reported as an evaluation failure rather than a setup
+    one.
+
+    Resolving the chain here gives the real file (``/usr/bin/python3.11``),
+    which is under the bind. Binding ``/etc`` would also fix it and is the wrong
+    trade: the point of the profile is that the candidate sees as little of the
+    host as possible.
+    """
+    resolved = os.path.realpath("/usr/bin/python3")
+    if os.path.isfile(resolved) and resolved.startswith("/usr/"):
+        return resolved
+    # A python3 outside /usr is not reachable under this profile whatever we do;
+    # say so here rather than as a puzzling execvp failure from inside bwrap.
+    if not os.path.isfile(resolved):
+        raise RuntimeError(f"/usr/bin/python3 resolves to {resolved!r}, which does not exist")
+    raise RuntimeError(
+        f"/usr/bin/python3 resolves to {resolved!r}, outside the /usr bind this "
+        "sandbox profile provides; install a system python3 under /usr")
+
+
 def _bubblewrap_command(
     candidate: Path,
     trials: int,
@@ -269,6 +296,7 @@ def _bubblewrap_command(
     bwrap = shutil.which("bwrap")
     if not bwrap:
         raise RuntimeError("Bubblewrap (bwrap) is required for candidate isolation")
+    interpreter = _sandbox_interpreter()
     command = [
         bwrap,
         "--ro-bind",
@@ -300,7 +328,7 @@ def _bubblewrap_command(
             "--setenv",
             "PATH",
             "/usr/bin",
-            "/usr/bin/python3",
+            interpreter,
             "-I",
             "/runner.py",
             "/candidate.py",

--- a/tests/test_era_srbench.py
+++ b/tests/test_era_srbench.py
@@ -639,6 +639,7 @@ def test_both_roots_exist_in_both_formats():
 
 def test_a_damaged_ground_truth_is_not_scorable_and_is_not_a_miss():
     """Both defects are the published copy's, not any answer's."""
+    pytest.importorskip("sympy")
     from tools import score_symbolic_accuracy as sa
     assert not sa.scorable("-0.19*A(t)**2 + 0.19_z*A(t)**2", ["t", "A"])
     assert not sa.scorable("F0*sin(t) - beta*sin(v(t))", ["x", "t", "v"])

--- a/tools/score_symbolic_accuracy.py
+++ b/tools/score_symbolic_accuracy.py
@@ -285,7 +285,8 @@ def scorable(truth: str, variables: Optional[List[str]] = None) -> bool:
 
     The second is caught by checking that every free symbol in the truth is one
     of the problem's own variables. That needs the variable list; without one
-    only the first check runs, which is why callers pass it.
+    only the first check runs, which is why callers pass it -- and it needs
+    ``sympy``, whose absence raises rather than answering ``False``.
     """
     if not truth or not truth.strip():
         return False
@@ -293,8 +294,12 @@ def scorable(truth: str, variables: Optional[List[str]] = None) -> bool:
         return False
     if variables is None:
         return True
+    # Not inside the `try`: a missing checker is not a damaged ground truth, and
+    # swallowing ModuleNotFoundError here made every row unscorable and printed
+    # "109 in the run, 0 with an intact ground truth" -- which reads as "the
+    # published benchmark is entirely broken" and means "sympy is not installed".
+    import sympy
     try:
-        import sympy
         expression = sympy.sympify(normalise(truth, list(variables)))
     except Exception:
         return False


### PR DESCRIPTION
`pytest tests/` on a clean checkout of `main` fails twice. Both are the same shape — **something absent, reported as something broken** — and both are a few lines.

## `scorable()` calls a missing checker a damaged ground truth

The sympy import sits inside `try: ... except Exception: return False`, so `ModuleNotFoundError` is swallowed along with genuine parse failures. Where sympy is not installed, every row is unscorable and `tools/score_symbolic_accuracy.py` prints:

```
Problems : 109 in the run, 0 with an intact ground truth, 109 not scorable
```

That reads as *"the published benchmark is entirely broken"* and means *"sympy is not installed"*. It is a clean, plausible, entirely wrong answer — and sympy is not declared anywhere in `pyproject.toml`, so this is the default experience.

The import moves out of the `try`. A ground truth that does not parse is still `False`; an absent checker now raises instead of answering. The checks that need no sympy are untouched:

```
mangled constant ->  False        # the 0.19_z defect, regex, no sympy
no variables     ->  True         # early return, no sympy
intact truth     ->  raises ModuleNotFoundError
```

`test_a_damaged_ground_truth_is_not_scorable_and_is_not_a_miss` gains the `pytest.importorskip("sympy")` that **three other tests in the same file already carry** — it was the only one of the four without it.

## The OpenEvolve sandbox exec's a symlink it deliberately does not bind

The Bubblewrap profile binds `/usr` read-only and, on purpose, not `/etc`. On Debian and Ubuntu:

```
/usr/bin/python3 → /etc/alternatives/python3 → /usr/bin/python3.11
```

so inside the sandbox the symlink dangles:

```
bwrap: execvp /usr/bin/python3: No such file or directory
```

This happens **before any candidate runs** and surfaces as an evaluation failure rather than a setup one — `evaluate_source` returns `successful_trials: 0`, so the caller sees a candidate that scored zero rather than a sandbox that could not start.

Resolving the symlink chain before it enters the sandbox yields the real file, already under the existing bind. Binding `/etc` would also fix it and is the wrong trade: the profile exists so a candidate sees as little of the host as possible. A `python3` that resolves outside `/usr` now says so plainly instead of failing puzzlingly from inside bwrap.

## Verification

| | `main` | this branch |
|---|---|---|
| `test_a_damaged_ground_truth_is_not_scorable_and_is_not_a_miss` | **FAILED** | skipped (sympy genuinely absent) |
| `test_initial_program_runs_deterministically_in_sandbox` | **FAILED** | **passed** |

Full `pytest tests/` is green on this branch. Three files, +37 −3, no behaviour change to anything that was working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JdKuZKNBrnZbS1pBEMAVyk

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdKuZKNBrnZbS1pBEMAVyk)_