### PR TITLE
Port EvoX Genesis (persistent recursive worlds) as Policies — the twentieth port

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Mechanisms that need state the pipeline does not keep — an archive, per-instan
 score rows, an island pool — take the `aggregator_factory` exit instead.
 [How to fill a slot →](https://birfy.github.io/agentdescent/policy-guide/)
 
-## Nineteen algorithm ports
+## Twenty algorithm ports
 
 Published self-evolution algorithms run as plug-ins rather than forks, under
 serial, synchronous or barrier-free scheduling without touching the engine —
@@ -223,14 +223,19 @@ each paper's own loop.
 
 **Benchmark-faithful (8):** ACE · GEPA · EvoSkill · SkillOpt · ADAS · DGM ·
 OpenEvolve · ERA
-**Microports and analogues (11):** PromptBreeder · AFlow · Self-Refine ·
+**Microports and analogues (12):** PromptBreeder · AFlow · Self-Refine ·
 Reflexion · SICA · Gödel Agent · Voyager · SkillWeaver · Absolute Zero · R-Zero ·
-Agent0
+Agent0 · **Genesis**
+
+Genesis is the one whose whole algorithm — a recursion over `(version, path)`
+worlds, a three-way merge and a parent's verdict — installs through
+`Policies(proposal=, acceptance=, conflict=)` and a `Strategy`, with **no engine
+change at all**.
 
 Fidelity is declared per port, follows each project's *released code* where it
 diverges from its paper, and analogues are not to be cited as benchmark
 reproductions. Every port has a `--dry-run` mode that needs no API key.
-[All nineteen, with their measured results →](https://birfy.github.io/agentdescent/self-evolution-examples/)
+[All twenty, with their measured results →](https://birfy.github.io/agentdescent/self-evolution-examples/)
 
 ## Documentation
 

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -87,6 +87,30 @@ engine's own defaults, which is how the rows below were measured.
 
 ## Measured results — compact formation domain
 
+### With a real model
+
+`deepseek-v4-flash` through an Anthropic-shaped endpoint, `--episodes 60
+--workers 4 --no-thinking`, three seeds. The repository starts implementation-empty
+and the model writes every line of what comes out.
+
+| seed | held-out | accepted events | agent episodes | observed depth | model calls | wall-clock |
+|---|---|---|---|---|---|---|
+| 0 | **1.000** | 5 | 34 | 3 | 284 | 135 s |
+| 1 | **1.000** | 5 | — | 3 | 306 | 173 s |
+| 2 | **1.000** | 5 | — | 2 | 242 | 100 s |
+
+Seed 0's repository was re-scored independently from what `--write-repo` wrote:
+**30/30 cases**. What it grew is `src/__init__.py` plus
+`frontend/{lexer,parser}.py` and `backend/evaluator.py`, and the `__init__.py`
+imports each stage lazily because the specification says to — so the agents read
+the contract rather than guessing it.
+
+Three defects of this port stood between a model and that result, each invisible
+until the one before it was gone; they are the section below, and none of them was
+the model.
+
+### With the offline actors
+
 Offline rule-based actors, `--episodes 96`, three seeds, one machine. The
 repository starts at **0.000** with five `CONTEXT.md` files and no implementation;
 held-out reward is the frozen staged suite (12 of 30 cases held out).
@@ -130,12 +154,18 @@ one from being built at all.
 !!! warning "What these numbers are not"
     Upstream's formation run is **123.4 hours, US$44.38, 248,989 lines and one
     sample**; its continuation and MESA-redevelopment runs are one sample each.
-    None of that is reproduced here and none of it is claimed. The domain is a
-    stand-in sized to finish offline, the actors are rule-based, and the
-    wall-clock column is dominated by child processes rather than model calls —
-    so the speedup is a property of this domain, not a result about Genesis.
-    What the rows support is that the **mechanism** runs, and how it differs from
-    the engine's defaults when it does.
+    None of that is reproduced here and none of it is claimed.
+
+    The **model** rows are three seeds, one model, one endpoint, one small domain.
+    They support "this organization can take an implementation-empty repository to
+    a working, spec-conformant one, and here is what it cost" — not any comparison
+    with upstream's scale, and not a claim about models in general.
+
+    The **offline** rows run rule-based actors, and their wall-clock is dominated
+    by child processes rather than model calls, so the speedup column is a property
+    of this domain. What they support is that the mechanism runs and how it differs
+    from the engine's defaults when it does — including the failure paths a
+    rule-based actor can never reach, which is why the section below exists.
 
 ## What a real-model run found that the offline arm could not
 

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -194,7 +194,10 @@ as repository-relative, the files fell outside the agent's subtree, became
 upward requests, and the root — which does have authority everywhere — granted
 them at the top level. Every layer behaved exactly as designed.
 
-Two fixes, because one alone is not enough. The protocol now names the agent's own
+Three defects of this port's own stood between a model and a working toolchain,
+and the second and third were only visible once the first was gone.
+
+**"Relative to what?"** Two fixes, because one alone is not enough. The protocol now names the agent's own
 path in every example it shows and is rendered per episode rather than once, so
 "relative" has one meaning. And `resolve_edit_path` resolves a path against the
 node before anything else looks at it, ordered so that a genuine cross-node
@@ -203,7 +206,40 @@ node, or an existing file of the node's, means node-relative; a path whose first
 segment is an existing top-level entry is repository-relative and therefore a
 request about somebody else's node. Resolutions are **counted**
 (`node_relative_paths`), because the alternative to counting is a file appearing
-somewhere nobody asked for it.
+somewhere nobody asked for it. After it, every file landed where it belongs.
+
+**The agents could not see the contract they were judged against.** The language
+specification lives at `spec/CONTEXT.md` — a sibling of `src/`, so on nobody's
+`CONTEXT.md` chain — and `situate()` handed an agent the chain, its own file
+listing, and nothing else. So every agent inferred the whole language from one
+failing input, and built a coherent toolchain with `('NUMBER', '1')` tokens and a
+`parse(tokens)` signature against a specification that says `("num", 1)` and
+`parse(source)`. Five correct files, every one to the wrong contract.
+
+That was a straight misreading of the paper: *"An agent may inspect the complete
+project represented by v, but it begins from p"* (§3.1). The chain is where an
+agent **begins**, not a wall around what it may read — upstream it would open the
+spec with a read tool, and an agent here has no tools, so the human-supplied
+contract travels in the brief or it is invisible. `situate(contracts=)` now shows
+it in full wherever the agent stands. The next run's lexer emitted
+`[('num', 1), ('op', '+'), ('num', 2)]`.
+
+**A manager that delegates was never asked to finish.** With the contract visible
+and every path correct, the run produced five correct modules and **no
+`src/__init__.py`** — the public surface the specification names did not exist, so
+every case still scored zero, and the `src` node's own `CONTEXT.md` had told its
+manager *"Own `src/__init__.py`"*. It delegated every time instead.
+
+Upstream's Architect works in three phases — *architecture & design →
+implementation delegation → **review & accountability*** — and is "ACCOUNTABLE for
+all code in its node path" (`agents/architect.ex:23`). This port stopped after the
+second. A manager now gets one turn at its own node **after** its children return,
+seeing the tree as they left it, restricted to files directly at the node because a
+manager free to rewrite its children's work would make the decomposition
+decorative (`--no-accountability` turns it back into a pure router). `situate()`
+also splits "files AT this node (yours to write)" from "files below it (each
+child's own)", because an agent is bad at noticing an absence inside a long list
+and the absence is the actionable part.
 
 ## Honesty boundary
 

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -182,18 +182,28 @@ exercises the mechanism and it cannot exercise the mechanism's *failure* paths,
 because a rule-based actor does not fail that way. Every counter on the world line
 exists because a model does.
 
-**Where the model arm stands, without dressing it up.** Across four runs of
-`deepseek-v4-flash` at 40–60 episodes, held-out reward stayed at **0.000**. The
-mechanism is visibly running — observed depth 3, real refusals, real merges, real
-upward requests — and the toolchain still does not come out working. The current
-failure mode is the actor, not the harness: executors ask for files at paths the
-project does not use (`lexer.py` at the repository root rather than under `src/`),
-and since the root *does* have authority there, the request is granted and the
-tree grows a second, wrong copy. A parent that "handles" a request by applying it
-is the weakest reading of upstream's rule; a parent that re-delegates it to the
-node that owns it is the next thing to try. Reported here rather than tuned away,
-because a port page that showed only the offline 1.000 would be describing a run
-nobody made.
+**"Relative to what?" cost four files and a whole run.** The run above put
+`lexer.py`, `parser.py`, `evaluator.py` and `__init__.py` at the **top of the
+repository** while the suite stayed at 0.000, and the first reading of that was
+"the model asks for paths the project does not use". It was not. The root
+`__init__.py` it wrote says *"Frontend package: tokenizer and parser"* and
+`from . import lexer`: the agent situated at `src/frontend` meant
+`src/frontend/__init__.py` and wrote the path **relative to its own node**. The
+protocol said "relative path" without saying relative to what, this port read it
+as repository-relative, the files fell outside the agent's subtree, became
+upward requests, and the root — which does have authority everywhere — granted
+them at the top level. Every layer behaved exactly as designed.
+
+Two fixes, because one alone is not enough. The protocol now names the agent's own
+path in every example it shows and is rendered per episode rather than once, so
+"relative" has one meaning. And `resolve_edit_path` resolves a path against the
+node before anything else looks at it, ordered so that a genuine cross-node
+request is never mangled into a nested copy of its own path: already inside the
+node, or an existing file of the node's, means node-relative; a path whose first
+segment is an existing top-level entry is repository-relative and therefore a
+request about somebody else's node. Resolutions are **counted**
+(`node_relative_paths`), because the alternative to counting is a file appearing
+somewhere nobody asked for it.
 
 ## Honesty boundary
 

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -154,8 +154,20 @@ The lesson is not "add more invariants". A suite of invariants needs **value
 anchors**, and this one was missing the ones that matter: not a single driven test
 pinned a nonzero number in a periodic box. It does now — a pair in mid-box and a
 pair across the seam against the closed form, a large box against no box, and an
-explicit "this field is not identically zero" — and the repository's own tests hold
-the guard by scoring a zeroed registry and checking the suite rejects it.
+explicit "this field is not identically zero".
+
+And the mechanism, rather than my having noticed: `TestSuite.baselines` holds
+**deliberately wrong implementations**, and a test requires every one of them to fail
+the suite — to at least two tests each, because the zero field died to exactly one
+and that one was the negative control. Six for md: the zero field, the real
+precedence bug, `round` for `floor`, an unshifted Lennard-Jones, Euler dressed as
+Verlet, and a centre-of-mass-corrected temperature. Writing it found two further
+holes in the same sitting: the `round` geometry — *the one thing the specification
+explicitly forbids* — passed the entire suite, and the temperature requirement hung
+on a single test. It is mutation testing in its small form, and note what it does not
+need: no reference in the **scoring** path. The reference sits beside the domain for
+jobs that are not scoring, and suite QA is one of them. Coverage would have caught
+none of it; the zero field executes every line of every test.
 
 A reference implementation still exists next to the domain, for two jobs that are
 not scoring: driving the offline rule-based actor, and letting a test prove the

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -46,6 +46,21 @@ itself. Only what the parent accepts is offered to the version history; a
 refused change leaves nothing behind except, where the refusal was recorded in
 `CONTEXT.md`, its reason.
 
+Three rules keep that recursion honest, and each is upstream's:
+
+* **A node is a directory.** Delegating to a file is refused — a path is a node
+  when it can hold children.
+* **An agent writes only inside its own path**, and a change it needs *outside*
+  it is **reported upward**, not made: the ancestor with authority there handles
+  it, under its own name. Upstream says this in as many words — *"report the need
+  back up to your parent agent, which will handle it"* (`agents/executor.ex:64`),
+  and the manager prompt explains it is the spatial contract, not an exception to
+  it.
+* **A sibling touching the same file is a merge, not a fault.** One child may sit
+  inside another's subtree, so both may legally write one path; the parent
+  three-way merges them and only a real overlap goes back as re-planning, which
+  is what `git merge --octopus` plus the conflict-file list does upstream.
+
 `CONTEXT.md` is not documentation in this system, and the port treats it the same
 way. It is part of `v`, so a later agent inherits it; the chain from the root
 down to `p` is what an entering agent is *given*; and its **routing table is
@@ -64,6 +79,7 @@ Every piece is a seam the engine already had. Nothing in `agentdescent/` changed
 | [`RecursiveDelegation`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_delegation.py) | `Policies(proposal=)` | One rollout is a whole episode tree at **one** version: manager → children → leaf executors → the parent's verdict → the merged edit set. |
 | [`OctopusConflict`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_octopus.py) | `Policies(conflict=)` | Three-way merges the contested values, so two agents editing two functions of one file both survive. Real overlaps fall through to the shipped rule. |
 | [`ParentJudge`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_judge.py) | `Policies(acceptance=)` | Upstream's monotone rule: *partial progress is accepted*; a regression is refused; a tie commits and sends more work to that subtree. |
+| [`suite_review`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_domain.py) | `RecursiveDelegation(review=)` | The parent's own test run on **one child's** contribution, inside the episode — the tests and integration evidence of paper §3.3, which the acceptance gate cannot see because it only ever sees what the whole episode returned. |
 | [`LocalWorld` / `WorldLog`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_world.py) | — | `(v,p)` itself; the `CONTEXT.md` chain an entering agent is given; `routing()`, the table that decides where a manager may delegate; and the archive that outlives the agents. |
 
 `--keyed-union` and `--engine-gate` turn the third and fourth rows back into the
@@ -146,10 +162,38 @@ counter doing its job and the prompt not doing its own. It now states that a nod
 is a directory, lists what the node's routing table actually routes to, and says
 that naming a new child adds it to that table.
 
+**Two more mechanisms were missing, and the model found them too.** With the node
+rule in place, one run logged 70 refused children and 17 dropped edits: executors
+kept producing changes outside their own path — `src/frontend` wanting to write
+`src/__init__.py`. Upstream that is not an overstep, it is a **report**: *"report
+the need back up to your parent agent, which will handle it"*
+(`agents/executor.ex:64`), and the manager prompt says in as many words that this
+*is* the spatial contract rather than an exception to it. The port had no such
+channel, so every one of those needs died as a refusal. It has one now — the
+ancestor with authority over the path makes the change, under its own name — and
+the same run goes to **0 refusals and 0 dropped edits, with 53 of 99 requests
+handled**. The other was the sibling case: a child situated inside another's
+subtree may legally write the same file, and rejecting on that collision threw
+away a whole contribution for touching a file a sibling also touched. That is now
+a three-way merge, like every other concurrent edit here.
+
 This is the general point about the offline arm, stated in one place: it
 exercises the mechanism and it cannot exercise the mechanism's *failure* paths,
-because a rule-based actor does not fail that way. Both counters exist because a
-model does.
+because a rule-based actor does not fail that way. Every counter on the world line
+exists because a model does.
+
+**Where the model arm stands, without dressing it up.** Across four runs of
+`deepseek-v4-flash` at 40–60 episodes, held-out reward stayed at **0.000**. The
+mechanism is visibly running — observed depth 3, real refusals, real merges, real
+upward requests — and the toolchain still does not come out working. The current
+failure mode is the actor, not the harness: executors ask for files at paths the
+project does not use (`lexer.py` at the repository root rather than under `src/`),
+and since the root *does* have authority there, the request is granted and the
+tree grows a second, wrong copy. A parent that "handles" a request by applying it
+is the weakest reading of upstream's rule; a parent that re-delegates it to the
+node that owns it is the next thing to try. Reported here rather than tuned away,
+because a port page that showed only the offline 1.000 would be describing a run
+nobody made.
 
 ## Honesty boundary
 
@@ -211,8 +255,14 @@ so would a reader of this page without this paragraph.
   (`Investigator`, `ContextExtractor`) exist to do nothing else. Here an agent
   writes `CONTEXT.md` on its own in exactly two cases, the routing entry for a
   node it opened and the refusal note for a child it rejected. An LLM executor
-  may write more; nothing requires it to. Skills (`.agents/skills/`,
-  `hierarchical_skill_names/2`) are not loaded at all.
+  may write more; nothing requires it to.
+* **Skills are inherited but never extracted.** `LocalWorld.skills()` collects
+  `.agents/skills/` along the node chain and puts the *names* in the brief, which
+  is what `hierarchical_skill_names/2` does upstream and what the paper means by
+  listing "reusable skills" among what an accepted version carries (§3.1). What
+  is missing is the other end: upstream's `SkillExtractor` distils a completed
+  contribution into a new skill, and nothing here does. The domain ships one
+  human-written skill so the inheritance path is live rather than decorative.
 * **Only two roles are ported.** The released code has ten agent modules; the
   paper's appendix §1.3 says the model has two — manager and leaf executor — and
   that "codebase lead / investigator / task scheduler are implementation labels,

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -477,6 +477,36 @@ also splits "files AT this node (yours to write)" from "files below it (each
 child's own)", because an agent is bad at noticing an absence inside a long list
 and the absence is the actionable part.
 
+## The paper's numbers, and this port's
+
+The mechanism is the thing being ported; the numbers are not, and putting them side by
+side is the clearest way to say which is which. Upstream's figures are the formation
+run — the one `md` stands in for — from §4.1 and the appendix tables.
+
+| | paper, formation run | this port, `md` | comparable? |
+|---|---|---|---|
+| wall clock | **123.402 h** (666.385 h of agent time) | 0.6 h | no — the domain is a stand-in, by design |
+| archived agent episodes | **1,019** | 237 (from ~42 proposals over 4 000 rollouts) | in kind only |
+| observed delegation depth | **5** (configured max 8, retries 15) | 3 (configured max 4) | in kind — both bottom out below their ceiling |
+| what one episode *is* | a supervised session of **up to 2 048 root turns / 128 child turns**, with file, shell and test tools | **one model call** (plus one for a manager's accountability turn, one for the parent's review) | **no**, and this is the largest single gap |
+| result size | 750 tracked files, **248 989** physical lines | 25 files, ~700 lines | no |
+| model-token cost | **US$44.3760** | not billed by this endpoint; 2.9 M prompt + 0.15 M completion tokens | no |
+| concurrency | max **22** overlapping episodes | 4 workers | in kind |
+| validation | complete c-testsuite, most LLVM and Csmith | a 67-task frozen suite, 16 of them held out | in kind |
+| `CONTEXT.md` maintenance | 26 files created, **62 later accepted updates affecting 19 files** | creations, plus routing entries and refusals; no other updates | **no** — and this is the second gap |
+
+Two of those rows are gaps rather than scale differences, and both are recorded below:
+an episode here is a single completion rather than a tool-using session, and the
+context records are written on two occasions rather than maintained. Everything else
+in the table differs by three orders of magnitude because the domain was chosen to
+finish in an afternoon, which is what `mechanism_microport` means.
+
+What *is* aligned is the shape: `(v,p)`, delegation that moves the path and not the
+version, the spatial contract, the parent's three-part validation, partial progress
+accepted, the octopus merge, `CONTEXT.md` as the routing mechanism, a worktree and a
+commit per episode with the worktree released, and termination by an agent's judgment.
+Each has its own row in the table at the top of this page and a test behind it.
+
 ## Honesty boundary
 
 `--offline` — the default — proposes with rule-based actors that reveal
@@ -625,6 +655,18 @@ so would a reader of this page without this paragraph.
   is missing is the other end: upstream's `SkillExtractor` distils a completed
   contribution into a new skill, and nothing here does. The domain ships one
   human-written skill so the inheritance path is live rather than decorative.
+* **An episode here is one model call; upstream it is a session.** The paper is
+  explicit — "the agent can execute multiple model–tool turns during one supervised
+  episode" — and the runs are configured at **2 048 root turns and 128 turns per
+  non-root episode**, with file, shell and test tools inside each one. Here an episode
+  is a single completion with no tools: the manager is asked once where to delegate,
+  the executor is asked once for whole files, and the brief has to carry everything
+  either of them could otherwise have fetched (which is what `situate(contracts=)` is
+  for). Everything downstream of that follows from it — why the domains are small, why
+  the actors cannot run the tests themselves, why a "rework" costs a whole new episode
+  rather than another turn. It is the largest single distance between this port and
+  the system it ports, and it is a property of the harness rather than of the
+  algorithm: `evolve()` proposes with one completion per rollout.
 * **Only two roles are ported.** The released code has ten agent modules; the
   paper's appendix §1.3 says the model has two — manager and leaf executor — and
   that "codebase lead / investigator / task scheduler are implementation labels,

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -180,6 +180,55 @@ together. So `md` splits the two jobs the single knob was doing:
 `audit reward` in the run header is therefore the honest headline number — the
 score on tests nothing that wrote the code has ever seen.
 
+### What the human supplies, and what the run has to invent
+
+A formation domain starts from fifteen files and not one line of implementation.
+That number deserves a challenge, and it got one. Sorted by who the author should
+be:
+
+| what | why a human writes it |
+|---|---|
+| `spec/CONTEXT.md` | the goal, in prose and formulas. Unavoidable: something has to say what to build. |
+| `tests/**` | the scoring. Upstream's equivalents are c-testsuite, LLVM and Csmith — also human-supplied, also frozen. |
+| `md.py` / `jqx.py` | a frozen entry point, so the result is a program rather than a package nobody can invoke. A choice, and a defensible one. |
+| `CONTEXT.md` **per node, with routing tables** | …this one is not defensible. |
+
+Six of md's fifteen files are `CONTEXT.md` records that name the nodes and what
+each is for: `src/potentials/pair/ -> one module per pair interaction`. That is the
+decomposition, and the paper's first phase is *architecture and design* — so a tree
+that ships with it has had its architecture handed to it. The machinery to grow one
+was always there and always measured (`routes_opened`: a manager may name a node
+its table does not reach, and the table records it afterwards); there was simply
+never a domain that started without one.
+
+`--cold-start` takes it away. What is left is the goal, the contract, the suite and
+the frozen driver — eight files for md — with the root's routing table emptied and
+the skills removed, because a hint about how to lay out Python packages is a hint
+about the shape of the answer. Nothing frozen is touched, so the scoring is
+identical; what changes is that the run has to write its own `CONTEXT.md` chain as
+it goes.
+
+Two defects were hiding behind the scaffolding, both of them invisible while every
+domain shipped a table at the root:
+
+* `routing()` falls back to the sub-directories that exist when a node has no
+  table. Cold-started, the root's only sub-directories are `spec/` and `tests/` —
+  so a manager was cheerfully told to delegate into the two places it is forbidden
+  to write. The world now carries the read-only globs and the fallback skips a
+  directory with nothing writable in it.
+* A routing note was always bookkeeping, trimmed before a source file when an
+  episode's edits exceeded the trust region. That is right for a note that adds a
+  line to an existing table and wrong for one that *creates* a node's record: the
+  source file is re-proposable next round, and the structure the system just
+  invented is written nowhere else. A record that brings a node into existence is
+  now trimmed last.
+
+Offline on md, cold, `--episodes 120`: **audit reward 1.000**, depth 3,
+`routes_opened=30` — the tables the run wrote are in the repository it wrote. That
+says the mechanism works from eight files; it says nothing about *inventing* a good
+decomposition, because the rule-based actor's plan **is** a decomposition. Only a
+model arm can speak to that, and it is measured separately below.
+
 ### What the domains share
 
 Everything that is not the software itself lives in [`_suite.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_suite.py):

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -154,61 +154,44 @@ the model.
 
 ### With the offline actors
 
-Offline rule-based actors, `--episodes 96`, three seeds, one machine. The
-repository starts at **0.000** with five `CONTEXT.md` files and no implementation;
-held-out reward is the frozen staged suite (12 of 30 cases held out).
+Offline rule-based actors, three seeds, one machine: `--episodes 96` on `minilang`
+and `160` on `stackvm`. Both repositories start at **0.000** — context records, a
+frozen spec and one skill, no implementation — and every number below is identical
+on all three seeds, because a rule-based actor on a fixed plan is deterministic.
 
-| arm | held-out reward | accepted events | agent episodes | observed depth | wall-clock |
-|---|---|---|---|---|---|
-| `--serial` (upstream semantics, 1 worker) | **1.000** ×3 | 6 | 18 | 2 | 4.6 s |
-| 4 workers | **1.000** ×3 | 6 | 55 | 2 | 2.7 s |
-| 8 workers | **1.000** ×3 | **4** | 98 | 2 | 2.7 s |
+| domain | arm | accepted events | `merged` | held-out |
+|---|---|---|---|---|
+| `minilang` | `--serial` (upstream semantics) | 5 | 0 | **1.000** |
+| `minilang` | 4 workers | **4** | 1 | **1.000** |
+| `minilang` | 8 workers | **3** | 1 | **1.000** |
+| `minilang` | 4 or 8 workers, `--keyed-union` | 5 | — | **1.000** |
+| `stackvm` | 8 workers | **6** | 1 | **1.000** |
+| `stackvm` | 8 workers, `--keyed-union` | 8 | — | **1.000** |
 
-Two things in that table are the port's own findings rather than restatements of
-the paper.
+**The three-way merge buys accepted events, and the keyed union buys nothing from
+parallelism at all.** That is the whole table in one line: under the engine's rule
+— where "same key" means "same file" — five accepted events at one worker, five at
+four, five at eight. Under a textual three-way merge: five, then four, then three.
+`stackvm` says the same at a different scale, 8 against 6. Two agents filling two
+different functions of one file is an edit a keyed union cannot fuse and a
+three-way merge can, and the counter (`merged=1`) says when it happened.
 
-**The three-way merge buys accepted events, not quality.** At eight workers the
-run reaches the same 1.000 in **four** accepted events instead of six, on every
-seed, and the counter says why: `merged=1`. Two agents fixed two different node
-kinds in one file in one round. Under `--keyed-union` — the engine's rule, where
-"same key" means "same file" — the same three seeds take **6** commits and
-`merged` is not available at all. That is the README's headline comparison at a
-finer granularity: a keyed union cannot fuse an intra-file edit, and a textual
-three-way can.
+**A claim this page used to make, and the measurement that retired it.** Before
+the manager's accountability turn existed, the offline arm under `--engine-gate`
+reached 0.333 / 0.750 / **0.000** on the three seeds, refusing 8–11 candidates
+each, and this page said the engine's statistical gate could not get a formation
+run started. The reason given was right: a node's first files are structure, and
+structure moves no case, so a gate demanding a measured improvement refuses them
+and the run never reaches the steps that would have improved.
 
-**The engine's statistical gate cannot get a formation run started.** Same budget,
-same everything, `--engine-gate`:
-
-| seed | held-out reward | accepted | refused |
-|---|---|---|---|
-| 0 | 0.333 | 3 | 9 |
-| 1 | 0.750 | 4 | 8 |
-| 2 | **0.000** | 1 | 11 |
-
-The reason is structural rather than statistical. The first files of an empty
-repository are structure — a package marker, an entry point — and structure moves
-no test case. A gate that requires a measured improvement refuses them, so the
-run never reaches the steps that *would* have improved. Upstream's rule accepts
-them and keeps going, which is what "partial progress is accepted" is for. This is
-the mirror image of ACE's departure on [the fidelity page](port-fidelity.md): there
-the engine's gate emptied an artifact whose claim was accumulation; here it stops
-one from being built at all.
-
-!!! warning "What these numbers are not"
-    Upstream's formation run is **123.4 hours, US$44.38, 248,989 lines and one
-    sample**; its continuation and MESA-redevelopment runs are one sample each.
-    None of that is reproduced here and none of it is claimed.
-
-    The **model** rows are three seeds, one model, one endpoint, one small domain.
-    They support "this organization can take an implementation-empty repository to
-    a working, spec-conformant one, and here is what it cost" — not any comparison
-    with upstream's scale, and not a claim about models in general.
-
-    The **offline** rows run rule-based actors, and their wall-clock is dominated
-    by child processes rather than model calls, so the speedup column is a property
-    of this domain. What they support is that the mechanism runs and how it differs
-    from the engine's defaults when it does — including the failure paths a
-    rule-based actor can never reach, which is why the section below exists.
+The accountability turn removed the *condition*, not the reasoning. A manager now
+writes its own node's file in the same episode as its children's work, so commits
+carry measurable progress from the first one, and `--engine-gate` reaches **1.000
+on every seed of both domains**. What is left is a cost, not a wall: on `stackvm`
+it refuses 8–11 candidates where the parent's rule refuses none, and on `minilang`
+0–1. Recorded this way round because a mechanism fix moving a published
+measurement is the normal case, and quietly keeping the old headline is how a
+results page stops being one.
 
 ## What a real-model run found that the offline arm could not
 

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -150,6 +150,27 @@ and 42 of the then 44 tests passed. Two noticed: the harmonic gradient, because
 harmonic has no cutoff, and the negative control, whose whole docstring is *the
 conservation tests must be able to fail, or they assert nothing*.
 
+And a suite is only as good as **how it is run**. The finished md run reported
+`audit reward 1.000`, and its repository contains this:
+
+```python
+# src/observe/__init__.py
+def rdf(positions, box, bins, rmax):
+    from .rdf import histogram      # importing the submodule rebinds
+    ...                             # src.observe.rdf from this function to
+                                    # the module: it destroys itself
+```
+
+The first call in a process works and every call after it raises
+`TypeError: 'module' object is not callable`. Scored one test per process — which is
+what one-task-per-test requires — it is perfect. Run the way a person runs a suite, in
+one interpreter, five tests fail. Upstream has no such blind spot: its manager runs
+`mix test` and its executor is told to "run ALL tests". So `TestSuite.suite_failures`
+now runs the whole suite in one process, the run reports it beside the per-task
+number, and `--complete-task` uses it as its precondition rather than the per-task
+score. `SUITE_ONLY_BASELINES` keeps that exact code as a baseline: 65/65 per test,
+60/65 in one process, and a test asserts both halves.
+
 The lesson is not "add more invariants". A suite of invariants needs **value
 anchors**, and this one was missing the ones that matter: not a single driven test
 pinned a nonzero number in a periodic box. It does now — a pair in mid-box and a

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -16,7 +16,7 @@ description: EvoX Genesis (persistent recursive worlds) as pluggable AgentDescen
 | **Paper** | *Persistent Recursive Worlds Enable Autonomous Software Evolution* — Beichen Huang, Zhenyu Liang, Bowen Zheng, Ran Cheng, 2026 ([arXiv:2608.10450](https://arxiv.org/abs/2608.10450)) |
 | **Upstream code** | [`EMI-Group/genesis`](https://github.com/EMI-Group/genesis) @ v0.12.6 (Elixir, AGPL-3.0) |
 | **Example** | [`examples/genesis/genesis_recursive_worlds.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/genesis_recursive_worlds.py) |
-| **Domain** | A compact formation run: a language toolchain grown from an implementation-empty repository against a frozen staged suite |
+| **Domains** | Two compact formation runs, `--domain`: **minilang** (an integer expression language, 2 nodes deep, 4 files) and **stackvm** (a stack machine and its assembler, 4 nodes deep, 10 files), each grown from an implementation-empty repository against a frozen staged suite |
 | **Layer** | L2 (`blast_radius=0.2`) — the evaluator is outside the artifact |
 | **Fidelity** | `mechanism_microport` — [what the classes mean](port-fidelity.md) |
 
@@ -79,13 +79,35 @@ Every piece is a seam the engine already had. Nothing in `agentdescent/` changed
 | [`RecursiveDelegation`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_delegation.py) | `Policies(proposal=)` | One rollout is a whole episode tree at **one** version: manager → children → leaf executors → the parent's verdict → the merged edit set. |
 | [`OctopusConflict`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_octopus.py) | `Policies(conflict=)` | Three-way merges the contested values, so two agents editing two functions of one file both survive. Real overlaps fall through to the shipped rule. |
 | [`ParentJudge`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_judge.py) | `Policies(acceptance=)` | Upstream's monotone rule: *partial progress is accepted*; a regression is refused; a tie commits and sends more work to that subtree. |
-| [`suite_review`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_domain.py) | `RecursiveDelegation(review=)` | The parent's own test run on **one child's** contribution, inside the episode — the tests and integration evidence of paper §3.3, which the acceptance gate cannot see because it only ever sees what the whole episode returned. |
+| [`Suite.review`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_suite.py) | `RecursiveDelegation(review=)` | The parent's own test run on **one child's** contribution, inside the episode — the tests and integration evidence of paper §3.3, which the acceptance gate cannot see because it only ever sees what the whole episode returned. |
 | [`LocalWorld` / `WorldLog`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_world.py) | — | `(v,p)` itself; the `CONTEXT.md` chain an entering agent is given; `routing()`, the table that decides where a manager may delegate; and the archive that outlives the agents. |
 
 `--keyed-union` and `--engine-gate` turn the third and fourth rows back into the
 engine's own defaults, which is how the rows below were measured.
 
-## Measured results — compact formation domain
+## Two domains, because one had nowhere for the recursion to go
+
+`--domain minilang` is the original: a lexer, a parser and an evaluator under
+`src/frontend` and `src/backend`, two nodes deep, four files for the agents to
+write. It exercises every mechanism, and its recursion bottoms out at depth 2 —
+which is fine for a merge comparison and thin for a system whose whole claim is
+recursive organisation.
+
+`--domain stackvm` grows a stack machine and its assembler: labels the assembler
+resolves to instruction indices, a dispatch table that depends on three sibling
+modules, and a loop in the suite. `src/vm/ops` is a node whose **parent is itself a
+child**, so an episode reaches depth 3 on the way to a leaf, and `arith.py` holds
+one independently-fillable function per opcode — so two agents working from two
+different failing programs edit two different parts of one file, which is the case
+a keyed union cannot fuse and a three-way merge can.
+
+What the two share is in [`_suite.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_suite.py):
+the child-process harness, the loader that computes every expectation from the
+reference, the frozen-file restore, the parent's integration check and the LLM
+actors. A domain is data on top of it — which is also why the second one could be
+added without touching a single mechanism.
+
+## Measured results — compact formation domains
 
 ### With a real model
 
@@ -93,17 +115,38 @@ engine's own defaults, which is how the rows below were measured.
 --workers 4 --no-thinking`, three seeds. The repository starts implementation-empty
 and the model writes every line of what comes out.
 
-| seed | held-out | accepted events | agent episodes | observed depth | model calls | wall-clock |
-|---|---|---|---|---|---|---|
-| 0 | **1.000** | 5 | 34 | 3 | 284 | 135 s |
-| 1 | **1.000** | 5 | — | 3 | 306 | 173 s |
-| 2 | **1.000** | 5 | — | 2 | 242 | 100 s |
+| domain | seed | held-out | accepted | episodes | depth | calls | wall-clock |
+|---|---|---|---|---|---|---|---|
+| `minilang` | 0 | **1.000** | 5 | 34 | 3 | 284 | 135 s |
+| `minilang` | 1 | **1.000** | 5 | — | 3 | 306 | 173 s |
+| `minilang` | 2 | **1.000** | 5 | — | 2 | 242 | 100 s |
+| `stackvm` (`--episodes 160`) | 0 | **1.000** | 12 | 114 | 3 | 659 | 902 s |
 
-Seed 0's repository was re-scored independently from what `--write-repo` wrote:
-**30/30 cases**. What it grew is `src/__init__.py` plus
-`frontend/{lexer,parser}.py` and `backend/evaluator.py`, and the `__init__.py`
-imports each stage lazily because the specification says to — so the agents read
-the contract rather than guessing it.
+Both seed-0 repositories were re-scored independently from what `--write-repo`
+wrote: **30/30** each. On `minilang` it grew `src/__init__.py` plus
+`frontend/{lexer,parser}.py` and `backend/evaluator.py`, with each stage imported
+lazily because the specification says to — so the agents read the contract rather
+than guessing it.
+
+!!! note "The suite constrains the surface, not the structure — and `stackvm` shows it"
+    The `stackvm` run passes every case and the repository it wrote is **not** the
+    one the `CONTEXT.md` tree proposed. The agents moved the tokenizer and the
+    interpreter to `src/tokenize.py` and `src/run.py` (their own node's files, in
+    the accountability turn), made `src/asm/parser` a package, and gave the
+    opcodes a calling convention of their own — consistently, and the public
+    surface honours the frozen spec exactly, which is why it scores 1.000.
+
+    It also left two pieces of dead code behind: `src/asm/lexer.py`, shadowed by
+    the `src/asm/lexer/` package that took its place, and `src/vm/machine.py`,
+    which imports `op_add` from a module that defines `add` and would raise on
+    import — nothing imports it, because `src/run.py` became the real interpreter.
+
+    This is the organization working as specified, not failing: acceptance is
+    gated on **validation**, the validation checks three entry points and the data
+    shapes, and anything the suite cannot see is not something any gate here can
+    refuse. Upstream has the same property, with a suite that checks far more. It
+    is worth stating plainly because "held-out 1.000" and "no dead code" are
+    different claims and only the first one is measured.
 
 Three defects of this port stood between a model and that result, each invisible
 until the one before it was gone; they are the section below, and none of them was

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -46,6 +46,14 @@ itself. Only what the parent accepts is offered to the version history; a
 refused change leaves nothing behind except, where the refusal was recorded in
 `CONTEXT.md`, its reason.
 
+`CONTEXT.md` is not documentation in this system, and the port treats it the same
+way. It is part of `v`, so a later agent inherits it; the chain from the root
+down to `p` is what an entering agent is *given*; and its **routing table is
+where a manager may delegate**. A node its parent does not route to is a node
+later agents cannot find, so a manager that opens one writes the entry at its own
+level — which is a write to the accepted version like any other, gated like any
+other.
+
 ## How it plugs into `evolve()`
 
 Every piece is a seam the engine already had. Nothing in `agentdescent/` changed.
@@ -56,7 +64,7 @@ Every piece is a seam the engine already had. Nothing in `agentdescent/` changed
 | [`RecursiveDelegation`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_delegation.py) | `Policies(proposal=)` | One rollout is a whole episode tree at **one** version: manager → children → leaf executors → the parent's verdict → the merged edit set. |
 | [`OctopusConflict`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_octopus.py) | `Policies(conflict=)` | Three-way merges the contested values, so two agents editing two functions of one file both survive. Real overlaps fall through to the shipped rule. |
 | [`ParentJudge`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_judge.py) | `Policies(acceptance=)` | Upstream's monotone rule: *partial progress is accepted*; a regression is refused; a tie commits and sends more work to that subtree. |
-| [`LocalWorld` / `WorldLog`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_world.py) | — | `(v,p)` itself, the `CONTEXT.md` chain an entering agent is given, and the archive that outlives the agents. |
+| [`LocalWorld` / `WorldLog`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_world.py) | — | `(v,p)` itself; the `CONTEXT.md` chain an entering agent is given; `routing()`, the table that decides where a manager may delegate; and the archive that outlives the agents. |
 
 `--keyed-union` and `--engine-gate` turn the third and fourth rows back into the
 engine's own defaults, which is how the rows below were measured.
@@ -113,6 +121,36 @@ one from being built at all.
     What the rows support is that the **mechanism** runs, and how it differs from
     the engine's defaults when it does.
 
+## What a real-model run found that the offline arm could not
+
+The offline actors are rule-based, so they never mistake a file for a node and
+never write outside their subtree. A run against `deepseek-v4-flash` through an
+Anthropic-shaped endpoint did both within forty episodes, and turned up two
+defects that no offline test could have reached.
+
+**A node is a directory, and nothing said so.** A manager delegated to
+`src/frontend/lexer.py` as though it were a node. The child was situated there,
+wrote `lexer.py/CONTEXT.md` and `lexer.py/__init__.py` *inside* it, and every
+stage accepted it: the key space is a flat dict, so `a/b.py` and `a/b.py/c.py`
+coexist happily until something tries to put them on a filesystem. The run died
+in `EvolutionResult.write_to` with `FileExistsError` after 328 model calls — the
+whole thing lost at the one point where it was being saved. Two rules now stop
+it, and they are separate on purpose because they need opposite fixes:
+`RecursiveDelegation` refuses a delegation whose target is an existing file
+(`mistaken_nodes`), and `SpatialContract` refuses any edit that would make the
+key space stop being a tree (`shape_violations`).
+
+**The manager prompt never taught what a node is.** With the rule in place the
+refusals were counted rather than fatal — 32 of them in one run — which is the
+counter doing its job and the prompt not doing its own. It now states that a node
+is a directory, lists what the node's routing table actually routes to, and says
+that naming a new child adds it to that table.
+
+This is the general point about the offline arm, stated in one place: it
+exercises the mechanism and it cannot exercise the mechanism's *failure* paths,
+because a rule-based actor does not fail that way. Both counters exist because a
+model does.
+
 ## Honesty boundary
 
 `--offline` — the default — proposes with rule-based actors that reveal
@@ -163,6 +201,18 @@ so would a reader of this page without this paragraph.
   the depth configured.
 * **Multi-repository work (`foreign_repos`), the Tauri desktop shell, the Phoenix
   dashboard and peak-hour scheduling are out of scope.**
+* **`CONTEXT.md` is inherited and routed from, but only partly maintained.**
+  The read half is faithful: the chain is assembled root-first exactly as
+  `ContextNode.build_context/2` does, and the routing table is load-bearing —
+  the offline manager's decomposition is *parsed from it*, not hardcoded, so
+  editing the table changes where the run delegates (there is a test that does
+  exactly that). The write half is not: upstream every `:read_write` agent keeps
+  its node current — intent, API surface, known issues — and the read-only roles
+  (`Investigator`, `ContextExtractor`) exist to do nothing else. Here an agent
+  writes `CONTEXT.md` on its own in exactly two cases, the routing entry for a
+  node it opened and the refusal note for a child it rejected. An LLM executor
+  may write more; nothing requires it to. Skills (`.agents/skills/`,
+  `hierarchical_skill_names/2`) are not loaded at all.
 * **Only two roles are ported.** The released code has ten agent modules; the
   paper's appendix §1.3 says the model has two — manager and leaf executor — and
   that "codebase lead / investigator / task scheduler are implementation labels,

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -1,0 +1,186 @@
+---
+description: EvoX Genesis (persistent recursive worlds) as pluggable AgentDescent policies - w=(v,p), recursive delegation, the octopus merge and the parent's verdict, measured on a compact formation run.
+---
+
+# Genesis — Persistent Recursive Worlds
+
+> **A software world that persists while its agents do not.** An agent is
+> situated by an accepted version *and* a repository path; delegation moves the
+> path, only acceptance moves the version. Runs through
+> [`evolve()`](evolution.md) as one `Strategy` and three `Policies` fields, with
+> **no engine change**. Example:
+> [`examples/genesis/genesis_recursive_worlds.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/genesis_recursive_worlds.py).
+
+| | |
+|---|---|
+| **Paper** | *Persistent Recursive Worlds Enable Autonomous Software Evolution* — Beichen Huang, Zhenyu Liang, Bowen Zheng, Ran Cheng, 2026 ([arXiv:2608.10450](https://arxiv.org/abs/2608.10450)) |
+| **Upstream code** | [`EMI-Group/genesis`](https://github.com/EMI-Group/genesis) @ v0.12.6 (Elixir, AGPL-3.0) |
+| **Example** | [`examples/genesis/genesis_recursive_worlds.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/genesis_recursive_worlds.py) |
+| **Domain** | A compact formation run: a language toolchain grown from an implementation-empty repository against a frozen staged suite |
+| **Layer** | L2 (`blast_radius=0.2`) — the evaluator is outside the artifact |
+| **Fidelity** | `mechanism_microport` — [what the classes mean](port-fidelity.md) |
+
+## The mechanism
+
+The paper's model is four objects and two operations.
+
+A **local software world** is a pair
+
+    w = (v, p)
+
+of an accepted version and a repository-relative path. `v` fixes the whole
+inheritable project; `p` says where an agent starts and what it is answerable
+for. A finite-lived agent produces a candidate `Δᵢ = Aᵢ((v,p), gᵢ)` and then
+ceases to exist — its conversation is not the identity of any later agent.
+
+The two operations differ in exactly one way:
+
+| operation | version | path |
+|---|---|---|
+| recursive delegation `(v,p) ⇝ (v,q)` | **unchanged** | moves to `q` |
+| accepted event `(v,p) → (v′,p′)` | **advances** | stays, or is explicitly mapped |
+
+Managers decompose and judge; leaf executors write files. A parent merges what
+its children return with `git merge --octopus` and resolves a real conflict
+itself. Only what the parent accepts is offered to the version history; a
+refused change leaves nothing behind except, where the refusal was recorded in
+`CONTEXT.md`, its reason.
+
+## How it plugs into `evolve()`
+
+Every piece is a seam the engine already had. Nothing in `agentdescent/` changed.
+
+| Plug-in | `evolve()` slot | What it does |
+|---|---|---|
+| [`SpatialContract`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_spatial.py) | `strategy=` | A directory, one key per path. An edit carries the path of the agent that made it, and an edit outside that subtree is dropped and **counted**. |
+| [`RecursiveDelegation`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_delegation.py) | `Policies(proposal=)` | One rollout is a whole episode tree at **one** version: manager → children → leaf executors → the parent's verdict → the merged edit set. |
+| [`OctopusConflict`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_octopus.py) | `Policies(conflict=)` | Three-way merges the contested values, so two agents editing two functions of one file both survive. Real overlaps fall through to the shipped rule. |
+| [`ParentJudge`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_judge.py) | `Policies(acceptance=)` | Upstream's monotone rule: *partial progress is accepted*; a regression is refused; a tie commits and sends more work to that subtree. |
+| [`LocalWorld` / `WorldLog`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_world.py) | — | `(v,p)` itself, the `CONTEXT.md` chain an entering agent is given, and the archive that outlives the agents. |
+
+`--keyed-union` and `--engine-gate` turn the third and fourth rows back into the
+engine's own defaults, which is how the rows below were measured.
+
+## Measured results — compact formation domain
+
+Offline rule-based actors, `--episodes 96`, three seeds, one machine. The
+repository starts at **0.000** with five `CONTEXT.md` files and no implementation;
+held-out reward is the frozen staged suite (12 of 30 cases held out).
+
+| arm | held-out reward | accepted events | agent episodes | observed depth | wall-clock |
+|---|---|---|---|---|---|
+| `--serial` (upstream semantics, 1 worker) | **1.000** ×3 | 6 | 18 | 2 | 4.6 s |
+| 4 workers | **1.000** ×3 | 6 | 55 | 2 | 2.7 s |
+| 8 workers | **1.000** ×3 | **4** | 98 | 2 | 2.7 s |
+
+Two things in that table are the port's own findings rather than restatements of
+the paper.
+
+**The three-way merge buys accepted events, not quality.** At eight workers the
+run reaches the same 1.000 in **four** accepted events instead of six, on every
+seed, and the counter says why: `merged=1`. Two agents fixed two different node
+kinds in one file in one round. Under `--keyed-union` — the engine's rule, where
+"same key" means "same file" — the same three seeds take **6** commits and
+`merged` is not available at all. That is the README's headline comparison at a
+finer granularity: a keyed union cannot fuse an intra-file edit, and a textual
+three-way can.
+
+**The engine's statistical gate cannot get a formation run started.** Same budget,
+same everything, `--engine-gate`:
+
+| seed | held-out reward | accepted | refused |
+|---|---|---|---|
+| 0 | 0.333 | 3 | 9 |
+| 1 | 0.750 | 4 | 8 |
+| 2 | **0.000** | 1 | 11 |
+
+The reason is structural rather than statistical. The first files of an empty
+repository are structure — a package marker, an entry point — and structure moves
+no test case. A gate that requires a measured improvement refuses them, so the
+run never reaches the steps that *would* have improved. Upstream's rule accepts
+them and keeps going, which is what "partial progress is accepted" is for. This is
+the mirror image of ACE's departure on [the fidelity page](port-fidelity.md): there
+the engine's gate emptied an artifact whose claim was accumulation; here it stops
+one from being built at all.
+
+!!! warning "What these numbers are not"
+    Upstream's formation run is **123.4 hours, US$44.38, 248,989 lines and one
+    sample**; its continuation and MESA-redevelopment runs are one sample each.
+    None of that is reproduced here and none of it is claimed. The domain is a
+    stand-in sized to finish offline, the actors are rule-based, and the
+    wall-clock column is dominated by child processes rather than model calls —
+    so the speedup is a property of this domain, not a result about Genesis.
+    What the rows support is that the **mechanism** runs, and how it differs from
+    the engine's defaults when it does.
+
+## Honesty boundary
+
+`--offline` — the default — proposes with rule-based actors that reveal
+pre-written module implementations one step at a time, the same device as
+[DGM](algo-dgm.md)'s surrogate objective and the [molecule search](porous-molecules.md)'s
+offline operators. It exercises the port's mechanism and says **nothing** about a
+model's ability to write software. `--model` supplies manager and executor agents
+that are asked instead of computed.
+
+Upstream's own task-level acceptance is a **human action**: `merge_and_report/4`
+never merges, it only creates a `genesis/agent_<hex>` branch, and the merge is a
+button on the dashboard (`EvoGit.Review.merge_branch/2,3`). The judging this port
+automates is the one that runs *inside* an episode — a parent on its child — plus
+the task-level gate, which is the aggregator. A reader who takes "123 hours
+autonomous" to mean "no human in the accept path" is reading upstream wrong, and
+so would a reader of this page without this paragraph.
+
+## Recorded deviations
+
+* **The benchmark is not reproduced.** See the warning above. Fidelity class is
+  `mechanism_microport` for that reason and no other — the mechanism maps cleanly.
+* **Tensor parallelism is refused rather than used.** TP is the engine's own
+  "each worker owns a disjoint section, conflict-free by construction", which is
+  word for word the spatial contract. It cannot be used here: its ownership map is
+  built once before round 0 from a declared key space, and a key outside it
+  belongs to no section — so **every newly created file is a `section-violation`**
+  (`evolution.py:2739`; `FileTree.keys` says so itself). Formation is nothing but
+  creating files. `SpatialContract` therefore declares no key space, which makes
+  `evolve()` *refuse* TP with a message naming the reason instead of silently
+  discarding the run's entire output, and enforces the contract in `to_diff`,
+  where creation is free.
+* **The world is L2, not L1.** The audit gate runs *before* acceptance and, above
+  `FAST_MAX`, vetoes every candidate that does not strictly improve — which
+  contradicts "partial progress is accepted" outright, and at L1 this domain
+  commits nothing at all. L2 is honest here because the agents cannot reach the
+  evaluator: the suite, its expectations and the harness that runs them live
+  outside the artifact, and `spec/**` is refused to every proposal and restored
+  pristine before scoring. Governance is deliberately not a seam, so this is
+  recorded as a boundary rather than routed around.
+* **"Request more work" is reconstructed.** `AcceptDecision` is a boolean whose
+  `category` is a closed vocabulary — the aggregator turns it into a
+  `MergeOutcome`, so an invented name raises inside the merge. A parent's *not
+  yet* therefore commits the partial step and leaves a request in the `WorldLog`
+  that the next round's manager re-delegates from, rather than becoming a third
+  engine outcome.
+* **Observed depth is 2 here, 4–8 upstream**, because the domain's decomposition
+  is three nodes deep. The number reported is always the depth *observed*, never
+  the depth configured.
+* **Multi-repository work (`foreign_repos`), the Tauri desktop shell, the Phoenix
+  dashboard and peak-hour scheduling are out of scope.**
+* **Only two roles are ported.** The released code has ten agent modules; the
+  paper's appendix §1.3 says the model has two — manager and leaf executor — and
+  that "codebase lead / investigator / task scheduler are implementation labels,
+  not additional roles". Porting ten would be porting an implementation.
+
+## Run it
+
+```bash
+python -m examples.genesis.genesis_recursive_worlds                            # offline, no API key
+python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
+python -m examples.genesis.genesis_recursive_worlds --episodes 96 --serial     # upstream semantics
+python -m examples.genesis.genesis_recursive_worlds --keyed-union              # control: engine merge
+python -m examples.genesis.genesis_recursive_worlds --engine-gate              # control: engine gate
+python -m examples.genesis.genesis_recursive_worlds --model claude-haiku-4-5   # real agents
+python -m examples.genesis.genesis_recursive_worlds --write-repo /tmp/world    # keep what it grew
+```
+
+`--dry-run` prints the plan with zero network access and no API key.
+
+Offline tests:
+[`tests/test_genesis_example.py`](https://github.com/Birfy/agentdescent/blob/main/tests/test_genesis_example.py).

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -131,7 +131,7 @@ reference. This is also what upstream does: Genesis validates against c-testsuit
 LLVM and Csmith, which are assertions, with no reference compiler anywhere in the
 loop.
 
-What that buys is assertions an oracle cannot make. Most of `md`'s tests are
+What that buys is assertions an oracle cannot make. Many of `md`'s tests are
 **invariants**: the forces sum to zero, every force component matches a central
 difference of the energy, energy and momentum survive a trajectory, reversing the
 velocities retraces it. One of them asserts that a far-too-large timestep does
@@ -139,6 +139,23 @@ velocities retraces it. One of them asserts that a far-too-large timestep does
 with a single force evaluation is stable, plausible, and caught — `tests/test_genesis_example.py`
 breaks the integrator that way and checks the suite notices, because a sampled
 position from a bounded trajectory often agrees to six decimal places.
+
+It also buys a trap, and a real run walked into it. **A field that returns zero
+everywhere satisfies every invariant above**: zero sums to zero, zero is the
+gradient of a constant, nothing moves so nothing drifts, and reversing nothing
+retraces it. A run shipped exactly that — `d -= box * (d / box + 0.5) // 1`, where
+the `// 1` binds after the multiplication, computing `floor(d + L/2)` instead of
+`L * floor(d/L + 0.5)` and pushing every pair in a periodic box past the cutoff —
+and 42 of the then 44 tests passed. Two noticed: the harmonic gradient, because
+harmonic has no cutoff, and the negative control, whose whole docstring is *the
+conservation tests must be able to fail, or they assert nothing*.
+
+The lesson is not "add more invariants". A suite of invariants needs **value
+anchors**, and this one was missing the ones that matter: not a single driven test
+pinned a nonzero number in a periodic box. It does now — a pair in mid-box and a
+pair across the seam against the closed form, a large box against no box, and an
+explicit "this field is not identically zero" — and the repository's own tests hold
+the guard by scoring a zeroed registry and checking the suite rejects it.
 
 A reference implementation still exists next to the domain, for two jobs that are
 not scoring: driving the offline rule-based actor, and letting a test prove the

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -560,16 +560,42 @@ so would a reader of this page without this paragraph.
   test at a time in the task prompt. `FROZEN` (what may not be written), `CONTRACTS`
   (what is pushed) and `readonly` (where a manager may not be sent) are three sets for
   three jobs; conflating the first two is how `md.py` once crowded out the spec.
-* **Termination is the engine's, not an agent's judgment.** Upstream an agent calls
-  `complete_task` when it believes the objective is met, and a human merges or rejects
-  afterwards. Here the run ends when the round budget ends, and `stop reason: rounds`
-  on a finished domain means exactly that — nobody decided it was done.
-* **Parallelism is the engine's workers, not worktrees.** Upstream isolates every
-  subagent in its own git worktree and requires "commit before delegating" so children
-  branch from a committed SHA; concurrency is unbounded and conflicts are resolved by
-  the spawning agent. Here `evolve()`'s workers propose concurrently against one
-  accepted version and `OctopusConflict` does the three-way merge in the parent, which
-  is `Git.merge_octopus/2`'s job. The observable consequence is the same — two children
+* **Termination can be an agent's judgment, with `--complete-task`.** Upstream an
+  agent calls `complete_task` when it believes the objective is met, and a human merges
+  or rejects afterwards on the dashboard; here the run ends when the round budget ends,
+  which is why a finished domain still reports `stop reason: rounds` — nobody decided
+  it was done. `CompletionJudge` asks instead, through `evolve(stop_when=)`, with
+  upstream's two gates in upstream's order: every test the agents can see must pass
+  first ("treat them as the definition of done"), and below that the question is not
+  asked and no model call is spent; then the root agent judges the **codebase** —
+  stubs, dead modules, anything it would not hand over as finished. It is never shown
+  the held-out reward: that number is this port's measurement, computed from tests no
+  agent may read, and handing it over would turn the judgment back into a threshold.
+  The human review at the end of upstream's chain is still out of scope.
+* **Worktree isolation and "commit before delegating", with `--worktrees`.** Upstream
+  this is the scheduling model, not a detail of it: "commit your changes, release your
+  worktree, and wait... If you don't commit, your changes are invisible to subagents."
+  Each episode now gets a git worktree of its own, commits its work there on a branch
+  of its own, and the worktree is **removed** — the release a cooperative scheduler
+  requires — with a ledger that has to balance. What that buys is not correctness:
+  siblings here branch from the same base by construction because the episode tree is
+  a pure function over a state dict, and a test holds that property directly. It buys
+  three things that were missing. The **phylogenetic graph becomes git history** — one
+  commit per episode, and a parent that kept three children leaves a four-parent merge
+  commit, so `Git.merge_octopus/2`'s shape is there and `phylo_graph_node.ex`'s
+  `find_merge_base/2` has something to find. "Commit before delegating" becomes
+  **checkable**, and acting on it found a real gap: a manager that opens a node now
+  writes that node into its routing table *before* briefing the child, which is what
+  `make_dir` (auto-commits) then spawn means, and before this the child arrived at a
+  node its own parent's table did not mention. And every episode record carries the
+  sha it could be **resurrected** from, which is the third field of upstream's
+  `(node_path, commit_sha, objective)` tuple and the one this port did not have.
+  Measured on md offline: 98 worktrees created, 98 removed, 98 commits, 41 of them
+  merges, five parents at the widest, same reward, 4% wall-clock.
+* **Parallelism is still the engine's workers.** Upstream's concurrency is unbounded
+  and each subagent's worktree is where its commands run; here `evolve()`'s workers
+  propose concurrently against one accepted version and `OctopusConflict` does the
+  three-way merge in the parent. The observable consequence is the same — two children
   editing one file both survive — and the measurement of that is in the table above.
 * **Skills are inherited but never extracted.** `LocalWorld.skills()` collects
   `.agents/skills/` along the node chain and puts the *names* in the brief, which

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -85,7 +85,7 @@ Every piece is a seam the engine already had. Nothing in `agentdescent/` changed
 `--keyed-union` and `--engine-gate` turn the third and fourth rows back into the
 engine's own defaults, which is how the rows below were measured.
 
-## Two domains, because one had nowhere for the recursion to go
+## Four domains, and what each one answers
 
 `--domain minilang` is the original: a lexer, a parser and an evaluator under
 `src/frontend` and `src/backend`, two nodes deep, four files for the agents to
@@ -101,11 +101,92 @@ one independently-fillable function per opcode — so two agents working from tw
 different failing programs edit two different parts of one file, which is the case
 a keyed union cannot fuse and a three-way merge can.
 
-What the two share is in [`_suite.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_suite.py):
-the child-process harness, the loader that computes every expectation from the
-reference, the frozen-file restore, the parent's integration check and the LLM
-actors. A domain is data on top of it — which is also why the second one could be
-added without touching a single mechanism.
+`--domain jqx` grows a JSON query language whose **command-line entry point is
+frozen beside the specification**. The agents never write `jqx.py`; they write the
+library it imports. A finished run is therefore a program you can run, not a
+package nobody can invoke — and the difference showed up immediately as a class of
+bug the other two domains cannot have, because a library that satisfies every case
+can still be unusable from a shell.
+
+`--domain md` grows Lennard-Jones molecular dynamics in reduced units — geometry,
+two pair potentials, velocity Verlet, thermodynamic observables, a pair-distance
+histogram — under a frozen driver that writes XYZ trajectories and an ASCII `g(r)`.
+It answers the thing the first three cannot, and it is a change of kind rather than
+of size: **there is no oracle in its scoring path**.
+
+### Two ways to score a formation run, and only one of them is honest about it
+
+The first three domains are scored by [`Suite`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_suite.py):
+a human writes a reference implementation, the loader runs it to compute the
+expected answer for every case, and a candidate is scored by matching. It is cheap,
+it is exact, and it is circular — you cannot ask a system to grow software you had
+to write first. It also shapes what can be asked: an expected-output line cannot
+carry a tolerance, an invariant, or "these two ways of computing this must agree".
+
+`md` uses `TestSuite` instead. A human writes a specification and a **test suite**,
+which is what a human actually writes. One task is one test function, a task's
+prompt is that test's own source — prelude included, so the agent sees what
+`CONFIG` is — and the reward is whether it passes. Nothing is compared against a
+reference. This is also what upstream does: Genesis validates against c-testsuite,
+LLVM and Csmith, which are assertions, with no reference compiler anywhere in the
+loop.
+
+What that buys is assertions an oracle cannot make. Most of `md`'s tests are
+**invariants**: the forces sum to zero, every force component matches a central
+difference of the energy, energy and momentum survive a trajectory, reversing the
+velocities retraces it. One of them asserts that a far-too-large timestep does
+*not* conserve energy, so an implementation that fakes conservation fails. Euler
+with a single force evaluation is stable, plausible, and caught — `tests/test_genesis_example.py`
+breaks the integrator that way and checks the suite notices, because a sampled
+position from a bounded trajectory often agrees to six decimal places.
+
+A reference implementation still exists next to the domain, for two jobs that are
+not scoring: driving the offline rule-based actor, and letting a test prove the
+suite is passable at all. Shipping a specification nobody has ever seen satisfied
+is its own kind of dishonesty.
+
+### The held-out tail is not a validation split
+
+`evolve()` holds out the tail of the task list and reports its reward as
+`final_reward`. For the oracle domains that is a generalisation estimate and it
+means something: the cases are sampled inputs over one grammar, and passing inputs
+you were not shown is the claim.
+
+For a test suite it is a category error, and an expensive one. Every task is a
+distinct **requirement**, so holding back 40% of them means refusing to tell the
+system four tenths of what it has to do and then grading it on them. Worse, the
+search never sees those requirements fail, so nothing is ever proposed for them.
+That is exactly how the `jqx` run stalled at 0.923 with `stop reason: rounds`: the
+case list was ordered by filter, two builtins appeared only in the held-out tail,
+and no rollout could ever fail on them. A test guards the property now, for every
+domain, and `TestSuite` interleaves its tasks across files so a positional split
+cannot quietly hide a file.
+
+Dropping the split entirely is also wrong, though, and for a reason specific to
+this port: the executor is handed **the source of the test it is failing**, so it
+could satisfy one assertion at a time without the physics underneath holding
+together. So `md` splits the two jobs the single knob was doing:
+
+* every **driven** test is part of the specification and every one of them drives
+  the search — `HELD_OUT_FRAC` is *computed* so that `evolve()`'s positional cut
+  lands exactly on the boundary;
+* the tail is an **audit set** of thirteen further tests that are **not in the
+  repository at all** — `frozen` stops a file being written, not read, and an audit
+  test in the tree is one the executor can read and write code against. They are
+  injected into the scratch copy only while a held-out task is being scored: a
+  different box shape, a brute-force search over periodic images, a harmonic
+  oscillator's period, the structure layer checked against the geometry layer.
+
+`audit reward` in the run header is therefore the honest headline number — the
+score on tests nothing that wrote the code has ever seen.
+
+### What the domains share
+
+Everything that is not the software itself lives in [`_suite.py`](https://github.com/Birfy/agentdescent/blob/main/examples/genesis/_suite.py):
+the child-process harness, the loader, the frozen-file restore, the parent's
+integration check and the LLM actors. A domain is data on top of it — which is also
+why the second, third and fourth could be added without touching a single
+mechanism, and why `TestSuite` sits beside `Suite` rather than replacing it.
 
 ## Measured results — compact formation domains
 
@@ -374,6 +455,7 @@ so would a reader of this page without this paragraph.
 
 ```bash
 python -m examples.genesis.genesis_recursive_worlds                            # offline, no API key
+python -m examples.genesis.genesis_recursive_worlds --domain md                # tests, not an oracle
 python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
 python -m examples.genesis.genesis_recursive_worlds --episodes 96 --serial     # upstream semantics
 python -m examples.genesis.genesis_recursive_worlds --keyed-union              # control: engine merge

--- a/docs/algo-genesis.md
+++ b/docs/algo-genesis.md
@@ -475,6 +475,20 @@ so would a reader of this page without this paragraph.
 
 ## Recorded deviations
 
+* **Upstream has no objective function, and this port's scalar is the engine's, not
+  Genesis's.** `grep -rio 'fitness|reward|score'` over `apps/evo_git` returns exactly
+  one hit, `oom_score_adjust`. Nothing in the released code computes a number over a
+  validation suite. What stands in that place is local: the executor verifies its own
+  work and writes tests (`agents/executor.ex`), the parent reviews the result and runs
+  the suite (`agents/manager.ex`), the architect's third phase runs the build and
+  reviews the implementation (`agents/architect.ex`), the tests are "the **definition
+  of done**" handed to the agents as guidance (`runtime/genesis.ex:152`), termination
+  is an agent calling `complete_task` "only when the codebase is complete, functional,
+  and polished", and a human merges or rejects on the dashboard review page.
+  `evolve()`, by contrast, *is* a reward-driven loop: it samples a failing task, asks
+  for a proposal, scores it, accepts or rejects, and reports a number. So the per-node
+  gate in this port is upstream's mechanism, and `audit reward` is **measurement** —
+  the thing that makes the port legible, not the thing that makes it work.
 * **The benchmark is not reproduced.** See the warning above. Fidelity class is
   `mechanism_microport` for that reason and no other — the mechanism maps cleanly.
 * **Tensor parallelism is refused rather than used.** TP is the engine's own
@@ -506,17 +520,57 @@ so would a reader of this page without this paragraph.
   the depth configured.
 * **Multi-repository work (`foreign_repos`), the Tauri desktop shell, the Phoenix
   dashboard and peak-hour scheduling are out of scope.**
+* **The parent's validation is both halves now, and was one for a long time.**
+  `agents/manager.ex` states it as three things in order — "Review subagent results.
+  Run tests to validate changes. Check for code quality: duplicated code, defensive
+  code that silently swallows errors, and missing test coverage. **Reject work that
+  introduces these anti-patterns**" — and the architect's Phase 3 is the same shape.
+  This port had only the middle one, `Suite.review`, which is a pass count. What a
+  pass count cannot see is a function that computes nothing, and that is exactly what
+  it failed to see: the zero-field run above. `_review.py` adds the reading half as
+  one model call per returned child, asking upstream's questions about the whole file;
+  a rejection sends the work back with a reason the next round re-delegates from.
+  "Missing test coverage" is left out of the questions on purpose — the suite is
+  frozen here, so no child could act on that finding. `--no-parent-review` turns it
+  off; the offline arm has no model and therefore no reviewer, which is one more
+  reason the offline numbers say less than they look like they do.
 * **`CONTEXT.md` is inherited and routed from, but only partly maintained.**
   The read half is faithful: the chain is assembled root-first exactly as
-  `ContextNode.build_context/2` does, and the routing table is load-bearing —
-  the offline manager's decomposition is *parsed from it*, not hardcoded, so
-  editing the table changes where the run delegates (there is a test that does
-  exactly that). The write half is not: upstream every `:read_write` agent keeps
-  its node current — intent, API surface, known issues — and the read-only roles
-  (`Investigator`, `ContextExtractor`) exist to do nothing else. Here an agent
-  writes `CONTEXT.md` on its own in exactly two cases, the routing entry for a
-  node it opened and the refusal note for a child it rejected. An LLM executor
-  may write more; nothing requires it to.
+  `ContextNode.build_context/2` does, each record truncated **per file** at
+  upstream's own `truncation.context_max_bytes` (65 536) with upstream's own marker
+  and no global budget — this port had one global 8 000-char cap instead, eight times
+  tighter, which is half of how md's agents never received their specification. The
+  routing table is load-bearing: the offline manager's decomposition is *parsed from
+  it*, not hardcoded, so editing the table changes where the run delegates (there is
+  a test that does exactly that). The human-written records carry upstream's four
+  standard sections — Intent, **API Surface**, Constraints, Routing Table — and
+  `API Surface` was missing from every one of them until the md run lost five of
+  seven keyword parameters. The write half is still thinner than upstream, where
+  every `:read_write` agent keeps its node current and two read-only roles exist to
+  do nothing else: here an agent writes `CONTEXT.md` on its own in exactly two cases,
+  the routing entry for a node it opened and the refusal for a child it rejected —
+  the latter under `## Known Issues`, which is upstream's heading for "problems to
+  avoid re-discovering". An LLM executor may write more; nothing requires it to.
+* **What the agent is handed, versus what it could fetch.** Upstream an agent has file
+  tools and *pulls* what it needs; the brief carries only the `CONTEXT.md` chain plus
+  its location. Agents here have no tools, so the contract has to travel with the
+  brief or be invisible — which is why `situate(contracts=)` exists at all. The push
+  is therefore deliberately narrower than "everything frozen": md pushes the
+  specification and the frozen driver, while the 12 kB test suite arrives one failing
+  test at a time in the task prompt. `FROZEN` (what may not be written), `CONTRACTS`
+  (what is pushed) and `readonly` (where a manager may not be sent) are three sets for
+  three jobs; conflating the first two is how `md.py` once crowded out the spec.
+* **Termination is the engine's, not an agent's judgment.** Upstream an agent calls
+  `complete_task` when it believes the objective is met, and a human merges or rejects
+  afterwards. Here the run ends when the round budget ends, and `stop reason: rounds`
+  on a finished domain means exactly that — nobody decided it was done.
+* **Parallelism is the engine's workers, not worktrees.** Upstream isolates every
+  subagent in its own git worktree and requires "commit before delegating" so children
+  branch from a committed SHA; concurrency is unbounded and conflicts are resolved by
+  the spawning agent. Here `evolve()`'s workers propose concurrently against one
+  accepted version and `OctopusConflict` does the three-way merge in the parent, which
+  is `Git.merge_octopus/2`'s job. The observable consequence is the same — two children
+  editing one file both survive — and the measurement of that is in the table above.
 * **Skills are inherited but never extracted.** `LocalWorld.skills()` collects
   `.agents/skills/` along the node chain and puts the *names* in the brief, which
   is what `hierarchical_skill_names/2` does upstream and what the paper means by

--- a/docs/matrix-overview.md
+++ b/docs/matrix-overview.md
@@ -33,7 +33,7 @@ generated, so edit the generator rather than the page.
     columns do not**: they were measured on the fixture whose baseline was 0.000
     by construction, which is why every cell reads `0.000 -> …`. Current quality
     numbers are the three-seed async rows on each port's own page, summarised in
-    [measured results — all nineteen](self-evolution-examples.md#measured-results-all-nineteen).
+    [measured results — all twenty](self-evolution-examples.md#measured-results-all-twenty).
 
 ## What the rerun has to report
 

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -452,9 +452,11 @@ passed.
   other labels are implementation labels; the code has ten agent modules. Two are
   ported.
 * **Departures**: the benchmark is not reproduced and is not claimed — upstream's
-  formation run is 123.4 h, US$44.38 and **one sample**, so the domain is a
-  compact formation stand-in and the fidelity class is `mechanism_microport` for
-  that reason alone. Multi-repository work, the desktop shell, the dashboard and
+  formation run is 123.4 h, US$44.38 and **one sample**, so the domains are
+  compact formation stand-ins and the fidelity class is `mechanism_microport` for
+  that reason alone. There are two of them because the first had nowhere for the
+  recursion to go: `minilang` bottoms out at depth 2, `stackvm` at depth 3 with a
+  node whose parent is itself a child. Multi-repository work, the desktop shell, the dashboard and
   peak-hour scheduling are out of scope. Observed recursion depth is 2 here and
   4–8 upstream, because the domain's decomposition is three nodes deep.
 * **Two engine boundaries it ran into, recorded rather than routed around.**

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -1,6 +1,6 @@
 # Port fidelity — what each port follows, and where it departs
 
-Nineteen published self-evolution algorithms run on this engine — eight as benchmark-faithful ports, eleven as declared microports and analogues. Every one of them
+Twenty published self-evolution algorithms run on this engine — eight as benchmark-faithful ports, twelve as declared microports and analogues. Every one of them
 was published as a **serial** loop, and every one of them here runs in parallel
 with a merge step the original does not have. That is only an interesting claim
 if the algorithm is otherwise untouched — a "parallelised GEPA" that quietly
@@ -20,9 +20,9 @@ the axis the differences actually fall on, and because the answer is not always
     contradicts reproduces something nobody ran.
 
 !!! note "Fidelity is a per-port property, not a tier"
-    All nineteen ports sit side by side in
+    All twenty ports sit side by side in
     [Self-evolution algorithms](self-evolution-examples.md); what differs is
-    each port's recorded fidelity class. Eleven of them run compact domains or
+    each port's recorded fidelity class. Twelve of them run compact domains or
     substituted environments and say so on their pages -- a mechanism
     microport or an environment, inference, or self-edit analogue is not a
     faithful benchmark port, and the [runtime matrix](matrix-overview.md)
@@ -426,6 +426,50 @@ speedup outright where the cells show the arms did not spend the same budget,
 which is the one check that cannot be done by reading the flags that were
 passed.
 
+## Genesis — Persistent Recursive Worlds
+
+* **Paper**: a software project that persists while its agents do not. An agent
+  is situated by `w = (v, p)` — an accepted version and a repository path;
+  delegation `(v,p) ⇝ (v,q)` moves the path and **not** the version, and only an
+  accepted event `(v,p) → (v′,p)` advances the project.
+* **Released code**: the parent merges its children with `git merge --octopus`
+  (`adapters/git.ex:284`) and hands a real conflict back to itself as prompt text
+  (`agent/subagent_processing.ex:527`); the parent's acceptance rule is monotone —
+  *"Partial progress is accepted — a version is accepted if it improves the
+  codebase, even if other parts remain broken"* (`agents/manager.ex:58`); the
+  spatial contract is *"every agent is only supposed to edit files belonging to
+  its own path"* (`agents/manager.ex:179`).
+* **This port follows**: the code, including the acceptance rule — which is the
+  *must not change* column above, so the engine's Beta gate is the opt-in control
+  arm (`--engine-gate`) rather than the default.
+* **Where the paper and the code disagree, and this port follows the code —
+  twice.** (1) The paper describes accepted events advancing the version history;
+  in the released code `Helpers.merge_and_report/4` **never merges** — it creates
+  a `genesis/agent_<hex>` branch, and the merge is a button on the dashboard
+  (`EvoGit.Review.merge_branch/2,3`). The automatic judging is the one inside the
+  recursion, parent on child; the task-level accept has a human in it. (2) The
+  paper's appendix §1.3 says the model has two roles and that the released code's
+  other labels are implementation labels; the code has ten agent modules. Two are
+  ported.
+* **Departures**: the benchmark is not reproduced and is not claimed — upstream's
+  formation run is 123.4 h, US$44.38 and **one sample**, so the domain is a
+  compact formation stand-in and the fidelity class is `mechanism_microport` for
+  that reason alone. Multi-repository work, the desktop shell, the dashboard and
+  peak-hour scheduling are out of scope. Observed recursion depth is 2 here and
+  4–8 upstream, because the domain's decomposition is three nodes deep.
+* **Two engine boundaries it ran into, recorded rather than routed around.**
+  Tensor parallelism is the engine's own statement of the spatial contract, and
+  it cannot be used: its ownership map is fixed before round 0, so every file the
+  run *creates* is a `section-violation` — and creating files is what a formation
+  run is. And the audit gate runs **before** acceptance, vetoing anything that
+  does not strictly improve above `FAST_MAX`, which contradicts "partial progress
+  is accepted"; the world therefore sits at L2, which is honest here only because
+  the suite and its harness live outside the artifact and `spec/**` is refused to
+  every proposal.
+* **Selection rule lives in**: nowhere separate — Genesis has no candidate
+  archive. The recursion is the search.
+* **Details**: [algo-genesis.md](algo-genesis.md)
+
 ## The eleven MethodPolicy ports
 
 Their departures are not repeated here. Each one's page carries a **Boundaries**
@@ -435,7 +479,7 @@ section naming exactly what its compact or substituted domain gives up, and a
 port is. Start from the
 [table of all eleven](self-evolution-examples.md#the-eleven-microports-and-analogues);
 their measured results are
-[in one place](self-evolution-examples.md#measured-results-all-nineteen), and the
+[in one place](self-evolution-examples.md#measured-results-all-twenty), and the
 scheduler comparison they exist for is the [runtime matrix](matrix-overview.md).
 
 What they share is the thing the fidelity class encodes: **a `mechanism_microport`

--- a/docs/port-fidelity.md
+++ b/docs/port-fidelity.md
@@ -442,6 +442,19 @@ passed.
 * **This port follows**: the code, including the acceptance rule — which is the
   *must not change* column above, so the engine's Beta gate is the opt-in control
   arm (`--engine-gate`) rather than the default.
+* **The released code has no objective function.** `grep -rio 'fitness|reward|score'`
+  over `apps/evo_git` returns one hit, `oom_score_adjust`. Nothing computes a number
+  over a validation suite: the executor verifies its own work and writes tests, the
+  parent reviews the result *and* runs the suite *and* rejects code-quality
+  anti-patterns it can see (`agents/manager.ex`), the architect's Phase 3 runs the
+  build and reviews the implementation, given tests are "the **definition of done**"
+  (`runtime/genesis.ex:152`), and termination is an agent calling `complete_task`.
+  `evolve()` is a reward-driven loop by construction, so this port's scalar is the
+  **engine's contract and its own measurement**, while the mechanism it reproduces is
+  the per-node one: the parent's tests (`Suite.review`), the parent reading the diff
+  (`_review.py`), and the root agent's completion judgment (`--complete-task`, through
+  `evolve(stop_when=)`). Reported as `audit reward`, on tests no agent may read, and
+  deliberately never shown to the agent that decides whether the work is done.
 * **Where the paper and the code disagree, and this port follows the code —
   twice.** (1) The paper describes accepted events advancing the version history;
   in the released code `Helpers.merge_and_report/4` **never merges** — it creates
@@ -454,11 +467,25 @@ passed.
 * **Departures**: the benchmark is not reproduced and is not claimed — upstream's
   formation run is 123.4 h, US$44.38 and **one sample**, so the domains are
   compact formation stand-ins and the fidelity class is `mechanism_microport` for
-  that reason alone. There are two of them because the first had nowhere for the
-  recursion to go: `minilang` bottoms out at depth 2, `stackvm` at depth 3 with a
-  node whose parent is itself a child. Multi-repository work, the desktop shell, the dashboard and
-  peak-hour scheduling are out of scope. Observed recursion depth is 2 here and
-  4–8 upstream, because the domain's decomposition is three nodes deep.
+  that reason alone. There are four of them because each answered something the one
+  before could not: `minilang` bottoms out at depth 2, `stackvm` at depth 3 with a
+  node whose parent is itself a child, `jqx` comes out as a program rather than a
+  package, and `md` takes the oracle out of the scoring path altogether. Observed
+  recursion depth is 3–4 here and 4–8 upstream. Multi-repository work, the desktop
+  shell, the dashboard and peak-hour scheduling are out of scope — including the
+  **human merge** at the end of upstream's chain, which means the last gate on an
+  accepted version is missing here rather than automated.
+* **The scheduling model is ported rather than imitated (`--worktrees`).** Upstream
+  "commit your changes, release your worktree, and wait" is how agents are scheduled
+  at all, so each episode takes a git worktree, commits on a branch of its own, and
+  the worktree is removed, with a ledger that balances. The phylogenetic graph is then
+  real git history — a parent that kept three children leaves a four-parent merge
+  commit, which is the shape `Git.merge_octopus/2` leaves — and `EpisodeRecord` carries
+  the third field of upstream's `(node_path, commit_sha, objective)` resurrection
+  tuple. It is not load-bearing for correctness here (the episode tree is a pure
+  function over a state dict, and siblings branch from one base by construction), and
+  acting on it found a real gap anyway: a manager that opens a node now records it
+  *before* briefing the child, as `make_dir` (auto-commits) then spawn requires.
 * **Two engine boundaries it ran into, recorded rather than routed around.**
   Tensor parallelism is the engine's own statement of the spatial contract, and
   it cannot be used: its ownership map is fixed before round 0, so every file the

--- a/docs/porting-checklist.md
+++ b/docs/porting-checklist.md
@@ -15,6 +15,6 @@ microports/analogues follow the [MethodPolicy checklist](porting-methodpolicy.md
 - [ ] Make `--dry-run` return before data/model setup: zero network and zero API key.
 - [ ] Add `tests/test_<name>_example.py`; all tests must run offline.
 - [ ] Add `docs/algo-<name>.md` in the shape every other port page has: lead blockquote, the Paper / Upstream code / Example / Domain / Layer / Fidelity table, the algorithm, how it plugs into `evolve()`, the plug-ins it implements, **Measured results — `<domain>`** (or why none exists), **Run it**, and the offline-tests line.
-- [ ] Add its rows to [the eight](self-evolution-examples.md#the-eight-benchmark-faithful-ports), to [all nineteen](self-evolution-examples.md#measured-results-all-nineteen), and to the README's fidelity table.
+- [ ] Add its rows to [the eight](self-evolution-examples.md#the-eight-benchmark-faithful-ports), to [all twenty](self-evolution-examples.md#measured-results-all-twenty), and to the README's fidelity table.
 - [ ] State heavy-infrastructure boundaries such as Docker or gated data instead of hiding them.
 - [ ] Record the port author/maintainer so later fidelity decisions have an owner.

--- a/docs/porting-methodpolicy.md
+++ b/docs/porting-methodpolicy.md
@@ -34,5 +34,5 @@ Use this for mechanism microports and analogues — declarative
 - [ ] Add its row to
   [the eleven](self-evolution-examples.md#the-eleven-microports-and-analogues)
   and, once measured, to
-  [all nineteen](self-evolution-examples.md#measured-results-all-nineteen).
+  [all twenty](self-evolution-examples.md#measured-results-all-twenty).
 - [ ] Record the port author and the upstream trace, exactly as Path A does.

--- a/docs/results.md
+++ b/docs/results.md
@@ -11,7 +11,7 @@ so you can reproduce it.
 ## The algorithm ports
 
 All nineteen port results live in one place — **[measured results, all
-nineteen](self-evolution-examples.md#measured-results-all-nineteen)** — with each
+twenty](self-evolution-examples.md#measured-results-all-twenty)** — with each
 row linked to the page that carries its full setup, its caveats and the run file
 it came from. They are not repeated here: a second copy of a number is a copy
 that goes stale, and this page's copy did.

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -290,14 +290,14 @@ that establish the port works end to end, not a comparison.
 The repository starts with no implementation in it, so "before" is 0.000 by
 construction rather than by a weak baseline. Model rows are three seeds at
 `--episodes 60 --workers 4`; offline rows are `--episodes 96` (`minilang`) and
-`160` (`stackvm`).
+`160` (`stackvm`), deterministic across seeds.
 
 | Method | Domain | held-out, before → after | accepted events | notes |
 |---|---|---:|---:|---|
 | [Genesis](algo-genesis.md#with-a-real-model) · `minilang`, deepseek-v4-flash | compact formation run, 2 nodes deep | 0.000 → **1.000** ×3 | 5 | the model writes every line; seed 0 re-scored independently at 30/30, observed depth 3, 284 calls in 135 s |
-| [Genesis](algo-genesis.md#with-the-offline-actors) · `minilang`, offline actors | the same | 0.000 → **1.000** ×3 | 6 serial / 6 at N=4 / **4** at N=8 | the three-way merge saves two accepted events at N=8; the engine's Beta gate reaches 0.000–0.750 on the same budget |
+| [Genesis](algo-genesis.md#with-the-offline-actors) · `minilang`, offline actors | the same | 0.000 → **1.000** ×3 | 5 serial / **4** at N=4 / **3** at N=8 | deterministic on every seed; `--keyed-union` takes 5 at *every* width, so the three-way merge is what parallelism buys here |
 | [Genesis](algo-genesis.md#with-a-real-model) · `stackvm`, deepseek-v4-flash | compact formation run, 4 nodes deep | 0.000 → **1.000** | 12 | re-scored independently at 30/30; it invented its own decomposition and left two pieces of dead code the suite cannot see — see the page |
-| [Genesis](algo-genesis.md#with-the-offline-actors) · `stackvm`, offline actors | the same | 0.000 → **1.000** | 6 at N=8 | ten files the agents write, observed depth 3, one three-way merge inside `arith.py` |
+| [Genesis](algo-genesis.md#with-the-offline-actors) · `stackvm`, offline actors | the same | 0.000 → **1.000** ×3 | **6** at N=8 | ten files the agents write, observed depth 3; `--keyed-union` takes 8 |
 
 !!! warning "One run per seed, and one seed on the bottom table"
     Nothing here is a paper-scale result. The eleven and Genesis carry three

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -1,19 +1,19 @@
 ---
-description: Nineteen published self-evolution algorithms ported as runnable plug-ins on one runtime, each with a declared fidelity class and a measured before-and-after result.
+description: Twenty published self-evolution algorithms ported as runnable plug-ins on one runtime, each with a declared fidelity class and a measured before-and-after result.
 ---
 
-# Self-evolution algorithms — nineteen ports
+# Self-evolution algorithms — twenty ports
 
 AgentDescent is a *general* engine for parallel, merge-based evolution. To show
-it is faithful to the field — not a toy — nineteen published **skill**,
+it is faithful to the field — not a toy — twenty published **skill**,
 **program** and **harness** self-evolution algorithms run on it, each as one
 runnable example with a dedicated page. Eight reproduce their paper's own
-benchmark; eleven preserve the mechanism on a compact domain and say so. What
+benchmark; twelve preserve the mechanism on a compact domain and say so. What
 each one follows and where it departs is recorded per port in
 [port fidelity](port-fidelity.md).
 
-**All nineteen run through the AgentDescent evolution engines.** No example
-bypasses the engine, and they reach it two ways:
+**All twenty run through the AgentDescent evolution engines.** No example
+bypasses the engine, and they reach it three ways:
 
 * the **eight benchmark-faithful ports** are each a custom `strategy=` and/or a
   custom `aggregator_factory=`, with their parent/gate rules extracted as named
@@ -23,9 +23,13 @@ bypasses the engine, and they reach it two ways:
   [`MethodPolicy`](policies.md) definitions over one shared runner — their
   mechanisms plug in as `Policies(...)` fields, their artifacts as shared
   [strategies](strategies.md), and the [runtime matrix](matrix-overview.md)
-  measures them under all three schedulers.
+  measures them under all three schedulers;
+* **Genesis** is neither: a custom `strategy=` like the first group, a
+  `mechanism_microport` fidelity class like the second, and its whole algorithm
+  installed through `Policies(proposal=, acceptance=, conflict=)` — the case that
+  shows the seams are enough on their own.
 
-**All nineteen are parallel — and can run async.** In synchronous mode their workers
+**All twenty are parallel — and can run async.** In synchronous mode their workers
 run **concurrently** (overlapping LLM rollouts) with the aggregator merge as the
 barrier (*synchronous data-parallelism*). Add **`--async`** and the same example
 runs **barrier-free** through
@@ -72,6 +76,17 @@ so they share a runner, a budget contract and a command line. Port author:
 | **Absolute Zero** | `inference_analogue` | self-play carts | frozen self-play evaluation; learnability signal | [→](algo-absolute-zero.md) |
 | **R-Zero** | `inference_analogue` | self-play carts | `AdvantageAcceptance` (GRPO shape), `DifficultyWeighted` | [→](algo-r-zero.md) |
 | **Agent0** | `inference_analogue` | self-play carts | `DifficultyWeighted`; calculator stop-and-go | [→](algo-agent0.md) |
+
+### The twentieth: Genesis, at the standard seams
+
+One port is a mechanism microport that is **not** a `MethodPolicy`: its algorithm
+is a recursion, so it installs as a proposal policy rather than as a declaration
+over a shared runner. It is listed on its own because putting it in either table
+above would make that table's opening sentence false.
+
+| Algorithm | Port author | Fidelity class | Domain | `evolve()` plug-ins | Page |
+|---|---|---|---|---|---|
+| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | compact formation run (a toolchain grown from an empty repository) | `strategy` + `Policies(proposal=, acceptance=, conflict=)` | [→](algo-genesis.md) |
 
 ### The shared command line
 
@@ -208,7 +223,7 @@ cannot be decorative. `run_port` also records all three in `framework`, and
 
 ---
 
-## Measured results — all nineteen
+## Measured results — all twenty
 
 Every port has been run and every number below is linked to the run that
 produced it. **The two halves of this page are not comparable with each other**,
@@ -270,11 +285,23 @@ that establish the port works end to end, not a comparison.
 | [OpenEvolve](algo-openevolve.md#measured-results-function-minimization) | function minimization | combined score 0.9638 → **1.4995** against a 1.5 ceiling, held-out seeds | async N=4, 24 rollouts |
 | [ERA](algo-era.md#measured-results-playground-s3e1) | Kaggle Playground S3E1 | test RMSE 0.7297 → **0.5913** (−19.0%) on 2,476 unseen rows; 7-node tree, all valid | async N=3, 6 expansions |
 
+### The twentieth, on a formation run
+
+Three seeds, `--episodes 96`, offline rule-based actors. The repository starts
+with no implementation in it, so "before" is 0.000 by construction rather than by
+a weak baseline.
+
+| Method | Domain | held-out, before → after | accepted events | notes |
+|---|---|---:|---:|---|
+| [Genesis](algo-genesis.md#measured-results-compact-formation-domain) | compact formation run | 0.000 → **1.000** ×3 | 6 serial / 6 at N=4 / **4** at N=8 | the three-way merge saves two accepted events at N=8; the engine's Beta gate reaches 0.000–0.750 on the same budget |
+
 !!! warning "One run per seed, and one seed on the bottom table"
-    Nothing here is a paper-scale result. The eleven carry three seeds and report
-    the spread on their own pages; the eight carry one, and a single run does not
-    pin a number on a sampled model. The quality columns are evidence the
-    mechanism runs and moves the metric it should, not evidence about how much.
+    Nothing here is a paper-scale result. The eleven and Genesis carry three
+    seeds and report the spread on their own pages; the eight carry one, and a
+    single run does not pin a number on a sampled model. The quality columns are
+    evidence the mechanism runs and moves the metric it should, not evidence about
+    how much. Genesis's rows are offline and deterministic, which makes their
+    spread a statement about scheduling rather than about a model.
 
 ---
 

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -86,7 +86,7 @@ above would make that table's opening sentence false.
 
 | Algorithm | Port author | Fidelity class | Domain | `evolve()` plug-ins | Page |
 |---|---|---|---|---|---|
-| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | two compact formation runs (`--domain minilang` / `stackvm`), each grown from an implementation-empty repository | `strategy` + `Policies(proposal=, acceptance=, conflict=)` | [→](algo-genesis.md) |
+| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | four compact formation runs (`--domain minilang` / `stackvm` / `jqx` / `md`), each grown from an implementation-empty repository; `md` is scored by a frozen test suite with no reference implementation in the loop | `strategy` + `Policies(proposal=, acceptance=, conflict=)` | [→](algo-genesis.md) |
 
 ### The shared command line
 

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -86,7 +86,7 @@ above would make that table's opening sentence false.
 
 | Algorithm | Port author | Fidelity class | Domain | `evolve()` plug-ins | Page |
 |---|---|---|---|---|---|
-| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | four compact formation runs (`--domain minilang` / `stackvm` / `jqx` / `md`), each grown from an implementation-empty repository; `md` is scored by a frozen test suite with no reference implementation in the loop | `strategy` + `Policies(proposal=, acceptance=, conflict=)` | [→](algo-genesis.md) |
+| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | four compact formation runs (`--domain minilang` / `stackvm` / `jqx` / `md`), each grown from an implementation-empty repository; `md` is scored by a frozen test suite with no reference implementation in the loop | `strategy` + `Policies(proposal=, acceptance=, conflict=)` + `stop_when=` | [→](algo-genesis.md) |
 
 ### The shared command line
 

--- a/docs/self-evolution-examples.md
+++ b/docs/self-evolution-examples.md
@@ -86,7 +86,7 @@ above would make that table's opening sentence false.
 
 | Algorithm | Port author | Fidelity class | Domain | `evolve()` plug-ins | Page |
 |---|---|---|---|---|---|
-| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | compact formation run (a toolchain grown from an empty repository) | `strategy` + `Policies(proposal=, acceptance=, conflict=)` | [→](algo-genesis.md) |
+| **Genesis** (Persistent Recursive Worlds) | chendanyang | `mechanism_microport` | two compact formation runs (`--domain minilang` / `stackvm`), each grown from an implementation-empty repository | `strategy` + `Policies(proposal=, acceptance=, conflict=)` | [→](algo-genesis.md) |
 
 ### The shared command line
 
@@ -285,23 +285,28 @@ that establish the port works end to end, not a comparison.
 | [OpenEvolve](algo-openevolve.md#measured-results-function-minimization) | function minimization | combined score 0.9638 → **1.4995** against a 1.5 ceiling, held-out seeds | async N=4, 24 rollouts |
 | [ERA](algo-era.md#measured-results-playground-s3e1) | Kaggle Playground S3E1 | test RMSE 0.7297 → **0.5913** (−19.0%) on 2,476 unseen rows; 7-node tree, all valid | async N=3, 6 expansions |
 
-### The twentieth, on a formation run
+### The twentieth, on two formation runs
 
-Three seeds, `--episodes 96`, offline rule-based actors. The repository starts
-with no implementation in it, so "before" is 0.000 by construction rather than by
-a weak baseline.
+The repository starts with no implementation in it, so "before" is 0.000 by
+construction rather than by a weak baseline. Model rows are three seeds at
+`--episodes 60 --workers 4`; offline rows are `--episodes 96` (`minilang`) and
+`160` (`stackvm`).
 
 | Method | Domain | held-out, before → after | accepted events | notes |
 |---|---|---:|---:|---|
-| [Genesis](algo-genesis.md#measured-results-compact-formation-domain) | compact formation run | 0.000 → **1.000** ×3 | 6 serial / 6 at N=4 / **4** at N=8 | the three-way merge saves two accepted events at N=8; the engine's Beta gate reaches 0.000–0.750 on the same budget |
+| [Genesis](algo-genesis.md#with-a-real-model) · `minilang`, deepseek-v4-flash | compact formation run, 2 nodes deep | 0.000 → **1.000** ×3 | 5 | the model writes every line; seed 0 re-scored independently at 30/30, observed depth 3, 284 calls in 135 s |
+| [Genesis](algo-genesis.md#with-the-offline-actors) · `minilang`, offline actors | the same | 0.000 → **1.000** ×3 | 6 serial / 6 at N=4 / **4** at N=8 | the three-way merge saves two accepted events at N=8; the engine's Beta gate reaches 0.000–0.750 on the same budget |
+| [Genesis](algo-genesis.md#with-a-real-model) · `stackvm`, deepseek-v4-flash | compact formation run, 4 nodes deep | 0.000 → **1.000** | 12 | re-scored independently at 30/30; it invented its own decomposition and left two pieces of dead code the suite cannot see — see the page |
+| [Genesis](algo-genesis.md#with-the-offline-actors) · `stackvm`, offline actors | the same | 0.000 → **1.000** | 6 at N=8 | ten files the agents write, observed depth 3, one three-way merge inside `arith.py` |
 
 !!! warning "One run per seed, and one seed on the bottom table"
     Nothing here is a paper-scale result. The eleven and Genesis carry three
     seeds and report the spread on their own pages; the eight carry one, and a
     single run does not pin a number on a sampled model. The quality columns are
     evidence the mechanism runs and moves the metric it should, not evidence about
-    how much. Genesis's rows are offline and deterministic, which makes their
-    spread a statement about scheduling rather than about a model.
+    how much. Genesis carries both kinds: its model rows are three seeds on one
+    model and one endpoint, and its offline rows are deterministic, which makes
+    *their* spread a statement about scheduling rather than about a model.
 
 ---
 

--- a/examples/_TEMPLATE.py
+++ b/examples/_TEMPLATE.py
@@ -7,7 +7,7 @@ Each port owns a directory. Create ``examples/<algorithm>/`` with an
 -- a sandbox runner, an evaluator, fixtures -- belongs in that directory too.
 
 Keep the upstream algorithm's vocabulary for its iteration flag: ``--rounds``,
-``--generations``, ``--iterations``, or ``--steps``. Record every deviation from
+``--generations``, ``--iterations``, ``--steps``, or ``--episodes``. Record every deviation from
 released code in ``docs/algo-<algorithm>.md``, and add the port to ``PORTS`` in
 ``tests/test_example_entrypoints.py`` -- a port outside that table is outside
 the whole command-line contract.

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -21,6 +21,8 @@ python -m examples.genesis.genesis_recursive_worlds --domain stackvm      # the 
 python -m examples.genesis.genesis_recursive_worlds --domain jqx          # a program, not a package
 python -m examples.genesis.genesis_recursive_worlds --domain md           # scored by tests, no oracle
 python -m examples.genesis.genesis_recursive_worlds --cold-start          # no node records: it writes its own
+python -m examples.genesis.genesis_recursive_worlds --worktrees           # a worktree and a commit per episode
+python -m examples.genesis.genesis_recursive_worlds --complete-task --model ...  # the root agent decides when it is done
 python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
 python -m examples.genesis.genesis_recursive_worlds --keyed-union         # control: no three-way merge
 python -m examples.genesis.genesis_recursive_worlds --engine-gate         # control: the Beta gate
@@ -45,7 +47,8 @@ the path, an accepted event moves the version. Each piece is one file here.
 | [`_spatial.py`](_spatial.py) | `Strategy`: an agent writes only inside its own subtree | `agents/manager.ex:179` |
 | [`_octopus.py`](_octopus.py) | `ConflictPolicy`: three-way merge, so two agents in one file both survive | `Git.merge_octopus/2` |
 | [`_judge.py`](_judge.py) | `AcceptancePolicy`: the parent's rule — *partial progress is accepted* | `agents/manager.ex:58` |
-| [`_review.py`](_review.py) | the parent **reading** its child's change — upstream's code-quality rejection, the half a pass count cannot see | `agents/manager.ex` "Validation", `agents/architect.ex` Phase 3 |
+| [`_review.py`](_review.py) | the parent **reading** its child's change, and the root agent's `complete_task` | `agents/manager.ex` "Validation", `agents/architect.ex` Phase 3, `runtime/genesis.ex` |
+| [`_worktree.py`](_worktree.py) | a worktree per episode, a commit per episode, the worktree removed after — and the phylogenetic graph as real git history | `agents/manager.ex` yielding model, `Git.merge_octopus/2`, `core/phylo_graph_node.ex` |
 | [`_suite.py`](_suite.py) | the machinery a domain needs and does not own: the harness, both loaders (`Suite` scores against a reference, `TestSuite` against a frozen test suite with no reference in the loop), the runner, the parent's integration check, the LLM actors | — |
 | [`_domain.py`](_domain.py) | **minilang** — an integer expression language, 2 nodes deep, 4 files | — |
 | [`_stackvm.py`](_stackvm.py) | **stackvm** — a stack machine and its assembler, 4 nodes deep, 10 files | — |

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -36,7 +36,7 @@ the path, an accepted event moves the version. Each piece is one file here.
 
 | file | what it is | upstream |
 |---|---|---|
-| [`_world.py`](_world.py) | `LocalWorld(v, p)`, the `CONTEXT.md` chain, the episode archive | paper §3.1, `core/context_node.ex` |
+| [`_world.py`](_world.py) | `LocalWorld(v, p)`, the `CONTEXT.md` chain **and its routing table**, the episode archive | paper §3.1, `core/context_node.ex` |
 | [`_delegation.py`](_delegation.py) | `ProposalPolicy`: one rollout is a whole episode tree at one version | paper §3.2, `agent/subagent_processing.ex` |
 | [`_spatial.py`](_spatial.py) | `Strategy`: an agent writes only inside its own subtree | `agents/manager.ex:179` |
 | [`_octopus.py`](_octopus.py) | `ConflictPolicy`: three-way merge, so two agents in one file both survive | `Git.merge_octopus/2` |

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -45,6 +45,7 @@ the path, an accepted event moves the version. Each piece is one file here.
 | [`_spatial.py`](_spatial.py) | `Strategy`: an agent writes only inside its own subtree | `agents/manager.ex:179` |
 | [`_octopus.py`](_octopus.py) | `ConflictPolicy`: three-way merge, so two agents in one file both survive | `Git.merge_octopus/2` |
 | [`_judge.py`](_judge.py) | `AcceptancePolicy`: the parent's rule — *partial progress is accepted* | `agents/manager.ex:58` |
+| [`_review.py`](_review.py) | the parent **reading** its child's change — upstream's code-quality rejection, the half a pass count cannot see | `agents/manager.ex` "Validation", `agents/architect.ex` Phase 3 |
 | [`_suite.py`](_suite.py) | the machinery a domain needs and does not own: the harness, both loaders (`Suite` scores against a reference, `TestSuite` against a frozen test suite with no reference in the loop), the runner, the parent's integration check, the LLM actors | — |
 | [`_domain.py`](_domain.py) | **minilang** — an integer expression language, 2 nodes deep, 4 files | — |
 | [`_stackvm.py`](_stackvm.py) | **stackvm** — a stack machine and its assembler, 4 nodes deep, 10 files | — |

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -9,7 +9,7 @@ policies rather than a fork of the loop.
 | Governance layer | L2 (`blast_radius=0.2`) — the agents cannot reach the evaluator |
 | Paper | "Persistent Recursive Worlds Enable Autonomous Software Evolution", Beichen Huang et al., 2026 ([arXiv:2608.10450](https://arxiv.org/abs/2608.10450)) |
 | Upstream code | https://github.com/EMI-Group/genesis @ v0.12.6 (Elixir, AGPL-3.0) |
-| Domains | Two compact formation runs — **not** upstream's 123.4 h C-compiler benchmark |
+| Domains | Four compact formation runs — **not** upstream's 123.4 h C-compiler benchmark |
 | `evolve()` plug-ins | `strategy` + `Policies(proposal=, acceptance=, conflict=)` |
 | Fidelity | `mechanism_microport` |
 
@@ -18,6 +18,8 @@ policies rather than a fork of the loop.
 ```bash
 python -m examples.genesis.genesis_recursive_worlds                       # offline, no API key
 python -m examples.genesis.genesis_recursive_worlds --domain stackvm      # the deeper world
+python -m examples.genesis.genesis_recursive_worlds --domain jqx          # a program, not a package
+python -m examples.genesis.genesis_recursive_worlds --domain md           # scored by tests, no oracle
 python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
 python -m examples.genesis.genesis_recursive_worlds --keyed-union         # control: no three-way merge
 python -m examples.genesis.genesis_recursive_worlds --engine-gate         # control: the Beta gate
@@ -42,9 +44,11 @@ the path, an accepted event moves the version. Each piece is one file here.
 | [`_spatial.py`](_spatial.py) | `Strategy`: an agent writes only inside its own subtree | `agents/manager.ex:179` |
 | [`_octopus.py`](_octopus.py) | `ConflictPolicy`: three-way merge, so two agents in one file both survive | `Git.merge_octopus/2` |
 | [`_judge.py`](_judge.py) | `AcceptancePolicy`: the parent's rule — *partial progress is accepted* | `agents/manager.ex:58` |
-| [`_suite.py`](_suite.py) | the machinery a domain needs and does not own: the harness, the loader, the runner, the parent's integration check, the LLM actors | — |
+| [`_suite.py`](_suite.py) | the machinery a domain needs and does not own: the harness, both loaders (`Suite` scores against a reference, `TestSuite` against a frozen test suite with no reference in the loop), the runner, the parent's integration check, the LLM actors | — |
 | [`_domain.py`](_domain.py) | **minilang** — an integer expression language, 2 nodes deep, 4 files | — |
 | [`_stackvm.py`](_stackvm.py) | **stackvm** — a stack machine and its assembler, 4 nodes deep, 10 files | — |
+| [`_jqx.py`](_jqx.py) | **jqx** — a JSON query tool whose command-line entry point is frozen, 4 nodes, 9 files | — |
+| [`_md.py`](_md.py) | **md** — Lennard-Jones molecular dynamics under a frozen driver, 6 nodes, 14 files, scored by a frozen test suite and audited by tests that are not in the repository | — |
 
 Nothing in `agentdescent/` changed.
 

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -9,7 +9,7 @@ policies rather than a fork of the loop.
 | Governance layer | L2 (`blast_radius=0.2`) — the agents cannot reach the evaluator |
 | Paper | "Persistent Recursive Worlds Enable Autonomous Software Evolution", Beichen Huang et al., 2026 ([arXiv:2608.10450](https://arxiv.org/abs/2608.10450)) |
 | Upstream code | https://github.com/EMI-Group/genesis @ v0.12.6 (Elixir, AGPL-3.0) |
-| Domain | A compact formation run — **not** upstream's 123.4 h C-compiler benchmark |
+| Domains | Two compact formation runs — **not** upstream's 123.4 h C-compiler benchmark |
 | `evolve()` plug-ins | `strategy` + `Policies(proposal=, acceptance=, conflict=)` |
 | Fidelity | `mechanism_microport` |
 
@@ -17,6 +17,7 @@ policies rather than a fork of the loop.
 
 ```bash
 python -m examples.genesis.genesis_recursive_worlds                       # offline, no API key
+python -m examples.genesis.genesis_recursive_worlds --domain stackvm      # the deeper world
 python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
 python -m examples.genesis.genesis_recursive_worlds --keyed-union         # control: no three-way merge
 python -m examples.genesis.genesis_recursive_worlds --engine-gate         # control: the Beta gate
@@ -41,7 +42,9 @@ the path, an accepted event moves the version. Each piece is one file here.
 | [`_spatial.py`](_spatial.py) | `Strategy`: an agent writes only inside its own subtree | `agents/manager.ex:179` |
 | [`_octopus.py`](_octopus.py) | `ConflictPolicy`: three-way merge, so two agents in one file both survive | `Git.merge_octopus/2` |
 | [`_judge.py`](_judge.py) | `AcceptancePolicy`: the parent's rule — *partial progress is accepted* | `agents/manager.ex:58` |
-| [`_domain.py`](_domain.py) | the compact formation domain and both sets of actors | — |
+| [`_suite.py`](_suite.py) | the machinery a domain needs and does not own: the harness, the loader, the runner, the parent's integration check, the LLM actors | — |
+| [`_domain.py`](_domain.py) | **minilang** — an integer expression language, 2 nodes deep, 4 files | — |
+| [`_stackvm.py`](_stackvm.py) | **stackvm** — a stack machine and its assembler, 4 nodes deep, 10 files | — |
 
 Nothing in `agentdescent/` changed.
 

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -20,6 +20,7 @@ python -m examples.genesis.genesis_recursive_worlds                       # offl
 python -m examples.genesis.genesis_recursive_worlds --domain stackvm      # the deeper world
 python -m examples.genesis.genesis_recursive_worlds --domain jqx          # a program, not a package
 python -m examples.genesis.genesis_recursive_worlds --domain md           # scored by tests, no oracle
+python -m examples.genesis.genesis_recursive_worlds --cold-start          # no node records: it writes its own
 python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
 python -m examples.genesis.genesis_recursive_worlds --keyed-union         # control: no three-way merge
 python -m examples.genesis.genesis_recursive_worlds --engine-gate         # control: the Beta gate

--- a/examples/genesis/README.md
+++ b/examples/genesis/README.md
@@ -1,0 +1,57 @@
+# EvoX Genesis — persistent recursive worlds
+
+Port of the released implementation onto the AgentDescent engine, as pluggable
+policies rather than a fork of the loop.
+
+| | |
+|---|---|
+| Kind | Software world (a directory that grows) |
+| Governance layer | L2 (`blast_radius=0.2`) — the agents cannot reach the evaluator |
+| Paper | "Persistent Recursive Worlds Enable Autonomous Software Evolution", Beichen Huang et al., 2026 ([arXiv:2608.10450](https://arxiv.org/abs/2608.10450)) |
+| Upstream code | https://github.com/EMI-Group/genesis @ v0.12.6 (Elixir, AGPL-3.0) |
+| Domain | A compact formation run — **not** upstream's 123.4 h C-compiler benchmark |
+| `evolve()` plug-ins | `strategy` + `Policies(proposal=, acceptance=, conflict=)` |
+| Fidelity | `mechanism_microport` |
+
+## Run
+
+```bash
+python -m examples.genesis.genesis_recursive_worlds                       # offline, no API key
+python -m examples.genesis.genesis_recursive_worlds --episodes 96 --workers 8
+python -m examples.genesis.genesis_recursive_worlds --keyed-union         # control: no three-way merge
+python -m examples.genesis.genesis_recursive_worlds --engine-gate         # control: the Beta gate
+python -m examples.genesis.genesis_recursive_worlds --model claude-haiku-4-5   # real agents
+```
+
+`--dry-run` prints the configuration and returns with **zero network access and
+no API key**. The default run needs no key either: the manager and executor are
+rule-based offline actors, which exercise the mechanism and say nothing about a
+model's ability to write code.
+
+## The mechanism, as four components
+
+The paper's model is `w = (v, p)` — an accepted version and a repository path —
+with two operations that differ in exactly one way: recursive delegation moves
+the path, an accepted event moves the version. Each piece is one file here.
+
+| file | what it is | upstream |
+|---|---|---|
+| [`_world.py`](_world.py) | `LocalWorld(v, p)`, the `CONTEXT.md` chain, the episode archive | paper §3.1, `core/context_node.ex` |
+| [`_delegation.py`](_delegation.py) | `ProposalPolicy`: one rollout is a whole episode tree at one version | paper §3.2, `agent/subagent_processing.ex` |
+| [`_spatial.py`](_spatial.py) | `Strategy`: an agent writes only inside its own subtree | `agents/manager.ex:179` |
+| [`_octopus.py`](_octopus.py) | `ConflictPolicy`: three-way merge, so two agents in one file both survive | `Git.merge_octopus/2` |
+| [`_judge.py`](_judge.py) | `AcceptancePolicy`: the parent's rule — *partial progress is accepted* | `agents/manager.ex:58` |
+| [`_domain.py`](_domain.py) | the compact formation domain and both sets of actors | — |
+
+Nothing in `agentdescent/` changed.
+
+## What is in here
+
+- [`genesis_recursive_worlds.py`](genesis_recursive_worlds.py) — the runnable port
+- Port notes, upstream trace, every recorded deviation and the measured results:
+  [`docs/algo-genesis.md`](../../docs/algo-genesis.md)
+- Offline tests: [`tests/test_genesis_example.py`](../../tests/test_genesis_example.py)
+
+The shared command-line contract (`--provider/--model/--seed/--async/--async-ratio/--max-seconds/--dry-run/--yes/--serial`)
+lives in [`examples/_common.py`](../_common.py) and is enforced by
+[`tests/test_example_entrypoints.py`](../../tests/test_example_entrypoints.py).

--- a/examples/genesis/__init__.py
+++ b/examples/genesis/__init__.py
@@ -1,0 +1,1 @@
+"""EvoX Genesis: persistent recursive worlds, as pluggable engine components."""

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -35,7 +35,7 @@ rather than a different algorithm.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from agentdescent.filetree import parse_tree
@@ -350,7 +350,7 @@ class RecursiveDelegation:
         brief = Brief(world=world, objective=f"review and accountability: {objective}",
                       context=world.situate(amended, contracts=self.contracts),
                       state=amended, task=ctx.task, output=ctx.output,
-                      reward=ctx.reward, depth=0)
+                      reward=ctx.reward, depth=depth)
         out: List[Edit] = []
         for raw in self.executor(brief) or ():
             path, relative = resolve_edit_path(amended, world.path, raw.path)

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -42,9 +42,9 @@ from agentdescent.filetree import parse_tree
 
 from ._octopus import three_way
 
-from ._world import (CONTEXT_FILE, EpisodeRecord, LocalWorld, WorldLog,
-                     directly_at, normalise, owns, resolve_edit_path,
-                     routing_entry)
+from ._world import (CONTEXT_FILE, KNOWN_ISSUES, EpisodeRecord, LocalWorld,
+                     WorldLog, directly_at, normalise, owns, resolve_edit_path,
+                     routing_entry, under_heading)
 
 __all__ = ["Brief", "Delegation", "Edit", "RecursiveDelegation", "render_edits"]
 
@@ -148,6 +148,12 @@ class RecursiveDelegation:
     #: paper's agent may inspect the whole project; one with no read tool can only
     #: inspect what the brief carries.
     contracts: Sequence[str] = ()
+    #: Globs that are read-only. Routing must not send a manager into a directory
+    #: where nothing is writable; separate from :attr:`contracts`, which is what
+    #: gets *pushed into the brief*. Upstream an agent pulls files with tools, so
+    #: "what may not be written" and "what is handed over unasked" are two sets.
+    #: Defaults to ``contracts``.
+    readonly: Sequence[str] = ()
     #: Upstream's review-and-accountability phase: after its children return, a
     #: manager gets one turn at its own node. Off makes a manager a pure router,
     #: which is what this port was and why a node's own file never appeared.
@@ -186,7 +192,7 @@ class RecursiveDelegation:
     def propose(self, ctx) -> Sequence[str]:
         state = _state_of(ctx.rendered)
         root = LocalWorld(version=int(ctx.base_version or 0), path=self.root_path,
-                          readonly=tuple(self.contracts))
+                          readonly=tuple(self.readonly or self.contracts))
 
         # A parent that asked for more work gets it before anything else is
         # chosen: this is the third verdict, arriving one round later because
@@ -475,9 +481,15 @@ class RecursiveDelegation:
                       reason: str) -> Optional[Edit]:
         """Write the refusal into the child's ``CONTEXT.md``, if it is new.
 
-        Appending unboundedly would make the note the artifact; upstream's own
-        guidance is that ``CONTEXT.md`` records current state and is pruned when
-        it grows. So one line, and only when it is not already there.
+        Under ``## Known Issues``, which is upstream's own heading for exactly this:
+        "findings worth preserving belong in CONTEXT.md... `## Known Issues`
+        (problems to avoid re-discovering)" (``agents/manager.ex``). A refusal is the
+        cheapest such finding there is -- the next agent at this node would otherwise
+        rediscover it by being refused again.
+
+        Appending unboundedly would make the note the artifact; upstream's guidance is
+        that ``CONTEXT.md`` records current state and is pruned when it grows. So one
+        line, and only when it is not already there.
         """
         if not child.path:
             return None
@@ -487,7 +499,7 @@ class RecursiveDelegation:
         if line in body:
             return None
         return Edit(owner=child.path, path=key, kind="context",
-                    content=body.rstrip("\n") + "\n" + line + "\n")
+                    content=under_heading(body, KNOWN_ISSUES, line))
 
     # -- bounds ------------------------------------------------------------
 

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -41,7 +41,7 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 from agentdescent.filetree import parse_tree
 
 from ._world import (CONTEXT_FILE, EpisodeRecord, LocalWorld, WorldLog,
-                     child_paths, normalise, owns)
+                     normalise, owns, routing_entry)
 
 __all__ = ["Brief", "Delegation", "Edit", "RecursiveDelegation", "render_edits"]
 
@@ -56,11 +56,18 @@ class Delegation:
 
 @dataclass(frozen=True)
 class Edit:
-    """One file write by the agent situated at ``owner``. ``content=None`` deletes."""
+    """One file write by the agent situated at ``owner``. ``content=None`` deletes.
+
+    ``kind`` separates the work from the bookkeeping. Maintaining ``CONTEXT.md``
+    is an obligation upstream puts on every agent, but it must never cost the
+    change it is describing: the trust region is small, and an edit set trimmed
+    to fit should lose its routing note before it loses a source file.
+    """
 
     owner: str
     path: str
     content: Optional[str]
+    kind: str = "work"          # "work" | "context"
 
 
 @dataclass(frozen=True)
@@ -124,6 +131,11 @@ class RecursiveDelegation:
     #: living in the acceptance gate where the held-out suite actually is.
     review: Optional[Review] = None
     truncated: int = 0
+    #: Child nodes opened at a path their parent did not yet route to, and
+    #: therefore written into the parent's routing table.
+    routes_opened: int = 0
+    #: Delegations refused because the target was a file, not a node.
+    mistaken_nodes: int = 0
 
     # -- the ProposalPolicy protocol ---------------------------------------
 
@@ -165,7 +177,7 @@ class RecursiveDelegation:
         delegations: Sequence[Delegation] = ()
         if depth < self.max_depth:
             delegations = [d for d in self.manager(brief) or ()
-                           if owns(world.path, d.path) and normalise(d.path) != world.path]
+                           if self._is_node(world, d, state)]
 
         if not delegations:
             # A leaf executor: it writes files, it does not delegate. Its edits
@@ -186,6 +198,8 @@ class RecursiveDelegation:
 
         merged: List[Edit] = []
         claimed: Dict[str, str] = {}          # path -> the child that took it
+        routed = world.routing(state)
+        opened: List[Delegation] = []         # children this node had not routed to
         for delegation in delegations:
             child = world.delegate(delegation.path)
             returned, child_record = self._episode(child, delegation.objective, state,
@@ -211,9 +225,35 @@ class RecursiveDelegation:
             for edit in returned:
                 claimed[edit.path] = child.path
             merged.extend(returned)
+            if normalise(delegation.path) not in routed:
+                opened.append(delegation)
+
+        # A node whose parent does not route to it is a node later agents cannot
+        # find. Upstream the manager that opens one writes the entry at its own
+        # level; here the same write, from the same agent, on its own CONTEXT.md.
+        note = self._routing_note(world, state, opened)
+        if note is not None:
+            merged.append(note)
 
         record.n_edits = len(merged)
         return merged, record
+
+    def _is_node(self, world: LocalWorld, delegation: Delegation,
+                 state: Mapping[str, str]) -> bool:
+        """May a child be situated here at all?
+
+        Inside the parent's subtree, not the parent itself, and **not an existing
+        file**. A node is a directory: upstream a path is a node when it holds at
+        least one tracked file, and delegating to `lexer.py` as though it were one
+        makes every write land *inside* a file. A real run did exactly that.
+        """
+        path = normalise(delegation.path)
+        if not owns(world.path, path) or path == world.path:
+            return False
+        if path in state:
+            self.mistaken_nodes += 1
+            return False
+        return True
 
     def _judge(self, child: LocalWorld, returned: Sequence[Edit], parent: Brief,
                claimed: Mapping[str, str]) -> "tuple[str, str]":
@@ -241,6 +281,28 @@ class RecursiveDelegation:
                 return "rework", complaint
         return "accepted", ""
 
+    def _routing_note(self, world: LocalWorld, state: Mapping[str, str],
+                      opened: Sequence[Delegation]) -> Optional[Edit]:
+        """Add every newly opened child to this node's routing table, once.
+
+        One edit for all of them rather than one each: the trust region counts
+        files, and a node's table is one file.
+        """
+        if not opened:
+            return None
+        key = world.context_key()
+        body = state.get(key, f"# {world.path or './'}\n")
+        changed = False
+        for delegation in opened:
+            updated = routing_entry(body, delegation.path,
+                                    delegation.objective.strip() or "delegated work")
+            if updated is not None:
+                body, changed = updated, True
+        if not changed:
+            return None
+        self.routes_opened += len(opened)
+        return Edit(owner=world.path, path=key, content=body, kind="context")
+
     def _failure_note(self, child: LocalWorld, state: Mapping[str, str],
                       reason: str) -> Optional[Edit]:
         """Write the refusal into the child's ``CONTEXT.md``, if it is new.
@@ -256,16 +318,23 @@ class RecursiveDelegation:
         body = state.get(key, f"# {child.path}\n")
         if line in body:
             return None
-        return Edit(owner=child.path, path=key, content=body.rstrip("\n") + "\n" + line + "\n")
+        return Edit(owner=child.path, path=key, kind="context",
+                    content=body.rstrip("\n") + "\n" + line + "\n")
 
     # -- bounds ------------------------------------------------------------
 
     def _bound(self, edits: Sequence[Edit]) -> List[Edit]:
-        """Last write per path wins, then the trust region, counted."""
+        """Last write per path wins, then the trust region, counted.
+
+        Work before bookkeeping, so a trimmed edit set loses a routing note
+        before it loses a source file -- see :class:`Edit`.
+        """
         by_path: Dict[str, Edit] = {}
         for edit in edits:
             by_path[edit.path] = edit
-        ordered = [by_path[p] for p in sorted(by_path)]
+        work = sorted((p for p, e in by_path.items() if e.kind == "work"))
+        context = sorted((p for p, e in by_path.items() if e.kind != "work"))
+        ordered = [by_path[p] for p in work + context]
         if len(ordered) > self.max_edits:
             self.truncated += len(ordered) - self.max_edits
             ordered = ordered[:self.max_edits]
@@ -276,7 +345,9 @@ class RecursiveDelegation:
                 f"{ctx.reward:.2f}: {getattr(ctx.task, 'prompt', '')}")
 
     def stats(self) -> str:
-        return f"delegation: {self.log.summary()} truncated_edits={self.truncated}"
+        return (f"delegation: {self.log.summary()} truncated_edits={self.truncated} "
+                f"routes_opened={self.routes_opened} "
+                f"mistaken_nodes={self.mistaken_nodes}")
 
 
 def _state_of(rendered: str) -> Dict[str, str]:

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -1,0 +1,287 @@
+"""Recursive delegation as a :class:`~agentdescent.policies.ProposalPolicy`.
+
+``(v, p) ⇝ (v, q)`` is the operation the engine has no counterpart for, and the
+reason it fits *inside* a proposal rather than beside it is the paper's own
+distinction: delegation **does not advance the accepted version**. A parent hands
+work to a child at a deeper path, the child returns a candidate, the parent
+accepts or refuses it -- and the project history has not moved. Only the
+accepted event ``(v, p) → (v′, p)`` moves it, and that is the aggregator's
+commit.
+
+So one rollout here is one whole episode tree: a root manager decomposes, children
+are situated deeper, leaf executors write files, each parent judges what came back,
+and the surviving edits are octopus-merged into the single proposal the engine
+consumes. Every version in that tree is the same ``v``; nothing in the middle
+touches the ledger. That is the shape upstream runs, and it is expressible with no
+engine change because ``ProposalPolicy`` is free to do whatever it likes between
+being handed a failure and returning a proposal.
+
+What the engine *does* see is unchanged: one proposal per rollout. The tree is
+recorded in the :class:`~examples.genesis._world.WorldLog` instead, which is where
+the observed depth and the per-episode verdicts come from -- upstream's archive,
+minus the parts that only matter to a desktop app.
+
+The two roles are callables the caller supplies, because that is the seam where a
+domain plugs in:
+
+    manager(brief)  -> [Delegation(path, objective), ...]   empty = do it here
+    executor(brief) -> [Edit(owner, path, content), ...]
+
+An offline rule-based pair and an LLM-backed pair are then the same mechanism run
+with different actors, which is what makes the offline mode a test of *this file*
+rather than a different algorithm.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+from agentdescent.filetree import parse_tree
+
+from ._world import (CONTEXT_FILE, EpisodeRecord, LocalWorld, WorldLog,
+                     child_paths, normalise, owns)
+
+__all__ = ["Brief", "Delegation", "Edit", "RecursiveDelegation", "render_edits"]
+
+
+@dataclass(frozen=True)
+class Delegation:
+    """``(v, p) ⇝ (v, q)``: where a child is situated, and what it is for."""
+
+    path: str
+    objective: str
+
+
+@dataclass(frozen=True)
+class Edit:
+    """One file write by the agent situated at ``owner``. ``content=None`` deletes."""
+
+    owner: str
+    path: str
+    content: Optional[str]
+
+
+@dataclass(frozen=True)
+class Brief:
+    """Everything a finite-lived agent is given when it enters its world.
+
+    Deliberately not "the whole repository": ``context`` is the ``CONTEXT.md``
+    chain from the root down to this node plus a listing of the files this node
+    is responsible for, which is what the path coordinate is *for*. ``state`` is
+    the full tree, because an agent may read anything under ``v`` even though it
+    may only write under ``p`` -- that asymmetry is the paper's, not a shortcut.
+    """
+
+    world: LocalWorld
+    objective: str
+    context: str
+    state: Mapping[str, str]
+    task: Any
+    output: str
+    reward: float
+    depth: int
+
+
+Manager = Callable[[Brief], Sequence[Delegation]]
+Executor = Callable[[Brief], Sequence[Edit]]
+Review = Callable[[Brief, Sequence[Edit]], Optional[str]]
+
+
+def render_edits(edits: Sequence[Edit], rationale: str) -> str:
+    """Serialise an edit set into the situated proposal protocol."""
+    return "<EDITS>" + json.dumps({
+        "rationale": rationale,
+        "edits": [
+            {"owner": e.owner, "path": e.path, **(
+                {"delete": True} if e.content is None else {"content": e.content})}
+            for e in edits
+        ],
+    }) + "</EDITS>"
+
+
+@dataclass
+class RecursiveDelegation:
+    """One rollout = one recursive episode tree rooted at ``(v, root_path)``.
+
+    ``max_depth`` bounds the recursion the way upstream's controller limits do.
+    ``max_edits`` bounds what comes back: the strategy drops a proposal that
+    exceeds its own per-diff cap *entirely*, so a tree that returns more edits
+    than the trust region allows would lose all of them rather than the excess.
+    Truncating here, and counting it, is the difference between a bounded
+    proposal and a silently empty round.
+    """
+
+    manager: Manager
+    executor: Executor
+    log: WorldLog
+    max_depth: int = 2
+    max_edits: int = 4
+    root_path: str = ""
+    #: Optional real judging of a child's returned work. ``None`` runs the scope
+    #: check alone -- the cheap half of the upstream rule, with the test half
+    #: living in the acceptance gate where the held-out suite actually is.
+    review: Optional[Review] = None
+    truncated: int = 0
+
+    # -- the ProposalPolicy protocol ---------------------------------------
+
+    def propose(self, ctx) -> Sequence[str]:
+        state = _state_of(ctx.rendered)
+        root = LocalWorld(version=int(ctx.base_version or 0), path=self.root_path)
+
+        # A parent that asked for more work gets it before anything else is
+        # chosen: this is the third verdict, arriving one round later because
+        # `AcceptDecision` cannot carry it (see examples/genesis/_judge.py).
+        pending = self.log.take_rework()
+        if pending is not None and owns(root.path, pending[0]):
+            world, objective = root.delegate(pending[0]), f"rework: {pending[1]}"
+            edits, _ = self._episode(world, objective, state, ctx, depth=1)
+            rationale = f"rework at {pending[0] or './'}"
+        else:
+            edits, _ = self._episode(root, self._objective(ctx), state, ctx, depth=0)
+            rationale = f"episode at {root.path or './'}"
+
+        edits = self._bound(edits)
+        if not edits:
+            return []
+        return [render_edits(edits, rationale)]
+
+    # -- the recursion -----------------------------------------------------
+
+    def _episode(self, world: LocalWorld, objective: str, state: Mapping[str, str],
+                 ctx, *, depth: int) -> "tuple[List[Edit], EpisodeRecord]":
+        """One finite-lived agent. Returns what it proposes, and its own record.
+
+        The record travels back with the work because the verdict on an episode
+        is its **parent's**, not its own: an agent that returns something it was
+        pleased with and a parent that refuses it are one episode, not two.
+        """
+        brief = Brief(world=world, objective=objective,
+                      context=world.situate(state), state=state, task=ctx.task,
+                      output=ctx.output, reward=ctx.reward, depth=depth)
+
+        delegations: Sequence[Delegation] = ()
+        if depth < self.max_depth:
+            delegations = [d for d in self.manager(brief) or ()
+                           if owns(world.path, d.path) and normalise(d.path) != world.path]
+
+        if not delegations:
+            # A leaf executor: it writes files, it does not delegate. Its edits
+            # are NOT filtered here -- the scope check belongs to the parent that
+            # asked for the work (and, at the root, to the strategy), and doing
+            # it twice would hide every refusal the parent is supposed to make.
+            edits = [Edit(owner=world.path, path=e.path, content=e.content)
+                     for e in self.executor(brief) or ()]
+            record = self.log.record(EpisodeRecord(
+                agent_id=self.log.next_id("executor"), role="executor",
+                path=world.path, depth=depth, version=world.version,
+                objective=objective, n_edits=len(edits)))
+            return edits, record
+
+        record = self.log.record(EpisodeRecord(
+            agent_id=self.log.next_id("manager"), role="manager", path=world.path,
+            depth=depth, version=world.version, objective=objective))
+
+        merged: List[Edit] = []
+        claimed: Dict[str, str] = {}          # path -> the child that took it
+        for delegation in delegations:
+            child = world.delegate(delegation.path)
+            returned, child_record = self._episode(child, delegation.objective, state,
+                                                   ctx, depth=depth + 1)
+            child_record.verdict, child_record.reason = self._judge(
+                child, returned, brief, claimed)
+            if child_record.verdict == "rejected":
+                # The rejected code does not survive; the *reason* can, as a
+                # record at the child's own node. Paper, appendix 1.4: a saved
+                # failure reason is a separate accepted event, and the code it
+                # came from is not.
+                note = self._failure_note(child, state, child_record.reason)
+                if note is not None:
+                    merged.append(note)
+                continue
+            if child_record.verdict == "rework":
+                # Not a refusal: the parent wants another attempt, so the node is
+                # queued rather than annotated. Writing a note for every "try
+                # again" would turn CONTEXT.md into a transcript, which is the
+                # one thing upstream says it must not become.
+                self.log.request_rework(child.path, child_record.reason)
+                continue
+            for edit in returned:
+                claimed[edit.path] = child.path
+            merged.extend(returned)
+
+        record.n_edits = len(merged)
+        return merged, record
+
+    def _judge(self, child: LocalWorld, returned: Sequence[Edit], parent: Brief,
+               claimed: Mapping[str, str]) -> "tuple[str, str]":
+        """The responsible parent's verdict on one child's returned work.
+
+        Scope first, because it is the check that does not need the suite: an
+        edit outside the child's subtree is not the child's to make, and a
+        sibling that has already claimed a path means two agents were given
+        overlapping responsibility -- a decomposition fault, which upstream sends
+        back rather than merging.
+        """
+        if not returned:
+            return "rework", "the child returned no change"
+
+        outside = [e.path for e in returned if not owns(child.path, e.path)]
+        if outside:
+            return "rejected", f"edit outside its subtree: {outside[0]}"
+        collision = next((e.path for e in returned if e.path in claimed), None)
+        if collision is not None:
+            return "rejected", (f"{collision} was already written by a sibling at "
+                                f"{claimed[collision]}; the decomposition overlaps")
+        if self.review is not None:
+            complaint = self.review(parent, returned)
+            if complaint:
+                return "rework", complaint
+        return "accepted", ""
+
+    def _failure_note(self, child: LocalWorld, state: Mapping[str, str],
+                      reason: str) -> Optional[Edit]:
+        """Write the refusal into the child's ``CONTEXT.md``, if it is new.
+
+        Appending unboundedly would make the note the artifact; upstream's own
+        guidance is that ``CONTEXT.md`` records current state and is pruned when
+        it grows. So one line, and only when it is not already there.
+        """
+        if not child.path:
+            return None
+        key = f"{child.path}/{CONTEXT_FILE}"
+        line = f"- refused: {reason}"
+        body = state.get(key, f"# {child.path}\n")
+        if line in body:
+            return None
+        return Edit(owner=child.path, path=key, content=body.rstrip("\n") + "\n" + line + "\n")
+
+    # -- bounds ------------------------------------------------------------
+
+    def _bound(self, edits: Sequence[Edit]) -> List[Edit]:
+        """Last write per path wins, then the trust region, counted."""
+        by_path: Dict[str, Edit] = {}
+        for edit in edits:
+            by_path[edit.path] = edit
+        ordered = [by_path[p] for p in sorted(by_path)]
+        if len(ordered) > self.max_edits:
+            self.truncated += len(ordered) - self.max_edits
+            ordered = ordered[:self.max_edits]
+        return ordered
+
+    def _objective(self, ctx) -> str:
+        return (f"validation case {getattr(ctx.task, 'id', '?')} scored "
+                f"{ctx.reward:.2f}: {getattr(ctx.task, 'prompt', '')}")
+
+    def stats(self) -> str:
+        return f"delegation: {self.log.summary()} truncated_edits={self.truncated}"
+
+
+def _state_of(rendered: str) -> Dict[str, str]:
+    """The tree behind a rendered artifact. ``{}`` when it has not been built yet."""
+    try:
+        return dict(parse_tree(rendered))
+    except Exception:  # noqa: BLE001 - an empty or not-yet-a-tree render
+        return {}

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -35,10 +35,12 @@ rather than a different algorithm.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from agentdescent.filetree import parse_tree
+
+from ._octopus import three_way
 
 from ._world import (CONTEXT_FILE, EpisodeRecord, LocalWorld, WorldLog,
                      normalise, owns, routing_entry)
@@ -93,7 +95,13 @@ class Brief:
 
 Manager = Callable[[Brief], Sequence[Delegation]]
 Executor = Callable[[Brief], Sequence[Edit]]
-Review = Callable[[Brief, Sequence[Edit]], Optional[str]]
+
+#: What the responsible parent does with a returned contribution beyond checking
+#: its scope. Returns ``None`` to accept, or ``(verdict, reason)`` with a verdict
+#: of ``"rejected"`` or ``"rework"``. Two outcomes rather than a complaint string,
+#: because the paper's parent has three: *accepted, rejected, or requires further
+#: work* (3.3), and collapsing the last two loses the one that comes back.
+Review = Callable[[Brief, Sequence[Edit]], Optional[Tuple[str, str]]]
 
 
 def render_edits(edits: Sequence[Edit], rationale: str) -> str:
@@ -126,9 +134,11 @@ class RecursiveDelegation:
     max_depth: int = 2
     max_edits: int = 4
     root_path: str = ""
-    #: Optional real judging of a child's returned work. ``None`` runs the scope
-    #: check alone -- the cheap half of the upstream rule, with the test half
-    #: living in the acceptance gate where the held-out suite actually is.
+    #: The parent's judgement beyond scope. Upstream a parent decides "using the
+    #: available tests, constraints and integration evidence" (paper 3.3), which
+    #: is a *test* run on the child's work before it is offered to the version
+    #: history at all -- not the same thing as the acceptance gate, which sees
+    #: only what the whole episode returned. ``None`` runs the scope check alone.
     review: Optional[Review] = None
     truncated: int = 0
     #: Child nodes opened at a path their parent did not yet route to, and
@@ -136,6 +146,14 @@ class RecursiveDelegation:
     routes_opened: int = 0
     #: Delegations refused because the target was a file, not a node.
     mistaken_nodes: int = 0
+    #: Sibling edits to one path reconciled by three-way merge, and not.
+    sibling_merges: int = 0
+    sibling_conflicts: int = 0
+    #: Changes an agent needed outside its own path: raised, handled by an
+    #: ancestor, and left unmet at the top of the chain.
+    requests_raised: int = 0
+    adopted_requests: int = 0
+    unmet_requests: int = 0
 
     # -- the ProposalPolicy protocol ---------------------------------------
 
@@ -149,11 +167,16 @@ class RecursiveDelegation:
         pending = self.log.take_rework()
         if pending is not None and owns(root.path, pending[0]):
             world, objective = root.delegate(pending[0]), f"rework: {pending[1]}"
-            edits, _ = self._episode(world, objective, state, ctx, depth=1)
+            edits, unmet, _ = self._episode(world, objective, state, ctx, depth=1)
             rationale = f"rework at {pending[0] or './'}"
         else:
-            edits, _ = self._episode(root, self._objective(ctx), state, ctx, depth=0)
+            edits, unmet, _ = self._episode(root, self._objective(ctx), state, ctx,
+                                            depth=0)
             rationale = f"episode at {root.path or './'}"
+        # A need that reached the top of this episode's chain and still fell
+        # outside its root's authority. Counted rather than dropped quietly: it
+        # means the decomposition put work where nobody could do it.
+        self.unmet_requests += len(unmet)
 
         edits = self._bound(edits)
         if not edits:
@@ -163,8 +186,8 @@ class RecursiveDelegation:
     # -- the recursion -----------------------------------------------------
 
     def _episode(self, world: LocalWorld, objective: str, state: Mapping[str, str],
-                 ctx, *, depth: int) -> "tuple[List[Edit], EpisodeRecord]":
-        """One finite-lived agent. Returns what it proposes, and its own record.
+                 ctx, *, depth: int) -> "tuple[List[Edit], List[Edit], EpisodeRecord]":
+        """One finite-lived agent: what it proposes, what it asks for, its record.
 
         The record travels back with the work because the verdict on an episode
         is its **parent's**, not its own: an agent that returns something it was
@@ -180,32 +203,51 @@ class RecursiveDelegation:
                            if self._is_node(world, d, state)]
 
         if not delegations:
-            # A leaf executor: it writes files, it does not delegate. Its edits
-            # are NOT filtered here -- the scope check belongs to the parent that
-            # asked for the work (and, at the root, to the strategy), and doing
-            # it twice would hide every refusal the parent is supposed to make.
-            edits = [Edit(owner=world.path, path=e.path, content=e.content)
-                     for e in self.executor(brief) or ()]
+            # A leaf executor: it writes files, it does not delegate. What it
+            # produces outside its own path is not a violation -- upstream an
+            # agent that needs a change it has no authority for "reports the need
+            # back up to the parent agent, which will handle it"
+            # (`agents/executor.ex:64`). So the split here is edits / requests,
+            # and the parent decides what to do with the second list.
+            produced = [Edit(owner=world.path, path=e.path, content=e.content,
+                             kind=e.kind)
+                        for e in self.executor(brief) or ()]
+            edits = [e for e in produced if owns(world.path, e.path)]
+            requests = [e for e in produced if not owns(world.path, e.path)]
+            self.requests_raised += len(requests)
             record = self.log.record(EpisodeRecord(
                 agent_id=self.log.next_id("executor"), role="executor",
                 path=world.path, depth=depth, version=world.version,
                 objective=objective, n_edits=len(edits)))
-            return edits, record
+            return edits, requests, record
 
         record = self.log.record(EpisodeRecord(
             agent_id=self.log.next_id("manager"), role="manager", path=world.path,
             depth=depth, version=world.version, objective=objective))
 
-        merged: List[Edit] = []
-        claimed: Dict[str, str] = {}          # path -> the child that took it
+        held: Dict[str, Edit] = {}            # path -> what the parent holds so far
+        owner_of: Dict[str, str] = {}         # path -> the child that wrote it
+        notes: List[Edit] = []
+        pending: List[Edit] = []              # needs this node cannot meet either
         routed = world.routing(state)
         opened: List[Delegation] = []         # children this node had not routed to
         for delegation in delegations:
             child = world.delegate(delegation.path)
-            returned, child_record = self._episode(child, delegation.objective, state,
-                                                   ctx, depth=depth + 1)
+            returned, asked, child_record = self._episode(
+                child, delegation.objective, state, ctx, depth=depth + 1)
             child_record.verdict, child_record.reason = self._judge(
-                child, returned, brief, claimed)
+                child, returned, asked, brief)
+            if child_record.verdict != "rejected" and asked:
+                # "Report the need back up to the parent, which will handle it."
+                # This node handles what falls inside its own authority and passes
+                # the rest further up; at the root, authority is the whole world,
+                # so nothing is left unmet.
+                mine = [replace(e, owner=world.path) for e in asked
+                        if owns(world.path, e.path)]
+                if mine:
+                    self.adopted_requests += len(mine)
+                    self._fold(held, owner_of, mine, world, state)
+                pending += [e for e in asked if not owns(world.path, e.path)]
             if child_record.verdict == "rejected":
                 # The rejected code does not survive; the *reason* can, as a
                 # record at the child's own node. Paper, appendix 1.4: a saved
@@ -213,7 +255,7 @@ class RecursiveDelegation:
                 # came from is not.
                 note = self._failure_note(child, state, child_record.reason)
                 if note is not None:
-                    merged.append(note)
+                    notes.append(note)
                 continue
             if child_record.verdict == "rework":
                 # Not a refusal: the parent wants another attempt, so the node is
@@ -222,21 +264,66 @@ class RecursiveDelegation:
                 # one thing upstream says it must not become.
                 self.log.request_rework(child.path, child_record.reason)
                 continue
-            for edit in returned:
-                claimed[edit.path] = child.path
-            merged.extend(returned)
+            conflicts = self._fold(held, owner_of, returned, child, state)
+            if conflicts:
+                # Upstream's octopus merge returns the conflicting file list to
+                # the parent, which resolves, aborts, or re-plans
+                # (`agent/subagent_processing.ex:527`). Re-planning is the one a
+                # parent here can take: the child's other edits stand, and the
+                # overlapping one goes back to it.
+                child_record.verdict = "rework"
+                child_record.reason = (
+                    f"{conflicts[0]} was also written by a sibling at "
+                    f"{owner_of.get(conflicts[0], '?')}, and the two edits overlap")
+                self.log.request_rework(child.path, child_record.reason)
             if normalise(delegation.path) not in routed:
                 opened.append(delegation)
+
+        merged: List[Edit] = list(held.values()) + notes
 
         # A node whose parent does not route to it is a node later agents cannot
         # find. Upstream the manager that opens one writes the entry at its own
         # level; here the same write, from the same agent, on its own CONTEXT.md.
-        note = self._routing_note(world, state, opened)
-        if note is not None:
-            merged.append(note)
+        routing = self._routing_note(world, state, opened)
+        if routing is not None:
+            merged.append(routing)
 
         record.n_edits = len(merged)
-        return merged, record
+        return merged, pending, record
+
+    def _fold(self, held: Dict[str, Edit], owner_of: Dict[str, str],
+              returned: Sequence[Edit], child: LocalWorld,
+              state: Mapping[str, str]) -> List[str]:
+        """Octopus-merge one child's edits into what the parent already holds.
+
+        Two children can legally write the same path when one is situated inside
+        the other's subtree, and upstream does not treat that as a fault: the
+        parent runs ``git merge --octopus`` over what came back and only a real
+        overlap becomes a conflict. Rejecting on a bare path collision -- which is
+        what this used to do -- discards a whole contribution for touching a file
+        a sibling also touched, which is exactly the merge the system is for.
+        """
+        conflicts: List[str] = []
+        for edit in returned:
+            mine = held.get(edit.path)
+            if mine is None:
+                held[edit.path] = edit
+                owner_of[edit.path] = child.path
+                continue
+            if mine.content == edit.content:
+                continue                      # the two agreed; nothing to merge
+            if mine.content is None or edit.content is None:
+                conflicts.append(edit.path)   # a delete against an edit
+                self.sibling_conflicts += 1
+                continue
+            fused = three_way(state.get(edit.path, ""), mine.content, edit.content)
+            if fused is None:
+                conflicts.append(edit.path)
+                self.sibling_conflicts += 1
+                continue
+            held[edit.path] = replace(mine, content=fused)
+            self.sibling_merges += 1
+        return conflicts
 
     def _is_node(self, world: LocalWorld, delegation: Delegation,
                  state: Mapping[str, str]) -> bool:
@@ -255,30 +342,28 @@ class RecursiveDelegation:
             return False
         return True
 
-    def _judge(self, child: LocalWorld, returned: Sequence[Edit], parent: Brief,
-               claimed: Mapping[str, str]) -> "tuple[str, str]":
+    def _judge(self, child: LocalWorld, returned: Sequence[Edit],
+               asked: Sequence[Edit], parent: Brief) -> "tuple[str, str]":
         """The responsible parent's verdict on one child's returned work.
 
-        Scope first, because it is the check that does not need the suite: an
-        edit outside the child's subtree is not the child's to make, and a
-        sibling that has already claimed a path means two agents were given
-        overlapping responsibility -- a decomposition fault, which upstream sends
-        back rather than merging.
+        Two things are deliberately *not* judged here. A change the child wanted
+        outside its own path is a **request**, not an overstep -- upstream an
+        agent reports such a need upward and the ancestor with authority handles
+        it. And an overlap with a sibling is a **merge**, handled in
+        :meth:`_fold`. What is left is the question the paper's parent actually
+        answers: is this contribution good, on the tests, constraints and
+        integration evidence available (3.3)?
         """
         if not returned:
+            if asked:
+                return "rework", (f"the child did no work at its own path; it asked "
+                                  f"for {len(asked)} change(s) elsewhere, starting "
+                                  f"with {asked[0].path}")
             return "rework", "the child returned no change"
-
-        outside = [e.path for e in returned if not owns(child.path, e.path)]
-        if outside:
-            return "rejected", f"edit outside its subtree: {outside[0]}"
-        collision = next((e.path for e in returned if e.path in claimed), None)
-        if collision is not None:
-            return "rejected", (f"{collision} was already written by a sibling at "
-                                f"{claimed[collision]}; the decomposition overlaps")
         if self.review is not None:
-            complaint = self.review(parent, returned)
-            if complaint:
-                return "rework", complaint
+            verdict = self.review(parent, returned)
+            if verdict is not None:
+                return verdict
         return "accepted", ""
 
     def _routing_note(self, world: LocalWorld, state: Mapping[str, str],
@@ -347,7 +432,11 @@ class RecursiveDelegation:
     def stats(self) -> str:
         return (f"delegation: {self.log.summary()} truncated_edits={self.truncated} "
                 f"routes_opened={self.routes_opened} "
-                f"mistaken_nodes={self.mistaken_nodes}")
+                f"mistaken_nodes={self.mistaken_nodes} "
+                f"sibling_merges={self.sibling_merges} "
+                f"sibling_conflicts={self.sibling_conflicts} "
+                f"requests={self.requests_raised}/"
+                f"{self.adopted_requests}/{self.unmet_requests}")
 
 
 def _state_of(rendered: str) -> Dict[str, str]:

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -43,7 +43,8 @@ from agentdescent.filetree import parse_tree
 from ._octopus import three_way
 
 from ._world import (CONTEXT_FILE, EpisodeRecord, LocalWorld, WorldLog,
-                     normalise, owns, resolve_edit_path, routing_entry)
+                     directly_at, normalise, owns, resolve_edit_path,
+                     routing_entry)
 
 __all__ = ["Brief", "Delegation", "Edit", "RecursiveDelegation", "render_edits"]
 
@@ -139,6 +140,10 @@ class RecursiveDelegation:
     #: paper's agent may inspect the whole project; one with no read tool can only
     #: inspect what the brief carries.
     contracts: Sequence[str] = ()
+    #: Upstream's review-and-accountability phase: after its children return, a
+    #: manager gets one turn at its own node. Off makes a manager a pure router,
+    #: which is what this port was and why a node's own file never appeared.
+    accountability: bool = True
     #: The parent's judgement beyond scope. Upstream a parent decides "using the
     #: available tests, constraints and integration evidence" (paper 3.3), which
     #: is a *test* run on the child's work before it is offered to the version
@@ -154,6 +159,10 @@ class RecursiveDelegation:
     #: Sibling edits to one path reconciled by three-way merge, and not.
     sibling_merges: int = 0
     sibling_conflicts: int = 0
+    #: Files a manager wrote at its own node in the accountability phase, and
+    #: edits it offered there that belonged to a child and were declined.
+    accountability_edits: int = 0
+    accountability_declined: int = 0
     #: Edits whose path was written relative to the agent's own node rather than
     #: to the repository. Counted because the alternative to counting is a file
     #: appearing somewhere nobody asked for it.
@@ -296,6 +305,19 @@ class RecursiveDelegation:
             if normalise(delegation.path) not in routed:
                 opened.append(delegation)
 
+        # Upstream's third phase. An Architect works "architecture & design ->
+        # implementation delegation -> **review & accountability**" and is
+        # "ACCOUNTABLE for all code in its node path" (`agents/architect.ex:23`):
+        # delegating does not discharge that, and the files that belong to the
+        # node itself are nobody else's to write. Without this a manager
+        # delegated forever and its own node's file was never written -- measured:
+        # five correct modules and no `src/__init__.py`, so the public surface the
+        # specification names did not exist and every case scored zero.
+        if self.accountability:
+            own = self._accountability_pass(world, objective, state, held, ctx, depth)
+            if own:
+                self._fold(held, owner_of, own, world, state)
+
         merged: List[Edit] = list(held.values()) + notes
 
         # A node whose parent does not route to it is a node later agents cannot
@@ -307,6 +329,39 @@ class RecursiveDelegation:
 
         record.n_edits = len(merged)
         return merged, pending, record
+
+    def _accountability_pass(self, world: LocalWorld, objective: str,
+                             state: Mapping[str, str], held: Mapping[str, Edit],
+                             ctx, depth: int) -> List[Edit]:
+        """One turn for the manager at its own node, after its children return.
+
+        It sees the tree **as its children just left it**, because what the node
+        still needs depends on what came back. Restricted to files directly at the
+        node: a manager is accountable for its whole subtree but a child's files
+        are the child's to write, and a manager free to rewrite them would make
+        the decomposition decorative.
+        """
+        amended = dict(state)
+        for edit in held.values():
+            if edit.content is None:
+                amended.pop(edit.path, None)
+            else:
+                amended[edit.path] = edit.content
+        brief = Brief(world=world, objective=f"review and accountability: {objective}",
+                      context=world.situate(amended, contracts=self.contracts),
+                      state=amended, task=ctx.task, output=ctx.output,
+                      reward=ctx.reward, depth=0)
+        out: List[Edit] = []
+        for raw in self.executor(brief) or ():
+            path, relative = resolve_edit_path(amended, world.path, raw.path)
+            self.resolved_relative += int(relative)
+            if directly_at(world.path, path):
+                out.append(Edit(owner=world.path, path=path, content=raw.content,
+                                kind=raw.kind))
+            else:
+                self.accountability_declined += 1
+        self.accountability_edits += len(out)
+        return out
 
     def _fold(self, held: Dict[str, Edit], owner_of: Dict[str, str],
               returned: Sequence[Edit], child: LocalWorld,
@@ -454,7 +509,9 @@ class RecursiveDelegation:
                 f"sibling_conflicts={self.sibling_conflicts} "
                 f"requests={self.requests_raised}/"
                 f"{self.adopted_requests}/{self.unmet_requests} "
-                f"node_relative_paths={self.resolved_relative}")
+                f"node_relative_paths={self.resolved_relative} "
+                f"accountability={self.accountability_edits}/"
+                f"{self.accountability_declined}")
 
 
 def _state_of(rendered: str) -> Dict[str, str]:

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -65,12 +65,20 @@ class Edit:
     is an obligation upstream puts on every agent, but it must never cost the
     change it is describing: the trust region is small, and an edit set trimmed
     to fit should lose its routing note before it loses a source file.
+
+    With one exception, and ``--cold-start`` is what found it. A note that *creates*
+    a node's record is ``"record"``, and it is trimmed **last** -- because then it is
+    not bookkeeping at all. It is the only place the decomposition the system just
+    invented is written down, and nothing else in the accepted version carries it;
+    the source file it would be dropped for is re-proposable next round, the
+    structure is not. While every domain shipped a ``CONTEXT.md`` per node this
+    could not show: the note only ever added a line to a table that already existed.
     """
 
     owner: str
     path: str
     content: Optional[str]
-    kind: str = "work"          # "work" | "context"
+    kind: str = "work"          # "record" | "work" | "context"
 
 
 @dataclass(frozen=True)
@@ -177,7 +185,8 @@ class RecursiveDelegation:
 
     def propose(self, ctx) -> Sequence[str]:
         state = _state_of(ctx.rendered)
-        root = LocalWorld(version=int(ctx.base_version or 0), path=self.root_path)
+        root = LocalWorld(version=int(ctx.base_version or 0), path=self.root_path,
+                          readonly=tuple(self.contracts))
 
         # A parent that asked for more work gets it before anything else is
         # chosen: this is the third verdict, arriving one round later because
@@ -458,7 +467,9 @@ class RecursiveDelegation:
         if not changed:
             return None
         self.routes_opened += len(opened)
-        return Edit(owner=world.path, path=key, content=body, kind="context")
+        # Creating the record outranks the work; adding a line to one does not.
+        return Edit(owner=world.path, path=key, content=body,
+                    kind="context" if key in state else "record")
 
     def _failure_note(self, child: LocalWorld, state: Mapping[str, str],
                       reason: str) -> Optional[Edit]:
@@ -483,15 +494,17 @@ class RecursiveDelegation:
     def _bound(self, edits: Sequence[Edit]) -> List[Edit]:
         """Last write per path wins, then the trust region, counted.
 
-        Work before bookkeeping, so a trimmed edit set loses a routing note
-        before it loses a source file -- see :class:`Edit`.
+        Work before bookkeeping, so a trimmed edit set loses a routing note before
+        it loses a source file -- and a record that brings a node into existence
+        before either, because nothing else in the accepted version says the node
+        exists. See :class:`Edit`.
         """
         by_path: Dict[str, Edit] = {}
         for edit in edits:
             by_path[edit.path] = edit
-        work = sorted((p for p, e in by_path.items() if e.kind == "work"))
-        context = sorted((p for p, e in by_path.items() if e.kind != "work"))
-        ordered = [by_path[p] for p in work + context]
+        order = {"record": 0, "work": 1}
+        ordered = [by_path[p] for p in
+                   sorted(by_path, key=lambda p: (order.get(by_path[p].kind, 2), p))]
         if len(ordered) > self.max_edits:
             self.truncated += len(ordered) - self.max_edits
             ordered = ordered[:self.max_edits]

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -43,7 +43,7 @@ from agentdescent.filetree import parse_tree
 from ._octopus import three_way
 
 from ._world import (CONTEXT_FILE, EpisodeRecord, LocalWorld, WorldLog,
-                     normalise, owns, routing_entry)
+                     normalise, owns, resolve_edit_path, routing_entry)
 
 __all__ = ["Brief", "Delegation", "Edit", "RecursiveDelegation", "render_edits"]
 
@@ -134,6 +134,11 @@ class RecursiveDelegation:
     max_depth: int = 2
     max_edits: int = 4
     root_path: str = ""
+    #: Human-supplied, read-only files every agent is shown in full, wherever it
+    #: stands -- the specification, the constraints, the validation contract. The
+    #: paper's agent may inspect the whole project; one with no read tool can only
+    #: inspect what the brief carries.
+    contracts: Sequence[str] = ()
     #: The parent's judgement beyond scope. Upstream a parent decides "using the
     #: available tests, constraints and integration evidence" (paper 3.3), which
     #: is a *test* run on the child's work before it is offered to the version
@@ -149,6 +154,10 @@ class RecursiveDelegation:
     #: Sibling edits to one path reconciled by three-way merge, and not.
     sibling_merges: int = 0
     sibling_conflicts: int = 0
+    #: Edits whose path was written relative to the agent's own node rather than
+    #: to the repository. Counted because the alternative to counting is a file
+    #: appearing somewhere nobody asked for it.
+    resolved_relative: int = 0
     #: Changes an agent needed outside its own path: raised, handled by an
     #: ancestor, and left unmet at the top of the chain.
     requests_raised: int = 0
@@ -194,8 +203,9 @@ class RecursiveDelegation:
         pleased with and a parent that refuses it are one episode, not two.
         """
         brief = Brief(world=world, objective=objective,
-                      context=world.situate(state), state=state, task=ctx.task,
-                      output=ctx.output, reward=ctx.reward, depth=depth)
+                      context=world.situate(state, contracts=self.contracts),
+                      state=state, task=ctx.task, output=ctx.output,
+                      reward=ctx.reward, depth=depth)
 
         delegations: Sequence[Delegation] = ()
         if depth < self.max_depth:
@@ -209,9 +219,16 @@ class RecursiveDelegation:
             # back up to the parent agent, which will handle it"
             # (`agents/executor.ex:64`). So the split here is edits / requests,
             # and the parent decides what to do with the second list.
-            produced = [Edit(owner=world.path, path=e.path, content=e.content,
-                             kind=e.kind)
-                        for e in self.executor(brief) or ()]
+            produced = []
+            for raw in self.executor(brief) or ():
+                # "relative path" means two things to an agent standing in a
+                # subtree, and reading it the wrong way sends real work to the
+                # repository root. Resolve it against the node before anything
+                # else looks at it, and count the ones that needed it.
+                path, relative = resolve_edit_path(state, world.path, raw.path)
+                self.resolved_relative += int(relative)
+                produced.append(Edit(owner=world.path, path=path,
+                                     content=raw.content, kind=raw.kind))
             edits = [e for e in produced if owns(world.path, e.path)]
             requests = [e for e in produced if not owns(world.path, e.path)]
             self.requests_raised += len(requests)
@@ -436,7 +453,8 @@ class RecursiveDelegation:
                 f"sibling_merges={self.sibling_merges} "
                 f"sibling_conflicts={self.sibling_conflicts} "
                 f"requests={self.requests_raised}/"
-                f"{self.adopted_requests}/{self.unmet_requests}")
+                f"{self.adopted_requests}/{self.unmet_requests} "
+                f"node_relative_paths={self.resolved_relative}")
 
 
 def _state_of(rendered: str) -> Dict[str, str]:

--- a/examples/genesis/_delegation.py
+++ b/examples/genesis/_delegation.py
@@ -113,6 +113,18 @@ Executor = Callable[[Brief], Sequence[Edit]]
 Review = Callable[[Brief, Sequence[Edit]], Optional[Tuple[str, str]]]
 
 
+def apply_edits(state: Mapping[str, str],
+                edits: Sequence[Edit]) -> Dict[str, str]:
+    """``state`` with ``edits`` applied. What a commit of this episode contains."""
+    out = dict(state)
+    for edit in edits:
+        if edit.content is None:
+            out.pop(edit.path, None)
+        else:
+            out[edit.path] = edit.content
+    return out
+
+
 def render_edits(edits: Sequence[Edit], rationale: str) -> str:
     """Serialise an edit set into the situated proposal protocol."""
     return "<EDITS>" + json.dumps({
@@ -148,6 +160,11 @@ class RecursiveDelegation:
     #: paper's agent may inspect the whole project; one with no read tool can only
     #: inspect what the brief carries.
     contracts: Sequence[str] = ()
+    #: ``() -> Rollout`` (see :mod:`examples.genesis._worktree`) or ``None``. When
+    #: set, every episode commits its work in a worktree of its own and the worktree
+    #: is removed afterwards, which is upstream's scheduling model rather than a
+    #: detail of it: "commit your changes, release your worktree, and wait".
+    rollout_factory: Optional[Callable[[], object]] = None
     #: Globs that are read-only. Routing must not send a manager into a directory
     #: where nothing is writable; separate from :attr:`contracts`, which is what
     #: gets *pushed into the brief*. Upstream an agent pulls files with tools, so
@@ -164,6 +181,10 @@ class RecursiveDelegation:
     #: history at all -- not the same thing as the acceptance gate, which sees
     #: only what the whole episode returned. ``None`` runs the scope check alone.
     review: Optional[Review] = None
+    #: The version the most recent rollout branched from -- the latest accepted state,
+    #: as the engine handed it over. Read by `CompletionJudge`, which has to look at
+    #: the codebase to answer upstream's question and is not given the reward.
+    last_state: Optional[Dict[str, str]] = None
     truncated: int = 0
     #: Child nodes opened at a path their parent did not yet route to, and
     #: therefore written into the parent's routing table.
@@ -191,20 +212,32 @@ class RecursiveDelegation:
 
     def propose(self, ctx) -> Sequence[str]:
         state = _state_of(ctx.rendered)
+        self.last_state = dict(state)
         root = LocalWorld(version=int(ctx.base_version or 0), path=self.root_path,
                           readonly=tuple(self.readonly or self.contracts))
+        # The workspace of a transient agent tree: created for this rollout, gone
+        # with it. `None` when worktrees are off, and every use of it is guarded.
+        rollout = self.rollout_factory() if self.rollout_factory else None
+        try:
+            return self._rollout(ctx, root, state, rollout)
+        finally:
+            if rollout is not None:
+                rollout.close()
 
+    def _rollout(self, ctx, root: LocalWorld, state: Mapping[str, str],
+                 rollout) -> Sequence[str]:
         # A parent that asked for more work gets it before anything else is
         # chosen: this is the third verdict, arriving one round later because
         # `AcceptDecision` cannot carry it (see examples/genesis/_judge.py).
         pending = self.log.take_rework()
         if pending is not None and owns(root.path, pending[0]):
             world, objective = root.delegate(pending[0]), f"rework: {pending[1]}"
-            edits, unmet, _ = self._episode(world, objective, state, ctx, depth=1)
+            edits, unmet, _ = self._episode(world, objective, state, ctx, depth=1,
+                                            rollout=rollout)
             rationale = f"rework at {pending[0] or './'}"
         else:
             edits, unmet, _ = self._episode(root, self._objective(ctx), state, ctx,
-                                            depth=0)
+                                            depth=0, rollout=rollout)
             rationale = f"episode at {root.path or './'}"
         # A need that reached the top of this episode's chain and still fell
         # outside its root's authority. Counted rather than dropped quietly: it
@@ -219,7 +252,8 @@ class RecursiveDelegation:
     # -- the recursion -----------------------------------------------------
 
     def _episode(self, world: LocalWorld, objective: str, state: Mapping[str, str],
-                 ctx, *, depth: int) -> "tuple[List[Edit], List[Edit], EpisodeRecord]":
+                 ctx, *, depth: int, rollout=None,
+                 base: str = "") -> "tuple[List[Edit], List[Edit], EpisodeRecord]":
         """One finite-lived agent: what it proposes, what it asks for, its record.
 
         The record travels back with the work because the verdict on an episode
@@ -260,6 +294,10 @@ class RecursiveDelegation:
                 agent_id=self.log.next_id("executor"), role="executor",
                 path=world.path, depth=depth, version=world.version,
                 objective=objective, n_edits=len(edits)))
+            # "Commit Your Work: Once the objective is satisfied, commit your
+            # changes" -- `agents/executor.ex`. In its own worktree, off its
+            # parent's commit, and the worktree is released when it returns.
+            record.commit = self._commit(rollout, record, state, edits, base)
             return edits, requests, record
 
         record = self.log.record(EpisodeRecord(
@@ -271,11 +309,29 @@ class RecursiveDelegation:
         notes: List[Edit] = []
         pending: List[Edit] = []              # needs this node cannot meet either
         routed = world.routing(state)
-        opened: List[Delegation] = []         # children this node had not routed to
+        opened = [d for d in delegations if normalise(d.path) not in routed]
+
+        # Upstream's order, from the architect's Phase 1: "Create `/backend` and
+        # `/frontend` directories with CONTEXT.md via `make_dir` (**auto-commits**),
+        # **then** spawn `subagent_architect` for each child." So a node this manager
+        # is opening is recorded *before* its child is briefed -- otherwise the child
+        # arrives at a node its own parent's routing table does not mention -- and
+        # that record is what the children branch from. "If you don't commit, your
+        # changes are invisible to subagents."
+        routing = self._routing_note(world, state, opened)
+        if routing is not None:
+            state = dict(state, **{routing.path: routing.content or ""})
+        child_base = base
+        if routing is not None or not base:
+            child_base = self._commit(rollout, record, state, (), base) or base
+
+        children: List[EpisodeRecord] = []
         for delegation in delegations:
             child = world.delegate(delegation.path)
             returned, asked, child_record = self._episode(
-                child, delegation.objective, state, ctx, depth=depth + 1)
+                child, delegation.objective, state, ctx, depth=depth + 1,
+                rollout=rollout, base=child_base)
+            children.append(child_record)
             child_record.verdict, child_record.reason = self._judge(
                 child, returned, asked, brief)
             if child_record.verdict != "rejected" and asked:
@@ -317,9 +373,6 @@ class RecursiveDelegation:
                     f"{conflicts[0]} was also written by a sibling at "
                     f"{owner_of.get(conflicts[0], '?')}, and the two edits overlap")
                 self.log.request_rework(child.path, child_record.reason)
-            if normalise(delegation.path) not in routed:
-                opened.append(delegation)
-
         # Upstream's third phase. An Architect works "architecture & design ->
         # implementation delegation -> **review & accountability**" and is
         # "ACCOUNTABLE for all code in its node path" (`agents/architect.ex:23`):
@@ -334,15 +387,20 @@ class RecursiveDelegation:
                 self._fold(held, owner_of, own, world, state)
 
         merged: List[Edit] = list(held.values()) + notes
-
         # A node whose parent does not route to it is a node later agents cannot
-        # find. Upstream the manager that opens one writes the entry at its own
-        # level; here the same write, from the same agent, on its own CONTEXT.md.
-        routing = self._routing_note(world, state, opened)
+        # find, so the entry travels with the work as well as with the base its
+        # children saw: the base is this episode's, and only an accepted episode
+        # puts it in the version everyone else will see.
         if routing is not None:
             merged.append(routing)
 
         record.n_edits = len(merged)
+        # The parent's merge. Its parents are the base it delegated from and every
+        # child commit it kept, which is what makes this a phylogenetic graph rather
+        # than a list -- `Git.merge_octopus/2` leaves the same shape.
+        kept = [r.commit for r in children if r.commit and r.verdict != "rejected"]
+        record.commit = self._commit(rollout, record, apply_edits(state, merged), (),
+                                     child_base, kept) or record.commit
         return merged, pending, record
 
     def _accountability_pass(self, world: LocalWorld, objective: str,
@@ -500,6 +558,31 @@ class RecursiveDelegation:
             return None
         return Edit(owner=child.path, path=key, kind="context",
                     content=under_heading(body, KNOWN_ISSUES, line))
+
+    # -- the workspace -----------------------------------------------------
+
+    def _commit(self, rollout, record: EpisodeRecord, state: Mapping[str, str],
+                edits: Sequence[Edit], base: str,
+                parents: Sequence[str] = ()) -> str:
+        """Commit what this episode produced, in a worktree of its own.
+
+        Returns the sha, or ``""`` when the run is not using worktrees. Never raises:
+        a git failure costs the history of one episode, not the episode.
+        """
+        if rollout is None:
+            return ""
+        from ._worktree import edited
+        lineage = [p for p in ([base] + list(parents)) if p]
+        try:
+            return rollout.commit(record.agent_id, edited(state, edits),
+                                  f"{record.role} {record.agent_id} at "
+                                  f"{record.path or './'}: {record.objective[:60]}",
+                                  lineage)
+        except Exception:  # noqa: BLE001 - the work stands even if git does not
+            ledger = getattr(rollout, "_ledger", None)
+            if ledger is not None:
+                ledger.failures += 1
+            return ""
 
     # -- bounds ------------------------------------------------------------
 

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -39,25 +39,19 @@ kind of constraint the paper says the human provides.
 
 from __future__ import annotations
 
-import json
-import os
-import shutil
-import subprocess
-import sys
-import tempfile
-from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
 from agentdescent.evolution import Task
-from agentdescent.filetree import materialize, parse_tree
 
 from ._delegation import Brief, Delegation, Edit
-from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
+from ._suite import CRASHED, PYTHON_MODULE_SKILL, Suite, reward, run_cases
+from ._suite import llm_executor as _llm_executor
+from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["FROZEN", "build_tasks", "initial_files", "llm_executor", "llm_manager",
-           "make_runner", "offline_executor", "offline_manager", "reward",
-           "suite_review"]
+__all__ = ["FROZEN", "MINILANG", "build_tasks", "initial_files", "llm_executor",
+           "llm_manager", "make_runner", "offline_executor", "offline_manager",
+           "reward", "suite_review"]
 
 #: Human-supplied and never the agents'. L0 in this repository's sense, and the
 #: role c-testsuite / LLVM / Csmith play upstream.
@@ -141,20 +135,6 @@ file rather than the same one.
 '''
 
 
-_SKILL = '''# Writing a module in this project
-
-A file is complete or it is not written. Never leave a partial module: the
-validation suite imports what is there, and a half-written module fails the
-stages after it as well as its own.
-
-- Keep one concern per file, and name it after that concern.
-- A package directory needs an `__init__.py`, even an empty one.
-- Import a sibling module relatively (`from .lexer import tokenize`).
-- Do not import a stage you do not need: `src/__init__.py` imports lazily on
-  purpose, and a module-level import undoes that.
-'''
-
-
 def initial_files() -> Dict[str, str]:
     """The implementation-empty repository the run starts from.
 
@@ -167,7 +147,7 @@ def initial_files() -> Dict[str, str]:
         "src/CONTEXT.md": _SRC_CONTEXT,
         "src/frontend/CONTEXT.md": _FRONTEND_CONTEXT,
         "src/backend/CONTEXT.md": _BACKEND_CONTEXT,
-        f"src/{SKILLS_DIR}/python-modules.md": _SKILL,
+        f"src/{SKILLS_DIR}/python-modules.md": PYTHON_MODULE_SKILL,
     }
 
 
@@ -303,21 +283,17 @@ _STUBS = {
 _PKG_INIT = '"""Package marker."""\n'
 
 
+def _filled_evaluator() -> str:
+    """The evaluator with every stub filled -- the oracle's copy."""
+    body = _EVALUATOR_SKELETON
+    for stub, filled in _STUBS.values():
+        body = body.replace(stub, filled)
+    return body
+
+
 def _reference_tree() -> Dict[str, str]:
     """The finished repository -- the oracle the frozen suite is computed from."""
-    evaluator = _EVALUATOR_SKELETON
-    for stub, filled in _STUBS.values():
-        evaluator = evaluator.replace(stub, filled)
-    tree = dict(initial_files())
-    tree.update({
-        ENTRY: _REF_ENTRY,
-        "src/frontend/__init__.py": _PKG_INIT,
-        "src/backend/__init__.py": _PKG_INIT,
-        LEXER: _REF_LEXER,
-        PARSER: _REF_PARSER,
-        EVALUATOR: evaluator,
-    })
-    return tree
+    return MINILANG.reference_tree()
 
 
 # ---------------------------------------------------------------------------
@@ -327,53 +303,6 @@ def _reference_tree() -> Dict[str, str]:
 #: Executed inside the materialised workspace, in a child process. A candidate
 #: is agent-written code: it can loop, raise or exit, and none of those may take
 #: the run with it.
-_HARNESS = r"""
-import json, sys
-sys.path.insert(0, sys.argv[1])
-cases = json.loads(sys.argv[2])
-import src
-out = []
-for kind, source in cases:
-    try:
-        if kind == "tok":
-            value = src.tokenize(source)
-        elif kind == "ast":
-            value = src.parse(source)
-        else:
-            value = src.evaluate(source)
-        out.append(repr(value))
-    except Exception as exc:            # a stage that is not built yet
-        out.append("ERROR:" + type(exc).__name__)
-print(json.dumps(out), end="")
-"""
-
-#: What a case scores when the workspace could not be run at all -- a syntax
-#: error in a generated module, a timeout, a missing package marker. Distinct
-#: from a wrong answer only in the transcript; both score zero, and conflating
-#: them in the *reward* would be the bug, not here.
-CRASHED = "ERROR:workspace"
-
-
-def _run_cases(state: Mapping[str, str], cases: Sequence[Sequence[str]],
-               *, timeout: float = 30.0) -> List[str]:
-    """Materialise ``state`` and evaluate every case in one child process."""
-    if not cases:
-        return []
-    workspace = tempfile.mkdtemp(prefix="genesis-run-")
-    try:
-        materialize(state, workspace)
-        proc = subprocess.run(
-            [sys.executable, "-c", _HARNESS, workspace, json.dumps(list(cases))],
-            capture_output=True, text=True, timeout=timeout, cwd=workspace)
-        if proc.returncode != 0:
-            return [CRASHED] * len(cases)
-        return list(json.loads(proc.stdout))
-    except (OSError, ValueError, subprocess.SubprocessError):
-        return [CRASHED] * len(cases)
-    finally:
-        shutil.rmtree(workspace, ignore_errors=True)
-
-
 #: The frozen validation suite: (stage, source). Ordered so that the held-out
 #: tail `evolve()` cuts is a mix of all three stages rather than one of them.
 _CASES = (
@@ -390,51 +319,45 @@ _CASES = (
 )
 
 
-def build_tasks(limit: Optional[int] = None) -> List[Task]:
-    """The suite, with every expected answer computed from the reference tree.
 
-    Computed rather than typed out: a hand-written expectation drifts from the
-    implementation it is supposed to pin, and a suite that disagrees with its own
-    oracle scores a correct candidate wrong. This is the loader, so it is also
-    the boundary ``--dry-run`` must not cross.
-    """
-    cases = list(_CASES)[:limit] if limit else list(_CASES)
-    gold = _run_cases(_reference_tree(), cases)
-    tasks: List[Task] = []
-    for i, ((kind, source), expected) in enumerate(zip(cases, gold)):
-        if expected.startswith("ERROR:"):
-            raise RuntimeError(
-                f"the reference implementation failed case {kind} {source!r} "
-                f"({expected}); the suite would score a correct candidate wrong")
-        tasks.append(Task(id=f"{kind}{i:02d}", prompt=source,
-                          meta={"kind": kind, "gold": expected}))
-    return tasks
+#: minilang as a :class:`~examples.genesis._suite.Suite`. Everything above is data;
+#: the harness, the loader, the runner and the parent's integration check are
+#: shared with every other formation domain.
+MINILANG = Suite(
+    name="minilang",
+    given=initial_files(),
+    frozen=FROZEN,
+    stages={"tok": "tokenize", "ast": "parse", "val": "evaluate"},
+    cases=_CASES,
+    reference={
+        ENTRY: _REF_ENTRY,
+        "src/frontend/__init__.py": _PKG_INIT,
+        "src/backend/__init__.py": _PKG_INIT,
+        LEXER: _REF_LEXER,
+        PARSER: _REF_PARSER,
+        EVALUATOR: _filled_evaluator(),
+    },
+)
 
-
-def make_runner() -> Callable[[str, Task], str]:
-    """``run(rendered, task)`` -- one case against one candidate repository."""
-
-    def run(rendered: str, task: Task) -> str:
-        try:
-            state = dict(parse_tree(rendered))
-        except Exception:  # noqa: BLE001 - an empty artifact, before anything exists
-            return CRASHED
-        # The frozen files are restored from the human's copy rather than taken
-        # from the candidate: a proposal can never write them, and a resumed
-        # ledger or a hand-built aggregator could still put state in front of
-        # this. Scoring against the agents' copy of the suite is the one failure
-        # mode that cannot be detected from a completed run.
-        for path, content in initial_files().items():
-            if path.startswith("spec/"):
-                state[path] = content
-        return _run_cases(state, [(task.meta["kind"], task.prompt)])[0]
-
-    return run
+build_tasks = MINILANG.build_tasks
+make_runner = MINILANG.make_runner
+suite_review = MINILANG.review
+STAGES = MINILANG.stages
 
 
-def reward(task: Task, output: str) -> float:
-    """Exact match against the frozen suite's expectation."""
-    return 1.0 if output == task.meta.get("gold") else 0.0
+def llm_manager(complete):
+    """The shared manager actor. Re-exported so a caller needs one import."""
+    return _llm_manager(complete)
+
+
+def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
+    """The shared executor actor, with this domain's frozen paths."""
+    return _llm_executor(complete, editable=editable, frozen=frozen)
+
+
+def _run_cases(state, cases, *, timeout: float = 60.0):
+    """This domain's stages, for a caller that has only (state, cases)."""
+    return run_cases(state, cases, MINILANG.stages, timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -550,185 +473,3 @@ def _has_unary_minus(source: str) -> bool:
         if not char.isspace():
             previous = char
     return False
-
-
-# ---------------------------------------------------------------------------
-# The parent's integration evidence
-# ---------------------------------------------------------------------------
-
-def suite_review(tasks: Sequence[Task], *, sample: int = 10):
-    """A :data:`~examples.genesis._delegation.Review`: run the suite on a child's work.
-
-    The paper's parent decides "using the available tests, constraints and
-    integration evidence" (3.3), and that is a different decision from the
-    acceptance gate's: it happens **inside** the episode, on one child's
-    contribution, before anything is offered to the version history. Without it
-    a parent here only checked scope, which is the cheap half of a rule whose
-    whole point is the other half.
-
-    Refuses a regression and says nothing otherwise -- structural work that moves
-    no case is exactly what upstream's "partial progress is accepted" is about,
-    so a parent that demanded a gain would refuse the first file of every node.
-
-    ``sample`` bounds the cost: this runs per child per episode, so it is a
-    subset of the suite rather than the whole of it -- integration evidence a
-    parent can afford, not the gate's measurement.
-    """
-    chosen = list(tasks)[:sample]
-    cases = [(t.meta["kind"], t.prompt) for t in chosen]
-    gold = [t.meta["gold"] for t in chosen]
-    cached: Dict[int, int] = {}
-
-    def score(state: Mapping[str, str]) -> int:
-        return sum(1 for out, want in zip(_run_cases(state, cases), gold) if out == want)
-
-    def review(parent, returned):
-        base_state = parent.state
-        key = id(base_state)
-        if key not in cached:
-            cached[key] = score(base_state)
-        candidate = dict(base_state)
-        for edit in returned:
-            if edit.content is None:
-                candidate.pop(edit.path, None)
-            else:
-                candidate[edit.path] = edit.content
-        after = score(candidate)
-        if after < cached[key]:
-            return ("rejected", f"integration check regressed "
-                                f"{cached[key]}/{len(cases)} -> {after}/{len(cases)}")
-        return None
-
-    return review
-
-
-# ---------------------------------------------------------------------------
-# The LLM actors: the same two seams, asked rather than computed
-# ---------------------------------------------------------------------------
-
-_MANAGER_PROMPT = """You are a manager agent in a recursive software world. You are \
-situated at the repository path `{path}` and you own everything under it.
-
-{context}
-
-This node's routing table says its children are: {routes}
-
-OBJECTIVE
-{objective}
-
-You do not write code. Decide whether to delegate to more specific paths inside \
-your own subtree, or to handle this yourself.
-
-Reply with ONE JSON object and nothing else:
-{{"delegations": [{{"path": "<a node inside {path}>", "objective": "<one sentence>"}}]}}
-
-Rules:
-- You are ACCOUNTABLE for all code under `{path}`, and delegating does not \
-discharge that. The files AT `{path}` itself are nobody else's to write: after \
-your children return you get one more turn to write them.
-- A node is a **directory**, never a file. `src/frontend` is a node; \
-`src/frontend/lexer.py` is a file that belongs to the agent situated at \
-`src/frontend`, and delegating to it is refused.
-- Prefer a child this node already routes to. Naming a new one is allowed and \
-adds it to this node's routing table -- do that only when the work genuinely \
-belongs to a new part of the tree.
-- An empty list means you will handle it at your own path, writing the files \
-that belong to `{path}` itself.
-- Never name a path outside your subtree -- it belongs to another agent."""
-
-_EXECUTOR_PROMPT = """You are an executor agent in a recursive software world. You are \
-situated at the repository path `{path}` and you may write ONLY files under it.
-
-{context}
-
-OBJECTIVE
-{objective}
-
-A validation case failed:
-  input    {prompt}
-  produced {output}
-  score    {reward:.2f}
-
-{protocol}"""
-
-
-def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
-    """Ask a model where to situate children. A bad reply means "handle it here"."""
-
-    def manager(brief: Brief) -> Sequence[Delegation]:
-        routes = brief.world.routing(brief.state)
-        reply = _ask(complete, _MANAGER_PROMPT.format(
-            path=brief.world.path or "./", context=brief.context,
-            routes=", ".join(f"`{r}/`" for r in routes) or "(none yet)",
-            objective=brief.objective))
-        try:
-            data = json.loads(_first_object(reply) or "{}")
-            items = data.get("delegations") or []
-        except Exception:  # noqa: BLE001 - malformed model output, not a bug
-            return ()
-        out = []
-        for item in items:
-            if isinstance(item, dict) and item.get("path"):
-                out.append(Delegation(normalise(str(item["path"])),
-                                      str(item.get("objective", brief.objective))))
-        return out
-
-    return manager
-
-
-def llm_executor(complete, *, editable: Sequence[str] = ("**",),
-                 frozen: Sequence[str] = FROZEN) -> Callable[[Brief], Sequence[Edit]]:
-    """Ask a model for situated edits. Unparseable replies cost their episode.
-
-    The protocol is rendered **per episode** rather than once, because it names
-    the agent's own path in every example it shows. A protocol that says
-    "relative path" without saying relative to what is read both ways, and the
-    wrong reading puts a node's files at the top of the repository.
-    """
-
-    def executor(brief: Brief) -> Sequence[Edit]:
-        owner = brief.world.path or "."
-        protocol = SITUATED_EDIT_PROTOCOL.format(
-            owner=owner, editable=", ".join(editable) or "(none)",
-            frozen=", ".join(frozen) or "(none)")
-        reply = _ask(complete, _EXECUTOR_PROMPT.format(
-            path=brief.world.path or "./", context=brief.context,
-            objective=brief.objective,
-            prompt=getattr(brief.task, "prompt", ""),
-            output=(brief.output or "")[:400], reward=brief.reward,
-            protocol=protocol))
-        return [Edit(owner=brief.world.path or "", path=edit["path"],
-                     content=edit["content"])
-                for edit in parse_situated_edits(reply)]
-
-    return executor
-
-
-def _ask(complete, prompt: str) -> str:
-    try:
-        return complete(prompt) or ""
-    except Exception:  # noqa: BLE001 - a dead backend costs this episode, not the run
-        return ""
-
-
-def _first_object(text: str) -> Optional[str]:
-    start = text.find("{")
-    if start < 0:
-        return None
-    depth, in_str, esc = 0, False, False
-    for i in range(start, len(text)):
-        c = text[i]
-        if in_str:
-            esc = (c == "\\") and not esc
-            if c == '"' and not esc:
-                in_str = False
-            continue
-        if c == '"':
-            in_str = True
-        elif c == "{":
-            depth += 1
-        elif c == "}":
-            depth -= 1
-            if depth == 0:
-                return text[start:i + 1]
-    return None

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -53,7 +53,7 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+__all__ = ["CASE_NOUN", "CONTRACTS", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
            "SCORING", "MINILANG", "build_tasks", "initial_files", "llm_executor",
            "llm_manager", "make_runner", "offline_executor", "offline_manager",
            "reference_tree", "reward", "suite_review"]
@@ -61,6 +61,9 @@ __all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
 #: Human-supplied and never the agents'. L0 in this repository's sense, and the
 #: role c-testsuite / LLVM / Csmith play upstream.
 FROZEN = ("spec/**",)
+
+#: What is pushed into every brief.
+CONTRACTS = FROZEN
 
 #: How the run is scored, and what the header line says about it.
 SCORING = "reference oracle, exact match"
@@ -114,7 +117,10 @@ _ROOT_CONTEXT = '''# minilang -- root
 Implement the language in `spec/CONTEXT.md`. The specification and its staged
 validation are given; no implementation exists yet.
 
-## Routing table
+## API Surface
+Nothing at the root. Every stage is reached through `src/__init__.py`.
+
+## Routing Table
 - `./src/` -> the implementation, and the three stage entry points
 
 ## Constraints
@@ -128,7 +134,11 @@ _SRC_CONTEXT = '''# src -- implementation root
 Own `src/__init__.py`, the public surface named by the spec: `tokenize`, `parse`
 and `evaluate`. Each MUST import its stage lazily.
 
-## Routing table
+## API Surface
+- `src/__init__.py`: `tokenize(source)`, `parse(source)`, `evaluate(source)` -- each
+  takes the **source text**, not the previous stage's output.
+
+## Routing Table
 - `./src/frontend/` -> tokenizer and parser
 - `./src/backend/`  -> evaluation of the parse tree
 '''
@@ -138,6 +148,10 @@ _FRONTEND_CONTEXT = '''# src/frontend -- source text to parse tree
 ## Intent
 `lexer.py` turns source text into the token list; `parser.py` turns tokens into
 the nested-tuple parse tree, honouring precedence and parentheses.
+
+## API Surface
+- `lexer.py`: `tokenize(source)`
+- `parser.py`: `parse(source)` -- the source text, and it tokenizes internally
 '''
 
 _BACKEND_CONTEXT = '''# src/backend -- parse tree to value
@@ -146,6 +160,9 @@ _BACKEND_CONTEXT = '''# src/backend -- parse tree to value
 `evaluator.py` walks the parse tree. One function per node kind, so that two
 agents fixing two different node kinds are editing two different parts of the
 file rather than the same one.
+
+## API Surface
+- `evaluator.py`: `evaluate(node)`, plus one `eval_*(node)` per node kind
 '''
 
 

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -437,21 +437,31 @@ def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
 
 
 def offline_manager(brief: Brief) -> Sequence[Delegation]:
-    """Decompose, or return nothing and become the executor of this node.
+    """Decompose along the node's routing table, or become its executor.
 
-    The routing table is read from the node's own ``CONTEXT.md`` upstream; here
-    it is the fixed decomposition the human wrote, which is the part of the
-    offline actor that is a surrogate. An LLM manager is not given it.
+    The decomposition is **read from ``CONTEXT.md``**, not hardcoded here:
+    ``LocalWorld.routing`` parses the routing table of the node the agent is
+    standing on, which is what that table is for upstream. What stays a surrogate
+    is only the choice of *which* routed child to work on, and that is decided by
+    what the node still owes rather than by a fixed list.
     """
-    path, owed = normalise(brief.world.path), _outstanding(brief.state)
-    if path == "":
-        return [Delegation("src", "implement the language under src/")]
-    if path == "src":
-        if ENTRY not in brief.state:
-            return ()                       # this node's own file: do it here
-        return [Delegation(node, f"clear the outstanding work under {node}/")
-                for node in ("src/frontend", "src/backend") if owed[node]]
-    return ()
+    path = normalise(brief.world.path)
+    if path == "src" and ENTRY not in brief.state:
+        return ()                           # this node's own file: do it here
+    return [Delegation(node, f"clear the outstanding work under {node}/")
+            for node in brief.world.routing(brief.state)
+            if _owes(brief.state, node)]
+
+
+def _owes(state: Mapping[str, str], node: str) -> bool:
+    """Does ``node`` or anything beneath it still have outstanding work?
+
+    Asked of the subtree rather than the node, so the root keeps delegating into
+    ``src/`` while the work is two levels further down.
+    """
+    node = normalise(node)
+    return any(items for key, items in _outstanding(state).items()
+               if key == node or key.startswith(node + "/"))
 
 
 def offline_executor(brief: Brief) -> Sequence[Edit]:
@@ -531,6 +541,8 @@ situated at the repository path `{path}` and you own everything under it.
 
 {context}
 
+This node's routing table says its children are: {routes}
+
 OBJECTIVE
 {objective}
 
@@ -538,10 +550,18 @@ You do not write code. Decide whether to delegate to more specific paths inside 
 your own subtree, or to handle this yourself.
 
 Reply with ONE JSON object and nothing else:
-{{"delegations": [{{"path": "<a path inside {path}>", "objective": "<one sentence>"}}]}}
+{{"delegations": [{{"path": "<a node inside {path}>", "objective": "<one sentence>"}}]}}
 
-An empty list means you will handle it at your own path. Never name a path \
-outside your subtree -- it belongs to another agent."""
+Rules:
+- A node is a **directory**, never a file. `src/frontend` is a node; \
+`src/frontend/lexer.py` is a file that belongs to the agent situated at \
+`src/frontend`, and delegating to it is refused.
+- Prefer a child this node already routes to. Naming a new one is allowed and \
+adds it to this node's routing table -- do that only when the work genuinely \
+belongs to a new part of the tree.
+- An empty list means you will handle it at your own path, writing the files \
+that belong to `{path}` itself.
+- Never name a path outside your subtree -- it belongs to another agent."""
 
 _EXECUTOR_PROMPT = """You are an executor agent in a recursive software world. You are \
 situated at the repository path `{path}` and you may write ONLY files under it.
@@ -563,8 +583,10 @@ def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
     """Ask a model where to situate children. A bad reply means "handle it here"."""
 
     def manager(brief: Brief) -> Sequence[Delegation]:
+        routes = brief.world.routing(brief.state)
         reply = _ask(complete, _MANAGER_PROMPT.format(
             path=brief.world.path or "./", context=brief.context,
+            routes=", ".join(f"`{r}/`" for r in routes) or "(none yet)",
             objective=brief.objective))
         try:
             data = json.loads(_first_object(reply) or "{}")

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -675,11 +675,19 @@ def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
 
 def llm_executor(complete, *, editable: Sequence[str] = ("**",),
                  frozen: Sequence[str] = FROZEN) -> Callable[[Brief], Sequence[Edit]]:
-    """Ask a model for situated edits. Unparseable replies cost their episode."""
-    protocol = SITUATED_EDIT_PROTOCOL.format(
-        editable=", ".join(editable) or "(none)", frozen=", ".join(frozen) or "(none)")
+    """Ask a model for situated edits. Unparseable replies cost their episode.
+
+    The protocol is rendered **per episode** rather than once, because it names
+    the agent's own path in every example it shows. A protocol that says
+    "relative path" without saying relative to what is read both ways, and the
+    wrong reading puts a node's files at the top of the repository.
+    """
 
     def executor(brief: Brief) -> Sequence[Edit]:
+        owner = brief.world.path or "."
+        protocol = SITUATED_EDIT_PROTOCOL.format(
+            owner=owner, editable=", ".join(editable) or "(none)",
+            frozen=", ".join(frozen) or "(none)")
         reply = _ask(complete, _EXECUTOR_PROMPT.format(
             path=brief.world.path or "./", context=brief.context,
             objective=brief.objective,

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -53,13 +53,23 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["FROZEN", "MINILANG", "build_tasks", "initial_files", "llm_executor",
+__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+           "SCORING", "MINILANG", "build_tasks", "initial_files", "llm_executor",
            "llm_manager", "make_runner", "offline_executor", "offline_manager",
-           "reward", "suite_review"]
+           "reference_tree", "reward", "suite_review"]
 
 #: Human-supplied and never the agents'. L0 in this repository's sense, and the
 #: role c-testsuite / LLVM / Csmith play upstream.
 FROZEN = ("spec/**",)
+
+#: How the run is scored, and what the header line says about it.
+SCORING = "reference oracle, exact match"
+CASE_NOUN = "validation cases"
+GROUP_NOUN = "stages"
+#: `evolve()`'s default. The cases are sampled expressions over one grammar, so the
+#: held-out tail is a genuine generalisation estimate -- unlike md, where every task
+#: is a requirement and the tail is an audit set instead.
+HELD_OUT_FRAC = 0.4
 
 ENTRY = "src/__init__.py"
 LEXER = "src/frontend/lexer.py"
@@ -295,7 +305,7 @@ def _filled_evaluator() -> str:
     return body
 
 
-def _reference_tree() -> Dict[str, str]:
+def reference_tree() -> Dict[str, str]:
     """The finished repository -- the oracle the frozen suite is computed from."""
     return MINILANG.reference_tree()
 

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -53,10 +53,11 @@ from agentdescent.filetree import materialize, parse_tree
 
 from ._delegation import Brief, Delegation, Edit
 from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
-from ._world import normalise
+from ._world import SKILLS_DIR, normalise
 
 __all__ = ["FROZEN", "build_tasks", "initial_files", "llm_executor", "llm_manager",
-           "make_runner", "offline_executor", "offline_manager", "reward"]
+           "make_runner", "offline_executor", "offline_manager", "reward",
+           "suite_review"]
 
 #: Human-supplied and never the agents'. L0 in this repository's sense, and the
 #: role c-testsuite / LLVM / Csmith play upstream.
@@ -140,14 +141,33 @@ file rather than the same one.
 '''
 
 
+_SKILL = '''# Writing a module in this project
+
+A file is complete or it is not written. Never leave a partial module: the
+validation suite imports what is there, and a half-written module fails the
+stages after it as well as its own.
+
+- Keep one concern per file, and name it after that concern.
+- A package directory needs an `__init__.py`, even an empty one.
+- Import a sibling module relatively (`from .lexer import tokenize`).
+- Do not import a stage you do not need: `src/__init__.py` imports lazily on
+  purpose, and a module-level import undoes that.
+'''
+
+
 def initial_files() -> Dict[str, str]:
-    """The implementation-empty repository the run starts from."""
+    """The implementation-empty repository the run starts from.
+
+    Context, constraints, one reusable skill -- the things the paper says an
+    accepted version carries besides source (3.1) -- and no implementation.
+    """
     return {
         "CONTEXT.md": _ROOT_CONTEXT,
         "spec/CONTEXT.md": _SPEC,
         "src/CONTEXT.md": _SRC_CONTEXT,
         "src/frontend/CONTEXT.md": _FRONTEND_CONTEXT,
         "src/backend/CONTEXT.md": _BACKEND_CONTEXT,
+        f"src/{SKILLS_DIR}/python-modules.md": _SKILL,
     }
 
 
@@ -530,6 +550,56 @@ def _has_unary_minus(source: str) -> bool:
         if not char.isspace():
             previous = char
     return False
+
+
+# ---------------------------------------------------------------------------
+# The parent's integration evidence
+# ---------------------------------------------------------------------------
+
+def suite_review(tasks: Sequence[Task], *, sample: int = 10):
+    """A :data:`~examples.genesis._delegation.Review`: run the suite on a child's work.
+
+    The paper's parent decides "using the available tests, constraints and
+    integration evidence" (3.3), and that is a different decision from the
+    acceptance gate's: it happens **inside** the episode, on one child's
+    contribution, before anything is offered to the version history. Without it
+    a parent here only checked scope, which is the cheap half of a rule whose
+    whole point is the other half.
+
+    Refuses a regression and says nothing otherwise -- structural work that moves
+    no case is exactly what upstream's "partial progress is accepted" is about,
+    so a parent that demanded a gain would refuse the first file of every node.
+
+    ``sample`` bounds the cost: this runs per child per episode, so it is a
+    subset of the suite rather than the whole of it -- integration evidence a
+    parent can afford, not the gate's measurement.
+    """
+    chosen = list(tasks)[:sample]
+    cases = [(t.meta["kind"], t.prompt) for t in chosen]
+    gold = [t.meta["gold"] for t in chosen]
+    cached: Dict[int, int] = {}
+
+    def score(state: Mapping[str, str]) -> int:
+        return sum(1 for out, want in zip(_run_cases(state, cases), gold) if out == want)
+
+    def review(parent, returned):
+        base_state = parent.state
+        key = id(base_state)
+        if key not in cached:
+            cached[key] = score(base_state)
+        candidate = dict(base_state)
+        for edit in returned:
+            if edit.content is None:
+                candidate.pop(edit.path, None)
+            else:
+                candidate[edit.path] = edit.content
+        after = score(candidate)
+        if after < cached[key]:
+            return ("rejected", f"integration check regressed "
+                                f"{cached[key]}/{len(cases)} -> {after}/{len(cases)}")
+        return None
+
+    return review
 
 
 # ---------------------------------------------------------------------------

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -1,4 +1,10 @@
-"""The compact formation domain: a language toolchain grown from an empty repo.
+"""minilang: an integer expression language, grown from an empty repository.
+
+The first of two formation domains -- :mod:`examples.genesis._stackvm` is the
+other, four nodes deep where this is two -- and the shallower one, so the
+reasoning they share is written out here and referred to from there. What both
+sit on is :mod:`examples.genesis._suite`: the harness, the loader, the frozen-file
+restore, the parent's integration check and the LLM actors. A domain is data.
 
 Upstream's formation run starts from a repository with **no implementation in
 it** and ends with a 248,989-line C compiler after 123.4 hours and 1,019
@@ -23,8 +29,8 @@ What is faithful here
 
 What is a surrogate, and says so
 --------------------------------
-``--offline`` proposes with rule-based actors that reveal pre-written module
-implementations one step at a time. It exercises *this port's mechanism* --
+The default (no ``--model``) proposes with rule-based actors that reveal
+pre-written module implementations one step at a time, driven by ``_PLAN``. It exercises *this port's mechanism* --
 delegation, the spatial contract, the octopus merge, the parent's verdict -- and
 it does not exercise a model's ability to write a compiler. It is the same
 device as DGM's surrogate objective and the molecule search's offline operators,
@@ -39,12 +45,10 @@ kind of constraint the paper says the human provides.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
-
-from agentdescent.evolution import Task
+from typing import Dict, List, Mapping, Optional, Sequence
 
 from ._delegation import Brief, Delegation, Edit
-from ._suite import CRASHED, PYTHON_MODULE_SKILL, Suite, reward, run_cases
+from ._suite import PYTHON_MODULE_SKILL, Suite, reward
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
@@ -342,7 +346,6 @@ MINILANG = Suite(
 build_tasks = MINILANG.build_tasks
 make_runner = MINILANG.make_runner
 suite_review = MINILANG.review
-STAGES = MINILANG.stages
 
 
 def llm_manager(complete):
@@ -355,45 +358,30 @@ def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
     return _llm_executor(complete, editable=editable, frozen=frozen)
 
 
-def _run_cases(state, cases, *, timeout: float = 60.0):
-    """This domain's stages, for a caller that has only (state, cases)."""
-    return run_cases(state, cases, MINILANG.stages, timeout=timeout)
-
-
 # ---------------------------------------------------------------------------
 # The offline actors: rule-based, deterministic, and a surrogate (see the header)
 # ---------------------------------------------------------------------------
 
+#: What each node owes, in the order its CONTEXT.md implies. The plan is the whole
+#: surrogate: a real executor decides what to write, this one is told. Same shape
+#: as :mod:`examples.genesis._stackvm`'s, so the two domains read alike.
+_PLAN = {
+    "src": [(ENTRY, _REF_ENTRY)],
+    "src/frontend": [("src/frontend/__init__.py", _PKG_INIT),
+                     (LEXER, _REF_LEXER), (PARSER, _REF_PARSER)],
+    "src/backend": [("src/backend/__init__.py", _PKG_INIT),
+                    (EVALUATOR, _EVALUATOR_SKELETON)],
+}
+
+
 def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
-    """What each node still owes, in the order its CONTEXT.md implies."""
-    owed: Dict[str, List[str]] = {"src": [], "src/frontend": [], "src/backend": []}
-    if ENTRY not in state:
-        owed["src"].append(ENTRY)
-    for node, files in (("src/frontend", ("src/frontend/__init__.py", LEXER, PARSER)),
-                        ("src/backend", ("src/backend/__init__.py", EVALUATOR))):
-        owed[node] = [f for f in files if f not in state]
+    owed = {node: [path for path, _ in steps if path not in state]
+            for node, steps in _PLAN.items()}
     if EVALUATOR in state:
         body = state[EVALUATOR]
         owed["src/backend"] += [f"{EVALUATOR}#{name}"
-                                for name, (stub, _) in _STUBS.items() if stub in body]
+                               for name, (stub, _) in _STUBS.items() if stub in body]
     return owed
-
-
-def offline_manager(brief: Brief) -> Sequence[Delegation]:
-    """Decompose along the node's routing table, or become its executor.
-
-    The decomposition is **read from ``CONTEXT.md``**, not hardcoded here:
-    ``LocalWorld.routing`` parses the routing table of the node the agent is
-    standing on, which is what that table is for upstream. What stays a surrogate
-    is only the choice of *which* routed child to work on, and that is decided by
-    what the node still owes rather than by a fixed list.
-    """
-    path = normalise(brief.world.path)
-    if path == "src" and ENTRY not in brief.state:
-        return ()                           # this node's own file: do it here
-    return [Delegation(node, f"clear the outstanding work under {node}/")
-            for node in brief.world.routing(brief.state)
-            if _owes(brief.state, node)]
 
 
 def _owes(state: Mapping[str, str], node: str) -> bool:
@@ -407,30 +395,32 @@ def _owes(state: Mapping[str, str], node: str) -> bool:
                if key == node or key.startswith(node + "/"))
 
 
+def offline_manager(brief: Brief) -> Sequence[Delegation]:
+    """Decompose along the node's routing table; accountability writes its own.
+
+    The decomposition is **read from ``CONTEXT.md``**, not hardcoded here:
+    ``LocalWorld.routing`` parses the routing table of the node the agent is
+    standing on, which is what that table is for upstream. What stays a surrogate
+    is only the choice of *which* routed child to work on, and that is decided by
+    what the node still owes rather than by a fixed list.
+    """
+    return [Delegation(node, f"clear the outstanding work under {node}/")
+            for node in brief.world.routing(brief.state)
+            if _owes(brief.state, node)]
+
+
 def offline_executor(brief: Brief) -> Sequence[Edit]:
     """Write exactly one file, the way a bounded episode does."""
     path, state = normalise(brief.world.path), brief.state
-    owed = _outstanding(state)
-
-    if path == "src" and ENTRY not in state:
-        return [Edit(owner=path, path=ENTRY, content=_REF_ENTRY)]
-    if path == "src/frontend":
-        for target, content in ((("src/frontend/__init__.py"), _PKG_INIT),
-                                (LEXER, _REF_LEXER), (PARSER, _REF_PARSER)):
-            if target not in state:
-                return [Edit(owner=path, path=target, content=content)]
-        return ()
-    if path == "src/backend":
-        if "src/backend/__init__.py" not in state:
-            return [Edit(owner=path, path="src/backend/__init__.py", content=_PKG_INIT)]
-        if EVALUATOR not in state:
-            return [Edit(owner=path, path=EVALUATOR, content=_EVALUATOR_SKELETON)]
+    for target, content in _PLAN.get(path, ()):
+        if target not in state:
+            return [Edit(owner=path, path=target, content=content)]
+    if path == "src/backend" and EVALUATOR in state:
         name = _stub_for(brief, state)
-        if name is None:
-            return ()
-        stub, filled = _STUBS[name]
-        return [Edit(owner=path, path=EVALUATOR,
-                     content=state[EVALUATOR].replace(stub, filled))]
+        if name is not None:
+            stub, filled = _STUBS[name]
+            return [Edit(owner=path, path=EVALUATOR,
+                         content=state[EVALUATOR].replace(stub, filled))]
     return ()
 
 

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 from typing import Dict, List, Mapping, Optional, Sequence
 
 from ._delegation import Brief, Delegation, Edit
-from ._suite import PYTHON_MODULE_SKILL, Suite, reward
+from ._suite import PYTHON_MODULE_SKILL, Suite, plan_delegations, reward
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
@@ -413,10 +413,11 @@ def offline_manager(brief: Brief) -> Sequence[Delegation]:
     standing on, which is what that table is for upstream. What stays a surrogate
     is only the choice of *which* routed child to work on, and that is decided by
     what the node still owes rather than by a fixed list.
+
+    Cold-started (`--cold-start`) there is no table to read, so it opens the nodes
+    its plan needs and the run records them -- see :func:`plan_delegations`.
     """
-    return [Delegation(node, f"clear the outstanding work under {node}/")
-            for node in brief.world.routing(brief.state)
-            if _owes(brief.state, node)]
+    return plan_delegations(brief, _owes, list(_PLAN))
 
 
 def offline_executor(brief: Brief) -> Sequence[Edit]:

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -623,6 +623,9 @@ Reply with ONE JSON object and nothing else:
 {{"delegations": [{{"path": "<a node inside {path}>", "objective": "<one sentence>"}}]}}
 
 Rules:
+- You are ACCOUNTABLE for all code under `{path}`, and delegating does not \
+discharge that. The files AT `{path}` itself are nobody else's to write: after \
+your children return you get one more turn to write them.
 - A node is a **directory**, never a file. `src/frontend` is a node; \
 `src/frontend/lexer.py` is a file that belongs to the agent situated at \
 `src/frontend`, and delegating to it is refused.

--- a/examples/genesis/_domain.py
+++ b/examples/genesis/_domain.py
@@ -1,0 +1,631 @@
+"""The compact formation domain: a language toolchain grown from an empty repo.
+
+Upstream's formation run starts from a repository with **no implementation in
+it** and ends with a 248,989-line C compiler after 123.4 hours and 1,019
+episodes. That is not a thing a test suite can run, so this is the same *shape*
+at a size that finishes offline in seconds: a human supplies the architecture,
+the constraints and a frozen validation suite; the agents supply every line of
+implementation, growing the tree as they go.
+
+What is faithful here
+---------------------
+* The repository starts implementation-empty -- ``CONTEXT.md`` records and a
+  frozen spec, and nothing else. Every source file in the result was created by
+  an episode.
+* Validation is **staged**, as a real compiler suite is: a case exercises the
+  lexer, the parser, or the evaluator. So the suite has a gradient before the
+  toolchain is complete, which is what lets any gate -- the engine's or the
+  parent's -- see progress at all. Upstream gets this from c-testsuite's own
+  spread; without it, formation has literally zero signal until the last file
+  lands, and no acceptance rule can help.
+* The frozen files are the human's, and stay the human's: ``spec/**`` is refused
+  to every proposal and restored pristine before scoring.
+
+What is a surrogate, and says so
+--------------------------------
+``--offline`` proposes with rule-based actors that reveal pre-written module
+implementations one step at a time. It exercises *this port's mechanism* --
+delegation, the spatial contract, the octopus merge, the parent's verdict -- and
+it does not exercise a model's ability to write a compiler. It is the same
+device as DGM's surrogate objective and the molecule search's offline operators,
+and it is why the offline numbers are a property of the harness rather than a
+result about models. Pass ``--model`` for actors that are asked to write the code.
+
+One human-supplied constraint is worth naming because the domain does not work
+without it: ``src/__init__.py`` imports each stage **lazily**, so a missing
+parser does not stop the lexer's cases from scoring. That is the architectural
+kind of constraint the paper says the human provides.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+from agentdescent.evolution import Task
+from agentdescent.filetree import materialize, parse_tree
+
+from ._delegation import Brief, Delegation, Edit
+from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
+from ._world import normalise
+
+__all__ = ["FROZEN", "build_tasks", "initial_files", "llm_executor", "llm_manager",
+           "make_runner", "offline_executor", "offline_manager", "reward"]
+
+#: Human-supplied and never the agents'. L0 in this repository's sense, and the
+#: role c-testsuite / LLVM / Csmith play upstream.
+FROZEN = ("spec/**",)
+
+ENTRY = "src/__init__.py"
+LEXER = "src/frontend/lexer.py"
+PARSER = "src/frontend/parser.py"
+EVALUATOR = "src/backend/evaluator.py"
+
+
+# ---------------------------------------------------------------------------
+# The human's repository: context, constraints, validation. No implementation.
+# ---------------------------------------------------------------------------
+
+_SPEC = '''# minilang -- the language this project implements
+
+An expression language over integers.
+
+    expr   := term (("+" | "-") term)*
+    term   := atom (("*" | "/") atom)*
+    atom   := NUMBER | "-" atom | "(" expr ")"
+
+`/` is floor division. Whitespace is insignificant.
+
+## The three validated stages
+
+| stage | entry point | what a case checks |
+|---|---|---|
+| `tok`  | `src.tokenize(source)` | the token list, as `repr` |
+| `ast`  | `src.parse(source)`    | the parse tree, as `repr` |
+| `val`  | `src.evaluate(source)` | the integer value, as `repr` |
+
+A stage is scored independently of the ones after it, so `src/__init__.py` MUST
+import each stage lazily, inside the function that needs it. A module-level
+import of a stage that does not exist yet would fail every case in the suite,
+including the ones that stage has nothing to do with.
+
+Tokens are `("num", <int>)` and `("op", <str>)`. The parse tree is nested tuples:
+`("num", n)`, `("neg", x)`, and `(op, left, right)` for the four binary operators.
+'''
+
+_ROOT_CONTEXT = '''# minilang -- root
+
+## Intent
+Implement the language in `spec/CONTEXT.md`. The specification and its staged
+validation are given; no implementation exists yet.
+
+## Routing table
+- `./src/` -> the implementation, and the three stage entry points
+
+## Constraints
+- `spec/` is read-only. It is the validation contract, not a work item.
+- Every agent edits only files under its own path.
+'''
+
+_SRC_CONTEXT = '''# src -- implementation root
+
+## Intent
+Own `src/__init__.py`, the public surface named by the spec: `tokenize`, `parse`
+and `evaluate`. Each MUST import its stage lazily.
+
+## Routing table
+- `./src/frontend/` -> tokenizer and parser
+- `./src/backend/`  -> evaluation of the parse tree
+'''
+
+_FRONTEND_CONTEXT = '''# src/frontend -- source text to parse tree
+
+## Intent
+`lexer.py` turns source text into the token list; `parser.py` turns tokens into
+the nested-tuple parse tree, honouring precedence and parentheses.
+'''
+
+_BACKEND_CONTEXT = '''# src/backend -- parse tree to value
+
+## Intent
+`evaluator.py` walks the parse tree. One function per node kind, so that two
+agents fixing two different node kinds are editing two different parts of the
+file rather than the same one.
+'''
+
+
+def initial_files() -> Dict[str, str]:
+    """The implementation-empty repository the run starts from."""
+    return {
+        "CONTEXT.md": _ROOT_CONTEXT,
+        "spec/CONTEXT.md": _SPEC,
+        "src/CONTEXT.md": _SRC_CONTEXT,
+        "src/frontend/CONTEXT.md": _FRONTEND_CONTEXT,
+        "src/backend/CONTEXT.md": _BACKEND_CONTEXT,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The reference implementation: what the offline actors reveal, and the oracle
+# the frozen suite's expectations are computed from.
+# ---------------------------------------------------------------------------
+
+_REF_ENTRY = '''"""Public surface. Each stage is imported lazily -- see spec/CONTEXT.md."""
+
+
+def tokenize(source):
+    from .frontend.lexer import tokenize as _tokenize
+    return _tokenize(source)
+
+
+def parse(source):
+    from .frontend.parser import parse as _parse
+    return _parse(source)
+
+
+def evaluate(source):
+    from .backend.evaluator import evaluate as _evaluate
+    return _evaluate(parse(source))
+'''
+
+_REF_LEXER = '''"""Source text -> a list of ("num", int) / ("op", str) tokens."""
+
+import re
+
+_TOKEN = re.compile(r"\\s*(?:(\\d+)|(.))")
+
+
+def tokenize(source):
+    tokens, pos = [], 0
+    while pos < len(source):
+        match = _TOKEN.match(source, pos)
+        if match is None:
+            break
+        pos = match.end()
+        number, char = match.group(1), match.group(2)
+        if number is not None:
+            tokens.append(("num", int(number)))
+        elif char is not None and not char.isspace():
+            tokens.append(("op", char))
+    return tokens
+'''
+
+_REF_PARSER = '''"""Tokens -> a nested-tuple parse tree, by recursive descent."""
+
+from .lexer import tokenize
+
+
+def parse(source):
+    node, _pos = _expr(tokenize(source), 0)
+    return node
+
+
+def _expr(tokens, pos):
+    node, pos = _term(tokens, pos)
+    while pos < len(tokens) and tokens[pos][0] == "op" and tokens[pos][1] in "+-":
+        op = tokens[pos][1]
+        right, pos = _term(tokens, pos + 1)
+        node = (op, node, right)
+    return node, pos
+
+
+def _term(tokens, pos):
+    node, pos = _atom(tokens, pos)
+    while pos < len(tokens) and tokens[pos][0] == "op" and tokens[pos][1] in "*/":
+        op = tokens[pos][1]
+        right, pos = _atom(tokens, pos + 1)
+        node = (op, node, right)
+    return node, pos
+
+
+def _atom(tokens, pos):
+    kind, value = tokens[pos]
+    if kind == "num":
+        return ("num", value), pos + 1
+    if value == "-":
+        node, pos = _atom(tokens, pos + 1)
+        return ("neg", node), pos
+    if value == "(":
+        node, pos = _expr(tokens, pos + 1)
+        return node, pos + 1
+    raise SyntaxError(value)
+'''
+
+#: The shape the backend CONTEXT.md asks for: one function per node kind, so two
+#: agents filling two different kinds edit two different hunks. That is what
+#: makes `OctopusConflict` do something a keyed union cannot.
+_EVALUATOR_SKELETON = '''"""Parse tree -> value. One function per node kind."""
+
+
+def evaluate(node):
+    kind = node[0]
+    if kind == "num":
+        return node[1]
+    if kind == "neg":
+        return eval_neg(node)
+    if kind in ("+", "-"):
+        return eval_addsub(node)
+    if kind in ("*", "/"):
+        return eval_muldiv(node)
+    raise ValueError(kind)
+
+
+def eval_neg(node):
+    raise NotImplementedError("neg")
+
+
+def eval_addsub(node):
+    raise NotImplementedError("addsub")
+
+
+def eval_muldiv(node):
+    raise NotImplementedError("muldiv")
+'''
+
+_STUBS = {
+    "neg": ('def eval_neg(node):\n    raise NotImplementedError("neg")\n',
+            'def eval_neg(node):\n    return -evaluate(node[1])\n'),
+    "addsub": ('def eval_addsub(node):\n    raise NotImplementedError("addsub")\n',
+               'def eval_addsub(node):\n    left, right = evaluate(node[1]), evaluate(node[2])\n'
+               '    return left + right if node[0] == "+" else left - right\n'),
+    "muldiv": ('def eval_muldiv(node):\n    raise NotImplementedError("muldiv")\n',
+               'def eval_muldiv(node):\n    left, right = evaluate(node[1]), evaluate(node[2])\n'
+               '    return left * right if node[0] == "*" else left // right\n'),
+}
+
+
+_PKG_INIT = '"""Package marker."""\n'
+
+
+def _reference_tree() -> Dict[str, str]:
+    """The finished repository -- the oracle the frozen suite is computed from."""
+    evaluator = _EVALUATOR_SKELETON
+    for stub, filled in _STUBS.values():
+        evaluator = evaluator.replace(stub, filled)
+    tree = dict(initial_files())
+    tree.update({
+        ENTRY: _REF_ENTRY,
+        "src/frontend/__init__.py": _PKG_INIT,
+        "src/backend/__init__.py": _PKG_INIT,
+        LEXER: _REF_LEXER,
+        PARSER: _REF_PARSER,
+        EVALUATOR: evaluator,
+    })
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# Running a candidate repository
+# ---------------------------------------------------------------------------
+
+#: Executed inside the materialised workspace, in a child process. A candidate
+#: is agent-written code: it can loop, raise or exit, and none of those may take
+#: the run with it.
+_HARNESS = r"""
+import json, sys
+sys.path.insert(0, sys.argv[1])
+cases = json.loads(sys.argv[2])
+import src
+out = []
+for kind, source in cases:
+    try:
+        if kind == "tok":
+            value = src.tokenize(source)
+        elif kind == "ast":
+            value = src.parse(source)
+        else:
+            value = src.evaluate(source)
+        out.append(repr(value))
+    except Exception as exc:            # a stage that is not built yet
+        out.append("ERROR:" + type(exc).__name__)
+print(json.dumps(out), end="")
+"""
+
+#: What a case scores when the workspace could not be run at all -- a syntax
+#: error in a generated module, a timeout, a missing package marker. Distinct
+#: from a wrong answer only in the transcript; both score zero, and conflating
+#: them in the *reward* would be the bug, not here.
+CRASHED = "ERROR:workspace"
+
+
+def _run_cases(state: Mapping[str, str], cases: Sequence[Sequence[str]],
+               *, timeout: float = 30.0) -> List[str]:
+    """Materialise ``state`` and evaluate every case in one child process."""
+    if not cases:
+        return []
+    workspace = tempfile.mkdtemp(prefix="genesis-run-")
+    try:
+        materialize(state, workspace)
+        proc = subprocess.run(
+            [sys.executable, "-c", _HARNESS, workspace, json.dumps(list(cases))],
+            capture_output=True, text=True, timeout=timeout, cwd=workspace)
+        if proc.returncode != 0:
+            return [CRASHED] * len(cases)
+        return list(json.loads(proc.stdout))
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return [CRASHED] * len(cases)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+#: The frozen validation suite: (stage, source). Ordered so that the held-out
+#: tail `evolve()` cuts is a mix of all three stages rather than one of them.
+_CASES = (
+    ("tok", "1 + 2"), ("ast", "1 + 2"), ("val", "1 + 2"),
+    ("tok", "7"), ("ast", "7"), ("val", "7"),
+    ("tok", "2 * 3"), ("ast", "2 * 3"), ("val", "2 * 3"),
+    ("tok", "-5"), ("ast", "-5"), ("val", "-5"),
+    ("tok", "8 / 2"), ("ast", "8 / 2"), ("val", "8 / 2"),
+    ("tok", "(1 + 2) * 3"), ("ast", "(1 + 2) * 3"), ("val", "(1 + 2) * 3"),
+    ("tok", "10 - 4 - 3"), ("ast", "10 - 4 - 3"), ("val", "10 - 4 - 3"),
+    ("tok", "2 * 3 + 4"), ("ast", "2 * 3 + 4"), ("val", "2 * 3 + 4"),
+    ("tok", "-(2 + 3)"), ("ast", "-(2 + 3)"), ("val", "-(2 + 3)"),
+    ("tok", "100 / 7"), ("ast", "100 / 7"), ("val", "100 / 7"),
+)
+
+
+def build_tasks(limit: Optional[int] = None) -> List[Task]:
+    """The suite, with every expected answer computed from the reference tree.
+
+    Computed rather than typed out: a hand-written expectation drifts from the
+    implementation it is supposed to pin, and a suite that disagrees with its own
+    oracle scores a correct candidate wrong. This is the loader, so it is also
+    the boundary ``--dry-run`` must not cross.
+    """
+    cases = list(_CASES)[:limit] if limit else list(_CASES)
+    gold = _run_cases(_reference_tree(), cases)
+    tasks: List[Task] = []
+    for i, ((kind, source), expected) in enumerate(zip(cases, gold)):
+        if expected.startswith("ERROR:"):
+            raise RuntimeError(
+                f"the reference implementation failed case {kind} {source!r} "
+                f"({expected}); the suite would score a correct candidate wrong")
+        tasks.append(Task(id=f"{kind}{i:02d}", prompt=source,
+                          meta={"kind": kind, "gold": expected}))
+    return tasks
+
+
+def make_runner() -> Callable[[str, Task], str]:
+    """``run(rendered, task)`` -- one case against one candidate repository."""
+
+    def run(rendered: str, task: Task) -> str:
+        try:
+            state = dict(parse_tree(rendered))
+        except Exception:  # noqa: BLE001 - an empty artifact, before anything exists
+            return CRASHED
+        # The frozen files are restored from the human's copy rather than taken
+        # from the candidate: a proposal can never write them, and a resumed
+        # ledger or a hand-built aggregator could still put state in front of
+        # this. Scoring against the agents' copy of the suite is the one failure
+        # mode that cannot be detected from a completed run.
+        for path, content in initial_files().items():
+            if path.startswith("spec/"):
+                state[path] = content
+        return _run_cases(state, [(task.meta["kind"], task.prompt)])[0]
+
+    return run
+
+
+def reward(task: Task, output: str) -> float:
+    """Exact match against the frozen suite's expectation."""
+    return 1.0 if output == task.meta.get("gold") else 0.0
+
+
+# ---------------------------------------------------------------------------
+# The offline actors: rule-based, deterministic, and a surrogate (see the header)
+# ---------------------------------------------------------------------------
+
+def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
+    """What each node still owes, in the order its CONTEXT.md implies."""
+    owed: Dict[str, List[str]] = {"src": [], "src/frontend": [], "src/backend": []}
+    if ENTRY not in state:
+        owed["src"].append(ENTRY)
+    for node, files in (("src/frontend", ("src/frontend/__init__.py", LEXER, PARSER)),
+                        ("src/backend", ("src/backend/__init__.py", EVALUATOR))):
+        owed[node] = [f for f in files if f not in state]
+    if EVALUATOR in state:
+        body = state[EVALUATOR]
+        owed["src/backend"] += [f"{EVALUATOR}#{name}"
+                                for name, (stub, _) in _STUBS.items() if stub in body]
+    return owed
+
+
+def offline_manager(brief: Brief) -> Sequence[Delegation]:
+    """Decompose, or return nothing and become the executor of this node.
+
+    The routing table is read from the node's own ``CONTEXT.md`` upstream; here
+    it is the fixed decomposition the human wrote, which is the part of the
+    offline actor that is a surrogate. An LLM manager is not given it.
+    """
+    path, owed = normalise(brief.world.path), _outstanding(brief.state)
+    if path == "":
+        return [Delegation("src", "implement the language under src/")]
+    if path == "src":
+        if ENTRY not in brief.state:
+            return ()                       # this node's own file: do it here
+        return [Delegation(node, f"clear the outstanding work under {node}/")
+                for node in ("src/frontend", "src/backend") if owed[node]]
+    return ()
+
+
+def offline_executor(brief: Brief) -> Sequence[Edit]:
+    """Write exactly one file, the way a bounded episode does."""
+    path, state = normalise(brief.world.path), brief.state
+    owed = _outstanding(state)
+
+    if path == "src" and ENTRY not in state:
+        return [Edit(owner=path, path=ENTRY, content=_REF_ENTRY)]
+    if path == "src/frontend":
+        for target, content in ((("src/frontend/__init__.py"), _PKG_INIT),
+                                (LEXER, _REF_LEXER), (PARSER, _REF_PARSER)):
+            if target not in state:
+                return [Edit(owner=path, path=target, content=content)]
+        return ()
+    if path == "src/backend":
+        if "src/backend/__init__.py" not in state:
+            return [Edit(owner=path, path="src/backend/__init__.py", content=_PKG_INIT)]
+        if EVALUATOR not in state:
+            return [Edit(owner=path, path=EVALUATOR, content=_EVALUATOR_SKELETON)]
+        name = _stub_for(brief, state)
+        if name is None:
+            return ()
+        stub, filled = _STUBS[name]
+        return [Edit(owner=path, path=EVALUATOR,
+                     content=state[EVALUATOR].replace(stub, filled))]
+    return ()
+
+
+def _stub_for(brief: Brief, state: Mapping[str, str]) -> Optional[str]:
+    """Which node kind this episode's failing case points at.
+
+    The *point* of routing by the failure: two workers holding two different
+    failing cases fill two different functions of one file, in the same round.
+    Those are two values for one key, so a keyed union drops one of them and a
+    three-way merge keeps both -- which is the whole comparison this port exists
+    to make runnable.
+    """
+    body = state.get(EVALUATOR, "")
+    open_stubs = [name for name, (stub, _) in _STUBS.items() if stub in body]
+    if not open_stubs:
+        return None
+    source = str(getattr(brief.task, "prompt", ""))
+    wants: List[str] = []
+    if _has_unary_minus(source):
+        wants.append("neg")
+    if "*" in source or "/" in source:
+        wants.append("muldiv")
+    if "+" in source or "-" in source:
+        wants.append("addsub")
+    for name in wants:
+        if name in open_stubs:
+            return name
+    # Nothing this case needs is still open. Upstream a manager would close the
+    # task; here the run would then stall with a stage unbuilt, so the episode
+    # takes the next outstanding item instead -- a surrogate's convenience, and
+    # the reason the offline arm always completes the toolchain.
+    return open_stubs[0]
+
+
+def _has_unary_minus(source: str) -> bool:
+    previous = ""
+    for char in source:
+        if char == "-" and previous in ("", "(", "+", "-", "*", "/"):
+            return True
+        if not char.isspace():
+            previous = char
+    return False
+
+
+# ---------------------------------------------------------------------------
+# The LLM actors: the same two seams, asked rather than computed
+# ---------------------------------------------------------------------------
+
+_MANAGER_PROMPT = """You are a manager agent in a recursive software world. You are \
+situated at the repository path `{path}` and you own everything under it.
+
+{context}
+
+OBJECTIVE
+{objective}
+
+You do not write code. Decide whether to delegate to more specific paths inside \
+your own subtree, or to handle this yourself.
+
+Reply with ONE JSON object and nothing else:
+{{"delegations": [{{"path": "<a path inside {path}>", "objective": "<one sentence>"}}]}}
+
+An empty list means you will handle it at your own path. Never name a path \
+outside your subtree -- it belongs to another agent."""
+
+_EXECUTOR_PROMPT = """You are an executor agent in a recursive software world. You are \
+situated at the repository path `{path}` and you may write ONLY files under it.
+
+{context}
+
+OBJECTIVE
+{objective}
+
+A validation case failed:
+  input    {prompt}
+  produced {output}
+  score    {reward:.2f}
+
+{protocol}"""
+
+
+def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
+    """Ask a model where to situate children. A bad reply means "handle it here"."""
+
+    def manager(brief: Brief) -> Sequence[Delegation]:
+        reply = _ask(complete, _MANAGER_PROMPT.format(
+            path=brief.world.path or "./", context=brief.context,
+            objective=brief.objective))
+        try:
+            data = json.loads(_first_object(reply) or "{}")
+            items = data.get("delegations") or []
+        except Exception:  # noqa: BLE001 - malformed model output, not a bug
+            return ()
+        out = []
+        for item in items:
+            if isinstance(item, dict) and item.get("path"):
+                out.append(Delegation(normalise(str(item["path"])),
+                                      str(item.get("objective", brief.objective))))
+        return out
+
+    return manager
+
+
+def llm_executor(complete, *, editable: Sequence[str] = ("**",),
+                 frozen: Sequence[str] = FROZEN) -> Callable[[Brief], Sequence[Edit]]:
+    """Ask a model for situated edits. Unparseable replies cost their episode."""
+    protocol = SITUATED_EDIT_PROTOCOL.format(
+        editable=", ".join(editable) or "(none)", frozen=", ".join(frozen) or "(none)")
+
+    def executor(brief: Brief) -> Sequence[Edit]:
+        reply = _ask(complete, _EXECUTOR_PROMPT.format(
+            path=brief.world.path or "./", context=brief.context,
+            objective=brief.objective,
+            prompt=getattr(brief.task, "prompt", ""),
+            output=(brief.output or "")[:400], reward=brief.reward,
+            protocol=protocol))
+        return [Edit(owner=brief.world.path or "", path=edit["path"],
+                     content=edit["content"])
+                for edit in parse_situated_edits(reply)]
+
+    return executor
+
+
+def _ask(complete, prompt: str) -> str:
+    try:
+        return complete(prompt) or ""
+    except Exception:  # noqa: BLE001 - a dead backend costs this episode, not the run
+        return ""
+
+
+def _first_object(text: str) -> Optional[str]:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth, in_str, esc = 0, False, False
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_str:
+            esc = (c == "\\") and not esc
+            if c == '"' and not esc:
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None

--- a/examples/genesis/_jqx.py
+++ b/examples/genesis/_jqx.py
@@ -30,13 +30,19 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["FROZEN", "JQX", "build_tasks", "initial_files", "llm_executor",
+__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+           "SCORING", "JQX", "build_tasks", "initial_files", "llm_executor",
            "llm_manager", "make_runner", "offline_executor", "offline_manager",
-           "reward", "suite_review"]
+           "reference_tree", "reward", "suite_review"]
 
 #: The specification and the command-line shell. Human-supplied, refused to every
 #: proposal, and restored pristine before scoring.
 FROZEN = ("spec/**", "jqx.py")
+
+SCORING = "reference oracle, exact match"
+CASE_NOUN = "validation cases"
+GROUP_NOUN = "stages"
+HELD_OUT_FRAC = 0.4
 
 ENTRY = "src/__init__.py"
 LANG_INIT = "src/lang/__init__.py"
@@ -541,7 +547,7 @@ def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
     return _llm_executor(complete, editable=editable, frozen=frozen)
 
 
-def _reference_tree() -> Dict[str, str]:
+def reference_tree() -> Dict[str, str]:
     return JQX.reference_tree()
 
 

--- a/examples/genesis/_jqx.py
+++ b/examples/genesis/_jqx.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import Dict, List, Mapping, Optional, Sequence
 
 from ._delegation import Brief, Delegation, Edit
-from ._suite import PYTHON_MODULE_SKILL, Suite, reward
+from ._suite import PYTHON_MODULE_SKILL, Suite, plan_delegations, reward
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
@@ -581,10 +581,12 @@ def _owes(state: Mapping[str, str], node: str) -> bool:
 
 
 def offline_manager(brief: Brief) -> Sequence[Delegation]:
-    """Decompose along the node's routing table; accountability writes its own."""
-    return [Delegation(node, f"clear the outstanding work under {node}/")
-            for node in brief.world.routing(brief.state)
-            if _owes(brief.state, node)]
+    """Decompose along the node's routing table; accountability writes its own.
+
+    Cold-started there is no table, so it opens the nodes its plan needs -- see
+    :func:`plan_delegations`.
+    """
+    return plan_delegations(brief, _owes, list(_PLAN))
 
 
 def offline_executor(brief: Brief) -> Sequence[Edit]:

--- a/examples/genesis/_jqx.py
+++ b/examples/genesis/_jqx.py
@@ -1,0 +1,614 @@
+"""jqx: a JSON query tool, grown from an empty repository.
+
+The third formation domain, and the one meant to come out as **software someone
+can use**: a filter language with a lexer, a parser, an evaluator, a builtin
+table and an output layer, behind a frozen command-line entry point the agents
+never touch. Run it when it is done::
+
+    python jqx.py '.users | map(.age) | add' people.json
+
+Why a third domain. minilang showed the mechanism, stackvm gave the recursion
+somewhere to go, and neither produces anything you would keep. This one does, and
+it is also the harder test: four validated stages rather than three, nine files
+across four nodes, and a builtin table whose five functions are five independent
+edits to one file -- the case a keyed union cannot fuse.
+
+What is faithful and what is a surrogate is as it is for the other two, and the
+reasoning is written out on :mod:`examples.genesis._domain`. One thing is new:
+``jqx.py`` is **frozen** alongside the specification. The agents grow a library;
+the human supplies the shell around it, so a finished run is a program rather than
+a package nobody can invoke.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from ._delegation import Brief, Delegation, Edit
+from ._suite import PYTHON_MODULE_SKILL, Suite, reward
+from ._suite import llm_executor as _llm_executor
+from ._suite import llm_manager as _llm_manager
+from ._world import SKILLS_DIR, normalise
+
+__all__ = ["FROZEN", "JQX", "build_tasks", "initial_files", "llm_executor",
+           "llm_manager", "make_runner", "offline_executor", "offline_manager",
+           "reward", "suite_review"]
+
+#: The specification and the command-line shell. Human-supplied, refused to every
+#: proposal, and restored pristine before scoring.
+FROZEN = ("spec/**", "jqx.py")
+
+ENTRY = "src/__init__.py"
+LANG_INIT = "src/lang/__init__.py"
+LEXER = "src/lang/lexer.py"
+PARSER = "src/lang/parser.py"
+EVAL_INIT = "src/eval/__init__.py"
+BUILTINS = "src/eval/builtins.py"
+ENGINE = "src/eval/engine.py"
+UI_INIT = "src/ui/__init__.py"
+FORMAT = "src/ui/format.py"
+
+
+# ---------------------------------------------------------------------------
+# The human's repository: the language, the decomposition, the entry point
+# ---------------------------------------------------------------------------
+
+_SPEC = r'''# jqx -- the filter language this project implements
+
+A filter maps one JSON value to a **list** of JSON values.
+
+## Grammar
+
+    filter   := pipeline
+    pipeline := term ("|" term)*            left-associative
+    term     := path | NAME | NAME "(" pipeline ")"
+    path     := "." step*
+    step     := NAME | "[" INT "]" | "[" "]"
+
+`.` on its own is the identity filter. `.a.b` is sugar for `.a | .b`, and the
+parser MUST desugar it: the AST never contains a multi-step path.
+
+## AST
+
+| node | means |
+|---|---|
+| `("identity",)` | the input, unchanged |
+| `("field", name)` | the value at `name`, or `null` when the input is not an object or has no such key |
+| `("index", n)` | element `n` of an array (negative counts from the end), or `null` when out of range or not an array |
+| `("iterate",)` | every element of an array, or every value of an object **in sorted-key order**; an empty list for anything else |
+| `("pipe", left, right)` | every result of `right` applied to every result of `left` |
+| `("call", name)` | a builtin with no argument |
+| `("call1", name, filter)` | a builtin with one filter argument; only `map` exists |
+
+## Builtins
+
+| builtin | on | result |
+|---|---|---|
+| `length` | array, object, string | its length; `null` -> `0`; anything else raises |
+| `keys` | object, array | sorted keys; for an array, `[0, 1, ...]` |
+| `values` | object, array | values in sorted-key order; for an array, itself |
+| `add` | array | the elements combined left to right with `+`; `[]` -> `null` |
+| `type` | anything | `"null"` `"boolean"` `"number"` `"string"` `"array"` `"object"` |
+| `map(f)` | array | one result: the concatenation of `f` applied to each element |
+
+## The four validated stages
+
+| stage | entry point | the argument | what a case checks |
+|---|---|---|---|
+| `lex` | `src.tokenize(filter)` | the filter text | the token list, as `repr` |
+| `ast` | `src.parse(filter)` | the filter text | the AST, as `repr` |
+| `val` | `src.query(payload)` | `{"filter": ..., "input": ...}` as JSON text | the result list, as `repr` |
+| `out` | `src.render(payload)` | the same payload | the text: one result per line, `json.dumps` with `sort_keys=True` and `(",", ":")` separators |
+
+Tokens are `("dot",)` `("name", str)` `("int", int)` `("lbracket",)`
+`("rbracket",)` `("lparen",)` `("rparen",)` `("pipe",)`.
+
+A stage is scored independently of the ones after it, so `src/__init__.py` MUST
+import each stage lazily, inside the function that needs it.
+'''
+
+_ROOT_CONTEXT = r'''# jqx -- root
+
+## Intent
+Implement the filter language in `spec/CONTEXT.md` as a library under `src/`.
+`jqx.py` is the command-line entry point and is already written.
+
+## Routing Table
+- `./src/` -> the library, and the four stage entry points
+
+## Constraints
+- `spec/` and `jqx.py` are read-only. They are the contract, not work items.
+- Every agent edits only files under its own path.
+'''
+
+_SRC_CONTEXT = r'''# src -- library root
+
+## Intent
+Own `src/__init__.py`, the public surface named by the spec: `tokenize`, `parse`,
+`query` and `render`. Each MUST import its stage lazily.
+
+## Routing Table
+- `./src/lang/` -> filter text to an AST
+- `./src/eval/` -> an AST applied to a value
+- `./src/ui/`   -> results to text
+'''
+
+_LANG_CONTEXT = r'''# src/lang -- filter text to an AST
+
+## Intent
+`lexer.py` turns filter text into the token list. `parser.py` turns tokens into
+the AST, desugaring `.a.b` into a pipe so the evaluator never sees a multi-step
+path, and rejecting a filter with tokens left over.
+'''
+
+_EVAL_CONTEXT = r'''# src/eval -- an AST applied to a value
+
+## Intent
+`engine.py` walks the AST; every node returns a **list** of results, so a pipe is
+a flat-map and nothing else needs to know about streams. `builtins.py` holds the
+builtins, **one function per builtin**, plus the table that maps a name to one --
+so that two agents fixing two different builtins are editing two different parts
+of the file rather than the same one.
+'''
+
+_UI_CONTEXT = r'''# src/ui -- results to text
+
+## Intent
+`format.py` renders a result list the way the spec's `out` stage describes: one
+JSON value per line, keys sorted, compact separators, a trailing newline on every
+line including the last.
+'''
+
+_ENTRY_SCRIPT = r'''#!/usr/bin/env python3
+"""jqx -- query JSON from the command line.
+
+Human-supplied, frozen, and never written by an agent: the library under ``src/``
+is what the run grows, and this is the shell around it so the result is a program
+rather than a package nobody can invoke.
+
+    python jqx.py '.users[].name' people.json
+    cat people.json | python jqx.py '.users | map(.age) | add'
+    python jqx.py --help
+"""
+
+import argparse
+import json
+import sys
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="jqx", description="Query JSON with a small filter language.",
+        epilog="See spec/CONTEXT.md for the filter language.")
+    parser.add_argument("filter", help="the filter, e.g. '.users[].name'")
+    parser.add_argument("file", nargs="?",
+                        help="JSON input file (default: standard input)")
+    parser.add_argument("-i", "--indent", type=int, default=None, metavar="N",
+                        help="pretty-print each result with N spaces of indent")
+    args = parser.parse_args(argv)
+
+    text = open(args.file, encoding="utf-8").read() if args.file else sys.stdin.read()
+    try:
+        document = json.loads(text)
+    except ValueError as exc:
+        print(f"jqx: input is not JSON: {exc}", file=sys.stderr)
+        return 2
+
+    from src import query
+    payload = json.dumps({"filter": args.filter, "input": document})
+    try:
+        results = query(payload)
+    except Exception as exc:                # a filter error is the user's, not a crash
+        print(f"jqx: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    for value in results:
+        print(json.dumps(value, sort_keys=True, indent=args.indent,
+                         separators=None if args.indent else (",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def initial_files() -> Dict[str, str]:
+    """The implementation-empty repository the run starts from."""
+    return {
+        "CONTEXT.md": _ROOT_CONTEXT,
+        "spec/CONTEXT.md": _SPEC,
+        "jqx.py": _ENTRY_SCRIPT,
+        "src/CONTEXT.md": _SRC_CONTEXT,
+        "src/lang/CONTEXT.md": _LANG_CONTEXT,
+        "src/eval/CONTEXT.md": _EVAL_CONTEXT,
+        "src/ui/CONTEXT.md": _UI_CONTEXT,
+        f"src/{SKILLS_DIR}/python-modules.md": PYTHON_MODULE_SKILL,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The reference implementation: the oracle, and what the offline actors reveal
+# ---------------------------------------------------------------------------
+
+_PKG_INIT = '"""Package marker."""\n'
+
+_REF_ENTRY = r'''"""Public surface. Each stage is imported lazily -- see spec/CONTEXT.md."""
+
+
+def tokenize(source):
+    from .lang.lexer import tokenize as _tokenize
+    return _tokenize(source)
+
+
+def parse(source):
+    from .lang.parser import parse as _parse
+    return _parse(source)
+
+
+def query(payload):
+    from .eval.engine import query as _query
+    return _query(payload)
+
+
+def render(payload):
+    from .ui.format import render as _render
+    return _render(payload)
+'''
+
+_REF_LEXER = r'''"""Filter text -> tokens."""
+
+_PUNCT = {".": "dot", "[": "lbracket", "]": "rbracket",
+          "(": "lparen", ")": "rparen", "|": "pipe"}
+
+
+def tokenize(source):
+    tokens, i = [], 0
+    while i < len(source):
+        ch = source[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch in _PUNCT:
+            tokens.append((_PUNCT[ch],))
+            i += 1
+            continue
+        if ch == "-" or ch.isdigit():
+            j = i + 1
+            while j < len(source) and source[j].isdigit():
+                j += 1
+            tokens.append(("int", int(source[i:j])))
+            i = j
+            continue
+        if ch.isalpha() or ch == "_":
+            j = i
+            while j < len(source) and (source[j].isalnum() or source[j] == "_"):
+                j += 1
+            tokens.append(("name", source[i:j]))
+            i = j
+            continue
+        raise ValueError("unexpected character: " + ch)
+    return tokens
+'''
+
+_REF_PARSER = r'''"""Tokens -> an AST. `.a.b` desugars to a pipe, so the evaluator stays small."""
+
+from .lexer import tokenize
+
+
+def parse(source):
+    tokens = tokenize(source)
+    node, pos = _pipeline(tokens, 0)
+    if pos != len(tokens):
+        raise ValueError("trailing tokens")
+    return node
+
+
+def _pipeline(tokens, pos):
+    node, pos = _term(tokens, pos)
+    while pos < len(tokens) and tokens[pos][0] == "pipe":
+        right, pos = _term(tokens, pos + 1)
+        node = ("pipe", node, right)
+    return node, pos
+
+
+def _term(tokens, pos):
+    if pos >= len(tokens):
+        raise ValueError("unexpected end of filter")
+    kind = tokens[pos][0]
+    if kind == "name":
+        name = tokens[pos][1]
+        pos += 1
+        if pos < len(tokens) and tokens[pos][0] == "lparen":
+            inner, pos = _pipeline(tokens, pos + 1)
+            if pos >= len(tokens) or tokens[pos][0] != "rparen":
+                raise ValueError("expected )")
+            return ("call1", name, inner), pos + 1
+        return ("call", name), pos
+    if kind != "dot":
+        raise ValueError("expected a path or a builtin")
+    steps, pos = [], pos + 1
+    while pos < len(tokens):
+        kind = tokens[pos][0]
+        if kind == "name":
+            steps.append(("field", tokens[pos][1]))
+            pos += 1
+        elif kind == "lbracket":
+            if pos + 1 < len(tokens) and tokens[pos + 1][0] == "rbracket":
+                steps.append(("iterate",))
+                pos += 2
+            elif (pos + 2 < len(tokens) and tokens[pos + 1][0] == "int"
+                  and tokens[pos + 2][0] == "rbracket"):
+                steps.append(("index", tokens[pos + 1][1]))
+                pos += 3
+            else:
+                raise ValueError("expected [] or [<int>]")
+        elif kind == "dot":
+            pos += 1
+        else:
+            break
+    if not steps:
+        return ("identity",), pos
+    node = steps[0]
+    for step in steps[1:]:
+        node = ("pipe", node, step)
+    return node, pos
+'''
+
+_REF_ENGINE = r'''"""AST -> a stream of results. A filter maps one value to a list of values."""
+
+import json
+
+from .builtins import TABLE
+
+
+def query(payload):
+    spec = json.loads(payload)
+    from ..lang.parser import parse
+    return apply_filter(parse(spec["filter"]), spec["input"])
+
+
+def apply_filter(node, value):
+    kind = node[0]
+    if kind == "identity":
+        return [value]
+    if kind == "field":
+        return [value.get(node[1]) if isinstance(value, dict) else None]
+    if kind == "index":
+        if isinstance(value, list) and -len(value) <= node[1] < len(value):
+            return [value[node[1]]]
+        return [None]
+    if kind == "iterate":
+        if isinstance(value, list):
+            return list(value)
+        if isinstance(value, dict):
+            return [value[k] for k in sorted(value)]
+        return []
+    if kind == "pipe":
+        out = []
+        for item in apply_filter(node[1], value):
+            out.extend(apply_filter(node[2], item))
+        return out
+    if kind == "call":
+        return [TABLE[node[1]](value)]
+    if kind == "call1":
+        if node[1] != "map":
+            raise ValueError("unknown builtin: " + node[1])
+        if not isinstance(value, list):
+            raise ValueError("map: not an array")
+        mapped = []
+        for item in value:
+            mapped.extend(apply_filter(node[2], item))
+        return [mapped]
+    raise ValueError("unknown node: " + kind)
+'''
+
+_REF_FORMAT = r'''"""Results -> text. One JSON value per line, keys sorted, compact separators."""
+
+import json
+
+
+def render(payload):
+    from ..eval.engine import query
+    lines = [json.dumps(value, sort_keys=True, separators=(",", ":"))
+             for value in query(payload)]
+    return "".join(line + "\n" for line in lines)
+'''
+
+#: The shape `src/eval/CONTEXT.md` asks for: one function per builtin, five of
+#: them, each independently fillable. Five edits to one file is what makes the
+#: three-way merge do something a keyed union cannot.
+_BUILTINS_SKELETON = r'''"""One function per builtin. Each takes a value and returns a value."""
+
+
+def length(value):
+    raise NotImplementedError("length")
+
+
+def keys(value):
+    raise NotImplementedError("keys")
+
+
+def values(value):
+    raise NotImplementedError("values")
+
+
+def add(value):
+    raise NotImplementedError("add")
+
+
+def type_of(value):
+    raise NotImplementedError("type_of")
+
+
+TABLE = {"length": length, "keys": keys, "values": values, "add": add,
+         "type": type_of}
+'''
+
+_STUBS = {'length': ('def length(value):\n    raise NotImplementedError("length")\n', 'def length(value):\n    if value is None:\n        return 0\n    if isinstance(value, (list, dict, str)):\n        return len(value)\n    raise ValueError("length: not a container")\n'), 'keys': ('def keys(value):\n    raise NotImplementedError("keys")\n', 'def keys(value):\n    if isinstance(value, dict):\n        return sorted(value)\n    if isinstance(value, list):\n        return list(range(len(value)))\n    raise ValueError("keys: not an object or array")\n'), 'values': ('def values(value):\n    raise NotImplementedError("values")\n', 'def values(value):\n    if isinstance(value, dict):\n        return [value[k] for k in sorted(value)]\n    if isinstance(value, list):\n        return list(value)\n    raise ValueError("values: not an object or array")\n'), 'add': ('def add(value):\n    raise NotImplementedError("add")\n', 'def add(value):\n    if not isinstance(value, list):\n        raise ValueError("add: not an array")\n    if not value:\n        return None\n    total = value[0]\n    for item in value[1:]:\n        total = total + item\n    return total\n'), 'type_of': ('def type_of(value):\n    raise NotImplementedError("type_of")\n', 'def type_of(value):\n    if value is None:\n        return "null"\n    if isinstance(value, bool):\n        return "boolean"\n    if isinstance(value, (int, float)):\n        return "number"\n    if isinstance(value, str):\n        return "string"\n    if isinstance(value, list):\n        return "array"\n    return "object"\n')}
+
+
+def _filled_builtins() -> str:
+    body = _BUILTINS_SKELETON
+    for stub, filled in _STUBS.values():
+        body = body.replace(stub, filled)
+    return body
+
+
+#: The frozen validation suite: (stage, source). `lex` and `ast` take the filter
+#: text; `val` and `out` take the payload. Interleaved by filter so the held-out
+#: tail `evolve()` cuts is a mix of stages rather than one stage's worth.
+_CASES = (
+    ("lex", 'keys'), ("ast", 'keys'),
+    ("val", '{"filter": "keys", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": "keys", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users[0] | keys'), ("ast", '.users[0] | keys'),
+    ("val", '{"filter": ".users[0] | keys", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[0] | keys", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users[0] | values'), ("ast", '.users[0] | values'),
+    ("val", '{"filter": ".users[0] | values", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[0] | values", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users | length'), ("ast", '.users | length'),
+    ("val", '{"filter": ".users | length", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users | length", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.n | type'), ("ast", '.n | type'),
+    ("val", '{"filter": ".n | type", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".n | type", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", 'add'), ("ast", 'add'),
+    ("val", '{"filter": "add", "input": [3, 1, 2]}'),
+    ("out", '{"filter": "add", "input": [3, 1, 2]}'),
+    ("lex", '.users | map(.age)'), ("ast", '.users | map(.age)'),
+    ("val", '{"filter": ".users | map(.age)", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users | map(.age)", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users | map(.age) | add'), ("ast", '.users | map(.age) | add'),
+    ("val", '{"filter": ".users | map(.age) | add", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users | map(.age) | add", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", 'length'), ("ast", 'length'),
+    ("val", '{"filter": "length", "input": [3, 1, 2]}'),
+    ("out", '{"filter": "length", "input": [3, 1, 2]}'),
+    ("lex", '.'), ("ast", '.'),
+    ("val", '{"filter": ".", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.n'), ("ast", '.n'),
+    ("val", '{"filter": ".n", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".n", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users[0].name'), ("ast", '.users[0].name'),
+    ("val", '{"filter": ".users[0].name", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[0].name", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users[].name'), ("ast", '.users[].name'),
+    ("val", '{"filter": ".users[].name", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[].name", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users[0].tags | length'), ("ast", '.users[0].tags | length'),
+    ("val", '{"filter": ".users[0].tags | length", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[0].tags | length", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.missing'), ("ast", '.missing'),
+    ("val", '{"filter": ".missing", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".missing", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.users[-1].name'), ("ast", '.users[-1].name'),
+    ("val", '{"filter": ".users[-1].name", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[-1].name", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("lex", '.[]'), ("ast", '.[]'),
+    ("val", '{"filter": ".[]", "input": [3, 1, 2]}'),
+    ("out", '{"filter": ".[]", "input": [3, 1, 2]}'),
+    ("lex", '.users[0].tags[0]'), ("ast", '.users[0].tags[0]'),
+    ("val", '{"filter": ".users[0].tags[0]", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+    ("out", '{"filter": ".users[0].tags[0]", "input": {"n": 2, "users": [{"age": 36, "name": "ada", "tags": ["x", "y"]}, {"age": 41, "name": "bob", "tags": []}]}}'),
+)
+
+JQX = Suite(
+    name="jqx",
+    given=initial_files(),
+    frozen=FROZEN,
+    stages={"lex": "tokenize", "ast": "parse", "val": "query", "out": "render"},
+    cases=_CASES,
+    reference={
+        ENTRY: _REF_ENTRY,
+        LANG_INIT: _PKG_INIT, LEXER: _REF_LEXER, PARSER: _REF_PARSER,
+        EVAL_INIT: _PKG_INIT, BUILTINS: _filled_builtins(), ENGINE: _REF_ENGINE,
+        UI_INIT: _PKG_INIT, FORMAT: _REF_FORMAT,
+    },
+)
+
+build_tasks = JQX.build_tasks
+make_runner = JQX.make_runner
+suite_review = JQX.review
+
+
+def llm_manager(complete):
+    return _llm_manager(complete)
+
+
+def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
+    return _llm_executor(complete, editable=editable, frozen=frozen)
+
+
+def _reference_tree() -> Dict[str, str]:
+    return JQX.reference_tree()
+
+
+# ---------------------------------------------------------------------------
+# The offline actors: rule-based, deterministic, and a surrogate
+# ---------------------------------------------------------------------------
+
+_PLAN = {
+    "src": [(ENTRY, _REF_ENTRY)],
+    "src/lang": [(LANG_INIT, _PKG_INIT), (LEXER, _REF_LEXER), (PARSER, _REF_PARSER)],
+    "src/eval": [(EVAL_INIT, _PKG_INIT), (BUILTINS, _BUILTINS_SKELETON),
+                 (ENGINE, _REF_ENGINE)],
+    "src/ui": [(UI_INIT, _PKG_INIT), (FORMAT, _REF_FORMAT)],
+}
+
+
+def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
+    owed = {node: [path for path, _ in steps if path not in state]
+             for node, steps in _PLAN.items()}
+    if BUILTINS in state:
+        body = state[BUILTINS]
+        owed["src/eval"] += [f"{BUILTINS}#{name}"
+                             for name, (stub, _) in _STUBS.items() if stub in body]
+    return owed
+
+
+def _owes(state: Mapping[str, str], node: str) -> bool:
+    node = normalise(node)
+    return any(items for key, items in _outstanding(state).items()
+               if key == node or key.startswith(node + "/"))
+
+
+def offline_manager(brief: Brief) -> Sequence[Delegation]:
+    """Decompose along the node's routing table; accountability writes its own."""
+    return [Delegation(node, f"clear the outstanding work under {node}/")
+            for node in brief.world.routing(brief.state)
+            if _owes(brief.state, node)]
+
+
+def offline_executor(brief: Brief) -> Sequence[Edit]:
+    """Write exactly one file, the way a bounded episode does."""
+    path, state = normalise(brief.world.path), brief.state
+    for target, content in _PLAN.get(path, ()):
+        if target not in state:
+            return [Edit(owner=path, path=target, content=content)]
+    if path == "src/eval" and BUILTINS in state:
+        name = _stub_for(brief, state)
+        if name is not None:
+            stub, filled = _STUBS[name]
+            return [Edit(owner=path, path=BUILTINS,
+                         content=state[BUILTINS].replace(stub, filled))]
+    return ()
+
+
+def _stub_for(brief: Brief, state: Mapping[str, str]) -> Optional[str]:
+    """Which builtin this episode's failing filter points at.
+
+    Two workers holding two different failing filters fill two different functions
+    of one file -- two values for one key, which a keyed union drops one of and a
+    three-way merge keeps both.
+    """
+    body = state.get(BUILTINS, "")
+    open_stubs = [n for n, (stub, _) in _STUBS.items() if stub in body]
+    if not open_stubs:
+        return None
+    source = str(getattr(brief.task, "prompt", ""))
+    for name in open_stubs:
+        if (name.replace("_of", "") in source):
+            return name
+    return open_stubs[0]

--- a/examples/genesis/_jqx.py
+++ b/examples/genesis/_jqx.py
@@ -30,7 +30,7 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+__all__ = ["CASE_NOUN", "CONTRACTS", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
            "SCORING", "JQX", "build_tasks", "initial_files", "llm_executor",
            "llm_manager", "make_runner", "offline_executor", "offline_manager",
            "reference_tree", "reward", "suite_review"]
@@ -38,6 +38,7 @@ __all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
 #: The specification and the command-line shell. Human-supplied, refused to every
 #: proposal, and restored pristine before scoring.
 FROZEN = ("spec/**", "jqx.py")
+CONTRACTS = FROZEN
 
 SCORING = "reference oracle, exact match"
 CASE_NOUN = "validation cases"
@@ -119,6 +120,10 @@ _ROOT_CONTEXT = r'''# jqx -- root
 Implement the filter language in `spec/CONTEXT.md` as a library under `src/`.
 `jqx.py` is the command-line entry point and is already written.
 
+## API Surface
+`jqx.py` -- the command-line shell. It reaches the library only through the four
+entry points below.
+
 ## Routing Table
 - `./src/` -> the library, and the four stage entry points
 
@@ -133,6 +138,10 @@ _SRC_CONTEXT = r'''# src -- library root
 Own `src/__init__.py`, the public surface named by the spec: `tokenize`, `parse`,
 `query` and `render`. Each MUST import its stage lazily.
 
+## API Surface
+- `src/__init__.py`: `tokenize(source)`, `parse(source)`, `query(payload)`,
+  `render(payload)` -- the first two take filter text, the last two a JSON payload.
+
 ## Routing Table
 - `./src/lang/` -> filter text to an AST
 - `./src/eval/` -> an AST applied to a value
@@ -145,6 +154,10 @@ _LANG_CONTEXT = r'''# src/lang -- filter text to an AST
 `lexer.py` turns filter text into the token list. `parser.py` turns tokens into
 the AST, desugaring `.a.b` into a pipe so the evaluator never sees a multi-step
 path, and rejecting a filter with tokens left over.
+
+## API Surface
+- `lexer.py`: `tokenize(source)`
+- `parser.py`: `parse(source)` -- the filter text, and it tokenizes internally
 '''
 
 _EVAL_CONTEXT = r'''# src/eval -- an AST applied to a value
@@ -155,6 +168,10 @@ a flat-map and nothing else needs to know about streams. `builtins.py` holds the
 builtins, **one function per builtin**, plus the table that maps a name to one --
 so that two agents fixing two different builtins are editing two different parts
 of the file rather than the same one.
+
+## API Surface
+- `engine.py`: `query(payload)`, `apply_filter(node, value) -> [value]`
+- `builtins.py`: one function per builtin, plus the name-to-function table
 '''
 
 _UI_CONTEXT = r'''# src/ui -- results to text
@@ -163,6 +180,9 @@ _UI_CONTEXT = r'''# src/ui -- results to text
 `format.py` renders a result list the way the spec's `out` stage describes: one
 JSON value per line, keys sorted, compact separators, a trailing newline on every
 line including the last.
+
+## API Surface
+- `format.py`: `render(payload)` -> the text
 '''
 
 _ENTRY_SCRIPT = r'''#!/usr/bin/env python3

--- a/examples/genesis/_judge.py
+++ b/examples/genesis/_judge.py
@@ -1,0 +1,168 @@
+"""The responsible parent's verdict, as an
+:class:`~agentdescent.policies.AcceptancePolicy`.
+
+Upstream, acceptance is not statistical. A parent agent decides whether a
+returned contribution is **accepted, rejected, or needs more work**, using the
+tests, constraints and integration evidence it has (paper 3.3), and the rule its
+prompt states is monotone::
+
+    Partial progress is accepted -- a version is accepted if it improves the
+    codebase, even if other parts remain broken.
+        -- genesis, apps/evo_git/lib/evo_git/agents/manager.ex:58
+
+The engine's shipped rule is a Beta posterior on held-out improvement. Swapping
+one for the other is a change to the **acceptance rule**, which
+``docs/port-fidelity.md`` puts in the *must not change* column -- so it is behind
+a flag, off by default, and the run prints which rule it used. ACE is the
+precedent and the warning: replacing an upstream acceptance rule with this
+engine's gate silently emptied an artifact whose entire claim was accumulation.
+
+Two things this cannot do, stated rather than worked around:
+
+* :class:`~agentdescent.policies.AcceptDecision` is a boolean, and its
+  ``category`` is a **closed vocabulary** -- the aggregator turns it into a
+  :class:`~agentdescent.aggregator.MergeOutcome`, so a policy that invents a name
+  raises inside the merge rather than reporting a new reason. "Needs more work"
+  therefore commits the partial progress (which is upstream's rule) and leaves a
+  request in the :class:`~examples.genesis._world.WorldLog` that the next round's
+  manager re-delegates from. The third verdict is reconstructed out of parts the
+  engine already has; it is not a third outcome in the engine.
+* **The audit gate runs before this policy**, and on an L1 artifact it vetoes any
+  candidate with ``oracle_cand <= oracle_base``. That is a strict-improvement rule
+  laid over acceptance, and it is incompatible with "partial progress is
+  accepted": a formation run's first structural steps move no case at all. The
+  port therefore runs the world at L2 and says why (see the entry point);
+  governance is deliberately not a seam, so this is a boundary to report, not one
+  to route around.
+* A parent judging *its own child* happens inside the recursion, before anything
+  reaches the ledger (see :mod:`examples.genesis._delegation`). This policy is
+  the other judging: the task-level one, on what the whole episode returned.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from agentdescent.defaults import DefaultAcceptance
+from agentdescent.policies import AcceptDecision, MergeContext
+
+from ._world import WorldLog, normalise
+
+__all__ = ["ParentJudge"]
+
+
+@dataclass
+class ParentJudge:
+    """Accept on improvement, refuse on regression, ask again on a tie.
+
+    With ``enabled=False`` every call is forwarded to ``inner`` untouched, so the
+    default run is the engine's and a golden comparison against
+    :class:`~agentdescent.defaults.DefaultAcceptance` is exact.
+    """
+
+    log: Optional[WorldLog] = None
+    enabled: bool = False
+    #: Below this, a held-out move is a tie rather than progress. Not a
+    #: threshold on significance -- the upstream rule has none -- but on
+    #: *measurement*: one task flipping on a 12-task split is 0.083, and calling
+    #: that "the codebase improved" would accept noise as progress.
+    tie: float = 1e-9
+    inner: Optional[object] = None
+    accepted: int = 0
+    rejected: int = 0
+    #: Accepted with no case moved -- upstream's "partial progress", and the
+    #: number to look at when a run commits a lot and improves little.
+    partial: int = 0
+
+    def __post_init__(self) -> None:
+        if self.inner is None:
+            self.inner = DefaultAcceptance()
+
+    def configure(self, config) -> None:
+        """Fill the inner rule's thresholds from the run's config."""
+        configure = getattr(self.inner, "configure", None)
+        if callable(configure):
+            configure(config)
+
+    def bind(self, verifier) -> None:
+        bind = getattr(self.inner, "bind", None)
+        if callable(bind):
+            bind(verifier)
+
+    def accept(self, ctx: MergeContext) -> AcceptDecision:
+        if not self.enabled:
+            return self.inner.accept(ctx)
+
+        base = ctx.rate(ctx.base_counts)
+        cand = ctx.rate(ctx.cand_counts)
+        observed = cand - base
+
+        if not ctx.comparable():
+            # Two measurements from different toolchains are not evidence about
+            # the change. The engine's own gate carries the same field for the
+            # same reason; a parent that ignored it would read an environment
+            # difference as progress.
+            self.rejected += 1
+            return AcceptDecision(False, "below-threshold",
+                                  f"incomparable: {ctx.base_env!r} vs {ctx.cand_env!r}",
+                                  observed_delta=observed)
+
+        if observed < -self.tie:
+            self.rejected += 1
+            return AcceptDecision(False, "below-threshold",
+                                  f"parent rejects regression {base:.3f} -> {cand:.3f}",
+                                  observed_delta=observed)
+
+        if observed > self.tie:
+            self.accepted += 1
+            return AcceptDecision(True, "committed",
+                                  f"parent accepts: {base:.3f} -> {cand:.3f}",
+                                  observed_delta=observed)
+
+        # A tie: nothing broke, and no case moved. This is the rule the port
+        # exists to run --
+        #
+        #     Partial progress is accepted -- a version is accepted if it
+        #     improves the codebase, even if other parts remain broken.
+        #
+        # -- and it is what lets a formation run start at all: the first files of
+        # an empty repository are structure, and structure moves no test. The
+        # parent accepts them *and* sends more work to the subtree they came
+        # from, which is the request the next round's manager picks up.
+        self.partial += 1
+        path = _deepest_touched(ctx)
+        if self.log is not None:
+            self.log.request_rework(
+                path, f"held-out unchanged at {cand:.3f}: the step was structural. "
+                      f"Continue in this subtree until a case moves")
+        return AcceptDecision(True, "committed",
+                              f"parent accepts partial progress at {path or './'} "
+                              f"({cand:.3f} unchanged)",
+                              observed_delta=observed)
+
+    def stats(self) -> str:
+        return (f"parent judge: accepted={self.accepted} rejected={self.rejected} "
+                f"partial={self.partial}")
+
+
+def _deepest_touched(ctx: MergeContext) -> str:
+    """The subtree a refusal should be sent back to.
+
+    The common ancestor of the keys the candidate touched: sending the request to
+    the root would ask the whole world to try again, and sending it to one file
+    would name a path no manager is situated at.
+    """
+    paths = sorted(getattr(ctx.diff, "ops", {}) or {})
+    if not paths:
+        return ""
+    parts = [normalise(p).split("/")[:-1] for p in paths]
+    common = parts[0]
+    for other in parts[1:]:
+        keep = []
+        for a, b in zip(common, other):
+            if a != b:
+                break
+            keep.append(a)
+        common = keep
+    return "/".join(common)

--- a/examples/genesis/_judge.py
+++ b/examples/genesis/_judge.py
@@ -41,7 +41,7 @@ Two things this cannot do, stated rather than worked around:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 from agentdescent.defaults import DefaultAcceptance

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -1,23 +1,35 @@
 """md: Lennard-Jones molecular dynamics, grown from an empty repository.
 
-The fourth formation domain and by some distance the largest: **ten** validated
-stages, fifteen files the agents write across six nodes, and a physics kernel that
-has to be right rather than merely parseable. A frozen driver sits on top, so a
-finished run is a program you can point at a box of argon::
+The fourth formation domain, the largest, and the only one with **no oracle in the
+scoring path**. A frozen test suite is the whole of the reward: fifty-seven test
+functions over six files, one task each, and a task's prompt is that test's own
+source. Nothing here is compared against a reference implementation, because asking
+a system to grow software you had to write first proves nothing. Upstream validates
+against c-testsuite, LLVM and Csmith -- assertions, not expected outputs -- and this
+is the same shape at a size that finishes in an afternoon.
 
-    python md.py --particles 108 --density 0.8 --temperature 1.2 --steps 1000 \
+What comes out is a program you can point at a box of argon::
+
+    python md.py --particles 108 --density 0.8 --temperature 1.2 --steps 2000 \
                  --thermostat 0.5 --trajectory traj.xyz --rdf 40
 
 Why this domain exists. minilang showed the mechanism, stackvm gave the recursion
-somewhere to go, jqx came out as usable software -- and all three can be passed by
-code that merely parses. This one cannot: four of its ten stages are **invariants**
-rather than values. Forces have to sum to zero, they have to match a central
-difference of the energy, and energy and momentum have to survive a trajectory. A
-stage that returns ``True`` without computing anything fails, because one ``cons``
-case uses a timestep far too large and its answer is ``False``.
+somewhere to go, jqx came out as usable software -- and all three are scored by
+matching a reference's output, which code that merely parses can sometimes do. This
+one cannot be bluffed: many of its tests are **invariants** rather than values. The
+forces must sum to zero and must match a central difference of the energy, energy
+and momentum must survive a trajectory, reversing the velocities must retrace it --
+and one test asserts that a far-too-large timestep does *not* conserve energy, so an
+implementation that fakes conservation fails.
 
-Floats are compared to six decimal places (``Suite.digits``), because two correct
-implementations of one sum differ in the last bits by summation order alone.
+The held-out tail is an **audit set**, not a validation split. Thirteen further
+tests live outside the repository entirely -- ``frozen`` stops a file being written,
+not read, and the executor is handed the source of the test it is failing, so an
+audit test in the tree is one it can write to. They are injected only while a
+held-out task is scored: a different box, a brute-force image search, a harmonic
+period, two layers composed. Every *driven* test is part of the specification and
+every one of them drives the search, which is the opposite of what a train/validation
+split does and the reason the jqx run once stalled at 0.923.
 
 What is faithful and what is a surrogate is as it is for the other three, and the
 reasoning is written out on :mod:`examples.genesis._domain`.
@@ -25,21 +37,28 @@ reasoning is written out on :mod:`examples.genesis._domain`.
 
 from __future__ import annotations
 
-from typing import Dict, List, Mapping, Optional, Sequence
+from typing import Dict, List, Mapping, Sequence
 
 from ._delegation import Brief, Delegation, Edit
-from ._suite import PYTHON_MODULE_SKILL, Suite, reward
+from ._suite import (PYTHON_MODULE_SKILL, TEST_FAILURE, TestSuite,
+                     reward_test)
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["FROZEN", "MD", "build_tasks", "initial_files", "llm_executor",
-           "llm_manager", "make_runner", "offline_executor", "offline_manager",
-           "reward", "suite_review"]
+__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC", "MD",
+           "SCORING", "build_tasks", "initial_files",
+           "llm_executor", "llm_manager", "make_runner", "offline_executor",
+           "offline_manager", "reference_tree", "reward", "suite_review"]
 
-#: The specification and the driver. Human-supplied, refused to every proposal,
-#: and restored pristine before scoring.
-FROZEN = ("spec/**", "md.py")
+#: The specification, the test suite and the driver. Human-supplied, refused to
+#: every proposal, and restored pristine before scoring.
+FROZEN = ("spec/**", "tests/**", "md.py")
+
+#: How the run is scored and what the header says about it.
+SCORING = "frozen test suite, no reference implementation in the scoring path"
+CASE_NOUN = "test functions"
+GROUP_NOUN = "test files"
 
 ENTRY = "src/__init__.py"
 CORE_INIT = "src/core/__init__.py"
@@ -55,11 +74,10 @@ VERLET = "src/integrate/verlet.py"
 OBS_INIT = "src/observe/__init__.py"
 THERMO = "src/observe/thermo.py"
 RDF = "src/observe/rdf.py"
-CHECKS = "src/observe/checks.py"
 
 
 # ---------------------------------------------------------------------------
-# The human's repository: the physics, the decomposition, the driver
+# The human's repository: the physics, the decomposition, the tests, the driver
 # ---------------------------------------------------------------------------
 
 _SPEC = r'''# md -- the molecular dynamics this project implements
@@ -69,8 +87,9 @@ k_B = 1, so energies, lengths and temperatures are all dimensionless.
 
 ## Geometry
 
-Periodic boundaries on every axis with a positive box length. The displacement
-from `a` to `b` is the **nearest image**:
+Periodic boundaries on every axis with a positive box length. A box length of `0`
+means that axis is not periodic. The displacement from `a` to `b` is the
+**nearest image**:
 
     d[i] = (b[i] - a[i]) - L[i] * floor((b[i] - a[i]) / L[i] + 0.5)
 
@@ -94,7 +113,8 @@ negative, where `d` is the displacement from *i* to *j*.
 
     dudr_over_r  = k * (r - r0) / r          (and `(0.0, 0.0)` at r == 0)
 
-Energies and forces sum over every **distinct** pair once.
+Energies and forces sum over every **distinct** pair once, which is what makes
+the forces sum to zero. An unknown potential name must raise.
 
 ## Integration
 
@@ -105,48 +125,68 @@ Velocity Verlet, one step with timestep `dt`:
 3. recompute the forces;
 4. `v += 0.5 * dt * f / m`.
 
-## Payload defaults
+Recomputing the forces between the two half-kicks is the whole point: it is what
+makes the scheme second-order and time-reversible. One force evaluation, or both
+kicks with the same forces, is a different and wrong integrator.
 
-Every stage takes one JSON object as text. `positions` is required; `velocities`
-defaults to zeros, `masses` to ones, `box` to `[0, 0, 0]` (no periodicity),
-`potential` to `"lennard_jones"`, `epsilon`/`sigma`/`k`/`r0` to `1.0` and `cutoff`
-to `2.5`.
+## The public surface
 
-## The ten validated stages
+`src/__init__.py` exposes exactly these seven functions. Nothing outside `src/`
+reaches past them -- not the driver, and not a single test.
 
-| stage | entry point | returns |
-|---|---|---|
-| `disp` | `src.displacement(p)` | the nearest-image vector from `p["a"]` to `p["b"]` |
-| `pot` | `src.energy(p)` | the total potential energy |
-| `force` | `src.forces(p)` | one force vector per particle |
-| `newton` | `src.forces_sum_to_zero(p)` | `True` when `max abs(sum of forces)` <= 1e-9 |
-| `fd` | `src.force_matches_gradient(p)` | `True` when every component agrees with a central difference of the energy (`h = 1e-6`) to 1e-4 |
-| `step` | `src.step(p)` | `{"positions": ..., "velocities": ...}` after one step of `p["dt"]` |
-| `obs` | `src.observables(p)` | `{"kinetic": ..., "temperature": ..., "momentum": [...]}` with `KE = sum(0.5*m*v.v)`, `T = 2*KE/(3*N)` and no centre-of-mass correction |
-| `rdf` | `src.rdf(p)` | **integer** counts of distinct pairs per bin over `[0, p["rmax"])` in `p["bins"]` bins; a pair at or beyond `rmax` is not counted |
-| `cons` | `src.energy_conserved(p)` | `True` when the total energy drifts by at most 1e-4 **relative** (`abs(after - before) / max(1, abs(before))`) over `p["steps"]` steps |
-| `mom` | `src.momentum_conserved(p)` | `True` when the total momentum drifts by at most 1e-9 over `p["steps"]` steps |
+| function | returns |
+|---|---|
+| `displacement(a, b, box)` | the nearest-image displacement from `a` to `b` |
+| `wrap(point, box)` | `point` folded into `[0, L)` on every periodic axis |
+| `energy(positions, **params)` | the total potential energy, a float |
+| `forces(positions, **params)` | one force vector per particle |
+| `step(positions, velocities, masses, dt, **params)` | `(positions, velocities)` after one step |
+| `observables(velocities, masses)` | `{"kinetic": f, "temperature": f, "momentum": [f, f, f]}` |
+| `rdf(positions, box, bins, rmax)` | **integer** counts of distinct pairs per bin over `[0, rmax)` |
 
-Floats are compared to **six decimal places**, so a different summation order is
-not a failure. The boolean stages are invariants, not opinions: one of the `cons`
-cases uses a timestep far too large and its answer is `False`, so a stage that
-always returns `True` fails the suite.
+`**params` is the same keyword set everywhere, with these defaults:
 
-A stage is scored independently of the ones after it, so `src/__init__.py` MUST
-import each stage lazily, inside the function that needs it.
+    box=(0.0, 0.0, 0.0)   potential="lennard_jones"   cutoff=2.5
+    epsilon=1.0           sigma=1.0                   k=1.0      r0=1.0
+
+`observables` takes no positions and no box: `KE = sum(0.5 * m * v.v)`,
+`T = 2 * KE / (3 * N)` with `k_B = 1` and **no** centre-of-mass correction, and
+`momentum` is the plain mass-weighted sum. A pair at or beyond `rmax` is not
+counted in the histogram.
+
+Every entry point MUST import its layer **lazily**, inside the function body.
+The tests for one layer then pass while another layer is still missing, which is
+how a partly-grown repository scores at all.
+
+## How this is scored
+
+`tests/` is frozen, and it is the whole of the reward: one task per test
+function, and the fraction that pass. There is no reference implementation
+anywhere in the loop -- the tests *are* the specification, made executable, and
+the prompt you are shown for a unit of work is the source of the test that is
+failing. Read it. It names the behaviour exactly, including the tolerance.
+
+Several of the tests are **invariants** rather than values: the forces sum to
+zero, every force component matches a central difference of the energy, energy
+and momentum survive a trajectory, and reversing the velocities retraces it.
+They cannot be satisfied by a lookup table, and one of them deliberately asserts
+that a far-too-large timestep does *not* conserve energy -- so an implementation
+that fakes conservation fails it.
 '''
 
 _ROOT_CONTEXT = r'''# md -- root
 
 ## Intent
 Implement the molecular dynamics in `spec/CONTEXT.md` as a library under `src/`.
-`md.py` is the simulation driver and is already written.
+`md.py` is the simulation driver and is already written; `tests/` is the suite
+your work is scored against.
 
 ## Routing Table
-- `./src/` -> the library, and the ten stage entry points
+- `./src/` -> the library, and the seven public entry points
 
 ## Constraints
-- `spec/` and `md.py` are read-only. They are the contract, not work items.
+- `spec/`, `tests/` and `md.py` are read-only. They are the contract, not work
+  items. A system that can edit its own tests has no tests.
 - Pure Python, no third-party packages: this has to run anywhere.
 - Every agent edits only files under its own path.
 '''
@@ -154,15 +194,16 @@ Implement the molecular dynamics in `spec/CONTEXT.md` as a library under `src/`.
 _SRC_CONTEXT = r'''# src -- library root
 
 ## Intent
-Own `src/__init__.py`: the ten entry points the spec names, each a thin wrapper
-that decodes the payload and calls into a child node. Each MUST import its stage
-lazily, so a missing layer does not stop the layers before it from scoring.
+Own `src/__init__.py`: the seven entry points `spec/CONTEXT.md` names, each a thin
+wrapper that calls into a child node. Each MUST import its layer **lazily**, inside
+the function body, so a missing layer does not stop the layers before it from
+passing their tests.
 
 ## Routing Table
 - `./src/core/`       -> geometry and the system container
 - `./src/potentials/` -> energies and forces
 - `./src/integrate/`  -> advancing time
-- `./src/observe/`    -> measuring and checking
+- `./src/observe/`    -> measuring
 '''
 
 _CORE_CONTEXT = r'''# src/core -- geometry and state
@@ -172,18 +213,18 @@ _CORE_CONTEXT = r'''# src/core -- geometry and state
 length, length, and wrapping a point into the box. Everything else in the project
 goes through it rather than writing `floor` arithmetic of its own.
 
-`state.py` owns the `System` container -- positions, velocities, masses, box --
-and the two functions that turn a decoded payload into one (`from_payload`) and
-read the potential's parameters out of it with the spec's defaults
-(`potential_spec`).
+`state.py` owns the `System` container -- positions, velocities, masses, box, with
+velocities defaulting to zeros and masses to ones -- and `make_spec`, which bundles
+the potential parameters the pair kernels are handed.
 '''
 
 _POT_CONTEXT = r'''# src/potentials -- energies and forces
 
 ## Intent
-Own `registry.py`: the name-to-kernel table, and the loop over distinct pairs that
-turns a kernel into a total energy and a force array. The loop applies Newton's
-third law once per pair, so the forces sum to zero by construction.
+Own `registry.py`: the name-to-kernel table, the refusal of an unknown name, and
+the loop over distinct pairs that turns a kernel into a total energy and a force
+array. The loop applies Newton's third law once per pair, which is what makes the
+forces sum to zero by construction rather than by luck.
 
 ## Routing Table
 - `./src/potentials/pair/` -> one module per pair interaction
@@ -200,21 +241,19 @@ exactly as the spec defines it. `lennard_jones.py` is shifted and cut off;
 _INT_CONTEXT = r'''# src/integrate -- advancing time
 
 ## Intent
-`verlet.py` owns velocity Verlet: `step` advances one timestep in place and
-returns the system, `run` applies it `steps` times. The position update wraps back
-into the box, and the forces are recomputed between the two half-kicks.
+`verlet.py` owns velocity Verlet: `step` advances one timestep in place and returns
+the system, `run` applies it `steps` times. The position update wraps back into the
+box, and the forces are recomputed between the two half-kicks -- that recomputation
+is what makes the scheme reversible, and the suite tests reversibility directly.
 '''
 
-_OBS_CONTEXT = r'''# src/observe -- measuring and checking
+_OBS_CONTEXT = r'''# src/observe -- measuring
 
 ## Intent
 `thermo.py` owns the thermodynamic observables: kinetic energy, temperature and
-total momentum. `rdf.py` owns the pair-distance histogram, in raw integer counts.
-
-`checks.py` owns the invariants, **one function per invariant**, so that two
-agents fixing two different checks are editing two different parts of the file
-rather than the same one: forces summing to zero, forces against a finite
-difference of the energy, and energy and momentum conserved across a run.
+total momentum, in reduced units with k_B = 1 and no centre-of-mass correction.
+`rdf.py` owns the pair-distance histogram, in raw integer counts of distinct pairs,
+and takes its distances from `src/core/vectors.py` rather than recomputing them.
 '''
 
 _DRIVER = r'''#!/usr/bin/env python3
@@ -222,28 +261,26 @@ _DRIVER = r'''#!/usr/bin/env python3
 
 Human-supplied, frozen, and never written by an agent: the library under ``src/``
 is what the run grows, and this is the shell around it so the result is a program
-rather than a package nobody can invoke.
+you can run rather than a package nobody can invoke.
 
     python md.py --particles 32 --steps 500
-    python md.py --particles 64 --density 0.8 --temperature 1.2 --steps 1000 \
+    python md.py --particles 108 --density 0.8 --temperature 1.2 --steps 2000 \
                  --thermostat 0.2 --trajectory traj.xyz
     python md.py --particles 32 --steps 200 --rdf 40
 
 Reduced Lennard-Jones units throughout: sigma = epsilon = mass = k_B = 1.
 
-It talks to the library only through the surface ``spec/CONTEXT.md`` pins --
-``step``, ``observables``, ``rdf`` -- so it works against any implementation that
-passes the suite, whatever the internal layout turns out to be. The price is a
-JSON round trip per step, which is why the defaults are small; raise them when you
-want a longer run and do not expect numpy speed from a pure-Python kernel.
+It touches the library only through the three entry points ``spec/CONTEXT.md``
+pins -- ``step``, ``observables``, ``rdf`` -- so it runs against any
+implementation that passes ``tests/``, whatever the internal layout turns out to
+be. The kernel is pure Python and O(N^2), so keep the defaults small and do not
+expect numpy speed.
 """
 
 import argparse
-import json
 import math
 import random
 import sys
-
 
 #: The four-atom face-centred-cubic basis, in cell units.
 _FCC_BASIS = ((0.0, 0.0, 0.0), (0.0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0))
@@ -334,10 +371,9 @@ def main(argv=None):
               f"(a full {cells}x{cells}x{cells} FCC lattice)")
     velocities = maxwell_velocities(count, args.temperature, args.seed)
     masses = [1.0] * count
-    common = {"box": box, "masses": masses, "cutoff": args.cutoff,
-              "potential": "lennard_jones", "epsilon": 1.0, "sigma": 1.0}
 
-    trajectory = open(args.trajectory, "w", encoding="utf-8") if args.trajectory else None
+    trajectory = (open(args.trajectory, "w", encoding="utf-8")
+                  if args.trajectory else None)
     print(f"# {count} particles, box {box[0]:.4f}, density {args.density}, "
           f"dt {args.dt}, cutoff {args.cutoff}"
           + (f", thermostat {args.thermostat} -> T={args.temperature}"
@@ -346,9 +382,7 @@ def main(argv=None):
     try:
         for n in range(args.steps + 1):
             if n % args.log_every == 0 or n == args.steps:
-                obs = observables(json.dumps(
-                    {"positions": positions, "velocities": velocities,
-                     "masses": masses, "box": box}))
+                obs = observables(velocities, masses)
                 speed = math.sqrt(sum(c * c for c in obs["momentum"]))
                 print(f"  {n:>8} {obs['temperature']:>12.6f} "
                       f"{obs['kinetic']:>14.6f} {speed:>12.3e}")
@@ -361,22 +395,20 @@ def main(argv=None):
                                          obs["temperature"], args.thermostat)
             if n == args.steps:
                 break
-            out = step(json.dumps(dict(common, positions=positions,
-                                       velocities=velocities, dt=args.dt)))
-            positions, velocities = out["positions"], out["velocities"]
+            positions, velocities = step(positions, velocities, masses, args.dt,
+                                         box=box, cutoff=args.cutoff)
     finally:
         if trajectory is not None:
             trajectory.close()
 
     if args.rdf:
-        counts = rdf(json.dumps({"positions": positions, "box": box,
-                                 "bins": args.rdf, "rmax": args.cutoff}))
+        counts = rdf(positions, box, args.rdf, args.cutoff)
         width = args.cutoff / args.rdf
         print(f"# pair-distance histogram, {args.rdf} bins over [0, {args.cutoff})")
         peak = max(counts) or 1
-        for i, count in enumerate(counts):
-            bar = "#" * int(40 * count / peak)
-            print(f"  {i * width:6.3f}-{(i + 1) * width:6.3f} {count:>6} {bar}")
+        for i, bin_count in enumerate(counts):
+            bar = "#" * int(40 * bin_count / peak)
+            print(f"  {i * width:6.3f}-{(i + 1) * width:6.3f} {bin_count:>6} {bar}")
     if args.trajectory:
         print(f"# wrote {args.trajectory}")
     return 0
@@ -386,10 +418,543 @@ if __name__ == "__main__":
     raise SystemExit(main())
 '''
 
+#: The suite. Frozen, in the repository, and the whole of the reward.
+_TESTS = {
+    'tests/test_forces.py': r'''"""The force field as a whole: invariants no correct implementation can miss."""
+
+from src import energy, forces
+
+BOX = [6.0, 6.0, 6.0]
+CONFIG = [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]]
+
+
+def test_forces_sum_to_zero():
+    """Newton's third law, applied once per pair."""
+    total = [sum(f[axis] for f in forces(CONFIG, box=BOX)) for axis in range(3)]
+    assert max(abs(c) for c in total) < 1e-9, total
+
+
+def test_every_force_component_matches_a_central_difference():
+    """The force is minus the gradient of the energy. This is the real test."""
+    analytic = forces(CONFIG, box=BOX)
+    h = 1e-6
+    for i in range(len(CONFIG)):
+        for axis in range(3):
+            plus = [list(p) for p in CONFIG]
+            minus = [list(p) for p in CONFIG]
+            plus[i][axis] += h
+            minus[i][axis] -= h
+            numeric = -(energy(plus, box=BOX) - energy(minus, box=BOX)) / (2.0 * h)
+            assert abs(numeric - analytic[i][axis]) < 1e-4, (i, axis, numeric,
+                                                            analytic[i][axis])
+
+
+def test_the_harmonic_force_also_matches_its_gradient():
+    kw = {"box": BOX, "potential": "harmonic", "k": 2.0, "r0": 1.0}
+    analytic = forces(CONFIG, **kw)
+    h = 1e-6
+    for i in (0, 2):
+        plus = [list(p) for p in CONFIG]
+        minus = [list(p) for p in CONFIG]
+        plus[i][1] += h
+        minus[i][1] -= h
+        numeric = -(energy(plus, **kw) - energy(minus, **kw)) / (2.0 * h)
+        assert abs(numeric - analytic[i][1]) < 1e-4, (i, numeric, analytic[i][1])
+
+
+def test_energy_does_not_change_when_everything_moves_together():
+    shifted = [[c + 0.37 for c in p] for p in CONFIG]
+    assert abs(energy(CONFIG, box=BOX) - energy(shifted, box=BOX)) < 1e-9
+
+
+def test_energy_does_not_change_when_a_particle_crosses_the_boundary():
+    """Periodicity: moving one particle by a whole box is the same configuration."""
+    moved = [list(p) for p in CONFIG]
+    moved[1][0] += BOX[0]
+    assert abs(energy(CONFIG, box=BOX) - energy(moved, box=BOX)) < 1e-9
+
+
+def test_an_isolated_pair_matches_the_closed_form():
+    r = 1.3
+    s6 = (1.0 / r) ** 6
+    expected = 4.0 * (s6 * s6 - s6) - 4.0 * ((1.0 / 2.5) ** 12 - (1.0 / 2.5) ** 6)
+    got = energy([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], box=[0.0, 0.0, 0.0])
+    assert abs(got - expected) < 1e-9, (got, expected)
+
+
+def test_pairs_beyond_the_cutoff_contribute_nothing():
+    near = energy([[0.0, 0.0, 0.0], [1.2, 0.0, 0.0]], box=[0.0, 0.0, 0.0])
+    with_far = energy([[0.0, 0.0, 0.0], [1.2, 0.0, 0.0], [40.0, 0.0, 0.0]],
+                      box=[0.0, 0.0, 0.0])
+    assert abs(near - with_far) < 1e-12, (near, with_far)
+
+
+def test_a_single_particle_feels_nothing():
+    assert energy([[1.0, 1.0, 1.0]], box=BOX) == 0.0
+    assert forces([[1.0, 1.0, 1.0]], box=BOX) == [[0.0, 0.0, 0.0]]
+
+
+def test_an_unknown_potential_is_refused():
+    try:
+        energy(CONFIG, box=BOX, potential="not_a_potential")
+    except Exception:
+        return
+    raise AssertionError("an unknown potential name should raise")
+''',
+    'tests/test_geometry.py': r'''"""Periodic geometry. Nothing here needs a force field."""
+
+from src import displacement, wrap
+
+BOX = [6.0, 6.0, 6.0]
+
+
+def test_displacement_of_nearby_points_is_the_plain_difference():
+    assert displacement([1.0, 2.0, 3.0], [1.5, 2.25, 3.5], BOX) == [0.5, 0.25, 0.5]
+
+
+def test_displacement_takes_the_nearest_image_across_a_boundary():
+    # 0.1 and 5.6 are 5.5 apart the long way and 0.5 apart the short way.
+    d = displacement([0.1, 0.0, 0.0], [5.6, 0.0, 0.0], BOX)
+    assert abs(d[0] - (-0.5)) < 1e-12, d
+
+
+def test_displacement_is_antisymmetric():
+    # No separation is exactly half a box: there the nearest image is genuinely
+    # ambiguous and the formula has to pick a side, so antisymmetry does not hold.
+    a, b = [0.3, 5.9, 1.0], [5.7, 0.2, 2.4]
+    forward, backward = displacement(a, b, BOX), displacement(b, a, BOX)
+    for i in range(3):
+        assert abs(forward[i] + backward[i]) < 1e-12, (forward, backward)
+
+
+def test_displacement_never_exceeds_half_a_box():
+    for x in (0.0, 0.7, 2.9, 3.1, 5.5):
+        d = displacement([0.0, 0.0, 0.0], [x, 0.0, 0.0], BOX)
+        assert abs(d[0]) <= 3.0 + 1e-12, (x, d)
+
+
+def test_a_zero_box_length_means_no_periodicity():
+    d = displacement([0.0, 0.0, 0.0], [100.0, 0.0, 0.0], [0.0, 0.0, 0.0])
+    assert d[0] == 100.0
+
+
+def test_wrap_folds_a_point_into_the_box():
+    assert wrap([6.5, -0.5, 3.0], BOX) == [0.5, 5.5, 3.0]
+
+
+def test_wrap_leaves_an_interior_point_alone():
+    assert wrap([1.0, 2.0, 3.0], BOX) == [1.0, 2.0, 3.0]
+''',
+    'tests/test_integration.py': r'''"""Velocity Verlet. The invariants here are what makes an integrator correct."""
+
+from src import energy, observables, step
+
+BOX = [6.0, 6.0, 6.0]
+CONFIG = [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]]
+VEL = [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]
+MASS = [1.0, 1.0, 1.0, 1.0]
+
+
+def total_energy(positions, velocities):
+    return (energy(positions, box=BOX)
+            + observables(velocities, MASS)["kinetic"])
+
+
+def run(positions, velocities, dt, steps):
+    for _ in range(steps):
+        positions, velocities = step(positions, velocities, MASS, dt, box=BOX)
+    return positions, velocities
+
+
+def test_a_free_particle_travels_at_constant_velocity():
+    p, v = step([[1.0, 1.0, 1.0]], [[0.5, 0.0, 0.0]], [1.0], 0.1, box=BOX)
+    assert abs(p[0][0] - 1.05) < 1e-12, p
+    assert abs(v[0][0] - 0.5) < 1e-12, v
+
+
+def test_energy_is_conserved_over_a_short_run():
+    before = total_energy(CONFIG, VEL)
+    p, v = run(CONFIG, VEL, 0.001, 40)
+    after = total_energy(p, v)
+    assert abs(after - before) / max(1.0, abs(before)) < 1e-4, (before, after)
+
+
+def test_momentum_is_conserved_over_a_short_run():
+    before = observables(VEL, MASS)["momentum"]
+    _, v = run(CONFIG, VEL, 0.001, 40)
+    after = observables(v, MASS)["momentum"]
+    assert max(abs(after[a] - before[a]) for a in range(3)) < 1e-9, (before, after)
+
+
+def test_a_far_too_large_timestep_does_not_conserve_energy():
+    """The conservation tests must be able to fail, or they assert nothing."""
+    before = total_energy(CONFIG, VEL)
+    p, v = run(CONFIG, VEL, 0.25, 40)
+    after = total_energy(p, v)
+    assert abs(after - before) / max(1.0, abs(before)) > 1e-3, (before, after)
+
+
+def test_reversing_the_velocities_retraces_the_trajectory():
+    """Velocity Verlet is time-reversible, which no wrong update order is."""
+    forward_p, forward_v = run(CONFIG, VEL, 0.002, 25)
+    back_p, _ = run(forward_p, [[-c for c in v] for v in forward_v], 0.002, 25)
+    for i in range(len(CONFIG)):
+        for axis in range(3):
+            gap = abs(back_p[i][axis] - CONFIG[i][axis]) % BOX[axis]
+            assert min(gap, BOX[axis] - gap) < 1e-6, (i, axis, back_p[i], CONFIG[i])
+
+
+def test_positions_come_back_inside_the_box():
+    p, _ = step([[5.99, 0.01, 3.0]], [[1.0, -1.0, 0.0]], [1.0], 0.05, box=BOX)
+    for axis in range(3):
+        assert 0.0 <= p[0][axis] < BOX[axis], p
+
+
+def test_a_heavier_particle_accelerates_less():
+    # No periodicity, so the comparison is a displacement rather than a wrapped
+    # coordinate; and a fresh velocity list per particle, because `[[0.0]*3]*2`
+    # is the same list twice and the two updates would land on each other.
+    start = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+    rest = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    free = [0.0, 0.0, 0.0]
+    light, _ = step(start, [list(free), list(free)], [1.0, 1.0], 0.01,
+                    box=[0.0, 0.0, 0.0])
+    heavy, _ = step(start, [list(free), list(free)], [4.0, 1.0], 0.01,
+                    box=[0.0, 0.0, 0.0])
+    assert rest is not None
+    assert abs(heavy[0][0]) < abs(light[0][0]) - 1e-9, (light[0], heavy[0])
+
+
+def test_zero_steps_change_nothing():
+    p, v = run(CONFIG, VEL, 0.001, 0)
+    assert p == CONFIG and v == VEL
+''',
+    'tests/test_observables.py': r'''"""Thermodynamics and structure, in reduced units with k_B = 1."""
+
+from src import observables, rdf
+
+
+def test_kinetic_energy_of_one_particle():
+    obs = observables([[2.0, 0.0, 0.0]], [3.0])
+    assert abs(obs["kinetic"] - 6.0) < 1e-12, obs
+
+
+def test_kinetic_energy_adds_over_particles():
+    obs = observables([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]], [1.0, 1.0])
+    assert abs(obs["kinetic"] - 2.5) < 1e-12, obs
+
+
+def test_temperature_is_two_thirds_of_the_kinetic_energy_per_particle():
+    velocities = [[1.0, 1.0, 1.0], [-1.0, 0.0, 0.5]]
+    obs = observables(velocities, [1.0, 1.0])
+    assert abs(obs["temperature"] - 2.0 * obs["kinetic"] / 6.0) < 1e-12, obs
+
+
+def test_momentum_of_opposing_particles_cancels():
+    obs = observables([[1.0, 0.0, 0.0], [-0.5, 0.0, 0.0]], [1.0, 2.0])
+    assert max(abs(c) for c in obs["momentum"]) < 1e-12, obs
+
+
+def test_momentum_is_mass_weighted():
+    obs = observables([[1.0, 0.0, 0.0]], [2.5])
+    assert abs(obs["momentum"][0] - 2.5) < 1e-12, obs
+
+
+def test_a_system_at_rest_has_no_temperature():
+    obs = observables([[0.0, 0.0, 0.0]] * 3, [1.0] * 3)
+    assert obs["kinetic"] == 0.0 and obs["temperature"] == 0.0
+
+
+def test_the_histogram_counts_every_distinct_pair_once():
+    positions = [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]]
+    counts = rdf(positions, [0.0, 0.0, 0.0], 10, 5.0)
+    assert sum(counts) == 3, counts
+
+
+def test_the_histogram_ignores_pairs_at_or_beyond_rmax():
+    positions = [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0]]
+    assert sum(rdf(positions, [0.0, 0.0, 0.0], 10, 2.0)) == 0
+
+
+def test_the_histogram_puts_a_distance_in_the_right_bin():
+    positions = [[0.0, 0.0, 0.0], [1.25, 0.0, 0.0]]
+    counts = rdf(positions, [0.0, 0.0, 0.0], 4, 2.0)   # bins 0.5 wide
+    assert counts == [0, 0, 1, 0], counts
+
+
+def test_the_histogram_uses_the_nearest_image():
+    positions = [[0.1, 0.0, 0.0], [5.9, 0.0, 0.0]]     # 0.2 apart across the seam
+    counts = rdf(positions, [6.0, 6.0, 6.0], 6, 3.0)   # bins 0.5 wide
+    assert counts[0] == 1 and sum(counts) == 1, counts
+''',
+    'tests/test_pair_potentials.py': r'''"""The pair interactions, probed through two-particle configurations."""
+
+from src import energy, forces
+
+FAR = [0.0, 0.0, 0.0]          # no periodicity: an isolated pair
+
+
+def pair_energy(r, **kw):
+    return energy([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], box=FAR, **kw)
+
+
+def test_lennard_jones_is_zero_at_the_cutoff():
+    """The potential is shifted, so it reaches the cutoff continuously."""
+    assert abs(pair_energy(2.5, cutoff=2.5)) < 1e-12, pair_energy(2.5, cutoff=2.5)
+
+
+def test_lennard_jones_is_zero_beyond_the_cutoff():
+    assert pair_energy(3.0, cutoff=2.5) == 0.0
+
+
+def test_lennard_jones_minimum_is_at_the_sixth_root_of_two():
+    """u(2**(1/6) sigma) = -epsilon, the textbook minimum, before the shift."""
+    r_min = 2.0 ** (1.0 / 6.0)
+    shift_free = pair_energy(r_min, cutoff=1e6)
+    assert abs(shift_free - (-1.0)) < 1e-9, shift_free
+
+
+def test_lennard_jones_is_repulsive_inside_sigma():
+    assert pair_energy(0.9, cutoff=1e6) > 0.0
+
+
+def test_the_force_vanishes_at_the_lennard_jones_minimum():
+    r_min = 2.0 ** (1.0 / 6.0)
+    f = forces([[0.0, 0.0, 0.0], [r_min, 0.0, 0.0]], box=FAR, cutoff=1e6)
+    assert abs(f[0][0]) < 1e-7, f
+
+
+def test_particles_inside_sigma_push_apart():
+    f = forces([[0.0, 0.0, 0.0], [0.9, 0.0, 0.0]], box=FAR, cutoff=1e6)
+    assert f[0][0] < 0.0 and f[1][0] > 0.0, f
+
+
+def test_particles_outside_the_minimum_pull_together():
+    f = forces([[0.0, 0.0, 0.0], [1.5, 0.0, 0.0]], box=FAR, cutoff=2.5)
+    assert f[0][0] > 0.0 and f[1][0] < 0.0, f
+
+
+def test_harmonic_is_zero_at_its_rest_length():
+    u = pair_energy(1.3, potential="harmonic", k=2.0, r0=1.3)
+    assert abs(u) < 1e-12, u
+
+
+def test_harmonic_grows_quadratically():
+    """Doubling the extension quadruples the energy."""
+    one = pair_energy(1.1, potential="harmonic", k=2.0, r0=1.0)
+    two = pair_energy(1.2, potential="harmonic", k=2.0, r0=1.0)
+    assert abs(two - 4.0 * one) < 1e-9, (one, two)
+
+
+def test_a_stretched_harmonic_bond_pulls_inward():
+    f = forces([[0.0, 0.0, 0.0], [1.5, 0.0, 0.0]], box=FAR,
+               potential="harmonic", k=2.0, r0=1.0)
+    assert f[0][0] > 0.0 and f[1][0] < 0.0, f
+''',
+}
+
+#: The audit set: never in the repository, injected only while a held-out task is
+#: scored. `frozen` stops a file being written, not read.
+_AUDIT = {
+    'audit/test_physics.py': r'''"""The audit set: the same physics, asked differently, and never in the repository.
+
+`tests/` is frozen but readable, and the executor is handed the source of the test
+it is failing -- so a run could in principle satisfy one assertion at a time without
+the physics underneath holding together. These tests are injected only while a
+held-out task is being scored, so nothing that wrote the code has ever seen them.
+Every probe here is deliberately *not* a restatement of a driven test: a different
+configuration, a different cutoff, a brute-force comparison, or two layers composed.
+"""
+
+import math
+import random
+
+from src import displacement, energy, forces, observables, rdf, step, wrap
+
+BOX = [7.3, 6.1, 5.4]          # deliberately not a cube
+MASSES = [1.0, 2.0, 0.5, 1.5, 1.0, 3.0]
+
+
+def a_random_configuration(seed, n=6, box=BOX):
+    """Spread out enough that nothing sits inside the repulsive core."""
+    rng = random.Random(seed)
+    while True:
+        points = [[rng.uniform(0.0, box[axis]) for axis in range(3)] for _ in range(n)]
+        if all(math.sqrt(sum(c * c for c in displacement(points[i], points[j], box)))
+               > 0.95 for i in range(n) for j in range(i + 1, n)):
+            return points
+
+
+def test_displacement_agrees_with_a_brute_force_search_over_images():
+    """The closed form, checked against the thing it is a closed form for."""
+    rng = random.Random(11)
+    for _ in range(40):
+        # Both points inside the box, so one box of shift per axis is enough to
+        # reach every candidate image -- and the search is then exhaustive.
+        a = [rng.uniform(0.0, BOX[axis]) for axis in range(3)]
+        b = [rng.uniform(0.0, BOX[axis]) for axis in range(3)]
+        got = displacement(a, b, BOX)
+        best = None
+        for i in (-1, 0, 1):
+            for j in (-1, 0, 1):
+                for k in (-1, 0, 1):
+                    shift = (i * BOX[0], j * BOX[1], k * BOX[2])
+                    candidate = [b[axis] + shift[axis] - a[axis] for axis in range(3)]
+                    length = sum(c * c for c in candidate)
+                    if best is None or length < best[0] - 1e-12:
+                        best = (length, candidate)
+        for axis in range(3):
+            assert abs(got[axis] - best[1][axis]) < 1e-9, (a, b, got, best[1])
+
+
+def test_wrapping_the_input_changes_no_displacement():
+    """Two layers composed: wrapping is a change of representative, not of geometry."""
+    points = a_random_configuration(3)
+    shifted = [wrap([p[0] + 3 * BOX[0], p[1] - 2 * BOX[1], p[2] + BOX[2]], BOX)
+               for p in points]
+    for i in range(len(points)):
+        for j in range(len(points)):
+            here = displacement(points[i], points[j], BOX)
+            there = displacement(shifted[i], shifted[j], BOX)
+            for axis in range(3):
+                assert abs(here[axis] - there[axis]) < 1e-9, (i, j, here, there)
+
+
+def test_the_pair_energy_matches_the_closed_form_at_an_unusual_cutoff():
+    """Not 2.5: a shift hard-coded for the default cutoff fails here."""
+    for r in (0.95, 1.0, 1.4, 2.2, 2.9):
+        s6 = (1.0 / r) ** 6
+        shift = 4.0 * ((1.0 / 3.0) ** 12 - (1.0 / 3.0) ** 6)
+        expect = 4.0 * (s6 * s6 - s6) - shift
+        got = energy([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], box=[0.0, 0.0, 0.0], cutoff=3.0)
+        assert abs(got - expect) < 1e-9, (r, got, expect)
+
+
+def test_epsilon_scales_the_energy_linearly():
+    config = a_random_configuration(5)
+    one = energy(config, box=BOX, epsilon=1.0)
+    three = energy(config, box=BOX, epsilon=3.0)
+    assert abs(three - 3.0 * one) < 1e-9, (one, three)
+
+
+def test_sigma_rescales_the_whole_problem():
+    """u(r; sigma, rc) = u(r/sigma; 1, rc/sigma): a pure change of length unit."""
+    r, sigma = 1.7, 1.3
+    scaled = energy([[0.0, 0.0, 0.0], [r, 0.0, 0.0]], box=[0.0, 0.0, 0.0],
+                    sigma=sigma, cutoff=2.5 * sigma)
+    plain = energy([[0.0, 0.0, 0.0], [r / sigma, 0.0, 0.0]], box=[0.0, 0.0, 0.0],
+                   sigma=1.0, cutoff=2.5)
+    assert abs(scaled - plain) < 1e-9, (scaled, plain)
+
+
+def test_forces_match_a_central_difference_on_a_random_box():
+    """The gradient check again, on a configuration no driven test names."""
+    config = a_random_configuration(7)
+    analytic = forces(config, box=BOX)
+    h = 1e-6
+    for i in range(len(config)):
+        for axis in range(3):
+            plus = [list(p) for p in config]
+            minus = [list(p) for p in config]
+            plus[i][axis] += h
+            minus[i][axis] -= h
+            numeric = -(energy(plus, box=BOX) - energy(minus, box=BOX)) / (2.0 * h)
+            assert abs(numeric - analytic[i][axis]) < 1e-4, (i, axis, numeric,
+                                                             analytic[i][axis])
+
+
+def test_the_harmonic_trio_matches_its_analytic_energy():
+    """Every pair is bonded, including the 1-3 pair: three springs, not two."""
+    config = [[0.0, 0.0, 0.0], [1.2, 0.0, 0.0], [2.4, 0.0, 0.0]]
+    expect = 0.5 * 3.0 * ((1.2 - 1.0) ** 2 + (1.2 - 1.0) ** 2 + (2.4 - 1.0) ** 2)
+    got = energy(config, box=[0.0, 0.0, 0.0], potential="harmonic", k=3.0, r0=1.0)
+    assert abs(got - expect) < 1e-9, (got, expect)
+
+
+def test_a_harmonic_oscillator_keeps_its_period():
+    """Two bonded particles, quarter period out and back: an integrator that is
+    merely stable rather than correct drifts in phase."""
+    k, mass = 4.0, 1.0
+    omega = math.sqrt(2.0 * k / mass)            # reduced mass mu = m / 2
+    positions = [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0]]
+    velocities = [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    dt, period = 1e-3, 2.0 * math.pi / omega
+    for _ in range(int(round(period / dt))):
+        positions, velocities = step(positions, velocities, [mass, mass], dt,
+                                     box=[0.0, 0.0, 0.0], potential="harmonic",
+                                     k=k, r0=1.0)
+    separation = displacement(positions[0], positions[1], [0.0, 0.0, 0.0])[0]
+    assert abs(separation - 1.3) < 1e-3, separation
+
+
+def test_energy_is_conserved_on_a_configuration_no_driven_test_names():
+    config = a_random_configuration(13)
+    velocities = [[0.05 * (i + 1) * (-1) ** i, 0.03 * i, -0.02 * (i + 2)]
+                  for i in range(len(config))]
+    masses = MASSES[:len(config)]
+
+    def total(p, v):
+        return energy(p, box=BOX) + observables(v, masses)["kinetic"]
+
+    before = total(config, velocities)
+    p, v = config, velocities
+    for _ in range(60):
+        p, v = step(p, v, masses, 5e-4, box=BOX)
+    assert abs(total(p, v) - before) / max(1.0, abs(before)) < 1e-4, (before,
+                                                                     total(p, v))
+
+
+def test_a_step_does_not_change_the_total_momentum():
+    """Integration and observables composed: the forces cancel pairwise, so the
+    two half-kicks move no momentum no matter what the configuration is."""
+    config = a_random_configuration(17)
+    masses = MASSES[:len(config)]
+    velocities = [[0.1, -0.2, 0.05] for _ in config]
+    before = observables(velocities, masses)["momentum"]
+    _, after_v = step(config, velocities, masses, 1e-3, box=BOX)
+    after = observables(after_v, masses)["momentum"]
+    for axis in range(3):
+        assert abs(after[axis] - before[axis]) < 1e-9, (before, after)
+
+
+def test_doubling_every_velocity_quadruples_the_temperature():
+    velocities = [[0.3, -0.1, 0.2], [0.0, 0.4, -0.3], [-0.2, 0.1, 0.1]]
+    masses = [1.0, 2.0, 0.5]
+    one = observables(velocities, masses)["temperature"]
+    two = observables([[2.0 * c for c in v] for v in velocities],
+                      masses)["temperature"]
+    assert abs(two - 4.0 * one) < 1e-12, (one, two)
+
+
+def test_the_histogram_accounts_for_every_pair_when_rmax_covers_the_box():
+    """Half the shortest box side is the largest distance the nearest image can be,
+    so nothing may fall outside the histogram here."""
+    config = a_random_configuration(19)
+    n = len(config)
+    rmax = 0.5 * math.sqrt(sum(length * length for length in BOX)) + 1.0
+    counts = rdf(config, BOX, 24, rmax)
+    assert sum(counts) == n * (n - 1) // 2, (sum(counts), n)
+    assert all(isinstance(c, int) for c in counts), counts
+
+
+def test_the_histogram_agrees_with_distances_computed_through_displacement():
+    """The structure layer against the geometry layer, bin by bin."""
+    config = a_random_configuration(23)
+    bins, rmax = 10, 3.0
+    expect = [0] * bins
+    for i in range(len(config)):
+        for j in range(i + 1, len(config)):
+            r = math.sqrt(sum(c * c for c in displacement(config[i], config[j], BOX)))
+            if r < rmax:
+                expect[int(r / (rmax / bins))] += 1
+    assert rdf(config, BOX, bins, rmax) == expect
+''',
+}
+
 
 def initial_files() -> Dict[str, str]:
     """The implementation-empty repository the run starts from."""
-    return {
+    files = {
         "CONTEXT.md": _ROOT_CONTEXT,
         "spec/CONTEXT.md": _SPEC,
         "md.py": _DRIVER,
@@ -401,93 +966,99 @@ def initial_files() -> Dict[str, str]:
         "src/observe/CONTEXT.md": _OBS_CONTEXT,
         f"src/{SKILLS_DIR}/python-modules.md": PYTHON_MODULE_SKILL,
     }
+    files.update(_TESTS)
+    return files
+
+
+MD = TestSuite(name="md", given=initial_files(), frozen=FROZEN, audit=_AUDIT)
+
+build_tasks = MD.build_tasks
+make_runner = MD.make_runner
+suite_review = MD.review
+#: One test, pass or fail. No tolerance of its own -- the test owns that.
+reward = reward_test
+#: Exactly the audit set in the held-out tail, and every driven test in the search.
+HELD_OUT_FRAC = MD.held_out_frac()
+
+
+def llm_manager(complete):
+    return _llm_manager(complete)
+
+
+def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
+    return _llm_executor(complete, editable=editable, frozen=frozen,
+                         failure=TEST_FAILURE)
 
 
 # ---------------------------------------------------------------------------
-# The reference implementation: the oracle, and what the offline actors reveal
+# A reference implementation, for the two jobs that are not scoring
 # ---------------------------------------------------------------------------
+# It drives the offline rule-based actor, and it lets a test prove the suite is
+# passable at all -- shipping a suite nobody has seen pass is its own dishonesty.
+# Nothing in the scoring path reads it.
 
 _PKG_INIT = '"""Package marker."""\n'
 
-_REF_ENTRY = r'''"""Public surface. Each stage is imported lazily -- see spec/CONTEXT.md."""
-
-import json
+_REF_ENTRY = r'''"""Public surface. Each function imports its stage lazily -- see spec/CONTEXT.md."""
 
 
-def _payload(source):
-    return json.loads(source)
-
-
-def displacement(source):
+def displacement(a, b, box):
+    """The nearest-image displacement from ``a`` to ``b``."""
     from .core.vectors import minimum_image
-    spec = _payload(source)
-    return minimum_image(spec["a"], spec["b"], spec["box"])
+    return minimum_image(a, b, box)
 
 
-def energy(source):
-    from .core.state import from_payload, potential_spec
+def wrap(point, box):
+    """``point`` folded into ``[0, L)`` on every periodic axis."""
+    from .core.vectors import wrap as _wrap
+    return _wrap(point, box)
+
+
+def energy(positions, box=(0.0, 0.0, 0.0), potential="lennard_jones",
+           epsilon=1.0, sigma=1.0, cutoff=2.5, k=1.0, r0=1.0):
+    """The total potential energy of a configuration."""
+    from .core.state import System, make_spec
     from .potentials.registry import evaluate
-    spec = _payload(source)
-    return evaluate(from_payload(spec), potential_spec(spec))[0]
+    system = System(positions, box=box)
+    spec = make_spec(potential, epsilon, sigma, cutoff, k, r0)
+    return evaluate(system, spec)[0]
 
 
-def forces(source):
-    from .core.state import from_payload, potential_spec
+def forces(positions, box=(0.0, 0.0, 0.0), potential="lennard_jones",
+           epsilon=1.0, sigma=1.0, cutoff=2.5, k=1.0, r0=1.0):
+    """One force vector per particle."""
+    from .core.state import System, make_spec
     from .potentials.registry import evaluate
-    spec = _payload(source)
-    return evaluate(from_payload(spec), potential_spec(spec))[1]
+    system = System(positions, box=box)
+    spec = make_spec(potential, epsilon, sigma, cutoff, k, r0)
+    return evaluate(system, spec)[1]
 
 
-def step(source):
-    from .core.state import from_payload, potential_spec
+def step(positions, velocities, masses, dt, box=(0.0, 0.0, 0.0),
+         potential="lennard_jones", epsilon=1.0, sigma=1.0, cutoff=2.5,
+         k=1.0, r0=1.0):
+    """One velocity-Verlet step. Returns ``(positions, velocities)``."""
+    from .core.state import System, make_spec
     from .integrate.verlet import step as one_step
-    spec = _payload(source)
-    system = one_step(from_payload(spec), potential_spec(spec), spec["dt"])
-    return {"positions": system.positions, "velocities": system.velocities}
+    system = System(positions, velocities, masses, box)
+    spec = make_spec(potential, epsilon, sigma, cutoff, k, r0)
+    one_step(system, spec, dt)
+    return system.positions, system.velocities
 
 
-def observables(source):
-    from .core.state import from_payload
+def observables(velocities, masses):
+    """``{"kinetic": ..., "temperature": ..., "momentum": [...]}``."""
     from .observe.thermo import kinetic, momentum, temperature
-    system = from_payload(_payload(source))
-    return {"kinetic": kinetic(system.velocities, system.masses),
-            "temperature": temperature(system.velocities, system.masses),
-            "momentum": momentum(system.velocities, system.masses)}
+    return {"kinetic": kinetic(velocities, masses),
+            "temperature": temperature(velocities, masses),
+            "momentum": momentum(velocities, masses)}
 
 
-def rdf(source):
-    from .core.state import from_payload
+def rdf(positions, box, bins, rmax):
+    """Integer counts of distinct pairs per bin over ``[0, rmax)``."""
+    from .core.state import System
     from .observe.rdf import histogram
-    spec = _payload(source)
-    return histogram(from_payload(spec), spec["bins"], spec["rmax"])
-
-
-def forces_sum_to_zero(source):
-    from .core.state import from_payload, potential_spec
-    from .observe.checks import forces_sum_to_zero as check
-    spec = _payload(source)
-    return check(from_payload(spec), potential_spec(spec))
-
-
-def force_matches_gradient(source):
-    from .core.state import from_payload, potential_spec
-    from .observe.checks import force_matches_gradient as check
-    spec = _payload(source)
-    return check(from_payload(spec), potential_spec(spec))
-
-
-def energy_conserved(source):
-    from .core.state import from_payload, potential_spec
-    from .observe.checks import energy_conserved as check
-    spec = _payload(source)
-    return check(from_payload(spec), potential_spec(spec), spec["dt"], spec["steps"])
-
-
-def momentum_conserved(source):
-    from .core.state import from_payload, potential_spec
-    from .observe.checks import momentum_conserved as check
-    spec = _payload(source)
-    return check(from_payload(spec), potential_spec(spec), spec["dt"], spec["steps"])
+    return histogram(System(positions, box=box), bins, rmax)
 '''
 
 _REF_VECTORS = r'''"""Geometry under periodic boundaries."""
@@ -530,7 +1101,7 @@ def wrap(point, box):
     return out
 '''
 
-_REF_STATE = r'''"""The System container, and the payload shape every stage is given."""
+_REF_STATE = r'''"""The System container, and the potential's parameters."""
 
 
 class System:
@@ -551,22 +1122,11 @@ class System:
         return System(self.positions, self.velocities, self.masses, self.box)
 
 
-def from_payload(payload):
-    """A System from a decoded stage payload."""
-    return System(payload["positions"], payload.get("velocities"),
-                  payload.get("masses"), payload.get("box", [0.0, 0.0, 0.0]))
-
-
-def potential_spec(payload):
-    """The potential's name and its parameters, with the spec's defaults."""
-    return {
-        "name": payload.get("potential", "lennard_jones"),
-        "epsilon": payload.get("epsilon", 1.0),
-        "sigma": payload.get("sigma", 1.0),
-        "cutoff": payload.get("cutoff", 2.5),
-        "k": payload.get("k", 1.0),
-        "r0": payload.get("r0", 1.0),
-    }
+def make_spec(potential="lennard_jones", epsilon=1.0, sigma=1.0, cutoff=2.5,
+              k=1.0, r0=1.0):
+    """The parameter bundle every pair kernel is handed."""
+    return {"name": potential, "epsilon": epsilon, "sigma": sigma,
+            "cutoff": cutoff, "k": k, "r0": r0}
 '''
 
 _REF_REGISTRY = r'''"""Which pair interaction a name means, and the O(N^2) loop over pairs."""
@@ -716,129 +1276,21 @@ def histogram(system, bins, rmax):
     return counts
 '''
 
-#: The shape `src/observe/CONTEXT.md` asks for: one function per invariant, four
-#: of them, each independently fillable and each reached by a different stage --
-#: so four agents holding four different failing stages edit four different parts
-#: of one file, which is what a keyed union cannot fuse.
-_CHECKS_SKELETON = r'''"""Invariants a correct force field and integrator must satisfy."""
-
-from ..integrate.verlet import run
-from ..observe.thermo import kinetic, momentum
-from ..potentials.registry import evaluate
-
-
-def forces_sum_to_zero(system, spec, tol=1e-9):
-    raise NotImplementedError("forces_sum_to_zero")
+REFERENCE = {
+    ENTRY: _REF_ENTRY,
+    CORE_INIT: _PKG_INIT, VECTORS: _REF_VECTORS, STATE: _REF_STATE,
+    POT_INIT: _PKG_INIT, REGISTRY: _REF_REGISTRY,
+    PAIR_INIT: _PKG_INIT, LJ: _REF_LJ, HARMONIC: _REF_HARMONIC,
+    INT_INIT: _PKG_INIT, VERLET: _REF_VERLET,
+    OBS_INIT: _PKG_INIT, THERMO: _REF_THERMO, RDF: _REF_RDF,
+}
 
 
-def force_matches_gradient(system, spec, h=1e-6, tol=1e-4):
-    raise NotImplementedError("force_matches_gradient")
-
-
-def energy_conserved(system, spec, dt, steps, tol=1e-4):
-    raise NotImplementedError("energy_conserved")
-
-
-def momentum_conserved(system, spec, dt, steps, tol=1e-9):
-    raise NotImplementedError("momentum_conserved")
-'''
-
-_STUBS = {'forces_sum_to_zero': ('def forces_sum_to_zero(system, spec, tol=1e-9):\n    raise NotImplementedError("forces_sum_to_zero")\n', 'def forces_sum_to_zero(system, spec, tol=1e-9):\n    """Newton\'s third law, pair by pair: the net force on the box is zero."""\n    _, forces = evaluate(system, spec)\n    total = [sum(f[axis] for f in forces) for axis in range(3)]\n    return max(abs(c) for c in total) <= tol\n'), 'force_matches_gradient': ('def force_matches_gradient(system, spec, h=1e-6, tol=1e-4):\n    raise NotImplementedError("force_matches_gradient")\n', 'def force_matches_gradient(system, spec, h=1e-6, tol=1e-4):\n    """Every force component against a central difference of the energy."""\n    _, forces = evaluate(system, spec)\n    worst = 0.0\n    for i in range(len(system)):\n        for axis in range(3):\n            original = system.positions[i][axis]\n            system.positions[i][axis] = original + h\n            plus, _ = evaluate(system, spec)\n            system.positions[i][axis] = original - h\n            minus, _ = evaluate(system, spec)\n            system.positions[i][axis] = original\n            worst = max(worst, abs(-(plus - minus) / (2.0 * h) - forces[i][axis]))\n    return worst <= tol\n'), 'energy_conserved': ('def energy_conserved(system, spec, dt, steps, tol=1e-4):\n    raise NotImplementedError("energy_conserved")\n', 'def energy_conserved(system, spec, dt, steps, tol=1e-4):\n    """Total energy before and after ``steps`` steps, as a relative drift."""\n    potential, _ = evaluate(system, spec)\n    before = potential + kinetic(system.velocities, system.masses)\n    run(system, spec, dt, steps)\n    potential, _ = evaluate(system, spec)\n    after = potential + kinetic(system.velocities, system.masses)\n    return abs(after - before) / max(1.0, abs(before)) <= tol\n'), 'momentum_conserved': ('def momentum_conserved(system, spec, dt, steps, tol=1e-9):\n    raise NotImplementedError("momentum_conserved")\n', 'def momentum_conserved(system, spec, dt, steps, tol=1e-9):\n    """Total momentum before and after ``steps`` steps."""\n    before = momentum(system.velocities, system.masses)\n    run(system, spec, dt, steps)\n    after = momentum(system.velocities, system.masses)\n    return max(abs(after[a] - before[a]) for a in range(3)) <= tol\n')}
-
-#: Which stage's failure points at which invariant. Routing by the stage rather
-#: than by the payload text, because an MD payload is numbers and mentions no
-#: function by name.
-_STAGE_STUB = {"newton": "forces_sum_to_zero", "fd": "force_matches_gradient",
-               "cons": "energy_conserved", "mom": "momentum_conserved"}
-
-
-def _filled_checks() -> str:
-    body = _CHECKS_SKELETON
-    for stub, filled in _STUBS.values():
-        body = body.replace(stub, filled)
-    return body
-
-
-_CASES = (
-    ('disp', '{"a": [0.1, 0.0, 0.0], "b": [5.6, 0.0, 0.0], "box": [6.0, 6.0, 6.0]}'),
-    ('pot', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('force', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('newton', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('fd', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('step', '{"box": [6.0, 6.0, 6.0], "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('obs', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('rdf', '{"bins": 8, "box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "rmax": 2.5, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('cons', '{"box": [6.0, 6.0, 6.0], "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "steps": 40, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('mom', '{"box": [6.0, 6.0, 6.0], "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "steps": 40, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('cons', '{"box": [6.0, 6.0, 6.0], "dt": 0.25, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "steps": 40, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
-    ('disp', '{"a": [1.0, 2.0, 3.0], "b": [1.5, 2.5, 3.5], "box": [8.0, 8.0, 8.0]}'),
-    ('pot', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('force', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('newton', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('fd', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('step', '{"box": [8.0, 8.0, 8.0], "dt": 0.002, "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('obs', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('rdf', '{"bins": 8, "box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "rmax": 2.5, "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('cons', '{"box": [8.0, 8.0, 8.0], "dt": 0.002, "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "steps": 30, "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('mom', '{"box": [8.0, 8.0, 8.0], "dt": 0.002, "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "steps": 30, "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
-    ('disp', '{"a": [0.0, 6.9, 0.0], "b": [0.0, 0.2, 0.0], "box": [7.0, 7.0, 7.0]}'),
-    ('pot', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('force', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('newton', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('fd', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('step', '{"box": [7.0, 7.0, 7.0], "dt": 0.001, "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('obs', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('rdf', '{"bins": 8, "box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "rmax": 2.5, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('cons', '{"box": [7.0, 7.0, 7.0], "dt": 0.001, "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "steps": 30, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('mom', '{"box": [7.0, 7.0, 7.0], "dt": 0.001, "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "steps": 30, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
-    ('disp', '{"a": [4.9, 4.9, 4.9], "b": [0.1, 0.1, 0.1], "box": [5.0, 5.0, 5.0]}'),
-    ('pot', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('force', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('newton', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('fd', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('step', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('obs', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('rdf', '{"bins": 8, "box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "rmax": 2.5, "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('cons', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "steps": 40, "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-    ('mom', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "steps": 40, "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
-)
-
-MD = Suite(
-    name="md",
-    given=initial_files(),
-    frozen=FROZEN,
-    stages={"disp": "displacement", "pot": "energy", "force": "forces",
-            "newton": "forces_sum_to_zero", "fd": "force_matches_gradient",
-            "step": "step", "obs": "observables", "rdf": "rdf",
-            "cons": "energy_conserved", "mom": "momentum_conserved"},
-    cases=_CASES,
-    reference={
-        ENTRY: _REF_ENTRY,
-        CORE_INIT: _PKG_INIT, VECTORS: _REF_VECTORS, STATE: _REF_STATE,
-        POT_INIT: _PKG_INIT, REGISTRY: _REF_REGISTRY,
-        PAIR_INIT: _PKG_INIT, LJ: _REF_LJ, HARMONIC: _REF_HARMONIC,
-        INT_INIT: _PKG_INIT, VERLET: _REF_VERLET,
-        OBS_INIT: _PKG_INIT, THERMO: _REF_THERMO, RDF: _REF_RDF,
-        CHECKS: _filled_checks(),
-    },
-    digits=6,
-)
-
-build_tasks = MD.build_tasks
-make_runner = MD.make_runner
-suite_review = MD.review
-
-
-def llm_manager(complete):
-    return _llm_manager(complete)
-
-
-def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
-    return _llm_executor(complete, editable=editable, frozen=frozen)
-
-
-def _reference_tree() -> Dict[str, str]:
-    return MD.reference_tree()
+def reference_tree() -> Dict[str, str]:
+    """The repository as a finished run should leave it."""
+    tree = initial_files()
+    tree.update(REFERENCE)
+    return tree
 
 
 # ---------------------------------------------------------------------------
@@ -852,19 +1304,13 @@ _PLAN = {
     "src/potentials/pair": [(PAIR_INIT, _PKG_INIT), (LJ, _REF_LJ),
                             (HARMONIC, _REF_HARMONIC)],
     "src/integrate": [(INT_INIT, _PKG_INIT), (VERLET, _REF_VERLET)],
-    "src/observe": [(OBS_INIT, _PKG_INIT), (THERMO, _REF_THERMO), (RDF, _REF_RDF),
-                    (CHECKS, _CHECKS_SKELETON)],
+    "src/observe": [(OBS_INIT, _PKG_INIT), (THERMO, _REF_THERMO), (RDF, _REF_RDF)],
 }
 
 
 def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
-    owed = {node: [path for path, _ in steps if path not in state]
-             for node, steps in _PLAN.items()}
-    if CHECKS in state:
-        body = state[CHECKS]
-        owed["src/observe"] += [f"{CHECKS}#{name}"
-                                for name, (stub, _) in _STUBS.items() if stub in body]
-    return owed
+    return {node: [path for path, _ in steps if path not in state]
+            for node, steps in _PLAN.items()}
 
 
 def _owes(state: Mapping[str, str], node: str) -> bool:
@@ -886,21 +1332,4 @@ def offline_executor(brief: Brief) -> Sequence[Edit]:
     for target, content in _PLAN.get(path, ()):
         if target not in state:
             return [Edit(owner=path, path=target, content=content)]
-    if path == "src/observe" and CHECKS in state:
-        name = _stub_for(brief, state)
-        if name is not None:
-            stub, filled = _STUBS[name]
-            return [Edit(owner=path, path=CHECKS,
-                         content=state[CHECKS].replace(stub, filled))]
     return ()
-
-
-def _stub_for(brief: Brief, state: Mapping[str, str]) -> Optional[str]:
-    """Which invariant this episode's failing stage points at."""
-    body = state.get(CHECKS, "")
-    open_stubs = [n for n, (stub, _) in _STUBS.items() if stub in body]
-    if not open_stubs:
-        return None
-    meta = getattr(brief.task, "meta", None) or {}
-    wanted = _STAGE_STUB.get(meta.get("kind"))
-    return wanted if wanted in open_stubs else open_stubs[0]

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -41,7 +41,7 @@ from typing import Dict, List, Mapping, Sequence
 
 from ._delegation import Brief, Delegation, Edit
 from ._suite import (PYTHON_MODULE_SKILL, TEST_FAILURE, TestSuite,
-                     reward_test)
+                     plan_delegations, reward_test)
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
@@ -1329,10 +1329,12 @@ def _owes(state: Mapping[str, str], node: str) -> bool:
 
 
 def offline_manager(brief: Brief) -> Sequence[Delegation]:
-    """Decompose along the node's routing table; accountability writes its own."""
-    return [Delegation(node, f"clear the outstanding work under {node}/")
-            for node in brief.world.routing(brief.state)
-            if _owes(brief.state, node)]
+    """Decompose along the node's routing table; accountability writes its own.
+
+    Cold-started there is no table, so it opens the nodes its plan needs -- see
+    :func:`plan_delegations`.
+    """
+    return plan_delegations(brief, _owes, list(_PLAN))
 
 
 def offline_executor(brief: Brief) -> Sequence[Edit]:

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -1,0 +1,906 @@
+"""md: Lennard-Jones molecular dynamics, grown from an empty repository.
+
+The fourth formation domain and by some distance the largest: **ten** validated
+stages, fifteen files the agents write across six nodes, and a physics kernel that
+has to be right rather than merely parseable. A frozen driver sits on top, so a
+finished run is a program you can point at a box of argon::
+
+    python md.py --particles 108 --density 0.8 --temperature 1.2 --steps 1000 \
+                 --thermostat 0.5 --trajectory traj.xyz --rdf 40
+
+Why this domain exists. minilang showed the mechanism, stackvm gave the recursion
+somewhere to go, jqx came out as usable software -- and all three can be passed by
+code that merely parses. This one cannot: four of its ten stages are **invariants**
+rather than values. Forces have to sum to zero, they have to match a central
+difference of the energy, and energy and momentum have to survive a trajectory. A
+stage that returns ``True`` without computing anything fails, because one ``cons``
+case uses a timestep far too large and its answer is ``False``.
+
+Floats are compared to six decimal places (``Suite.digits``), because two correct
+implementations of one sum differ in the last bits by summation order alone.
+
+What is faithful and what is a surrogate is as it is for the other three, and the
+reasoning is written out on :mod:`examples.genesis._domain`.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from ._delegation import Brief, Delegation, Edit
+from ._suite import PYTHON_MODULE_SKILL, Suite, reward
+from ._suite import llm_executor as _llm_executor
+from ._suite import llm_manager as _llm_manager
+from ._world import SKILLS_DIR, normalise
+
+__all__ = ["FROZEN", "MD", "build_tasks", "initial_files", "llm_executor",
+           "llm_manager", "make_runner", "offline_executor", "offline_manager",
+           "reward", "suite_review"]
+
+#: The specification and the driver. Human-supplied, refused to every proposal,
+#: and restored pristine before scoring.
+FROZEN = ("spec/**", "md.py")
+
+ENTRY = "src/__init__.py"
+CORE_INIT = "src/core/__init__.py"
+VECTORS = "src/core/vectors.py"
+STATE = "src/core/state.py"
+POT_INIT = "src/potentials/__init__.py"
+REGISTRY = "src/potentials/registry.py"
+PAIR_INIT = "src/potentials/pair/__init__.py"
+LJ = "src/potentials/pair/lennard_jones.py"
+HARMONIC = "src/potentials/pair/harmonic.py"
+INT_INIT = "src/integrate/__init__.py"
+VERLET = "src/integrate/verlet.py"
+OBS_INIT = "src/observe/__init__.py"
+THERMO = "src/observe/thermo.py"
+RDF = "src/observe/rdf.py"
+CHECKS = "src/observe/checks.py"
+
+
+# ---------------------------------------------------------------------------
+# The human's repository: the physics, the decomposition, the driver
+# ---------------------------------------------------------------------------
+
+_SPEC = r'''# md -- the molecular dynamics this project implements
+
+Lennard-Jones molecular dynamics in **reduced units**: sigma = epsilon = mass =
+k_B = 1, so energies, lengths and temperatures are all dimensionless.
+
+## Geometry
+
+Periodic boundaries on every axis with a positive box length. The displacement
+from `a` to `b` is the **nearest image**:
+
+    d[i] = (b[i] - a[i]) - L[i] * floor((b[i] - a[i]) / L[i] + 0.5)
+
+`floor(x + 0.5)`, never `round`: Python's `round` is banker's rounding, so two
+implementations disagree exactly at half a box. A position is wrapped into
+`[0, L)` with `x - L * floor(x / L)`.
+
+## Pair interactions
+
+A pair kernel takes the **squared** distance and returns `(u, dudr_over_r)`. The
+caller puts the force on particle *i* at `dudr_over_r * d` and on *j* at its
+negative, where `d` is the displacement from *i* to *j*.
+
+**`lennard_jones`**, shifted so that `u(cutoff) == 0`, and zero beyond it:
+
+    s6  = (sigma**2 / r2) ** 3          s12 = s6 * s6
+    u            = 4*eps*(s12 - s6) - 4*eps*((sigma/rc)**12 - (sigma/rc)**6)
+    dudr_over_r  = -24*eps*(2*s12 - s6) / r2
+
+**`harmonic`**, with no cutoff, `u = 0.5 * k * (r - r0)**2`:
+
+    dudr_over_r  = k * (r - r0) / r          (and `(0.0, 0.0)` at r == 0)
+
+Energies and forces sum over every **distinct** pair once.
+
+## Integration
+
+Velocity Verlet, one step with timestep `dt`:
+
+1. `v += 0.5 * dt * f / m` with the forces at the current positions;
+2. `x += dt * v`, then **wrap** `x` into the box;
+3. recompute the forces;
+4. `v += 0.5 * dt * f / m`.
+
+## Payload defaults
+
+Every stage takes one JSON object as text. `positions` is required; `velocities`
+defaults to zeros, `masses` to ones, `box` to `[0, 0, 0]` (no periodicity),
+`potential` to `"lennard_jones"`, `epsilon`/`sigma`/`k`/`r0` to `1.0` and `cutoff`
+to `2.5`.
+
+## The ten validated stages
+
+| stage | entry point | returns |
+|---|---|---|
+| `disp` | `src.displacement(p)` | the nearest-image vector from `p["a"]` to `p["b"]` |
+| `pot` | `src.energy(p)` | the total potential energy |
+| `force` | `src.forces(p)` | one force vector per particle |
+| `newton` | `src.forces_sum_to_zero(p)` | `True` when `max abs(sum of forces)` <= 1e-9 |
+| `fd` | `src.force_matches_gradient(p)` | `True` when every component agrees with a central difference of the energy (`h = 1e-6`) to 1e-4 |
+| `step` | `src.step(p)` | `{"positions": ..., "velocities": ...}` after one step of `p["dt"]` |
+| `obs` | `src.observables(p)` | `{"kinetic": ..., "temperature": ..., "momentum": [...]}` with `KE = sum(0.5*m*v.v)`, `T = 2*KE/(3*N)` and no centre-of-mass correction |
+| `rdf` | `src.rdf(p)` | **integer** counts of distinct pairs per bin over `[0, p["rmax"])` in `p["bins"]` bins; a pair at or beyond `rmax` is not counted |
+| `cons` | `src.energy_conserved(p)` | `True` when the total energy drifts by at most 1e-4 **relative** (`abs(after - before) / max(1, abs(before))`) over `p["steps"]` steps |
+| `mom` | `src.momentum_conserved(p)` | `True` when the total momentum drifts by at most 1e-9 over `p["steps"]` steps |
+
+Floats are compared to **six decimal places**, so a different summation order is
+not a failure. The boolean stages are invariants, not opinions: one of the `cons`
+cases uses a timestep far too large and its answer is `False`, so a stage that
+always returns `True` fails the suite.
+
+A stage is scored independently of the ones after it, so `src/__init__.py` MUST
+import each stage lazily, inside the function that needs it.
+'''
+
+_ROOT_CONTEXT = r'''# md -- root
+
+## Intent
+Implement the molecular dynamics in `spec/CONTEXT.md` as a library under `src/`.
+`md.py` is the simulation driver and is already written.
+
+## Routing Table
+- `./src/` -> the library, and the ten stage entry points
+
+## Constraints
+- `spec/` and `md.py` are read-only. They are the contract, not work items.
+- Pure Python, no third-party packages: this has to run anywhere.
+- Every agent edits only files under its own path.
+'''
+
+_SRC_CONTEXT = r'''# src -- library root
+
+## Intent
+Own `src/__init__.py`: the ten entry points the spec names, each a thin wrapper
+that decodes the payload and calls into a child node. Each MUST import its stage
+lazily, so a missing layer does not stop the layers before it from scoring.
+
+## Routing Table
+- `./src/core/`       -> geometry and the system container
+- `./src/potentials/` -> energies and forces
+- `./src/integrate/`  -> advancing time
+- `./src/observe/`    -> measuring and checking
+'''
+
+_CORE_CONTEXT = r'''# src/core -- geometry and state
+
+## Intent
+`vectors.py` owns periodic geometry: the nearest-image displacement, squared
+length, length, and wrapping a point into the box. Everything else in the project
+goes through it rather than writing `floor` arithmetic of its own.
+
+`state.py` owns the `System` container -- positions, velocities, masses, box --
+and the two functions that turn a decoded payload into one (`from_payload`) and
+read the potential's parameters out of it with the spec's defaults
+(`potential_spec`).
+'''
+
+_POT_CONTEXT = r'''# src/potentials -- energies and forces
+
+## Intent
+Own `registry.py`: the name-to-kernel table, and the loop over distinct pairs that
+turns a kernel into a total energy and a force array. The loop applies Newton's
+third law once per pair, so the forces sum to zero by construction.
+
+## Routing Table
+- `./src/potentials/pair/` -> one module per pair interaction
+'''
+
+_PAIR_CONTEXT = r'''# src/potentials/pair -- the pair interactions
+
+## Intent
+One module per interaction, each exposing `pair(r2, spec) -> (u, dudr_over_r)`
+exactly as the spec defines it. `lennard_jones.py` is shifted and cut off;
+`harmonic.py` has no cutoff. Neither knows anything about boxes or loops.
+'''
+
+_INT_CONTEXT = r'''# src/integrate -- advancing time
+
+## Intent
+`verlet.py` owns velocity Verlet: `step` advances one timestep in place and
+returns the system, `run` applies it `steps` times. The position update wraps back
+into the box, and the forces are recomputed between the two half-kicks.
+'''
+
+_OBS_CONTEXT = r'''# src/observe -- measuring and checking
+
+## Intent
+`thermo.py` owns the thermodynamic observables: kinetic energy, temperature and
+total momentum. `rdf.py` owns the pair-distance histogram, in raw integer counts.
+
+`checks.py` owns the invariants, **one function per invariant**, so that two
+agents fixing two different checks are editing two different parts of the file
+rather than the same one: forces summing to zero, forces against a finite
+difference of the energy, and energy and momentum conserved across a run.
+'''
+
+_DRIVER = r'''#!/usr/bin/env python3
+"""md -- a Lennard-Jones molecular dynamics driver.
+
+Human-supplied, frozen, and never written by an agent: the library under ``src/``
+is what the run grows, and this is the shell around it so the result is a program
+rather than a package nobody can invoke.
+
+    python md.py --particles 32 --steps 500
+    python md.py --particles 64 --density 0.8 --temperature 1.2 --steps 1000 \
+                 --thermostat 0.2 --trajectory traj.xyz
+    python md.py --particles 32 --steps 200 --rdf 40
+
+Reduced Lennard-Jones units throughout: sigma = epsilon = mass = k_B = 1.
+
+It talks to the library only through the surface ``spec/CONTEXT.md`` pins --
+``step``, ``observables``, ``rdf`` -- so it works against any implementation that
+passes the suite, whatever the internal layout turns out to be. The price is a
+JSON round trip per step, which is why the defaults are small; raise them when you
+want a longer run and do not expect numpy speed from a pure-Python kernel.
+"""
+
+import argparse
+import json
+import math
+import random
+import sys
+
+
+#: The four-atom face-centred-cubic basis, in cell units.
+_FCC_BASIS = ((0.0, 0.0, 0.0), (0.0, 0.5, 0.5), (0.5, 0.0, 0.5), (0.5, 0.5, 0.0))
+
+
+def fcc_lattice(cells, density):
+    """A full FCC lattice of ``4 * cells**3`` atoms at ``density``.
+
+    FCC rather than simple cubic, and *full* rather than partly filled, because
+    both shortcuts break the physics rather than the code. A simple-cubic lattice
+    at rho=0.8 puts neighbours 0.855 sigma apart -- inside the repulsive core --
+    so the run converts a huge potential energy into heat and reports T=22 from a
+    T=1 start. FCC at the same density puts them at a/sqrt(2) = 1.21 sigma.
+    """
+    a = (4.0 / density) ** (1.0 / 3.0)
+    points = []
+    for i in range(cells):
+        for j in range(cells):
+            for k in range(cells):
+                for bx, by, bz in _FCC_BASIS:
+                    points.append([(i + bx) * a, (j + by) * a, (k + bz) * a])
+    return points, [cells * a] * 3
+
+
+def fcc_cells(requested):
+    """The smallest FCC side giving at least ``requested`` atoms."""
+    cells = 1
+    while 4 * cells ** 3 < requested:
+        cells += 1
+    return cells
+
+
+def maxwell_velocities(n, temperature, seed):
+    """Gaussian velocities at ``temperature``, with the drift removed."""
+    rng = random.Random(seed)
+    sigma = math.sqrt(temperature)
+    velocities = [[rng.gauss(0.0, sigma) for _ in range(3)] for _ in range(n)]
+    drift = [sum(v[axis] for v in velocities) / n for axis in range(3)]
+    for v in velocities:
+        for axis in range(3):
+            v[axis] -= drift[axis]
+    return velocities
+
+
+def rescale(velocities, target, current, strength):
+    """Velocity rescaling, blended: ``strength=1`` hits the target exactly."""
+    if current <= 0.0 or target <= 0.0 or strength <= 0.0:
+        return velocities
+    factor = math.sqrt(1.0 + strength * (target / current - 1.0))
+    return [[c * factor for c in v] for v in velocities]
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        prog="md", description="Lennard-Jones molecular dynamics in reduced units.")
+    p.add_argument("-n", "--particles", type=int, default=32,
+                   help="rounded up to a full FCC lattice: 4, 32, 108, 256, ...")
+    p.add_argument("-d", "--density", type=float, default=0.8)
+    p.add_argument("-T", "--temperature", type=float, default=1.0,
+                   help="initial (and, with --thermostat, target) temperature")
+    p.add_argument("-s", "--steps", type=int, default=500)
+    p.add_argument("--dt", type=float, default=0.002)
+    p.add_argument("--cutoff", type=float, default=2.5)
+    p.add_argument("--thermostat", type=float, default=0.0, metavar="STRENGTH",
+                   help="velocity rescaling, 0 = off (constant energy), 1 = every "
+                        "logged step rescaled exactly to the target")
+    p.add_argument("--log-every", type=int, default=50)
+    p.add_argument("--trajectory", metavar="FILE", help="write an XYZ trajectory")
+    p.add_argument("--rdf", type=int, default=0, metavar="BINS",
+                   help="print a pair-distance histogram over [0, cutoff) at the end")
+    p.add_argument("--seed", type=int, default=0)
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.particles < 2:
+        print("md: need at least two particles", file=sys.stderr)
+        return 2
+
+    from src import observables, rdf, step
+
+    cells = fcc_cells(args.particles)
+    positions, box = fcc_lattice(cells, args.density)
+    count = len(positions)
+    if count != args.particles:
+        print(f"# {args.particles} rounded up to {count} "
+              f"(a full {cells}x{cells}x{cells} FCC lattice)")
+    velocities = maxwell_velocities(count, args.temperature, args.seed)
+    masses = [1.0] * count
+    common = {"box": box, "masses": masses, "cutoff": args.cutoff,
+              "potential": "lennard_jones", "epsilon": 1.0, "sigma": 1.0}
+
+    trajectory = open(args.trajectory, "w", encoding="utf-8") if args.trajectory else None
+    print(f"# {count} particles, box {box[0]:.4f}, density {args.density}, "
+          f"dt {args.dt}, cutoff {args.cutoff}"
+          + (f", thermostat {args.thermostat} -> T={args.temperature}"
+             if args.thermostat else ", constant energy"))
+    print(f"# {'step':>8} {'T':>12} {'KE':>14} {'|P|':>12}")
+    try:
+        for n in range(args.steps + 1):
+            if n % args.log_every == 0 or n == args.steps:
+                obs = observables(json.dumps(
+                    {"positions": positions, "velocities": velocities,
+                     "masses": masses, "box": box}))
+                speed = math.sqrt(sum(c * c for c in obs["momentum"]))
+                print(f"  {n:>8} {obs['temperature']:>12.6f} "
+                      f"{obs['kinetic']:>14.6f} {speed:>12.3e}")
+                if trajectory is not None:
+                    trajectory.write(f"{count}\nstep {n}\n")
+                    for p in positions:
+                        trajectory.write(f"Ar {p[0]:.6f} {p[1]:.6f} {p[2]:.6f}\n")
+                if args.thermostat:
+                    velocities = rescale(velocities, args.temperature,
+                                         obs["temperature"], args.thermostat)
+            if n == args.steps:
+                break
+            out = step(json.dumps(dict(common, positions=positions,
+                                       velocities=velocities, dt=args.dt)))
+            positions, velocities = out["positions"], out["velocities"]
+    finally:
+        if trajectory is not None:
+            trajectory.close()
+
+    if args.rdf:
+        counts = rdf(json.dumps({"positions": positions, "box": box,
+                                 "bins": args.rdf, "rmax": args.cutoff}))
+        width = args.cutoff / args.rdf
+        print(f"# pair-distance histogram, {args.rdf} bins over [0, {args.cutoff})")
+        peak = max(counts) or 1
+        for i, count in enumerate(counts):
+            bar = "#" * int(40 * count / peak)
+            print(f"  {i * width:6.3f}-{(i + 1) * width:6.3f} {count:>6} {bar}")
+    if args.trajectory:
+        print(f"# wrote {args.trajectory}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def initial_files() -> Dict[str, str]:
+    """The implementation-empty repository the run starts from."""
+    return {
+        "CONTEXT.md": _ROOT_CONTEXT,
+        "spec/CONTEXT.md": _SPEC,
+        "md.py": _DRIVER,
+        "src/CONTEXT.md": _SRC_CONTEXT,
+        "src/core/CONTEXT.md": _CORE_CONTEXT,
+        "src/potentials/CONTEXT.md": _POT_CONTEXT,
+        "src/potentials/pair/CONTEXT.md": _PAIR_CONTEXT,
+        "src/integrate/CONTEXT.md": _INT_CONTEXT,
+        "src/observe/CONTEXT.md": _OBS_CONTEXT,
+        f"src/{SKILLS_DIR}/python-modules.md": PYTHON_MODULE_SKILL,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The reference implementation: the oracle, and what the offline actors reveal
+# ---------------------------------------------------------------------------
+
+_PKG_INIT = '"""Package marker."""\n'
+
+_REF_ENTRY = r'''"""Public surface. Each stage is imported lazily -- see spec/CONTEXT.md."""
+
+import json
+
+
+def _payload(source):
+    return json.loads(source)
+
+
+def displacement(source):
+    from .core.vectors import minimum_image
+    spec = _payload(source)
+    return minimum_image(spec["a"], spec["b"], spec["box"])
+
+
+def energy(source):
+    from .core.state import from_payload, potential_spec
+    from .potentials.registry import evaluate
+    spec = _payload(source)
+    return evaluate(from_payload(spec), potential_spec(spec))[0]
+
+
+def forces(source):
+    from .core.state import from_payload, potential_spec
+    from .potentials.registry import evaluate
+    spec = _payload(source)
+    return evaluate(from_payload(spec), potential_spec(spec))[1]
+
+
+def step(source):
+    from .core.state import from_payload, potential_spec
+    from .integrate.verlet import step as one_step
+    spec = _payload(source)
+    system = one_step(from_payload(spec), potential_spec(spec), spec["dt"])
+    return {"positions": system.positions, "velocities": system.velocities}
+
+
+def observables(source):
+    from .core.state import from_payload
+    from .observe.thermo import kinetic, momentum, temperature
+    system = from_payload(_payload(source))
+    return {"kinetic": kinetic(system.velocities, system.masses),
+            "temperature": temperature(system.velocities, system.masses),
+            "momentum": momentum(system.velocities, system.masses)}
+
+
+def rdf(source):
+    from .core.state import from_payload
+    from .observe.rdf import histogram
+    spec = _payload(source)
+    return histogram(from_payload(spec), spec["bins"], spec["rmax"])
+
+
+def forces_sum_to_zero(source):
+    from .core.state import from_payload, potential_spec
+    from .observe.checks import forces_sum_to_zero as check
+    spec = _payload(source)
+    return check(from_payload(spec), potential_spec(spec))
+
+
+def force_matches_gradient(source):
+    from .core.state import from_payload, potential_spec
+    from .observe.checks import force_matches_gradient as check
+    spec = _payload(source)
+    return check(from_payload(spec), potential_spec(spec))
+
+
+def energy_conserved(source):
+    from .core.state import from_payload, potential_spec
+    from .observe.checks import energy_conserved as check
+    spec = _payload(source)
+    return check(from_payload(spec), potential_spec(spec), spec["dt"], spec["steps"])
+
+
+def momentum_conserved(source):
+    from .core.state import from_payload, potential_spec
+    from .observe.checks import momentum_conserved as check
+    spec = _payload(source)
+    return check(from_payload(spec), potential_spec(spec), spec["dt"], spec["steps"])
+'''
+
+_REF_VECTORS = r'''"""Geometry under periodic boundaries."""
+
+import math
+
+
+def minimum_image(a, b, box):
+    """The displacement b - a, taking the nearest periodic image of b.
+
+    ``floor(d / L + 0.5)`` rather than ``round``: Python's round is
+    banker's rounding, so two implementations disagree exactly at half a box.
+    """
+    out = []
+    for i in range(3):
+        d = b[i] - a[i]
+        length = box[i]
+        if length > 0.0:
+            d -= length * math.floor(d / length + 0.5)
+        out.append(d)
+    return out
+
+
+def norm2(v):
+    """The squared length of a vector."""
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def norm(v):
+    return math.sqrt(norm2(v))
+
+
+def wrap(point, box):
+    """``point`` folded into ``[0, L)`` on every axis with a positive length."""
+    out = []
+    for i in range(3):
+        length = box[i]
+        out.append(point[i] - length * math.floor(point[i] / length)
+                   if length > 0.0 else point[i])
+    return out
+'''
+
+_REF_STATE = r'''"""The System container, and the payload shape every stage is given."""
+
+
+class System:
+    """Positions, velocities, masses and the box. Mutable, and copied on demand."""
+
+    def __init__(self, positions, velocities=None, masses=None, box=(0.0, 0.0, 0.0)):
+        self.positions = [list(p) for p in positions]
+        self.velocities = ([list(v) for v in velocities] if velocities is not None
+                           else [[0.0, 0.0, 0.0] for _ in self.positions])
+        self.masses = (list(masses) if masses is not None
+                       else [1.0] * len(self.positions))
+        self.box = list(box)
+
+    def __len__(self):
+        return len(self.positions)
+
+    def copy(self):
+        return System(self.positions, self.velocities, self.masses, self.box)
+
+
+def from_payload(payload):
+    """A System from a decoded stage payload."""
+    return System(payload["positions"], payload.get("velocities"),
+                  payload.get("masses"), payload.get("box", [0.0, 0.0, 0.0]))
+
+
+def potential_spec(payload):
+    """The potential's name and its parameters, with the spec's defaults."""
+    return {
+        "name": payload.get("potential", "lennard_jones"),
+        "epsilon": payload.get("epsilon", 1.0),
+        "sigma": payload.get("sigma", 1.0),
+        "cutoff": payload.get("cutoff", 2.5),
+        "k": payload.get("k", 1.0),
+        "r0": payload.get("r0", 1.0),
+    }
+'''
+
+_REF_REGISTRY = r'''"""Which pair interaction a name means, and the O(N^2) loop over pairs."""
+
+from ..core.vectors import minimum_image, norm2
+from .pair import harmonic, lennard_jones
+
+TABLE = {"lennard_jones": lennard_jones.pair, "harmonic": harmonic.pair}
+
+
+def get(name):
+    if name not in TABLE:
+        raise ValueError("unknown potential: " + str(name))
+    return TABLE[name]
+
+
+def evaluate(system, spec):
+    """``(energy, forces)`` for every distinct pair, Newton's third law applied once."""
+    kernel = get(spec["name"])
+    positions, box = system.positions, system.box
+    n = len(positions)
+    forces = [[0.0, 0.0, 0.0] for _ in range(n)]
+    energy = 0.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = minimum_image(positions[i], positions[j], box)
+            r2 = norm2(d)
+            if r2 == 0.0:
+                continue
+            u, dudr_over_r = kernel(r2, spec)
+            energy += u
+            for axis in range(3):
+                component = dudr_over_r * d[axis]
+                forces[i][axis] += component
+                forces[j][axis] -= component
+    return energy, forces
+'''
+
+_REF_LJ = r'''"""The shifted Lennard-Jones pair interaction."""
+
+
+def pair(r2, spec):
+    """``(u, dudr_over_r)`` for one pair at squared distance ``r2``.
+
+    Shifted so that ``u(cutoff) == 0``; zero beyond the cutoff. The caller puts
+    the force on particle *i* at ``dudr_over_r * d`` with ``d = x_j - x_i``.
+    """
+    cutoff = spec["cutoff"]
+    if r2 >= cutoff * cutoff:
+        return 0.0, 0.0
+    epsilon, sigma = spec["epsilon"], spec["sigma"]
+    s6 = (sigma * sigma / r2) ** 3
+    s12 = s6 * s6
+    sc6 = (sigma / cutoff) ** 6
+    shift = 4.0 * epsilon * (sc6 * sc6 - sc6)
+    u = 4.0 * epsilon * (s12 - s6) - shift
+    dudr_over_r = -24.0 * epsilon * (2.0 * s12 - s6) / r2
+    return u, dudr_over_r
+'''
+
+_REF_HARMONIC = r'''"""A harmonic spring between every pair, with no cutoff."""
+
+import math
+
+
+def pair(r2, spec):
+    """``(u, dudr_over_r)`` for ``u = 0.5 * k * (r - r0) ** 2``."""
+    k, r0 = spec["k"], spec["r0"]
+    r = math.sqrt(r2)
+    if r == 0.0:
+        return 0.0, 0.0
+    stretch = r - r0
+    return 0.5 * k * stretch * stretch, k * stretch / r
+'''
+
+_REF_VERLET = r'''"""Velocity Verlet."""
+
+from ..core.vectors import wrap
+from ..potentials.registry import evaluate
+
+
+def step(system, spec, dt):
+    """One step, in place. Positions are wrapped back into the box."""
+    _, forces = evaluate(system, spec)
+    half = 0.5 * dt
+    for i, mass in enumerate(system.masses):
+        for axis in range(3):
+            system.velocities[i][axis] += half * forces[i][axis] / mass
+            system.positions[i][axis] += dt * system.velocities[i][axis]
+        system.positions[i] = wrap(system.positions[i], system.box)
+    _, forces = evaluate(system, spec)
+    for i, mass in enumerate(system.masses):
+        for axis in range(3):
+            system.velocities[i][axis] += half * forces[i][axis] / mass
+    return system
+
+
+def run(system, spec, dt, steps):
+    for _ in range(steps):
+        step(system, spec, dt)
+    return system
+'''
+
+_REF_THERMO = r'''"""Thermodynamic observables, in reduced units with k_B = 1."""
+
+
+def kinetic(velocities, masses):
+    """The total kinetic energy."""
+    total = 0.0
+    for v, mass in zip(velocities, masses):
+        total += 0.5 * mass * (v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+    return total
+
+
+def temperature(velocities, masses):
+    """``2 * KE / (3 * N)`` -- no centre-of-mass correction, k_B = 1."""
+    n = len(masses)
+    if n == 0:
+        return 0.0
+    return 2.0 * kinetic(velocities, masses) / (3.0 * n)
+
+
+def momentum(velocities, masses):
+    """The total momentum vector."""
+    total = [0.0, 0.0, 0.0]
+    for v, mass in zip(velocities, masses):
+        for axis in range(3):
+            total[axis] += mass * v[axis]
+    return total
+'''
+
+_REF_RDF = r'''"""Pair-distance histogram -- the raw counts an g(r) is built from."""
+
+from ..core.vectors import minimum_image, norm
+
+
+def histogram(system, bins, rmax):
+    """Counts of distinct pairs per bin over ``[0, rmax)``, ``bins`` bins wide."""
+    counts = [0] * bins
+    width = rmax / bins
+    positions = system.positions
+    for i in range(len(positions)):
+        for j in range(i + 1, len(positions)):
+            r = norm(minimum_image(positions[i], positions[j], system.box))
+            if r < rmax:
+                counts[int(r / width)] += 1
+    return counts
+'''
+
+#: The shape `src/observe/CONTEXT.md` asks for: one function per invariant, four
+#: of them, each independently fillable and each reached by a different stage --
+#: so four agents holding four different failing stages edit four different parts
+#: of one file, which is what a keyed union cannot fuse.
+_CHECKS_SKELETON = r'''"""Invariants a correct force field and integrator must satisfy."""
+
+from ..integrate.verlet import run
+from ..observe.thermo import kinetic, momentum
+from ..potentials.registry import evaluate
+
+
+def forces_sum_to_zero(system, spec, tol=1e-9):
+    raise NotImplementedError("forces_sum_to_zero")
+
+
+def force_matches_gradient(system, spec, h=1e-6, tol=1e-4):
+    raise NotImplementedError("force_matches_gradient")
+
+
+def energy_conserved(system, spec, dt, steps, tol=1e-4):
+    raise NotImplementedError("energy_conserved")
+
+
+def momentum_conserved(system, spec, dt, steps, tol=1e-9):
+    raise NotImplementedError("momentum_conserved")
+'''
+
+_STUBS = {'forces_sum_to_zero': ('def forces_sum_to_zero(system, spec, tol=1e-9):\n    raise NotImplementedError("forces_sum_to_zero")\n', 'def forces_sum_to_zero(system, spec, tol=1e-9):\n    """Newton\'s third law, pair by pair: the net force on the box is zero."""\n    _, forces = evaluate(system, spec)\n    total = [sum(f[axis] for f in forces) for axis in range(3)]\n    return max(abs(c) for c in total) <= tol\n'), 'force_matches_gradient': ('def force_matches_gradient(system, spec, h=1e-6, tol=1e-4):\n    raise NotImplementedError("force_matches_gradient")\n', 'def force_matches_gradient(system, spec, h=1e-6, tol=1e-4):\n    """Every force component against a central difference of the energy."""\n    _, forces = evaluate(system, spec)\n    worst = 0.0\n    for i in range(len(system)):\n        for axis in range(3):\n            original = system.positions[i][axis]\n            system.positions[i][axis] = original + h\n            plus, _ = evaluate(system, spec)\n            system.positions[i][axis] = original - h\n            minus, _ = evaluate(system, spec)\n            system.positions[i][axis] = original\n            worst = max(worst, abs(-(plus - minus) / (2.0 * h) - forces[i][axis]))\n    return worst <= tol\n'), 'energy_conserved': ('def energy_conserved(system, spec, dt, steps, tol=1e-4):\n    raise NotImplementedError("energy_conserved")\n', 'def energy_conserved(system, spec, dt, steps, tol=1e-4):\n    """Total energy before and after ``steps`` steps, as a relative drift."""\n    potential, _ = evaluate(system, spec)\n    before = potential + kinetic(system.velocities, system.masses)\n    run(system, spec, dt, steps)\n    potential, _ = evaluate(system, spec)\n    after = potential + kinetic(system.velocities, system.masses)\n    return abs(after - before) / max(1.0, abs(before)) <= tol\n'), 'momentum_conserved': ('def momentum_conserved(system, spec, dt, steps, tol=1e-9):\n    raise NotImplementedError("momentum_conserved")\n', 'def momentum_conserved(system, spec, dt, steps, tol=1e-9):\n    """Total momentum before and after ``steps`` steps."""\n    before = momentum(system.velocities, system.masses)\n    run(system, spec, dt, steps)\n    after = momentum(system.velocities, system.masses)\n    return max(abs(after[a] - before[a]) for a in range(3)) <= tol\n')}
+
+#: Which stage's failure points at which invariant. Routing by the stage rather
+#: than by the payload text, because an MD payload is numbers and mentions no
+#: function by name.
+_STAGE_STUB = {"newton": "forces_sum_to_zero", "fd": "force_matches_gradient",
+               "cons": "energy_conserved", "mom": "momentum_conserved"}
+
+
+def _filled_checks() -> str:
+    body = _CHECKS_SKELETON
+    for stub, filled in _STUBS.values():
+        body = body.replace(stub, filled)
+    return body
+
+
+_CASES = (
+    ('disp', '{"a": [0.1, 0.0, 0.0], "b": [5.6, 0.0, 0.0], "box": [6.0, 6.0, 6.0]}'),
+    ('pot', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('force', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('newton', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('fd', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('step', '{"box": [6.0, 6.0, 6.0], "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('obs', '{"box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('rdf', '{"bins": 8, "box": [6.0, 6.0, 6.0], "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "rmax": 2.5, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('cons', '{"box": [6.0, 6.0, 6.0], "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "steps": 40, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('mom', '{"box": [6.0, 6.0, 6.0], "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "steps": 40, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('cons', '{"box": [6.0, 6.0, 6.0], "dt": 0.25, "masses": [1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.1, 0.0, 0.0], [0.0, 1.2, 0.0], [2.0, 2.0, 2.0]], "steps": 40, "velocities": [[0.1, 0.0, 0.0], [-0.1, 0.05, 0.0], [0.0, -0.05, 0.2], [0.0, 0.0, -0.2]]}'),
+    ('disp', '{"a": [1.0, 2.0, 3.0], "b": [1.5, 2.5, 3.5], "box": [8.0, 8.0, 8.0]}'),
+    ('pot', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('force', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('newton', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('fd', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('step', '{"box": [8.0, 8.0, 8.0], "dt": 0.002, "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('obs', '{"box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('rdf', '{"bins": 8, "box": [8.0, 8.0, 8.0], "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "rmax": 2.5, "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('cons', '{"box": [8.0, 8.0, 8.0], "dt": 0.002, "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "steps": 30, "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('mom', '{"box": [8.0, 8.0, 8.0], "dt": 0.002, "masses": [1.0, 2.0], "positions": [[1.0, 1.0, 1.0], [2.15, 1.0, 1.0]], "steps": 30, "velocities": [[0.0, 0.2, 0.0], [0.0, -0.2, 0.0]]}'),
+    ('disp', '{"a": [0.0, 6.9, 0.0], "b": [0.0, 0.2, 0.0], "box": [7.0, 7.0, 7.0]}'),
+    ('pot', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('force', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('newton', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('fd', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('step', '{"box": [7.0, 7.0, 7.0], "dt": 0.001, "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('obs', '{"box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('rdf', '{"bins": 8, "box": [7.0, 7.0, 7.0], "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "rmax": 2.5, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('cons', '{"box": [7.0, 7.0, 7.0], "dt": 0.001, "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "steps": 30, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('mom', '{"box": [7.0, 7.0, 7.0], "dt": 0.001, "k": 2.0, "masses": [1.0, 1.0, 1.5], "positions": [[0.0, 0.0, 0.0], [1.3, 0.0, 0.0], [0.0, 0.9, 0.4]], "potential": "harmonic", "r0": 1.0, "steps": 30, "velocities": [[0.05, 0.0, 0.0], [-0.05, 0.1, 0.0], [0.0, -0.1, 0.0]]}'),
+    ('disp', '{"a": [4.9, 4.9, 4.9], "b": [0.1, 0.1, 0.1], "box": [5.0, 5.0, 5.0]}'),
+    ('pot', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('force', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('newton', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('fd', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('step', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('obs', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('rdf', '{"bins": 8, "box": [5.0, 5.0, 5.0], "cutoff": 2.0, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "rmax": 2.5, "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('cons', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "steps": 40, "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+    ('mom', '{"box": [5.0, 5.0, 5.0], "cutoff": 2.0, "dt": 0.001, "masses": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "positions": [[0.0, 0.0, 0.0], [1.15, 0.0, 0.0], [0.0, 1.15, 0.0], [0.0, 0.0, 1.15], [2.3, 0.0, 0.0], [1.15, 1.15, 1.15]], "steps": 40, "velocities": [[0.0, 0.1, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.1], [-0.1, 0.0, 0.0], [0.0, -0.1, 0.0], [0.0, 0.0, -0.1]]}'),
+)
+
+MD = Suite(
+    name="md",
+    given=initial_files(),
+    frozen=FROZEN,
+    stages={"disp": "displacement", "pot": "energy", "force": "forces",
+            "newton": "forces_sum_to_zero", "fd": "force_matches_gradient",
+            "step": "step", "obs": "observables", "rdf": "rdf",
+            "cons": "energy_conserved", "mom": "momentum_conserved"},
+    cases=_CASES,
+    reference={
+        ENTRY: _REF_ENTRY,
+        CORE_INIT: _PKG_INIT, VECTORS: _REF_VECTORS, STATE: _REF_STATE,
+        POT_INIT: _PKG_INIT, REGISTRY: _REF_REGISTRY,
+        PAIR_INIT: _PKG_INIT, LJ: _REF_LJ, HARMONIC: _REF_HARMONIC,
+        INT_INIT: _PKG_INIT, VERLET: _REF_VERLET,
+        OBS_INIT: _PKG_INIT, THERMO: _REF_THERMO, RDF: _REF_RDF,
+        CHECKS: _filled_checks(),
+    },
+    digits=6,
+)
+
+build_tasks = MD.build_tasks
+make_runner = MD.make_runner
+suite_review = MD.review
+
+
+def llm_manager(complete):
+    return _llm_manager(complete)
+
+
+def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
+    return _llm_executor(complete, editable=editable, frozen=frozen)
+
+
+def _reference_tree() -> Dict[str, str]:
+    return MD.reference_tree()
+
+
+# ---------------------------------------------------------------------------
+# The offline actors: rule-based, deterministic, and a surrogate
+# ---------------------------------------------------------------------------
+
+_PLAN = {
+    "src": [(ENTRY, _REF_ENTRY)],
+    "src/core": [(CORE_INIT, _PKG_INIT), (VECTORS, _REF_VECTORS), (STATE, _REF_STATE)],
+    "src/potentials": [(POT_INIT, _PKG_INIT), (REGISTRY, _REF_REGISTRY)],
+    "src/potentials/pair": [(PAIR_INIT, _PKG_INIT), (LJ, _REF_LJ),
+                            (HARMONIC, _REF_HARMONIC)],
+    "src/integrate": [(INT_INIT, _PKG_INIT), (VERLET, _REF_VERLET)],
+    "src/observe": [(OBS_INIT, _PKG_INIT), (THERMO, _REF_THERMO), (RDF, _REF_RDF),
+                    (CHECKS, _CHECKS_SKELETON)],
+}
+
+
+def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
+    owed = {node: [path for path, _ in steps if path not in state]
+             for node, steps in _PLAN.items()}
+    if CHECKS in state:
+        body = state[CHECKS]
+        owed["src/observe"] += [f"{CHECKS}#{name}"
+                                for name, (stub, _) in _STUBS.items() if stub in body]
+    return owed
+
+
+def _owes(state: Mapping[str, str], node: str) -> bool:
+    node = normalise(node)
+    return any(items for key, items in _outstanding(state).items()
+               if key == node or key.startswith(node + "/"))
+
+
+def offline_manager(brief: Brief) -> Sequence[Delegation]:
+    """Decompose along the node's routing table; accountability writes its own."""
+    return [Delegation(node, f"clear the outstanding work under {node}/")
+            for node in brief.world.routing(brief.state)
+            if _owes(brief.state, node)]
+
+
+def offline_executor(brief: Brief) -> Sequence[Edit]:
+    """Write exactly one file, the way a bounded episode does."""
+    path, state = normalise(brief.world.path), brief.state
+    for target, content in _PLAN.get(path, ()):
+        if target not in state:
+            return [Edit(owner=path, path=target, content=content)]
+    if path == "src/observe" and CHECKS in state:
+        name = _stub_for(brief, state)
+        if name is not None:
+            stub, filled = _STUBS[name]
+            return [Edit(owner=path, path=CHECKS,
+                         content=state[CHECKS].replace(stub, filled))]
+    return ()
+
+
+def _stub_for(brief: Brief, state: Mapping[str, str]) -> Optional[str]:
+    """Which invariant this episode's failing stage points at."""
+    body = state.get(CHECKS, "")
+    open_stubs = [n for n, (stub, _) in _STUBS.items() if stub in body]
+    if not open_stubs:
+        return None
+    meta = getattr(brief.task, "meta", None) or {}
+    wanted = _STAGE_STUB.get(meta.get("kind"))
+    return wanted if wanted in open_stubs else open_stubs[0]

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -60,7 +60,7 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["BASELINES", "CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+__all__ = ["BASELINES", "CASE_NOUN", "CONTRACTS", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
            "MD",
            "SCORING", "build_tasks", "initial_files",
            "llm_executor", "llm_manager", "make_runner", "offline_executor",
@@ -69,6 +69,13 @@ __all__ = ["BASELINES", "CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
 #: The specification, the test suite and the driver. Human-supplied, refused to
 #: every proposal, and restored pristine before scoring.
 FROZEN = ("spec/**", "tests/**", "md.py")
+
+#: What is **pushed into every brief**, in this order. Upstream an agent pulls files
+#: with a read tool, so what it may not write and what it is handed unasked are two
+#: different sets: the whole suite in every prompt would be 12 kB of tests the
+#: episode was not asked about, and the one test that is failing arrives in the task
+#: prompt already.
+CONTRACTS = ("spec/**", "md.py")
 
 #: How the run is scored and what the header says about it.
 SCORING = "frozen test suite, no reference implementation in the scoring path"
@@ -210,6 +217,10 @@ Implement the molecular dynamics in `spec/CONTEXT.md` as a library under `src/`.
 `md.py` is the simulation driver and is already written; `tests/` is the suite
 your work is scored against.
 
+## API Surface
+`md.py` -- the command-line driver. It imports `step`, `observables` and `rdf` from
+`src` and nothing else.
+
 ## Routing Table
 - `./src/` -> the library, and the seven public entry points
 
@@ -228,6 +239,14 @@ wrapper that calls into a child node. Each MUST import its layer **lazily**, ins
 the function body, so a missing layer does not stop the layers before it from
 passing their tests.
 
+## API Surface
+`src/__init__.py` exposes exactly seven names, with the signatures
+`spec/CONTEXT.md` gives verbatim: `displacement(a, b, box)`, `wrap(point, box)`,
+`energy(positions, **params)`, `forces(positions, **params)`,
+`step(positions, velocities, masses, dt, **params)`, `observables(velocities, masses)`,
+`rdf(positions, box, bins, rmax)`. Nothing else is public, and the keyword set reaches
+every layer below.
+
 ## Routing Table
 - `./src/core/`       -> geometry and the system container
 - `./src/potentials/` -> energies and forces
@@ -245,6 +264,12 @@ goes through it rather than writing `floor` arithmetic of its own.
 `state.py` owns the `System` container -- positions, velocities, masses, box, with
 velocities defaulting to zeros and masses to ones -- and `make_spec`, which bundles
 the potential parameters the pair kernels are handed.
+
+## API Surface
+- `vectors.py`: `minimum_image(a, b, box)`, `norm2(v)`, `norm(v)`, `wrap(point, box)`
+- `state.py`: `System(positions, velocities=None, masses=None, box=(0,0,0))` with
+  `.positions`, `.velocities`, `.masses`, `.box`, `__len__`, `copy()`;
+  `make_spec(potential, epsilon, sigma, cutoff, k, r0) -> dict`
 '''
 
 _POT_CONTEXT = r'''# src/potentials -- energies and forces
@@ -254,6 +279,10 @@ Own `registry.py`: the name-to-kernel table, the refusal of an unknown name, and
 the loop over distinct pairs that turns a kernel into a total energy and a force
 array. The loop applies Newton's third law once per pair, which is what makes the
 forces sum to zero by construction rather than by luck.
+
+## API Surface
+- `registry.py`: `get(name) -> kernel` (raises on an unknown name),
+  `evaluate(system, spec) -> (energy, forces)`
 
 ## Routing Table
 - `./src/potentials/pair/` -> one module per pair interaction
@@ -265,6 +294,10 @@ _PAIR_CONTEXT = r'''# src/potentials/pair -- the pair interactions
 One module per interaction, each exposing `pair(r2, spec) -> (u, dudr_over_r)`
 exactly as the spec defines it. `lennard_jones.py` is shifted and cut off;
 `harmonic.py` has no cutoff. Neither knows anything about boxes or loops.
+
+## API Surface
+- `lennard_jones.py`: `pair(r2, spec) -> (u, dudr_over_r)`
+- `harmonic.py`: `pair(r2, spec) -> (u, dudr_over_r)`
 '''
 
 _INT_CONTEXT = r'''# src/integrate -- advancing time
@@ -274,6 +307,10 @@ _INT_CONTEXT = r'''# src/integrate -- advancing time
 the system, `run` applies it `steps` times. The position update wraps back into the
 box, and the forces are recomputed between the two half-kicks -- that recomputation
 is what makes the scheme reversible, and the suite tests reversibility directly.
+
+## API Surface
+- `verlet.py`: `step(system, spec, dt) -> system` (in place),
+  `run(system, spec, dt, steps) -> system`
 '''
 
 _OBS_CONTEXT = r'''# src/observe -- measuring
@@ -283,6 +320,11 @@ _OBS_CONTEXT = r'''# src/observe -- measuring
 total momentum, in reduced units with k_B = 1 and no centre-of-mass correction.
 `rdf.py` owns the pair-distance histogram, in raw integer counts of distinct pairs,
 and takes its distances from `src/core/vectors.py` rather than recomputing them.
+
+## API Surface
+- `thermo.py`: `kinetic(velocities, masses)`, `temperature(velocities, masses)`,
+  `momentum(velocities, masses)`
+- `rdf.py`: `histogram(system, bins, rmax) -> [int]`
 '''
 
 _DRIVER = r'''#!/usr/bin/env python3

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -60,9 +60,10 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["BASELINES", "CASE_NOUN", "CONTRACTS", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+__all__ = ["BASELINES", "CASE_NOUN", "CONTRACTS", "FROZEN",
+           "SUITE_ONLY_BASELINES", "GROUP_NOUN", "HELD_OUT_FRAC",
            "MD",
-           "SCORING", "build_tasks", "initial_files",
+           "SCORING", "build_tasks", "initial_files", "suite_failures",
            "llm_executor", "llm_manager", "make_runner", "offline_executor",
            "offline_manager", "reference_tree", "reward", "suite_review"]
 
@@ -1299,6 +1300,28 @@ def momentum(velocities, masses):
     return total
 '''
 
+_SELF_CLOBBERING = r'''"""A public entry point that destroys itself on first call.
+
+`from .rdf import histogram` imports the submodule `src.observe.rdf`, and importing a
+submodule **rebinds that name on the package** -- over the function of the same name
+defined right here. The first call works and every call after it raises. Taken from a
+real run, unchanged.
+"""
+
+
+def observables(velocities, masses):
+    from .thermo import kinetic, momentum, temperature
+    return {"kinetic": kinetic(velocities, masses),
+            "temperature": temperature(velocities, masses),
+            "momentum": momentum(velocities, masses)}
+
+
+def rdf(positions, box, bins, rmax):
+    from .rdf import histogram
+    from ..core.state import System
+    return histogram(System(positions, box=box), bins, rmax)
+'''
+
 #: Each of these must fail at least two tests. See :meth:`TestSuite.kill_report`.
 BASELINES = {
     "zero-field": {REGISTRY: _ZERO_FIELD},
@@ -1310,12 +1333,15 @@ BASELINES = {
 }
 
 
+
 MD = TestSuite(name="md", given=initial_files(), frozen=FROZEN, audit=_AUDIT,
                baselines=BASELINES)
 
 build_tasks = MD.build_tasks
 make_runner = MD.make_runner
 suite_review = MD.review
+#: The whole suite in one interpreter -- `mix test`, not one process per test.
+suite_failures = MD.suite_failures
 #: One test, pass or fail. No tolerance of its own -- the test owns that.
 reward = reward_test
 #: Exactly the audit set in the held-out tail, and every driven test in the search.
@@ -1632,6 +1658,22 @@ def reference_tree() -> Dict[str, str]:
     tree = initial_files()
     tree.update(REFERENCE)
     return tree
+
+
+#: The public entry point routed through the package the way the real run wrote it,
+#: which is what turns the self-clobbering import above into a visible failure.
+_ROUTED_ENTRY = _REF_ENTRY.replace(
+    """    from .core.state import System
+    from .observe.rdf import histogram
+    return histogram(System(positions, box=box), bins, rmax)""",
+    """    from .observe import rdf as _rdf
+    return _rdf(positions, box, bins, rmax)""")
+
+#: The one a per-test score cannot catch, kept separate because it is not a failure of
+#: the suite -- it is a failure of *how the suite is run*, and the guard for it is
+#: `suite_failures` rather than `kill_report`.
+SUITE_ONLY_BASELINES = {"self-clobbering-import": {ENTRY: _ROUTED_ENTRY,
+                                                   OBS_INIT: _SELF_CLOBBERING}}
 
 
 # ---------------------------------------------------------------------------

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -1,7 +1,7 @@
 """md: Lennard-Jones molecular dynamics, grown from an empty repository.
 
 The fourth formation domain, the largest, and the only one with **no oracle in the
-scoring path**. A frozen test suite is the whole of the reward: sixty-two test
+scoring path**. A frozen test suite is the whole of the reward: sixty-five test
 functions over six files, one task each, and a task's prompt is that test's own
 source. Nothing here is compared against a reference implementation, because asking
 a system to grow software you had to write first proves nothing. Upstream validates
@@ -26,11 +26,17 @@ Invariants alone are not enough, which a real run demonstrated: a field that ret
 **zero everywhere** satisfies every one of them (zero sums to zero, zero is the
 gradient of a constant, nothing moves so nothing drifts), and a run shipped exactly
 that from a minimum-image expression whose ``// 1`` bound after the multiplication.
-Forty-two of the then forty-four tests passed. The suite pins values in a periodic
-box now, and ``tests/test_genesis_example.py`` holds both guards: the zero field is
-rejected, and so is Euler dressed as Verlet.
+Forty-two of the then forty-four tests passed, and the only test that noticed was the
+negative control.
 
-The held-out tail is an **audit set**, not a validation split. Fourteen further
+So the suite is checked against :data:`BASELINES` -- six deliberately wrong
+implementations that all have to die, and to at least two tests each, because one
+test between a false 1.000 and the truth is not a margin. Writing that check found
+two more holes immediately: a ``round``-based geometry, the one thing the spec
+explicitly forbids, passed everything; and the centre-of-mass-corrected temperature
+died to a single test.
+
+The held-out tail is an **audit set**, not a validation split. Fifteen further
 tests live outside the repository entirely -- ``frozen`` stops a file being written,
 not read, and the executor is handed the source of the test it is failing, so an
 audit test in the tree is one it can write to. They are injected only while a
@@ -54,7 +60,8 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC", "MD",
+__all__ = ["BASELINES", "CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+           "MD",
            "SCORING", "build_tasks", "initial_files",
            "llm_executor", "llm_manager", "make_runner", "offline_executor",
            "offline_manager", "reference_tree", "reward", "suite_review"]
@@ -610,6 +617,18 @@ def test_wrap_folds_a_point_into_the_box():
 
 def test_wrap_leaves_an_interior_point_alone():
     assert wrap([1.0, 2.0, 3.0], BOX) == [1.0, 2.0, 3.0]
+
+
+def test_a_separation_of_exactly_half_a_box_takes_the_negative_image():
+    """The one place two correct-looking implementations disagree.
+
+    This is why the spec pins `floor(d/L + 0.5)` and forbids `round`: Python's round
+    is banker's rounding, so `round(0.5)` is 0 and `round(2.5)` is 2, and the sign of
+    the image comes out the other way. Nothing else in the suite can tell the two
+    apart -- a `round`-based geometry passed every other test here.
+    """
+    assert displacement([0.0, 0.0, 0.0], [3.0, 0.0, 0.0], BOX)[0] == -3.0
+    assert displacement([0.0, 0.0, 0.0], [15.0, 0.0, 0.0], BOX)[0] == -3.0
 ''',
     'tests/test_integration.py': r'''"""Velocity Verlet. The invariants here are what makes an integrator correct."""
 
@@ -752,6 +771,18 @@ def test_the_histogram_uses_the_nearest_image():
     positions = [[0.1, 0.0, 0.0], [5.9, 0.0, 0.0]]     # 0.2 apart across the seam
     counts = rdf(positions, [6.0, 6.0, 6.0], 6, 3.0)   # bins 0.5 wide
     assert counts[0] == 1 and sum(counts) == 1, counts
+
+
+def test_temperature_divides_by_three_n_and_not_by_the_degrees_of_freedom():
+    """`T = 2 KE / (3N)`, with no centre-of-mass correction.
+
+    The corrected form divides by `3N - 3`, which differs by `N / (N - 1)` -- 1.5 at
+    N = 3. A ratio test between two temperatures cancels the factor and cannot see
+    it, so the number is pinned here.
+    """
+    obs = observables([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], [1.0] * 3)
+    assert abs(obs["kinetic"] - 1.5) < 1e-12, obs
+    assert abs(obs["temperature"] - 1.0 / 3.0) < 1e-12, obs      # 2 * 1.5 / 9, not / 6
 ''',
     'tests/test_pair_potentials.py': r'''"""The pair interactions, probed through two-particle configurations."""
 
@@ -1028,6 +1059,21 @@ def test_the_field_in_a_non_cubic_box_is_not_identically_zero():
     s6 = (1.0 / 0.25) ** 6
     shift = 4.0 * ((1.0 / 2.5) ** 12 - (1.0 / 2.5) ** 6)
     assert abs(u - (4.0 * (s6 * s6 - s6) - shift)) / u < 1e-9, u
+
+
+def test_half_a_box_takes_the_negative_image_on_every_axis():
+    """The banker's-rounding trap again, on a box with three different sides.
+
+    `floor(d/L + 0.5)` at `d = L/2` gives `floor(1.0) = 1` and the image is `-L/2`;
+    `round(0.5)` is 0 and it comes out `+L/2`. The magnitude is the same either way,
+    so only a signed displacement can see this -- no distance, energy or histogram
+    can. It is in the audit set as well as the suite because a requirement the spec
+    states explicitly should not hang on one test.
+    """
+    for axis, length in enumerate(BOX):
+        b = [0.0, 0.0, 0.0]
+        b[axis] = length / 2.0
+        assert displacement([0.0, 0.0, 0.0], b, BOX)[axis] == -length / 2.0
 ''',
 }
 
@@ -1050,7 +1096,180 @@ def initial_files() -> Dict[str, str]:
     return files
 
 
-MD = TestSuite(name="md", given=initial_files(), frozen=FROZEN, audit=_AUDIT)
+# ---------------------------------------------------------------------------
+# Deliberately wrong implementations, for checking the suite rejects them
+# ---------------------------------------------------------------------------
+# Not scoring, and not the algorithm: upstream has no objective function at all,
+# and what stands in its place is a parent that reads the diff and runs the tests.
+# This is the harness checking its own measurement. Every one of these has to die,
+# and to more than one test -- the zero field originally died to exactly one, which
+# is how close this domain came to reporting 1.000 for a repository with no force
+# field in it.
+
+_ZERO_FIELD = r'''"""The cheapest way to pass a suite of invariants: compute nothing."""
+
+from ..core.vectors import minimum_image, norm2
+from .pair import harmonic, lennard_jones
+
+TABLE = {"lennard_jones": lennard_jones.pair, "harmonic": harmonic.pair}
+
+
+def get(name):
+    if name not in TABLE:
+        raise ValueError("unknown potential: " + str(name))
+    return TABLE[name]
+
+
+def evaluate(system, spec):
+    get(spec["name"])
+    return 0.0, [[0.0, 0.0, 0.0] for _ in system.positions]
+'''
+
+_BANKERS_ROUNDING = r'''"""Geometry with `round` where the spec says `floor(x + 0.5)`."""
+
+import math
+
+
+def minimum_image(a, b, box):
+    out = []
+    for i in range(3):
+        d = b[i] - a[i]
+        length = box[i]
+        if length > 0.0:
+            d -= length * round(d / length)
+        out.append(d)
+    return out
+
+
+def norm2(v):
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def norm(v):
+    return math.sqrt(norm2(v))
+
+
+def wrap(point, box):
+    out = []
+    for i in range(3):
+        length = box[i]
+        out.append(point[i] - length * math.floor(point[i] / length)
+                   if length > 0.0 else point[i])
+    return out
+'''
+
+_PRECEDENCE_BUG = r'''"""The real one, from a real run: `// 1` binding after the multiplication.
+
+`floor(d + L/2)` instead of `L * floor(d/L + 0.5)`, which pushes every pair in a
+periodic box past the cutoff and leaves the force field identically zero.
+"""
+
+import math
+
+
+def minimum_image(a, b, box):
+    out = []
+    for i in range(3):
+        d = b[i] - a[i]
+        length = box[i]
+        if length > 0.0:
+            d -= length * (d / length + 0.5) // 1
+        out.append(d)
+    return out
+
+
+def norm2(v):
+    return v[0] * v[0] + v[1] * v[1] + v[2] * v[2]
+
+
+def norm(v):
+    return math.sqrt(norm2(v))
+
+
+def wrap(point, box):
+    out = []
+    for i in range(3):
+        length = box[i]
+        out.append(point[i] - length * math.floor(point[i] / length)
+                   if length > 0.0 else point[i])
+    return out
+'''
+
+_UNSHIFTED_LJ = r'''"""Lennard-Jones without the shift: discontinuous at the cutoff."""
+
+
+def pair(r2, spec):
+    cutoff = spec["cutoff"]
+    if r2 >= cutoff * cutoff:
+        return 0.0, 0.0
+    epsilon, sigma = spec["epsilon"], spec["sigma"]
+    s6 = (sigma * sigma / r2) ** 3
+    s12 = s6 * s6
+    u = 4.0 * epsilon * (s12 - s6)
+    dudr_over_r = -24.0 * epsilon * (2.0 * s12 - s6) / r2
+    return u, dudr_over_r
+'''
+
+_EULER = r'''"""One force evaluation per step: stable, plausible, first-order, irreversible."""
+
+from ..core.vectors import wrap
+from ..potentials.registry import evaluate
+
+
+def step(system, spec, dt):
+    _, forces = evaluate(system, spec)
+    for i, mass in enumerate(system.masses):
+        for axis in range(3):
+            system.velocities[i][axis] += dt * forces[i][axis] / mass
+            system.positions[i][axis] += dt * system.velocities[i][axis]
+        system.positions[i] = wrap(system.positions[i], system.box)
+    return system
+
+
+def run(system, spec, dt, steps):
+    for _ in range(steps):
+        step(system, spec, dt)
+    return system
+'''
+
+_NO_COM_DRIFT = r'''"""Temperature with a centre-of-mass correction the spec says not to apply."""
+
+
+def kinetic(velocities, masses):
+    total = 0.0
+    for v, mass in zip(velocities, masses):
+        total += 0.5 * mass * (v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
+    return total
+
+
+def temperature(velocities, masses):
+    n = len(masses)
+    if n == 0:
+        return 0.0
+    return 2.0 * kinetic(velocities, masses) / (3.0 * n - 3.0) if n > 1 else 0.0
+
+
+def momentum(velocities, masses):
+    total = [0.0, 0.0, 0.0]
+    for v, mass in zip(velocities, masses):
+        for axis in range(3):
+            total[axis] += mass * v[axis]
+    return total
+'''
+
+#: Each of these must fail at least two tests. See :meth:`TestSuite.kill_report`.
+BASELINES = {
+    "zero-field": {REGISTRY: _ZERO_FIELD},
+    "precedence-bug": {VECTORS: _PRECEDENCE_BUG},
+    "bankers-rounding": {VECTORS: _BANKERS_ROUNDING},
+    "unshifted-lennard-jones": {LJ: _UNSHIFTED_LJ},
+    "euler-not-verlet": {VERLET: _EULER},
+    "com-corrected-temperature": {THERMO: _NO_COM_DRIFT},
+}
+
+
+MD = TestSuite(name="md", given=initial_files(), frozen=FROZEN, audit=_AUDIT,
+               baselines=BASELINES)
 
 build_tasks = MD.build_tasks
 make_runner = MD.make_runner

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -1,7 +1,7 @@
 """md: Lennard-Jones molecular dynamics, grown from an empty repository.
 
 The fourth formation domain, the largest, and the only one with **no oracle in the
-scoring path**. A frozen test suite is the whole of the reward: fifty-seven test
+scoring path**. A frozen test suite is the whole of the reward: sixty-two test
 functions over six files, one task each, and a task's prompt is that test's own
 source. Nothing here is compared against a reference implementation, because asking
 a system to grow software you had to write first proves nothing. Upstream validates
@@ -22,7 +22,15 @@ and momentum must survive a trajectory, reversing the velocities must retrace it
 and one test asserts that a far-too-large timestep does *not* conserve energy, so an
 implementation that fakes conservation fails.
 
-The held-out tail is an **audit set**, not a validation split. Thirteen further
+Invariants alone are not enough, which a real run demonstrated: a field that returns
+**zero everywhere** satisfies every one of them (zero sums to zero, zero is the
+gradient of a constant, nothing moves so nothing drifts), and a run shipped exactly
+that from a minimum-image expression whose ``// 1`` bound after the multiplication.
+Forty-two of the then forty-four tests passed. The suite pins values in a periodic
+box now, and ``tests/test_genesis_example.py`` holds both guards: the zero field is
+rejected, and so is Euler dressed as Verlet.
+
+The held-out tail is an **audit set**, not a validation split. Fourteen further
 tests live outside the repository entirely -- ``frozen`` stops a file being written,
 not read, and the executor is handed the source of the test it is failing, so an
 audit test in the tree is one it can write to. They are injected only while a
@@ -181,6 +189,11 @@ and momentum survive a trajectory, and reversing the velocities retraces it.
 They cannot be satisfied by a lookup table, and one of them deliberately asserts
 that a far-too-large timestep does *not* conserve energy -- so an implementation
 that fakes conservation fails it.
+
+Others pin **values in a periodic box**, because every invariant above is also
+satisfied by a force field that returns zero everywhere. If `energy(..., box=L)`
+comes out at zero for particles a sigma apart, the minimum image is wrong, however
+many invariants still pass.
 '''
 
 _ROOT_CONTEXT = r'''# md -- root
@@ -509,6 +522,50 @@ def test_an_unknown_potential_is_refused():
     except Exception:
         return
     raise AssertionError("an unknown potential name should raise")
+
+
+def lj_closed_form(r, cutoff=2.5):
+    """u(r) for epsilon = sigma = 1, shifted at `cutoff`."""
+    s6 = (1.0 / r) ** 6
+    sc6 = (1.0 / cutoff) ** 6
+    return 4.0 * (s6 * s6 - s6) - 4.0 * (sc6 * sc6 - sc6)
+
+
+def test_the_field_in_a_periodic_box_is_not_identically_zero():
+    """Non-vacuity, stated as a test because it had to be.
+
+    Every invariant above is satisfied by a field that returns zero everywhere:
+    zero sums to zero, zero is the gradient of a constant, and nothing moves so
+    nothing drifts. A run produced exactly that -- a minimum-image expression whose
+    `// 1` bound after the multiplication, computing `floor(d + L/2)` instead of
+    `L * floor(d/L + 0.5)`, which pushed every pair in a box past the cutoff. Two
+    tests out of forty-four noticed.
+    """
+    u = energy(CONFIG, box=BOX)
+    f = forces(CONFIG, box=BOX)
+    # 1.1 and 1.2 sigma are just past the minimum at 2**(1/6), so this
+    # configuration is bound: the energy is around -2 and the forces are order 1.
+    assert u < -0.5, u
+    assert max(abs(c) for vector in f for c in vector) > 1.0, f
+
+
+def test_a_periodic_pair_in_the_middle_of_the_box_matches_the_closed_form():
+    """A box must not change a pair that is nowhere near a boundary."""
+    got = energy([[3.0, 3.0, 3.0], [4.1, 3.0, 3.0]], box=BOX)
+    assert abs(got - lj_closed_form(1.1)) < 1e-9, (got, lj_closed_form(1.1))
+
+
+def test_a_periodic_pair_across_the_seam_matches_the_closed_form():
+    """5.9 to 0.3 is 0.4 the short way and 5.6 the long way."""
+    got = energy([[5.9, 2.0, 2.0], [0.3, 2.0, 2.0]], box=BOX)
+    assert abs(got - lj_closed_form(0.4)) < 1e-6, (got, lj_closed_form(0.4))
+
+
+def test_a_pair_in_a_large_box_is_the_same_as_a_pair_in_no_box():
+    """Periodicity that cannot be reached is periodicity that changes nothing."""
+    pair = [[10.0, 10.0, 10.0], [11.3, 10.0, 10.0]]
+    assert abs(energy(pair, box=[20.0, 20.0, 20.0])
+               - energy(pair, box=[0.0, 0.0, 0.0])) < 1e-12
 ''',
     'tests/test_geometry.py': r'''"""Periodic geometry. Nothing here needs a force field."""
 
@@ -957,6 +1014,20 @@ def test_the_histogram_agrees_with_distances_computed_through_displacement():
             if r < rmax:
                 expect[int(r / (rmax / bins))] += 1
     assert rdf(config, BOX, bins, rmax) == expect
+
+
+def test_the_field_in_a_non_cubic_box_is_not_identically_zero():
+    """The same non-vacuity check the driven suite makes, in a box with three
+    different side lengths and across the shortest axis' seam."""
+    close = [[1.0, 1.0, 5.3], [1.0, 1.0, 0.15]]        # 0.25 apart across z = 5.4
+    u = energy(close, box=BOX)
+    f = forces(close, box=BOX)
+    assert u > 1000.0, u                                # deep in the repulsive core
+    assert abs(f[0][2]) > 1000.0, f
+    # and the closed form, to pin the number rather than its sign
+    s6 = (1.0 / 0.25) ** 6
+    shift = 4.0 * ((1.0 / 2.5) ** 12 - (1.0 / 2.5) ** 6)
+    assert abs(u - (4.0 * (s6 * s6 - s6) - shift)) / u < 1e-9, u
 ''',
 }
 

--- a/examples/genesis/_md.py
+++ b/examples/genesis/_md.py
@@ -134,25 +134,34 @@ kicks with the same forces, is a different and wrong integrator.
 `src/__init__.py` exposes exactly these seven functions. Nothing outside `src/`
 reaches past them -- not the driver, and not a single test.
 
-| function | returns |
-|---|---|
-| `displacement(a, b, box)` | the nearest-image displacement from `a` to `b` |
-| `wrap(point, box)` | `point` folded into `[0, L)` on every periodic axis |
-| `energy(positions, **params)` | the total potential energy, a float |
-| `forces(positions, **params)` | one force vector per particle |
-| `step(positions, velocities, masses, dt, **params)` | `(positions, velocities)` after one step |
-| `observables(velocities, masses)` | `{"kinetic": f, "temperature": f, "momentum": [f, f, f]}` |
-| `rdf(positions, box, bins, rmax)` | **integer** counts of distinct pairs per bin over `[0, rmax)` |
+These are the signatures, exactly -- every keyword is part of the surface even
+where a caller rarely overrides it, and the tests pass them **by name**:
 
-`**params` is the same keyword set everywhere, with these defaults:
+    def displacement(a, b, box)
+    def wrap(point, box)
 
-    box=(0.0, 0.0, 0.0)   potential="lennard_jones"   cutoff=2.5
-    epsilon=1.0           sigma=1.0                   k=1.0      r0=1.0
+    def energy(positions, box=(0.0, 0.0, 0.0), potential="lennard_jones",
+               epsilon=1.0, sigma=1.0, cutoff=2.5, k=1.0, r0=1.0)
+    def forces(positions, box=(0.0, 0.0, 0.0), potential="lennard_jones",
+               epsilon=1.0, sigma=1.0, cutoff=2.5, k=1.0, r0=1.0)
+    def step(positions, velocities, masses, dt, box=(0.0, 0.0, 0.0),
+             potential="lennard_jones", epsilon=1.0, sigma=1.0, cutoff=2.5,
+             k=1.0, r0=1.0)
 
-`observables` takes no positions and no box: `KE = sum(0.5 * m * v.v)`,
-`T = 2 * KE / (3 * N)` with `k_B = 1` and **no** centre-of-mass correction, and
-`momentum` is the plain mass-weighted sum. A pair at or beyond `rmax` is not
-counted in the histogram.
+    def observables(velocities, masses)
+    def rdf(positions, box, bins, rmax)
+
+`energy` returns a float; `forces` one vector per particle; `step` the pair
+`(positions, velocities)` after one timestep; `rdf` a list of **integer** counts.
+`observables` returns `{"kinetic": f, "temperature": f, "momentum": [f, f, f]}` --
+it takes no positions and no box, with `KE = sum(0.5 * m * v.v)`,
+`T = 2 * KE / (3 * N)` at `k_B = 1` and **no** centre-of-mass correction, and
+`momentum` the plain mass-weighted sum. A pair at or beyond `rmax` is not counted
+in the histogram.
+
+The keyword set reaches all the way down: a layer that accepts `potential` and
+then hard-codes Lennard-Jones fails, and so does one that takes `cutoff` but not
+`epsilon`. Thread the parameters through rather than rediscovering them.
 
 Every entry point MUST import its layer **lazily**, inside the function body.
 The tests for one layer then pass while another layer is still missing, which is

--- a/examples/genesis/_octopus.py
+++ b/examples/genesis/_octopus.py
@@ -1,0 +1,175 @@
+"""``git merge --octopus``, as a :class:`~agentdescent.policies.ConflictPolicy`.
+
+The engine's contradiction rule is one line::
+
+    same key, different proposed value        -- aggregator.diffs_contradict
+
+With a file tree the key is a **file path**, so two agents that touch different
+functions of the same file contradict, and one of them is dropped on held-out
+score. Genesis does not do that. Its parent merges every returned child with
+``git merge --octopus`` (``adapters/git.ex:284``), so the same two edits merge
+cleanly whenever their *hunks* do not overlap; only a real overlap produces
+``{:error, {:conflict, _}}``, and only then is the parent asked to resolve it
+(``agent/subagent_processing.ex:527``).
+
+So the difference is granularity, and it is worth having as a policy rather than
+as a paragraph: this one three-way merges the contested values against the
+artifact's current content, and the cards it reconciles stop contradicting -- at
+which point the engine's own fusion unions them exactly as it would for edits to
+different files. Only the values that genuinely overlap fall through to the inner
+rule, which is the shipped
+:class:`~agentdescent.defaults.DefaultConflict` unless a caller passes another.
+
+This is the third arm of the comparison the README's headline row is about
+(``keyed union fuses 0 of 48 · reflective merge 42 of 48``): keyed union, textual
+three-way, and model-synthesised merge are three answers to the same question,
+and only the first two are free.
+
+``git`` is the merge engine because it is the one Genesis uses and because the
+ledger already requires it. Without it every contested key is reported as a
+conflict and the inner policy decides -- degraded, never wrong.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field, replace
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from agentdescent.defaults import DefaultConflict
+from agentdescent.evolvable import EvidenceCard, Evolvable
+
+__all__ = ["OctopusConflict", "three_way", "git_available"]
+
+
+def git_available() -> bool:
+    return shutil.which("git") is not None
+
+
+def three_way(base: str, ours: str, theirs: str, *, timeout: float = 10.0) -> Optional[str]:
+    """``git merge-file`` on three strings. ``None`` means the hunks overlap.
+
+    Identical to what a git merge does to one file, which is the point -- an
+    approximation written here would answer a slightly different question from
+    the system being ported.
+    """
+    if ours == theirs:
+        return ours
+    if base == ours:
+        return theirs
+    if base == theirs:
+        return ours
+    if not git_available():
+        return None
+    tmp = tempfile.mkdtemp(prefix="genesis-merge-")
+    try:
+        paths = {}
+        for name, text in (("ours", ours), ("base", base), ("theirs", theirs)):
+            path = os.path.join(tmp, name)
+            # A missing trailing newline makes git treat the last line as
+            # changed on both sides and conflict where the content agrees.
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(text if text.endswith("\n") or not text else text + "\n")
+            paths[name] = path
+        proc = subprocess.run(
+            ["git", "merge-file", "-p", "--quiet", paths["ours"], paths["base"],
+             paths["theirs"]],
+            capture_output=True, text=True, timeout=timeout)
+        # Exit status: 0 clean, >0 the number of conflicts, <0 an error.
+        return proc.stdout if proc.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+@dataclass
+class OctopusConflict:
+    """Reconcile contested keys by three-way merge; defer the rest.
+
+    ``inner`` is the rule for values that really overlap. It defaults to the
+    engine's own, so turning this policy on changes *only* the outcome for edits
+    that upstream would have merged -- which is the property that makes the
+    comparison against the default meaningful.
+    """
+
+    inner: Optional[object] = None
+    #: Contested keys reconciled textually, and keys that fell through.
+    merged: int = 0
+    conflicted: int = 0
+
+    def __post_init__(self) -> None:
+        if self.inner is None:
+            self.inner = DefaultConflict()
+
+    def bind(self, verifier) -> None:
+        """Forward the engine's verifier to the inner rule (see `install_policy`)."""
+        bind = getattr(self.inner, "bind", None)
+        if callable(bind):
+            bind(verifier)
+
+    def configure(self, config) -> None:
+        configure = getattr(self.inner, "configure", None)
+        if callable(configure):
+            configure(config)
+
+    def resolve(self, artifact: Evolvable,
+                cards: Sequence[EvidenceCard]) -> Tuple[List[EvidenceCard], int]:
+        cards = list(cards)
+        if len(cards) < 2:
+            return cards, 0
+        state = dict(getattr(artifact, "state", {}) or {})
+        proposals: Dict[str, List[int]] = {}
+        for i, card in enumerate(cards):
+            for key in card.diff.ops:
+                proposals.setdefault(key, []).append(i)
+
+        resolved: Dict[str, str] = {}
+        for key, owners in proposals.items():
+            values = [cards[i].diff.ops[key] for i in owners]
+            if len(owners) < 2 or all(v == values[0] for v in values):
+                continue                       # not contested, or already agreed
+            if any(v is None for v in values):
+                self.conflicted += 1           # a delete against an edit
+                continue
+            base = state.get(key, "")
+            folded: Optional[str] = values[0]
+            for value in values[1:]:
+                folded = three_way(base, folded, value) if folded is not None else None
+                if folded is None:
+                    break
+            if folded is None:
+                self.conflicted += 1
+            else:
+                resolved[key] = folded
+                self.merged += 1
+
+        if resolved:
+            cards = [self._rewrite(card, resolved) for card in cards]
+        # Whatever still contradicts genuinely overlaps: the inner rule decides,
+        # exactly as it would have for the whole batch without this policy.
+        return self.inner.resolve(artifact, cards)
+
+    @staticmethod
+    def _rewrite(card: EvidenceCard, resolved: Dict[str, str]) -> EvidenceCard:
+        """A copy of ``card`` carrying the merged value for every reconciled key.
+
+        A copy rather than a mutation: a card outlives the diff it justifies (a
+        stale one settles back into the pool), so editing one in place would
+        change a record the run may read again later.
+        """
+        touched = [k for k in card.diff.ops if k in resolved]
+        if not touched:
+            return card
+        ops = dict(card.diff.ops)
+        for key in touched:
+            ops[key] = resolved[key]
+        diff = replace(card.diff, ops=ops,
+                       diff_id=f"{card.diff.diff_id}+octopus")
+        return replace(card, diff=diff)
+
+    def stats(self) -> str:
+        return f"octopus: merged={self.merged} conflicted={self.conflicted}"

--- a/examples/genesis/_octopus.py
+++ b/examples/genesis/_octopus.py
@@ -36,7 +36,7 @@ import os
 import shutil
 import subprocess
 import tempfile
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from agentdescent.defaults import DefaultConflict

--- a/examples/genesis/_review.py
+++ b/examples/genesis/_review.py
@@ -1,0 +1,179 @@
+"""The parent's review of what a child returned -- upstream's other half.
+
+``agents/manager.ex`` states the parent's validation as three things, in this order:
+
+    **Validation.** Review subagent results. Run tests to validate changes. Check
+    for code quality: duplicated code (copy-paste instead of reusing existing
+    helpers), defensive code that silently swallows errors (empty catch blocks
+    returning defaults -- these create impossible-to-debug silent failures), and
+    missing test coverage. Reject work that introduces these anti-patterns.
+
+and the architect's third phase is the same shape: "Run `cargo build` and tests;
+review the implementation. Delegate fixes/refinements to `subagent_manager` if
+needed."
+
+This port had only the middle one. :func:`examples.genesis._suite.Suite.review`
+runs the tests and rejects a regression, which is a number; *reading the change* was
+missing, and the cost of missing it is on the record. A run returned a registry whose
+minimum-image expression bound ``// 1`` after the multiplication, so every pair in a
+periodic box fell past the cutoff and the force field was identically zero. The tests
+could not see it -- zero satisfies every invariant they asserted -- and the run
+reported 1.000. A reviewer *reading* that function has a fair chance: it is four
+lines, and the question "does this compute anything" is one a reader asks and a
+pass-count cannot.
+
+So: one model call per returned child, asking upstream's questions about the diff.
+The verdict is the parent's, as everywhere else in this port -- a rejection sends the
+work back with a reason and the next round re-delegates from it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Callable, Mapping, Optional, Sequence, Tuple
+
+from ._delegation import Edit
+from ._world import normalise
+
+__all__ = ["CODE_REVIEW_PROMPT", "ParentCodeReview", "chain_reviews"]
+
+#: Upstream's questions, and nothing else. "Missing test coverage" is in
+#: ``manager.ex``'s list and is left out here on purpose: in this port the suite is
+#: frozen and the agents cannot write tests, so asking would invite a rejection for
+#: something no child is allowed to fix.
+CODE_REVIEW_PROMPT = """You are the manager agent at `{path}`, reviewing work a child \
+agent at `{child}` just returned. You did not write this and you are accountable for it.
+
+{context}
+
+The child was asked to: {objective}
+
+It returned these files. This is the whole of each one:
+
+{diff}
+
+Review it the way a responsible owner does, and answer ONLY these questions:
+
+1. **Does it actually compute something?** A function that returns a constant, an
+   empty list, zeros, or its input unchanged where real work was required is the
+   failure that matters most -- a suite of invariants cannot see it, and a reader can.
+2. **Is it a stub or a placeholder?** `pass`, `NotImplementedError`, `TODO`, a
+   docstring with no body, a hard-coded answer for one case.
+3. **Does it silently swallow errors?** An empty `except` returning a default, or
+   `if x is None: return 0`. A silent failure is worse than a crash.
+4. **Does it duplicate logic that already exists** in the files listed above it,
+   instead of calling it?
+5. **Does it contradict the contract** you were given -- a signature, a parameter, a
+   documented formula?
+
+Reply with ONE JSON object and nothing else:
+{{"verdict": "accept" | "reject", "reason": "<one sentence, empty when accepting>"}}
+
+Reject only for something you can point at in the text above. A change that is
+incomplete is **not** grounds for rejection -- partial progress is accepted, and the
+next round continues from it. Wrong, fake, or silently broken is."""
+
+
+class ParentCodeReview:
+    """``review(parent, returned)`` -- the parent reads the diff before accepting.
+
+    Installs where the integration check does, so a domain can have either or both;
+    :func:`chain_reviews` runs the cheap deterministic one first.
+    """
+
+    def __init__(self, complete, *, contracts: Sequence[str] = (),
+                 max_chars: int = 12_000):
+        self._complete = complete
+        self._contracts = tuple(contracts)
+        self._max_chars = max_chars
+        #: How many children were read, and how many of them were sent back.
+        self.reviewed = 0
+        self.rejected = 0
+        self.unparsed = 0
+
+    def __call__(self, parent, returned: Sequence[Edit]) -> Optional[Tuple[str, str]]:
+        work = [e for e in returned if e.kind == "work" and e.content is not None]
+        if not work:
+            return None                      # bookkeeping only: nothing to read
+        prompt = CODE_REVIEW_PROMPT.format(
+            path=normalise(parent.world.path) or "./",
+            child=_child_of(work),
+            context=parent.world.situate(parent.state, contracts=self._contracts),
+            objective=parent.objective,
+            diff=_render(work, self._max_chars))
+        self.reviewed += 1
+        try:
+            reply = self._complete(prompt) or ""
+        except Exception:  # noqa: BLE001 - a dead call must not reject the work
+            return None
+        verdict, reason = _parse(reply)
+        if verdict != "reject":
+            # An unparseable reply is not a rejection. The child did the work; a
+            # reviewer that cannot speak is not evidence against it.
+            self.unparsed += int(verdict is None)
+            return None
+        self.rejected += 1
+        return ("rejected", f"parent review: {reason or 'unspecified'}")
+
+
+def chain_reviews(*reviews) -> Optional[Callable]:
+    """Run each review in order and return the first refusal.
+
+    Tests before the reviewer, because the tests are free and deterministic and a
+    regression needs no second opinion. ``None`` entries are skipped, so a caller can
+    pass a disabled review without branching.
+    """
+    active = [r for r in reviews if r is not None]
+    if not active:
+        return None
+    if len(active) == 1:
+        return active[0]
+
+    def review(parent, returned):
+        for one in active:
+            verdict = one(parent, returned)
+            if verdict is not None:
+                return verdict
+        return None
+
+    return review
+
+
+def _child_of(work: Sequence[Edit]) -> str:
+    owners = {normalise(e.owner) for e in work}
+    return ", ".join(sorted(owners)) or "./"
+
+
+def _render(work: Sequence[Edit], budget: int) -> str:
+    """Whole files, not a patch: a reviewer judging four lines of arithmetic needs
+    the arithmetic, and the edits are whole files everywhere else in this port."""
+    out, spent = [], 0
+    for edit in work:
+        body = edit.content or ""
+        room = max(0, budget - spent)
+        if not room:
+            out.append(f"# {edit.path}\n(not shown: the review budget is spent)")
+            continue
+        shown = body if len(body) <= room else body[:room] + "\n... [truncated] ..."
+        spent += len(shown)
+        out.append(f"# {edit.path}\n```\n{shown}\n```")
+    return "\n\n".join(out)
+
+
+def _parse(reply: str) -> Tuple[Optional[str], str]:
+    """``(verdict, reason)``; ``(None, "")`` when the reply is not usable."""
+    match = re.search(r"\{.*\}", reply, re.S)
+    if not match:
+        return None, ""
+    try:
+        data = json.loads(match.group(0))
+    except Exception:  # noqa: BLE001 - malformed model output, not a bug
+        return None, ""
+    if not isinstance(data, Mapping):
+        return None, ""
+    verdict = str(data.get("verdict", "")).strip().lower()
+    reason = " ".join(str(data.get("reason", "")).split())[:240]
+    if verdict not in ("accept", "reject"):
+        return None, reason
+    return verdict, reason

--- a/examples/genesis/_review.py
+++ b/examples/genesis/_review.py
@@ -247,6 +247,11 @@ class CompletionJudge:
         self._contracts = tuple(contracts)
         self._root = root_path
         self._objective = objective
+        #: The last version this judge scored, and what it concluded about it. A round
+        #: that accepted nothing is the same codebase, and re-running fifty tests on it
+        #: would cost more than the rounds it is watching.
+        self._scored = None
+        self._answer = False
         #: Rounds where the suite was green and the question was therefore asked.
         self.asked = 0
         #: What it said, the last time it said anything.
@@ -261,10 +266,12 @@ class CompletionJudge:
         from ._world import LocalWorld
 
         rendered = canonical(state)
-        failing = [t.id for t in self._driven
-                   if self._reward(t, self._run(rendered, t)) < 1.0]
-        if failing:
-            return False                     # not the question yet -- and no call
+        if rendered == self._scored:
+            return self._answer              # nothing was accepted: the same codebase
+        self._scored, self._answer = rendered, False
+        for task in self._driven:
+            if self._reward(task, self._run(rendered, task)) < 1.0:
+                return False                 # not the question yet -- and no call
         self.asked += 1
         world = LocalWorld(version=int(getattr(info, "round", 0)), path=self._root)
         try:
@@ -277,7 +284,8 @@ class CompletionJudge:
         self.verdict, self.reason = ("complete" if verdict else
                                      ("incomplete" if verdict is not None else
                                       "unparsed")), reason
-        return bool(verdict)
+        self._answer = bool(verdict)
+        return self._answer
 
 
 def _parse_flag(reply: str, key: str) -> Tuple[Optional[bool], str]:

--- a/examples/genesis/_review.py
+++ b/examples/genesis/_review.py
@@ -36,7 +36,8 @@ from typing import Callable, Mapping, Optional, Sequence, Tuple
 from ._delegation import Edit
 from ._world import normalise
 
-__all__ = ["CODE_REVIEW_PROMPT", "ParentCodeReview", "chain_reviews"]
+__all__ = ["CODE_REVIEW_PROMPT", "COMPLETE_TASK_PROMPT", "CompletionJudge",
+           "ParentCodeReview", "chain_reviews"]
 
 #: Upstream's questions, and nothing else. "Missing test coverage" is in
 #: ``manager.ex``'s list and is left out here on purpose: in this port the suite is
@@ -177,3 +178,116 @@ def _parse(reply: str) -> Tuple[Optional[str], str]:
     if verdict not in ("accept", "reject"):
         return None, reason
     return verdict, reason
+
+
+#: What the root agent is asked, once the tests it can see are all passing. Upstream's
+#: own bar, from ``runtime/genesis.ex``: "Call complete_task only when the codebase is
+#: complete, functional, and polished -- when you can confidently say the original
+#: objective has been 100% delivered."
+COMPLETE_TASK_PROMPT = """You are the root agent of this task, deciding whether it is \
+finished.
+
+{context}
+
+The original objective:
+{objective}
+
+The given test suite is the definition of done for your work, and **all {total} of \
+its tests now pass**. That is necessary and it is not sufficient: a suite passes on \
+stubs if the stubs are shaped right.
+
+Look at what is in the tree above and answer for the codebase, not for the suite:
+
+1. Is every part the objective asked for actually implemented, with real working code
+   rather than a stub, a placeholder, or a hard-coded answer?
+2. Is anything there that should not be -- a dead module shadowed by another, a file
+   that cannot be imported, a leftover scaffold?
+3. Would you hand this to someone as finished?
+
+Reply with ONE JSON object and nothing else:
+{{"complete": true | false, "reason": "<one sentence>"}}
+
+`false` is the safe answer and costs only more rounds. Say `true` only when you can \
+say the objective has been 100% delivered."""
+
+
+class CompletionJudge:
+    """``stop_when(info)`` -- the run ends when the root agent says it is done.
+
+    Upstream nothing watches a number. An agent decides its objective is met and calls
+    ``complete_task``; the root agent's completion ends the phase, and a human merges
+    or rejects afterwards on the dashboard. This port ends when ``evolve()``'s round
+    budget ends, which is why a finished domain still reports ``stop reason: rounds``
+    -- nobody decided it was done.
+
+    So: ask. Two gates, in upstream's order, and the cheap one first.
+
+    * **The tests it can see must all pass.** "When tests are given to guide
+      development, aim for a 100% pass rate on the given test suites if possible --
+      treat them as the definition of done for your work" (``runtime/genesis.ex``).
+      Below that, the question is not asked and no call is spent.
+    * **Then the root agent judges the codebase**, not the suite. A suite passes on
+      stubs if the stubs are shaped right, and this port has measured exactly that
+      twice -- a shadowed lexer and an unimportable module on stackvm, a zero force
+      field on md.
+
+    The held-out reward is deliberately **not** shown to it: that number is this
+    port's measurement, it is computed from tests no agent may see, and handing it
+    over would make the decision a threshold again.
+    """
+
+    def __init__(self, complete, *, tasks, run, reward, state_of,
+                 contracts: Sequence[str] = (), root_path: str = "",
+                 objective: str = ""):
+        self._complete = complete
+        self._driven = [t for t in tasks if not t.meta.get("audit")]
+        self._run = run
+        self._reward = reward
+        self._state_of = state_of
+        self._contracts = tuple(contracts)
+        self._root = root_path
+        self._objective = objective
+        #: Rounds where the suite was green and the question was therefore asked.
+        self.asked = 0
+        #: What it said, the last time it said anything.
+        self.verdict = ""
+        self.reason = ""
+
+    def __call__(self, info) -> bool:
+        state = self._state_of()
+        if state is None:
+            return False
+        from agentdescent.filetree import canonical
+        from ._world import LocalWorld
+
+        rendered = canonical(state)
+        failing = [t.id for t in self._driven
+                   if self._reward(t, self._run(rendered, t)) < 1.0]
+        if failing:
+            return False                     # not the question yet -- and no call
+        self.asked += 1
+        world = LocalWorld(version=int(getattr(info, "round", 0)), path=self._root)
+        try:
+            reply = self._complete(COMPLETE_TASK_PROMPT.format(
+                context=world.situate(state, contracts=self._contracts),
+                objective=self._objective, total=len(self._driven))) or ""
+        except Exception:  # noqa: BLE001 - a dead call is not a completion
+            return False
+        verdict, reason = _parse_flag(reply, "complete")
+        self.verdict, self.reason = ("complete" if verdict else
+                                     ("incomplete" if verdict is not None else
+                                      "unparsed")), reason
+        return bool(verdict)
+
+
+def _parse_flag(reply: str, key: str) -> Tuple[Optional[bool], str]:
+    match = re.search(r"\{.*\}", reply, re.S)
+    if not match:
+        return None, ""
+    try:
+        data = json.loads(match.group(0))
+    except Exception:  # noqa: BLE001 - malformed model output, not a bug
+        return None, ""
+    if not isinstance(data, Mapping) or not isinstance(data.get(key), bool):
+        return None, " ".join(str(data.get("reason", "")).split())[:240]
+    return bool(data[key]), " ".join(str(data.get("reason", "")).split())[:240]

--- a/examples/genesis/_review.py
+++ b/examples/genesis/_review.py
@@ -237,9 +237,13 @@ class CompletionJudge:
     """
 
     def __init__(self, complete, *, tasks, run, reward, state_of,
-                 contracts: Sequence[str] = (), root_path: str = "",
-                 objective: str = ""):
+                 suite_failures=None, contracts: Sequence[str] = (),
+                 root_path: str = "", objective: str = ""):
         self._complete = complete
+        #: ``state -> [failure]``, the whole suite in one process. Preferred when the
+        #: domain has one, because that is what `mix test` is and what "run ALL tests"
+        #: means: a per-test score cannot see one test poisoning the next.
+        self._suite_failures = suite_failures
         self._driven = [t for t in tasks if not t.meta.get("audit")]
         self._run = run
         self._reward = reward
@@ -269,9 +273,13 @@ class CompletionJudge:
         if rendered == self._scored:
             return self._answer              # nothing was accepted: the same codebase
         self._scored, self._answer = rendered, False
-        for task in self._driven:
-            if self._reward(task, self._run(rendered, task)) < 1.0:
+        if self._suite_failures is not None:
+            if self._suite_failures(state):
                 return False                 # not the question yet -- and no call
+        else:
+            for task in self._driven:
+                if self._reward(task, self._run(rendered, task)) < 1.0:
+                    return False
         self.asked += 1
         world = LocalWorld(version=int(getattr(info, "round", 0)), path=self._root)
         try:

--- a/examples/genesis/_spatial.py
+++ b/examples/genesis/_spatial.py
@@ -1,0 +1,217 @@
+"""The spatial contract as a :class:`~agentdescent.strategies.Strategy`.
+
+Genesis's central invariant is one sentence, and both projects wrote it
+independently::
+
+    every agent is only supposed to edit files belonging to its own path
+        -- genesis, apps/evo_git/lib/evo_git/agents/manager.ex
+
+    each worker owns a section, so edits are conflict-free *by construction*
+        -- agentdescent/parallel.py, TensorParallel
+
+The engine's version of it is tensor parallelism, and TP cannot be used here for
+a reason that is structural rather than incidental: its ownership map is built
+once, before round 0, from a declared key space, and a key that is not in the map
+belongs to no section -- so **every newly created file is a section violation**
+(``evolution.py:2739``; ``FileTree.keys`` says so in its own docstring). Genesis's
+formation setting is a repository with no implementation in it. Creating files is
+not an edge case there, it is the entire run.
+
+So the contract is enforced one layer lower, where creation is free: a strategy's
+``to_diff`` already receives the ``author`` and the proposal, and it is the only
+place a proposal becomes a diff. An edit carries the path of the agent that made
+it, and an edit outside that agent's subtree is dropped and **counted**. Nothing
+in the engine changes, and a file appearing for the first time is ordinary.
+
+What that costs, stated rather than hidden: TP's guarantee is checked by the
+engine against a map it owns, and this one is checked by example code against a
+claim the proposal makes about itself. It binds a cooperative proposer -- which
+is what the upstream system has too, since there the boundary is the sandbox's
+write scope, not the agent's honesty.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from agentdescent.evolvable import Diff, stable_hash
+from agentdescent.filetree import (DEFAULT_MAX_FILE_BYTES, TreeError, canonical,
+                                   match_any, safe_relpath)
+
+from ._world import WorldLog, normalise, owns
+
+__all__ = ["SITUATED_EDIT_PROTOCOL", "SpatialContract", "parse_situated_edits"]
+
+
+#: The proposal protocol. `FileTree`'s, plus the one field that makes an edit
+#: *situated*: the path of the finite-lived agent that produced it. Whole-file
+#: replacement for `FileTree`'s reason -- a model-written patch that does not
+#: apply fails silently, a whole file either parses or does not.
+SITUATED_EDIT_PROTOCOL = """Reply with ONE block in exactly this format and nothing else:
+
+<EDITS>
+{{"rationale": "<one sentence>",
+ "edits": [{{"owner": "<the path you were situated at>",
+            "path": "<relative path, inside that subtree>",
+            "content": "<the COMPLETE new file>"}}]}}
+</EDITS>
+
+Rules:
+- `content` is the whole file, never a patch or an excerpt.
+- `owner` is your own path. `path` MUST lie inside it -- an edit outside your
+  subtree belongs to the agent responsible for that path, not to you.
+- Only these paths are editable: {editable}
+- Never edit: {frozen}
+- To delete a file use {{"owner": "...", "path": "...", "delete": true}}."""
+
+
+def parse_situated_edits(proposal: str) -> List[Dict[str, Any]]:
+    """Parse a reply into ``[{owner, path, content|None}]``.
+
+    Lenient about the wrapper and strict about the payload, for
+    :func:`~agentdescent.treestrategy.parse_edits`' reason: a proposer that
+    ignores the protocol is a quality problem the run should absorb and count,
+    not a crash. An item with no ``owner`` is attributed to the root, which is
+    the only attribution that cannot silently widen anyone's authority.
+    """
+    raw = _payload(proposal)
+    if raw is None:
+        return []
+    try:
+        data = json.loads(raw)
+    except Exception:  # noqa: BLE001 - malformed proposer output, not a bug
+        return []
+    if not isinstance(data, dict):
+        return []
+    items = data["edits"] if isinstance(data.get("edits"), list) else (
+        [data] if "path" in data else [])
+    out: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict) or "path" not in item:
+            continue
+        try:
+            path = safe_relpath(str(item["path"]))
+        except TreeError:
+            continue                        # a hostile or malformed path: drop it
+        entry: Dict[str, Any] = {"owner": normalise(str(item.get("owner", ""))),
+                                 "path": path}
+        if item.get("delete") is True:
+            entry["content"] = None
+        elif isinstance(item.get("content"), str):
+            entry["content"] = item["content"]
+        else:
+            continue
+        out.append(entry)
+    return out
+
+
+def _payload(proposal: str) -> Optional[str]:
+    """The JSON object inside an ``<EDITS>`` block, a fence, or bare text."""
+    if not isinstance(proposal, str) or not proposal.strip():
+        return None
+    lowered = proposal.lower()
+    start_tag, end_tag = lowered.find("<edits>"), lowered.rfind("</edits>")
+    if start_tag >= 0 and end_tag > start_tag:
+        proposal = proposal[start_tag + len("<edits>"):end_tag]
+    return _first_json_object(proposal)
+
+
+def _first_json_object(text: str) -> Optional[str]:
+    """The first balanced ``{...}`` run, ignoring braces inside strings."""
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth, in_str, esc = 0, False, False
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None
+
+
+@dataclass
+class SpatialContract:
+    """A directory, one key per file path, with authority scoped by subtree.
+
+    Deliberately does **not** implement ``keys()``. A strategy that declares one
+    is offering tensor parallelism a key space to partition, and this artifact
+    does not have a fixed one -- it grows. Withholding it makes ``evolve()``
+    *refuse* TP with a message naming the reason, which is the behaviour worth
+    having; declaring a partial one would let TP run and discard every creation.
+    """
+
+    initial_files: Mapping[str, str] = field(default_factory=dict)
+    editable: Sequence[str] = ("**",)
+    #: Human-supplied validation, never the agents'. The paper's compiler run
+    #: uses c-testsuite / LLVM / Csmith exactly this way, and it is also L0 in
+    #: this repository's sense: a system that can edit its own evaluator has no
+    #: evaluator. Enforced here for *proposals* and, where the frozen files are
+    #: what score the candidate, by the runner's pristine overlay.
+    frozen: Sequence[str] = ()
+    max_files_per_diff: int = 4
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES
+    #: Where dropped edits are counted. Optional so the strategy can be used on
+    #: its own in a test without building a log first.
+    log: Optional[WorldLog] = None
+
+    def __post_init__(self) -> None:
+        self.initial_files = {safe_relpath(k): v for k, v in dict(self.initial_files).items()}
+
+    # -- the Strategy protocol ---------------------------------------------
+
+    def initial(self) -> Dict[str, str]:
+        return dict(self.initial_files)
+
+    def render(self, state: Mapping[str, str]) -> str:
+        return canonical(state)
+
+    def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:
+        ops: Dict[str, Optional[str]] = {}
+        for edit in parse_situated_edits(proposal):
+            owner, path, content = edit["owner"], edit["path"], edit["content"]
+            if not owns(owner, path):
+                # The contract. Counted, never silent -- see WorldLog.
+                if self.log is not None:
+                    self.log.note_contract_violation()
+                continue
+            if not self.writable(path):
+                continue
+            if content is None:
+                if path in state:
+                    ops[path] = None        # delete
+                continue
+            if len(content) > self.max_file_bytes:
+                continue                    # would be rejected as oversized anyway
+            if state.get(path) != content:
+                ops[path] = content
+        if not ops or len(ops) > self.max_files_per_diff:
+            return None
+        fingerprint = stable_hash(tuple(sorted((k, v) for k, v in ops.items())))
+        return Diff(diff_id=f"{author}:{fingerprint & 0xFFFFFFFF:08x}:{base_version}",
+                    target=target, ops=dict(ops), author=author)
+
+    # -- helpers -----------------------------------------------------------
+
+    def writable(self, path: str) -> bool:
+        """May the loop write this path? ``frozen`` beats ``editable``."""
+        return match_any(path, self.editable) and not match_any(path, self.frozen)
+
+    def frozen_files(self, source: Mapping[str, str]) -> Dict[str, str]:
+        """The pristine content of every frozen path, for the runner's overlay."""
+        return {p: c for p, c in source.items() if match_any(p, self.frozen)}

--- a/examples/genesis/_spatial.py
+++ b/examples/genesis/_spatial.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from agentdescent.evolvable import Diff, stable_hash
 from agentdescent.filetree import (DEFAULT_MAX_FILE_BYTES, TreeError, canonical,

--- a/examples/genesis/_spatial.py
+++ b/examples/genesis/_spatial.py
@@ -189,6 +189,10 @@ class SpatialContract:
     #: its own in a test without building a log first.
     log: Optional[WorldLog] = None
 
+    #: The most recent state the engine asked this strategy to render. Not part of
+    #: the contract -- a watcher's window, see :meth:`render`.
+    last_rendered: Optional[Dict[str, str]] = None
+
     def __post_init__(self) -> None:
         self.initial_files = {safe_relpath(k): v for k, v in dict(self.initial_files).items()}
 
@@ -198,6 +202,13 @@ class SpatialContract:
         return dict(self.initial_files)
 
     def render(self, state: Mapping[str, str]) -> str:
+        # The engine renders the **accepted** artifact every time it evaluates it,
+        # which is once a round whether or not anything was proposed. That makes this
+        # the one place a watcher can see the current version: the proposal policy
+        # only sees a state when it is asked for a proposal, and it stops being asked
+        # exactly when the run is finished -- which is how `--complete-task` came to
+        # score a stale tree forever and ask nobody anything.
+        self.last_rendered = dict(state)
         return canonical(state)
 
     def to_diff(self, state, proposal, author, base_version, target) -> Optional[Diff]:

--- a/examples/genesis/_spatial.py
+++ b/examples/genesis/_spatial.py
@@ -53,18 +53,22 @@ SITUATED_EDIT_PROTOCOL = """Reply with ONE block in exactly this format and noth
 
 <EDITS>
 {{"rationale": "<one sentence>",
- "edits": [{{"owner": "<the path you were situated at>",
-            "path": "<relative path, inside that subtree>",
+ "edits": [{{"owner": "{owner}",
+            "path": "{owner}/<file>",
             "content": "<the COMPLETE new file>"}}]}}
 </EDITS>
 
 Rules:
 - `content` is the whole file, never a patch or an excerpt.
-- `owner` is your own path. `path` MUST lie inside it -- an edit outside your
-  subtree belongs to the agent responsible for that path, not to you.
+- **`path` is relative to the REPOSITORY ROOT, not to your own directory.** You
+  are situated at `{owner}`, so a file of yours is `{owner}/<name>` -- writing
+  just `<name>` names a file at the top of the repository, which is not yours.
+- `owner` is your own path, `{owner}`, and `path` must lie inside it. A change you
+  need somewhere else is not yours to make: name it anyway and the agent
+  responsible for that path will be asked to handle it.
 - Only these paths are editable: {editable}
 - Never edit: {frozen}
-- To delete a file use {{"owner": "...", "path": "...", "delete": true}}."""
+- To delete a file use {{"owner": "{owner}", "path": "{owner}/<file>", "delete": true}}."""
 
 
 def parse_situated_edits(proposal: str) -> List[Dict[str, Any]]:

--- a/examples/genesis/_spatial.py
+++ b/examples/genesis/_spatial.py
@@ -145,6 +145,21 @@ def _first_json_object(text: str) -> Optional[str]:
     return None
 
 
+def _collides(state: Mapping[str, str], path: str) -> bool:
+    """Would writing ``path`` make the key space stop being a tree?
+
+    Either an ancestor of ``path`` is already a file (``a/b.py`` exists, and this
+    wants ``a/b.py/c``), or ``path`` is already a directory prefix of other keys
+    (``a/b/c`` exists, and this wants to write a file at ``a/b``).
+    """
+    parts = path.split("/")
+    for i in range(1, len(parts)):
+        if "/".join(parts[:i]) in state:
+            return True
+    prefix = path + "/"
+    return any(key.startswith(prefix) for key in state)
+
+
 @dataclass
 class SpatialContract:
     """A directory, one key per file path, with authority scoped by subtree.
@@ -189,6 +204,19 @@ class SpatialContract:
                 # The contract. Counted, never silent -- see WorldLog.
                 if self.log is not None:
                     self.log.note_contract_violation()
+                continue
+            if content is not None and _collides(state, path):
+                # A key space of paths is only a *tree* if no path is a prefix
+                # of another: `a/b.py` and `a/b.py/c.py` cannot both exist on a
+                # filesystem. The engine's state is a flat dict and never checks,
+                # so the pair survives every stage and detonates at the end, in
+                # `EvolutionResult.write_to` -- a whole run lost at the one point
+                # where it was being saved. Measured: an agent delegated to
+                # `src/frontend/lexer.py` as though it were a node, wrote a
+                # CONTEXT.md and an __init__.py *inside* it, and `write_to`
+                # raised FileExistsError after 40 episodes and 328 model calls.
+                if self.log is not None:
+                    self.log.note_shape_violation()
                 continue
             if not self.writable(path):
                 continue

--- a/examples/genesis/_stackvm.py
+++ b/examples/genesis/_stackvm.py
@@ -26,12 +26,13 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+__all__ = ["CASE_NOUN", "CONTRACTS", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
            "SCORING", "STACKVM", "build_tasks", "initial_files", "llm_executor",
            "llm_manager", "make_runner", "offline_executor", "offline_manager",
            "reference_tree", "reward", "suite_review"]
 
 FROZEN = ("spec/**",)
+CONTRACTS = FROZEN
 
 SCORING = "reference oracle, exact match"
 CASE_NOUN = "validation cases"
@@ -99,6 +100,9 @@ _ROOT_CONTEXT = '''# stackvm -- root
 Implement the machine in `spec/CONTEXT.md`. The specification and its staged
 validation are given; no implementation exists yet.
 
+## API Surface
+Nothing at the root. Every stage is reached through `src/__init__.py`.
+
 ## Routing Table
 - `./src/` -> the implementation, and the three stage entry points
 
@@ -113,6 +117,10 @@ _SRC_CONTEXT = '''# src -- implementation root
 Own `src/__init__.py`, the public surface named by the spec: `tokenize`,
 `assemble` and `run`. Each MUST import its stage lazily.
 
+## API Surface
+- `src/__init__.py`: `tokenize(source)`, `assemble(source)`, `run(source)` -- each
+  takes the **assembly text**, not the previous stage's output.
+
 ## Routing Table
 - `./src/asm/` -> assembly text to a program
 - `./src/vm/`  -> executing a program
@@ -124,6 +132,10 @@ _ASM_CONTEXT = '''# src/asm -- assembly text to a program
 `lexer.py` turns text into the token list. `parser.py` turns tokens into the
 program, resolving every label reference to the index of the instruction it
 labels -- so the VM never sees a label.
+
+## API Surface
+- `lexer.py`: `tokenize(source)`
+- `parser.py`: `assemble(source)` -> the program
 '''
 
 _VM_CONTEXT = '''# src/vm -- executing a program
@@ -133,6 +145,9 @@ Own `machine.py`: the machine state, the opcode table, and the interpreter loop.
 `push` carries its operand so the loop handles it directly; every other opcode is
 a function looked up in the table. Bound the loop so a program that never halts
 cannot hang the suite.
+
+## API Surface
+- `machine.py`: `run_program(program)` -> the machine's output
 
 ## Routing Table
 - `./src/vm/ops/` -> one module per family of opcodes
@@ -151,6 +166,11 @@ same one.
 
 Every opcode function takes the machine as its first argument and mutates it;
 `jmp` and `jz` take the target index as a second argument.
+
+## API Surface
+- `arith.py`: `add(vm)` `sub(vm)` `mul(vm)` `div(vm)`
+- `stack.py`: `dup(vm)` `swap(vm)` `drop(vm)`
+- `control.py`: `jmp(vm, target)` `jz(vm, target)` `emit(vm)` `halt(vm)`
 '''
 
 

--- a/examples/genesis/_stackvm.py
+++ b/examples/genesis/_stackvm.py
@@ -1,0 +1,456 @@
+"""The second formation domain: a stack machine, grown four levels deep.
+
+minilang (:mod:`examples.genesis._domain`) is two nodes deep and four files. This
+one is **four** nodes deep and ten, with a real instruction set: labels the
+assembler has to resolve to indices, a dispatch table that depends on three
+sibling modules, and a loop in the suite. The point is not that it is harder code
+-- it is that the *recursion* has somewhere to go. ``src/vm/ops`` is a node whose
+parent is itself a child, so an episode reaches depth 3 on the way to a leaf, and
+``arith.py`` holds one independently-fillable function per opcode so two agents
+working from two different failing programs edit two different parts of one file.
+
+What is faithful and what is a surrogate is exactly as it is for minilang, and the
+reasoning is on that module: the repository starts implementation-empty, the
+validation is staged so the run has a gradient before the toolchain is complete,
+the spec is frozen and restored pristine before scoring, and ``--offline`` reveals
+pre-written modules one step at a time and says so.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+from agentdescent.evolution import Task
+
+from ._delegation import Brief, Delegation, Edit
+from ._suite import PYTHON_MODULE_SKILL, Suite, reward, run_cases
+from ._suite import llm_executor as _llm_executor
+from ._suite import llm_manager as _llm_manager
+from ._world import SKILLS_DIR, normalise
+
+__all__ = ["FROZEN", "STACKVM", "build_tasks", "initial_files", "llm_executor",
+           "llm_manager", "make_runner", "offline_executor", "offline_manager",
+           "reward", "suite_review"]
+
+FROZEN = ("spec/**",)
+
+ENTRY = "src/__init__.py"
+ASM_INIT = "src/asm/__init__.py"
+LEXER = "src/asm/lexer.py"
+PARSER = "src/asm/parser.py"
+VM_INIT = "src/vm/__init__.py"
+MACHINE = "src/vm/machine.py"
+OPS_INIT = "src/vm/ops/__init__.py"
+ARITH = "src/vm/ops/arith.py"
+STACK = "src/vm/ops/stack.py"
+CONTROL = "src/vm/ops/control.py"
+
+
+# ---------------------------------------------------------------------------
+# The human's repository: the instruction set, the decomposition, the contract
+# ---------------------------------------------------------------------------
+
+_SPEC = '''# stackvm -- the machine this project implements
+
+A stack machine and its assembler.
+
+## Instruction set
+
+| instruction | effect |
+|---|---|
+| `push N` | push the integer N |
+| `add` `sub` `mul` `div` | pop b, pop a, push `a OP b`; `div` is floor division |
+| `dup` | push a copy of the top |
+| `swap` | exchange the top two |
+| `drop` | discard the top |
+| `emit` | append the top to the output, without popping it |
+| `jmp L` | continue at label L |
+| `jz L` | pop; if it is 0, continue at label L |
+| `halt` | stop |
+| `L:` | declare label L at this position |
+
+`#` starts a comment that runs to the end of the line. Blank lines are ignored.
+
+## The three validated stages
+
+| stage | entry point | what a case checks |
+|---|---|---|
+| `lex` | `src.tokenize(source)` | the token list, as `repr` |
+| `asm` | `src.assemble(source)` | the program, as `repr` |
+| `run` | `src.run(source)` | the list of emitted values, as `repr` |
+
+A stage is scored independently of the ones after it, so `src/__init__.py` MUST
+import each stage lazily, inside the function that needs it.
+
+Tokens are `("label", name)`, `("op", name)` and `("arg", value)`, where an
+integer argument is an `int` and a label reference is a `str`. A program is a list
+of tuples `(op, *args)` in which **every label reference has been replaced by the
+index of the instruction it labels**. Execution stops on `halt` or when the
+program counter leaves the program.
+'''
+
+_ROOT_CONTEXT = '''# stackvm -- root
+
+## Intent
+Implement the machine in `spec/CONTEXT.md`. The specification and its staged
+validation are given; no implementation exists yet.
+
+## Routing Table
+- `./src/` -> the implementation, and the three stage entry points
+
+## Constraints
+- `spec/` is read-only. It is the validation contract, not a work item.
+- Every agent edits only files under its own path.
+'''
+
+_SRC_CONTEXT = '''# src -- implementation root
+
+## Intent
+Own `src/__init__.py`, the public surface named by the spec: `tokenize`,
+`assemble` and `run`. Each MUST import its stage lazily.
+
+## Routing Table
+- `./src/asm/` -> assembly text to a program
+- `./src/vm/`  -> executing a program
+'''
+
+_ASM_CONTEXT = '''# src/asm -- assembly text to a program
+
+## Intent
+`lexer.py` turns text into the token list. `parser.py` turns tokens into the
+program, resolving every label reference to the index of the instruction it
+labels -- so the VM never sees a label.
+'''
+
+_VM_CONTEXT = '''# src/vm -- executing a program
+
+## Intent
+Own `machine.py`: the machine state, the opcode table, and the interpreter loop.
+`push` carries its operand so the loop handles it directly; every other opcode is
+a function looked up in the table. Bound the loop so a program that never halts
+cannot hang the suite.
+
+## Routing Table
+- `./src/vm/ops/` -> one module per family of opcodes
+'''
+
+_OPS_CONTEXT = '''# src/vm/ops -- the opcodes themselves
+
+## Intent
+One module per family, and **one function per opcode**, so that two agents fixing
+two different opcodes are editing two different parts of the file rather than the
+same one.
+
+- `arith.py`   -> `add` `sub` `mul` `div`
+- `stack.py`   -> `dup` `swap` `drop`
+- `control.py` -> `jmp` `jz` `emit` `halt`
+
+Every opcode function takes the machine as its first argument and mutates it;
+`jmp` and `jz` take the target index as a second argument.
+'''
+
+
+def initial_files() -> Dict[str, str]:
+    """The implementation-empty repository the run starts from."""
+    return {
+        "CONTEXT.md": _ROOT_CONTEXT,
+        "spec/CONTEXT.md": _SPEC,
+        "src/CONTEXT.md": _SRC_CONTEXT,
+        "src/asm/CONTEXT.md": _ASM_CONTEXT,
+        "src/vm/CONTEXT.md": _VM_CONTEXT,
+        "src/vm/ops/CONTEXT.md": _OPS_CONTEXT,
+        f"src/{SKILLS_DIR}/python-modules.md": PYTHON_MODULE_SKILL,
+    }
+
+
+# ---------------------------------------------------------------------------
+# The reference implementation: the oracle, and what the offline actors reveal
+# ---------------------------------------------------------------------------
+
+_PKG_INIT = '"""Package marker."""\n'
+
+_REF_ENTRY = '''"""Public surface. Each stage is imported lazily -- see spec/CONTEXT.md."""
+
+
+def tokenize(source):
+    from .asm.lexer import tokenize as _tokenize
+    return _tokenize(source)
+
+
+def assemble(source):
+    from .asm.parser import assemble as _assemble
+    return _assemble(source)
+
+
+def run(source):
+    from .vm.machine import run_program
+    return run_program(assemble(source))
+'''
+
+_REF_LEXER = '''"""Assembly text -> ("label", name) / ("op", name) / ("arg", value) tokens."""
+
+
+def tokenize(source):
+    tokens = []
+    for raw in source.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.endswith(":"):
+            tokens.append(("label", line[:-1].strip()))
+            continue
+        parts = line.split()
+        tokens.append(("op", parts[0]))
+        for arg in parts[1:]:
+            tokens.append(("arg", int(arg) if _integer(arg) else arg))
+    return tokens
+
+
+def _integer(text):
+    return text.lstrip("-").isdigit()
+'''
+
+_REF_PARSER = '''"""Tokens -> a program: (op, *args) per instruction, labels resolved to indices."""
+
+from .lexer import tokenize
+
+
+def assemble(source):
+    labels, draft = {}, []
+    for kind, value in tokenize(source):
+        if kind == "label":
+            labels[value] = len(draft)
+        elif kind == "op":
+            draft.append([value])
+        else:
+            draft[-1].append(value)
+    program = []
+    for instruction in draft:
+        op, args = instruction[0], instruction[1:]
+        program.append(tuple([op] + [labels.get(a, a) if isinstance(a, str) else a
+                                     for a in args]))
+    return program
+'''
+
+_REF_MACHINE = '''"""The interpreter loop and the opcode table."""
+
+from .ops import arith, control, stack
+
+MAX_STEPS = 10_000
+
+
+class Machine:
+    def __init__(self):
+        self.stack = []
+        self.pc = 0
+        self.out = []
+        self.halted = False
+
+
+TABLE = {
+    "add": arith.add, "sub": arith.sub, "mul": arith.mul, "div": arith.div,
+    "dup": stack.dup, "swap": stack.swap, "drop": stack.drop,
+    "jmp": control.jmp, "jz": control.jz, "emit": control.emit,
+    "halt": control.halt,
+}
+
+
+def run_program(program):
+    vm, steps = Machine(), 0
+    while not vm.halted and 0 <= vm.pc < len(program):
+        op, args = program[vm.pc][0], program[vm.pc][1:]
+        vm.pc += 1
+        if op == "push":
+            vm.stack.append(args[0])
+        else:
+            TABLE[op](vm, *args)
+        steps += 1
+        if steps > MAX_STEPS:
+            raise RuntimeError("step limit exceeded")
+    return vm.out
+'''
+
+_REF_STACK = '''"""Stack-shuffling opcodes."""
+
+
+def dup(vm):
+    vm.stack.append(vm.stack[-1])
+
+
+def swap(vm):
+    vm.stack[-1], vm.stack[-2] = vm.stack[-2], vm.stack[-1]
+
+
+def drop(vm):
+    vm.stack.pop()
+'''
+
+_REF_CONTROL = '''"""Control-flow and output opcodes."""
+
+
+def jmp(vm, target):
+    vm.pc = target
+
+
+def jz(vm, target):
+    if vm.stack.pop() == 0:
+        vm.pc = target
+
+
+def emit(vm):
+    vm.out.append(vm.stack[-1])
+
+
+def halt(vm):
+    vm.halted = True
+'''
+
+#: The shape `src/vm/ops/CONTEXT.md` asks for: one function per opcode, each
+#: independently fillable, so `OctopusConflict` has something a keyed union cannot
+#: do -- two agents filling two opcodes in one file, in one round.
+_ARITH_SKELETON = '''"""Arithmetic opcodes. Each pops two operands and pushes one result."""
+
+
+def add(vm):
+    raise NotImplementedError("add")
+
+
+def sub(vm):
+    raise NotImplementedError("sub")
+
+
+def mul(vm):
+    raise NotImplementedError("mul")
+
+
+def div(vm):
+    raise NotImplementedError("div")
+'''
+
+_STUBS = {'add': ('def add(vm):\n    raise NotImplementedError("add")\n', 'def add(vm):\n    b, a = vm.stack.pop(), vm.stack.pop()\n    vm.stack.append(a + b)\n'), 'sub': ('def sub(vm):\n    raise NotImplementedError("sub")\n', 'def sub(vm):\n    b, a = vm.stack.pop(), vm.stack.pop()\n    vm.stack.append(a - b)\n'), 'mul': ('def mul(vm):\n    raise NotImplementedError("mul")\n', 'def mul(vm):\n    b, a = vm.stack.pop(), vm.stack.pop()\n    vm.stack.append(a * b)\n'), 'div': ('def div(vm):\n    raise NotImplementedError("div")\n', 'def div(vm):\n    b, a = vm.stack.pop(), vm.stack.pop()\n    vm.stack.append(a // b)\n')}
+
+
+def _filled_arith() -> str:
+    body = _ARITH_SKELETON
+    for stub, filled in _STUBS.values():
+        body = body.replace(stub, filled)
+    return body
+
+
+#: The frozen validation suite: (stage, source). Interleaved by stage so the
+#: held-out tail `evolve()` cuts is a mix rather than one stage's worth.
+_CASES = (
+    ("lex", 'push 2\npush 3\nadd\nemit\nhalt'), ("asm", 'push 2\npush 3\nadd\nemit\nhalt'), ("run", 'push 2\npush 3\nadd\nemit\nhalt'),
+    ("lex", 'push 10\npush 4\nsub\nemit\nhalt'), ("asm", 'push 10\npush 4\nsub\nemit\nhalt'), ("run", 'push 10\npush 4\nsub\nemit\nhalt'),
+    ("lex", 'push 6\npush 7\nmul\nemit\nhalt'), ("asm", 'push 6\npush 7\nmul\nemit\nhalt'), ("run", 'push 6\npush 7\nmul\nemit\nhalt'),
+    ("lex", 'push 100\npush 7\ndiv\nemit\nhalt'), ("asm", 'push 100\npush 7\ndiv\nemit\nhalt'), ("run", 'push 100\npush 7\ndiv\nemit\nhalt'),
+    ("lex", 'push 5\ndup\nadd\nemit\nhalt'), ("asm", 'push 5\ndup\nadd\nemit\nhalt'), ("run", 'push 5\ndup\nadd\nemit\nhalt'),
+    ("lex", 'push 1\npush 2\nswap\nemit\nhalt'), ("asm", 'push 1\npush 2\nswap\nemit\nhalt'), ("run", 'push 1\npush 2\nswap\nemit\nhalt'),
+    ("lex", 'push 1\npush 2\ndrop\nemit\nhalt'), ("asm", 'push 1\npush 2\ndrop\nemit\nhalt'), ("run", 'push 1\npush 2\ndrop\nemit\nhalt'),
+    ("lex", 'push 0\njz skip\npush 99\nemit\nskip:\npush 7\nemit\nhalt'), ("asm", 'push 0\njz skip\npush 99\nemit\nskip:\npush 7\nemit\nhalt'), ("run", 'push 0\njz skip\npush 99\nemit\nskip:\npush 7\nemit\nhalt'),
+    ("lex", 'push 3\nloop:\ndup\nemit\npush 1\nsub\ndup\njz done\njmp loop\ndone:\nhalt'), ("asm", 'push 3\nloop:\ndup\nemit\npush 1\nsub\ndup\njz done\njmp loop\ndone:\nhalt'), ("run", 'push 3\nloop:\ndup\nemit\npush 1\nsub\ndup\njz done\njmp loop\ndone:\nhalt'),
+    ("lex", '# add two numbers\npush 8\n\npush 9   # second\nadd\nemit\nhalt'), ("asm", '# add two numbers\npush 8\n\npush 9   # second\nadd\nemit\nhalt'), ("run", '# add two numbers\npush 8\n\npush 9   # second\nadd\nemit\nhalt'),
+)
+
+STACKVM = Suite(
+    name="stackvm",
+    given=initial_files(),
+    frozen=FROZEN,
+    stages={"lex": "tokenize", "asm": "assemble", "run": "run"},
+    cases=_CASES,
+    reference={
+        ENTRY: _REF_ENTRY,
+        ASM_INIT: _PKG_INIT, LEXER: _REF_LEXER, PARSER: _REF_PARSER,
+        VM_INIT: _PKG_INIT, MACHINE: _REF_MACHINE,
+        OPS_INIT: _PKG_INIT, ARITH: _filled_arith(),
+        STACK: _REF_STACK, CONTROL: _REF_CONTROL,
+    },
+)
+
+build_tasks = STACKVM.build_tasks
+make_runner = STACKVM.make_runner
+suite_review = STACKVM.review
+STAGES = STACKVM.stages
+
+
+def llm_manager(complete):
+    return _llm_manager(complete)
+
+
+def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
+    return _llm_executor(complete, editable=editable, frozen=frozen)
+
+
+def _reference_tree() -> Dict[str, str]:
+    return STACKVM.reference_tree()
+
+
+# ---------------------------------------------------------------------------
+# The offline actors: rule-based, deterministic, and a surrogate
+# ---------------------------------------------------------------------------
+
+#: What each node owes, in the order its CONTEXT.md implies. The plan is the whole
+#: surrogate: a real executor decides what to write, this one is told.
+_PLAN = {
+    "src": [(ENTRY, _REF_ENTRY)],
+    "src/asm": [(ASM_INIT, _PKG_INIT), (LEXER, _REF_LEXER), (PARSER, _REF_PARSER)],
+    "src/vm": [(VM_INIT, _PKG_INIT), (MACHINE, _REF_MACHINE)],
+    "src/vm/ops": [(OPS_INIT, _PKG_INIT), (ARITH, _ARITH_SKELETON),
+                   (STACK, _REF_STACK), (CONTROL, _REF_CONTROL)],
+}
+
+
+def _outstanding(state: Mapping[str, str]) -> Dict[str, List[str]]:
+    owed = {node: [path for path, _ in steps if path not in state]
+             for node, steps in _PLAN.items()}
+    if ARITH in state:
+        body = state[ARITH]
+        owed["src/vm/ops"] += [f"{ARITH}#{name}"
+                               for name, (stub, _) in _STUBS.items() if stub in body]
+    return owed
+
+
+def _owes(state: Mapping[str, str], node: str) -> bool:
+    node = normalise(node)
+    return any(items for key, items in _outstanding(state).items()
+               if key == node or key.startswith(node + "/"))
+
+
+def offline_manager(brief: Brief) -> Sequence[Delegation]:
+    """Decompose along the node's routing table; accountability writes its own."""
+    return [Delegation(node, f"clear the outstanding work under {node}/")
+            for node in brief.world.routing(brief.state)
+            if _owes(brief.state, node)]
+
+
+def offline_executor(brief: Brief) -> Sequence[Edit]:
+    """Write exactly one file, the way a bounded episode does."""
+    path, state = normalise(brief.world.path), brief.state
+    for target, content in _PLAN.get(path, ()):
+        if target not in state:
+            return [Edit(owner=path, path=target, content=content)]
+    if path == "src/vm/ops" and ARITH in state:
+        name = _stub_for(brief, state)
+        if name is not None:
+            stub, filled = _STUBS[name]
+            return [Edit(owner=path, path=ARITH,
+                         content=state[ARITH].replace(stub, filled))]
+    return ()
+
+
+def _stub_for(brief: Brief, state: Mapping[str, str]) -> Optional[str]:
+    """Which opcode this episode's failing program points at.
+
+    The point of routing by the failure: two workers holding two different failing
+    programs fill two different functions of one file, which is two values for one
+    key -- a keyed union drops one and a three-way merge keeps both.
+    """
+    body = state.get(ARITH, "")
+    open_stubs = [n for n, (stub, _) in _STUBS.items() if stub in body]
+    if not open_stubs:
+        return None
+    source = str(getattr(brief.task, "prompt", ""))
+    for name in open_stubs:
+        if name in source.split():
+            return name
+    return open_stubs[0]

--- a/examples/genesis/_stackvm.py
+++ b/examples/genesis/_stackvm.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from typing import Dict, List, Mapping, Optional, Sequence
 
 from ._delegation import Brief, Delegation, Edit
-from ._suite import PYTHON_MODULE_SKILL, Suite, reward
+from ._suite import PYTHON_MODULE_SKILL, Suite, plan_delegations, reward
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
@@ -420,10 +420,12 @@ def _owes(state: Mapping[str, str], node: str) -> bool:
 
 
 def offline_manager(brief: Brief) -> Sequence[Delegation]:
-    """Decompose along the node's routing table; accountability writes its own."""
-    return [Delegation(node, f"clear the outstanding work under {node}/")
-            for node in brief.world.routing(brief.state)
-            if _owes(brief.state, node)]
+    """Decompose along the node's routing table; accountability writes its own.
+
+    Cold-started there is no table, so it opens the nodes its plan needs -- see
+    :func:`plan_delegations`.
+    """
+    return plan_delegations(brief, _owes, list(_PLAN))
 
 
 def offline_executor(brief: Brief) -> Sequence[Edit]:

--- a/examples/genesis/_stackvm.py
+++ b/examples/genesis/_stackvm.py
@@ -26,11 +26,17 @@ from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
 
-__all__ = ["FROZEN", "STACKVM", "build_tasks", "initial_files", "llm_executor",
+__all__ = ["CASE_NOUN", "FROZEN", "GROUP_NOUN", "HELD_OUT_FRAC",
+           "SCORING", "STACKVM", "build_tasks", "initial_files", "llm_executor",
            "llm_manager", "make_runner", "offline_executor", "offline_manager",
-           "reward", "suite_review"]
+           "reference_tree", "reward", "suite_review"]
 
 FROZEN = ("spec/**",)
+
+SCORING = "reference oracle, exact match"
+CASE_NOUN = "validation cases"
+GROUP_NOUN = "stages"
+HELD_OUT_FRAC = 0.4
 
 ENTRY = "src/__init__.py"
 ASM_INIT = "src/asm/__init__.py"
@@ -378,7 +384,7 @@ def llm_executor(complete, *, editable=("**",), frozen=FROZEN):
     return _llm_executor(complete, editable=editable, frozen=frozen)
 
 
-def _reference_tree() -> Dict[str, str]:
+def reference_tree() -> Dict[str, str]:
     return STACKVM.reference_tree()
 
 

--- a/examples/genesis/_stackvm.py
+++ b/examples/genesis/_stackvm.py
@@ -10,7 +10,7 @@ parent is itself a child, so an episode reaches depth 3 on the way to a leaf, an
 working from two different failing programs edit two different parts of one file.
 
 What is faithful and what is a surrogate is exactly as it is for minilang, and the
-reasoning is on that module: the repository starts implementation-empty, the
+reasoning is written out on :mod:`examples.genesis._domain`: the repository starts implementation-empty, the
 validation is staged so the run has a gradient before the toolchain is complete,
 the spec is frozen and restored pristine before scoring, and ``--offline`` reveals
 pre-written modules one step at a time and says so.
@@ -18,12 +18,10 @@ pre-written modules one step at a time and says so.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
-
-from agentdescent.evolution import Task
+from typing import Dict, List, Mapping, Optional, Sequence
 
 from ._delegation import Brief, Delegation, Edit
-from ._suite import PYTHON_MODULE_SKILL, Suite, reward, run_cases
+from ._suite import PYTHON_MODULE_SKILL, Suite, reward
 from ._suite import llm_executor as _llm_executor
 from ._suite import llm_manager as _llm_manager
 from ._world import SKILLS_DIR, normalise
@@ -370,7 +368,6 @@ STACKVM = Suite(
 build_tasks = STACKVM.build_tasks
 make_runner = STACKVM.make_runner
 suite_review = STACKVM.review
-STAGES = STACKVM.stages
 
 
 def llm_manager(complete):

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -1,0 +1,357 @@
+"""The machinery a formation domain needs, with the domain itself left out.
+
+A formation run needs four things that have nothing to do with *which* software is
+being grown: a frozen validation suite whose expectations are computed from a
+reference rather than typed out, a way to run a candidate repository in a child
+process, the parent's integration check, and a pair of LLM actors. All four are
+here, parameterised by :class:`Suite`; the domains -- :mod:`examples.genesis._domain`
+(minilang) and :mod:`examples.genesis._stackvm` -- are data on top of it.
+
+Split out when the second domain arrived, for the reason the first one should have
+been: the two differ in the software they grow and in nothing else, and a copy of
+the harness per domain is two places for the frozen-file restore to drift.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from agentdescent.evolution import Task
+from agentdescent.filetree import match_any, materialize, parse_tree
+
+from ._delegation import Brief, Delegation, Edit
+from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
+from ._world import normalise
+
+__all__ = ["CRASHED", "PYTHON_MODULE_SKILL", "Suite", "llm_executor",
+           "llm_manager", "reward", "run_cases"]
+
+#: One human-written skill, shared by the formation domains because the advice
+#: is about writing a Python module rather than about either language. Shipped so
+#: the skill-inheritance path (`LocalWorld.skills`) is live rather than
+#: decorative; nothing here extracts a new one -- see docs/algo-genesis.md.
+PYTHON_MODULE_SKILL = '''# Writing a module in this project
+
+A file is complete or it is not written. Never leave a partial module: the
+validation suite imports what is there, and a half-written module fails the
+stages after it as well as its own.
+
+- Keep one concern per file, and name it after that concern.
+- A package directory needs an `__init__.py`, even an empty one.
+- Import a sibling module relatively (`from .lexer import tokenize`).
+- Do not import a stage you do not need: `src/__init__.py` imports lazily on
+  purpose, and a module-level import undoes that.
+'''
+
+
+#: What a case scores when the workspace could not be run at all -- a syntax
+#: error in a generated module, a timeout, a missing package marker. Distinct
+#: from a wrong answer only in the transcript; both score zero, and conflating
+#: them in the *reward* would be the bug, not here.
+CRASHED = "ERROR:workspace"
+
+#: Executed inside the materialised workspace, in a child process. A candidate is
+#: agent-written code: it can loop, raise or exit, and none of those may take the
+#: run with it. The stage -> attribute map arrives as JSON so the harness itself
+#: is domain-independent.
+_HARNESS = r"""
+import json, sys
+sys.path.insert(0, sys.argv[1])
+cases = json.loads(sys.argv[2])
+stages = json.loads(sys.argv[3])
+import src
+out = []
+for kind, source in cases:
+    try:
+        out.append(repr(getattr(src, stages[kind])(source)))
+    except Exception as exc:            # a stage that is not built yet
+        out.append("ERROR:" + type(exc).__name__)
+print(json.dumps(out), end="")
+"""
+
+
+def run_cases(state: Mapping[str, str], cases: Sequence[Sequence[str]],
+              stages: Mapping[str, str], *, timeout: float = 60.0) -> List[str]:
+    """Materialise ``state`` and evaluate every case in one child process."""
+    if not cases:
+        return []
+    workspace = tempfile.mkdtemp(prefix="genesis-run-")
+    try:
+        materialize(state, workspace)
+        proc = subprocess.run(
+            [sys.executable, "-c", _HARNESS, workspace, json.dumps(list(cases)),
+             json.dumps(dict(stages))],
+            capture_output=True, text=True, timeout=timeout, cwd=workspace)
+        if proc.returncode != 0:
+            return [CRASHED] * len(cases)
+        return list(json.loads(proc.stdout))
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return [CRASHED] * len(cases)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def reward(task: Task, output: str) -> float:
+    """Exact match against the frozen suite's expectation."""
+    return 1.0 if output == task.meta.get("gold") else 0.0
+
+
+@dataclass(frozen=True)
+class Suite:
+    """One formation domain's data: what is given, what is grown, how it is scored.
+
+    ``stages`` maps a case kind to the attribute of ``src`` that answers it, which
+    is what makes the suite *staged*: a case exercising only the first stage scores
+    as soon as that stage lands, so the run has a gradient before the toolchain is
+    complete. Without staging a formation run has literally zero signal until the
+    last file arrives, and no acceptance rule can help.
+    """
+
+    name: str
+    #: Human-supplied and never the agents': context records, constraints, the
+    #: specification, any skill. This is the repository a run starts from.
+    given: Mapping[str, str]
+    #: Globs refused to every proposal and restored pristine before scoring.
+    frozen: Sequence[str]
+    #: ``{case kind: attribute of src}``.
+    stages: Mapping[str, str]
+    #: ``(kind, source)`` pairs. Interleaved by stage so the held-out tail
+    #: ``evolve()`` cuts is a mix rather than one stage's worth.
+    cases: Sequence[Sequence[str]]
+    #: The finished repository: the oracle the expectations come from, and what
+    #: the offline actors reveal.
+    reference: Mapping[str, str]
+
+    # -- the repository -----------------------------------------------------
+
+    def initial_files(self) -> Dict[str, str]:
+        return dict(self.given)
+
+    def reference_tree(self) -> Dict[str, str]:
+        return dict(self.given, **dict(self.reference))
+
+    # -- the suite ----------------------------------------------------------
+
+    def build_tasks(self, limit: Optional[int] = None) -> List[Task]:
+        """The suite, with every expected answer computed from the reference.
+
+        Computed rather than typed out: a hand-written expectation drifts from the
+        implementation it is supposed to pin, and a suite that disagrees with its
+        own oracle scores a correct candidate wrong. This is the loader, so it is
+        also the boundary ``--dry-run`` must not cross.
+        """
+        cases = list(self.cases)[:limit] if limit else list(self.cases)
+        gold = run_cases(self.reference_tree(), cases, self.stages)
+        tasks: List[Task] = []
+        for i, ((kind, source), expected) in enumerate(zip(cases, gold)):
+            if expected.startswith("ERROR:"):
+                raise RuntimeError(
+                    f"the {self.name} reference failed case {kind} {source!r} "
+                    f"({expected}); the suite would score a correct candidate wrong")
+            tasks.append(Task(id=f"{kind}{i:02d}", prompt=source,
+                              meta={"kind": kind, "gold": expected}))
+        return tasks
+
+    def make_runner(self) -> Callable[[str, Task], str]:
+        """``run(rendered, task)`` -- one case against one candidate repository."""
+
+        def run(rendered: str, task: Task) -> str:
+            try:
+                state = dict(parse_tree(rendered))
+            except Exception:  # noqa: BLE001 - an empty artifact, before anything
+                return CRASHED
+            # The frozen files are restored from the human's copy rather than
+            # taken from the candidate: a proposal can never write them, and a
+            # resumed ledger or a hand-built aggregator could still put state in
+            # front of this. Scoring against the agents' own copy of the suite is
+            # the one failure mode that cannot be detected from a completed run.
+            for path, content in self.given.items():
+                if match_any(path, self.frozen):
+                    state[path] = content
+            return run_cases(state, [(task.meta["kind"], task.prompt)], self.stages)[0]
+
+        return run
+
+    # -- the parent's integration evidence ---------------------------------
+
+    def review(self, tasks: Sequence[Task], *, sample: int = 10):
+        """A :data:`~examples.genesis._delegation.Review`: the suite on a child's work.
+
+        The paper's parent decides "using the available tests, constraints and
+        integration evidence" (3.3), and that is a different decision from the
+        acceptance gate's: it happens **inside** the episode, on one child's
+        contribution, before anything is offered to the version history.
+
+        Refuses a regression and says nothing otherwise -- structural work that
+        moves no case is what upstream's "partial progress is accepted" is about,
+        so a parent that demanded a gain would refuse the first file of every node.
+
+        ``sample`` bounds the cost: this runs per child per episode, so it is a
+        subset of the suite rather than the whole of it -- integration evidence a
+        parent can afford, not the gate's measurement.
+        """
+        chosen = list(tasks)[:sample]
+        cases = [(t.meta["kind"], t.prompt) for t in chosen]
+        gold = [t.meta["gold"] for t in chosen]
+        cached: Dict[int, int] = {}
+
+        def score(state: Mapping[str, str]) -> int:
+            got = run_cases(state, cases, self.stages)
+            return sum(1 for out, want in zip(got, gold) if out == want)
+
+        def review(parent, returned):
+            key = id(parent.state)
+            if key not in cached:
+                cached[key] = score(parent.state)
+            candidate = dict(parent.state)
+            for edit in returned:
+                if edit.content is None:
+                    candidate.pop(edit.path, None)
+                else:
+                    candidate[edit.path] = edit.content
+            after = score(candidate)
+            if after < cached[key]:
+                return ("rejected", f"integration check regressed "
+                                    f"{cached[key]}/{len(cases)} -> {after}/{len(cases)}")
+            return None
+
+        return review
+
+
+# ---------------------------------------------------------------------------
+# The LLM actors: the same two seams, asked rather than computed
+# ---------------------------------------------------------------------------
+
+_MANAGER_PROMPT = """You are a manager agent in a recursive software world. You are \
+situated at the repository path `{path}` and you own everything under it.
+
+{context}
+
+This node's routing table says its children are: {routes}
+
+OBJECTIVE
+{objective}
+
+You do not write code. Decide whether to delegate to more specific paths inside \
+your own subtree, or to handle this yourself.
+
+Reply with ONE JSON object and nothing else:
+{{"delegations": [{{"path": "<a node inside {path}>", "objective": "<one sentence>"}}]}}
+
+Rules:
+- You are ACCOUNTABLE for all code under `{path}`, and delegating does not \
+discharge that. The files AT `{path}` itself are nobody else's to write: after \
+your children return you get one more turn to write them.
+- A node is a **directory**, never a file. `src/frontend` is a node; \
+`src/frontend/lexer.py` is a file that belongs to the agent situated at \
+`src/frontend`, and delegating to it is refused.
+- Prefer a child this node already routes to. Naming a new one is allowed and \
+adds it to this node's routing table -- do that only when the work genuinely \
+belongs to a new part of the tree.
+- An empty list means you will handle it at your own path, writing the files \
+that belong to `{path}` itself.
+- Never name a path outside your subtree -- it belongs to another agent."""
+
+_EXECUTOR_PROMPT = """You are an executor agent in a recursive software world. You are \
+situated at the repository path `{path}` and you may write ONLY files under it.
+
+{context}
+
+OBJECTIVE
+{objective}
+
+A validation case failed:
+  input    {prompt}
+  produced {output}
+  score    {reward:.2f}
+
+{protocol}"""
+
+
+def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
+    """Ask a model where to situate children. A bad reply means "handle it here"."""
+
+    def manager(brief: Brief) -> Sequence[Delegation]:
+        routes = brief.world.routing(brief.state)
+        reply = _ask(complete, _MANAGER_PROMPT.format(
+            path=brief.world.path or "./", context=brief.context,
+            routes=", ".join(f"`{r}/`" for r in routes) or "(none yet)",
+            objective=brief.objective))
+        try:
+            data = json.loads(_first_object(reply) or "{}")
+            items = data.get("delegations") or []
+        except Exception:  # noqa: BLE001 - malformed model output, not a bug
+            return ()
+        out = []
+        for item in items:
+            if isinstance(item, dict) and item.get("path"):
+                out.append(Delegation(normalise(str(item["path"])),
+                                      str(item.get("objective", brief.objective))))
+        return out
+
+    return manager
+
+
+def llm_executor(complete, *, editable: Sequence[str] = ("**",),
+                 frozen: Sequence[str] = ()) -> Callable[[Brief], Sequence[Edit]]:
+    """Ask a model for situated edits. Unparseable replies cost their episode.
+
+    The protocol is rendered **per episode** rather than once, because it names the
+    agent's own path in every example it shows. A protocol that says "relative
+    path" without saying relative to what is read both ways, and the wrong reading
+    puts a node's files at the top of the repository.
+    """
+
+    def executor(brief: Brief) -> Sequence[Edit]:
+        owner = brief.world.path or "."
+        protocol = SITUATED_EDIT_PROTOCOL.format(
+            owner=owner, editable=", ".join(editable) or "(none)",
+            frozen=", ".join(frozen) or "(none)")
+        reply = _ask(complete, _EXECUTOR_PROMPT.format(
+            path=brief.world.path or "./", context=brief.context,
+            objective=brief.objective,
+            prompt=getattr(brief.task, "prompt", ""),
+            output=(brief.output or "")[:400], reward=brief.reward,
+            protocol=protocol))
+        return [Edit(owner=brief.world.path or "", path=edit["path"],
+                     content=edit["content"])
+                for edit in parse_situated_edits(reply)]
+
+    return executor
+
+
+def _ask(complete, prompt: str) -> str:
+    try:
+        return complete(prompt) or ""
+    except Exception:  # noqa: BLE001 - a dead backend costs this episode, not the run
+        return ""
+
+
+def _first_object(text: str) -> Optional[str]:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth, in_str, esc = 0, False, False
+    for i in range(start, len(text)):
+        c = text[i]
+        if in_str:
+            esc = (c == "\\") and not esc
+            if c == '"' and not esc:
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -1,11 +1,19 @@
 """The machinery a formation domain needs, with the domain itself left out.
 
 A formation run needs four things that have nothing to do with *which* software is
-being grown: a frozen validation suite whose expectations are computed from a
-reference rather than typed out, a way to run a candidate repository in a child
-process, the parent's integration check, and a pair of LLM actors. All four are
-here, parameterised by :class:`Suite`; the domains -- :mod:`examples.genesis._domain`
-(minilang) and :mod:`examples.genesis._stackvm` -- are data on top of it.
+being grown: a frozen validation suite, a way to run a candidate repository in a
+child process, the parent's integration check, and a pair of LLM actors. All four
+are here, and the domains -- :mod:`examples.genesis._domain` (minilang),
+:mod:`examples.genesis._stackvm`, :mod:`examples.genesis._jqx`,
+:mod:`examples.genesis._md` -- are data on top of them.
+
+The suite comes in two shapes, and the difference matters more than it looks.
+:class:`Suite` computes each case's expected answer by running a **reference
+implementation**: cheap to write, and circular -- you cannot ask a system to grow
+software you had to write first. :class:`TestSuite` scores against a **frozen test
+suite** instead: one task per test function, reward is whether it passes, and no
+reference appears anywhere in the scoring path. That is what upstream does
+(c-testsuite, LLVM, Csmith) and what a human actually writes.
 
 Split out when the second domain arrived, for the reason the first one should have
 been: the two differ in the software they grow and in nothing else, and a copy of
@@ -15,12 +23,15 @@ the harness per domain is two places for the frozen-file restore to drift.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass
-from typing import Callable, Dict, List, Mapping, Optional, Sequence
+from dataclasses import dataclass, field
+from itertools import zip_longest
+from typing import (Callable, Dict, List, Mapping, Optional, Sequence,
+                    Tuple)
 
 from agentdescent.evolution import Task
 from agentdescent.filetree import match_any, materialize, parse_tree
@@ -29,8 +40,8 @@ from ._delegation import Brief, Delegation, Edit
 from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
 from ._world import normalise
 
-__all__ = ["CRASHED", "PYTHON_MODULE_SKILL", "Suite", "llm_executor",
-           "llm_manager", "reward", "run_cases"]
+__all__ = ["CRASHED", "PYTHON_MODULE_SKILL", "Suite", "TestSuite", "llm_executor",
+           "llm_manager", "reward", "reward_test", "run_cases", "run_test"]
 
 #: One human-written skill, shared by the formation domains because the advice
 #: is about writing a Python module rather than about either language. Shipped so
@@ -302,12 +313,29 @@ situated at the repository path `{path}` and you may write ONLY files under it.
 OBJECTIVE
 {objective}
 
-A validation case failed:
-  input    {prompt}
-  produced {output}
-  score    {reward:.2f}
+{failure}
 
 {protocol}"""
+
+#: How an oracle-scored domain shows the executor what went wrong: one input, the
+#: output it produced, and the score that got.
+ORACLE_FAILURE = """A validation case failed:
+  input    {prompt}
+  produced {output}
+  score    {reward:.2f}"""
+
+#: How a test-scored domain shows it: the failing test's own source. The
+#: specification is executable here, so the evidence *is* the specification --
+#: including the tolerance, which an expected-output line cannot carry.
+TEST_FAILURE = """A test in the frozen suite is failing. Here it is, exactly as it \
+runs:
+
+{prompt}
+
+and it reports: {output}
+
+`tests/` is read-only. The implementation has to meet the test, never the other \
+way round -- and the tests that already pass have to keep passing."""
 
 
 def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
@@ -335,13 +363,18 @@ def llm_manager(complete) -> Callable[[Brief], Sequence[Delegation]]:
 
 
 def llm_executor(complete, *, editable: Sequence[str] = ("**",),
-                 frozen: Sequence[str] = ()) -> Callable[[Brief], Sequence[Edit]]:
+                 frozen: Sequence[str] = (),
+                 failure: str = ORACLE_FAILURE) -> Callable[[Brief], Sequence[Edit]]:
     """Ask a model for situated edits. Unparseable replies cost their episode.
 
     The protocol is rendered **per episode** rather than once, because it names the
     agent's own path in every example it shows. A protocol that says "relative
     path" without saying relative to what is read both ways, and the wrong reading
     puts a node's files at the top of the repository.
+
+    ``failure`` is how the evidence is worded: :data:`ORACLE_FAILURE` for a domain
+    scored against a reference, :data:`TEST_FAILURE` for one scored by a test suite,
+    where "input / produced" describes nothing the agent can act on.
     """
 
     def executor(brief: Brief) -> Sequence[Edit]:
@@ -352,8 +385,9 @@ def llm_executor(complete, *, editable: Sequence[str] = ("**",),
         reply = _ask(complete, _EXECUTOR_PROMPT.format(
             path=brief.world.path or "./", context=brief.context,
             objective=brief.objective,
-            prompt=getattr(brief.task, "prompt", ""),
-            output=(brief.output or "")[:400], reward=brief.reward,
+            failure=failure.format(prompt=getattr(brief.task, "prompt", ""),
+                                   output=(brief.output or "")[:400],
+                                   reward=brief.reward),
             protocol=protocol))
         return [Edit(owner=brief.world.path or "", path=edit["path"],
                      content=edit["content"])
@@ -390,3 +424,247 @@ def _first_object(text: str) -> Optional[str]:
             if depth == 0:
                 return text[start:i + 1]
     return None
+
+
+# ---------------------------------------------------------------------------
+# Scoring by a frozen test suite instead of by an oracle
+# ---------------------------------------------------------------------------
+
+#: One test, in a child process. Executed rather than imported as a module, so a
+#: test file needs no package plumbing and a candidate that cannot even be
+#: imported fails the test it was asked about instead of taking the run down.
+_TEST_HARNESS = r"""
+import sys
+workspace, path, func = sys.argv[1], sys.argv[2], sys.argv[3]
+sys.path.insert(0, workspace)
+try:
+    namespace = {"__name__": "_genesis_test", "__file__": path}
+    with open(path, encoding="utf-8") as handle:
+        exec(compile(handle.read(), path, "exec"), namespace)
+    namespace[func]()
+except BaseException as exc:                 # a failed assertion is a result
+    detail = " ".join(str(exc).split())[:240]
+    print("FAIL:" + type(exc).__name__ + (": " + detail if detail else ""), end="")
+else:
+    print("PASS", end="")
+"""
+
+#: What a test scores when it could not be run at all.
+TEST_CRASHED = "FAIL:workspace"
+
+
+def reward_test(task: Task, output: str) -> float:
+    """One frozen test, passed or not. No expected value anywhere."""
+    return 1.0 if output == "PASS" else 0.0
+
+
+def run_test(state: Mapping[str, str], path: str, func: str,
+             *, timeout: float = 60.0) -> str:
+    """Materialise ``state`` and run one test function in a child process."""
+    workspace = tempfile.mkdtemp(prefix="genesis-test-")
+    try:
+        materialize(state, workspace)
+        proc = subprocess.run(
+            [sys.executable, "-c", _TEST_HARNESS, workspace,
+             os.path.join(workspace, *path.split("/")), func],
+            capture_output=True, text=True, timeout=timeout, cwd=workspace)
+        out = proc.stdout.strip()
+        return out if out.startswith(("PASS", "FAIL")) else TEST_CRASHED
+    except subprocess.TimeoutExpired:
+        return "FAIL:Timeout"
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return TEST_CRASHED
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _discover_tests(files: Mapping[str, str]) -> List[Tuple[str, str, str]]:
+    """``(file, function, prompt)`` for every top-level ``test_*`` in ``files``.
+
+    The prompt is the test's own source **with its file's prelude above it** --
+    imports, module constants, helper functions -- because a test body that reads
+    ``forces(CONFIG, box=BOX)`` says nothing on its own about what ``CONFIG`` is.
+    Everything in the file that is not itself a test goes in, in file order.
+    """
+    import ast
+
+    def segment(body: str, node) -> str:
+        return ast.get_source_segment(body, node) or ""
+
+    found: List[Tuple[str, str, str]] = []
+    for path in sorted(files):
+        if not path.endswith(".py"):
+            continue
+        body = files[path]
+        nodes = ast.parse(body, path).body
+        tests = [n for n in nodes
+                 if isinstance(n, ast.FunctionDef) and n.name.startswith("test_")]
+        prelude = "\n\n".join(s for s in (segment(body, n) for n in nodes
+                                           if n not in tests) if s)
+        for node in tests:
+            source = segment(body, node) or node.name
+            found.append((path, node.name,
+                          f"# {path}\n{prelude}\n\n\n{source}" if prelude else source))
+    return found
+
+
+@dataclass(frozen=True)
+class TestSuite:
+    """A formation domain scored by a **frozen test suite**, with no oracle.
+
+    :class:`Suite` needs a reference implementation: it runs it to compute the
+    expected answer for every case, and a candidate is scored by matching it. That
+    is circular for the thing this port is for -- you cannot ask a system to grow
+    software you had to write first -- and it is not what upstream does. Genesis
+    validates against **c-testsuite, LLVM and Csmith**: assertions, not expected
+    outputs, and no reference compiler anywhere in the loop.
+
+    So here a task is one **test function**, its prompt is that test's own source,
+    and its reward is whether it passes. The human writes a specification and a
+    test suite, which is what a human actually writes; what the tests assert --
+    tolerances, invariants, equivalences -- is theirs to choose, and nothing has to
+    agree bit for bit with an implementation that already exists.
+
+    A reference implementation may still exist beside the domain, for two jobs that
+    are not scoring: driving the offline rule-based actor, and letting a test prove
+    the suite is passable at all. Shipping a suite nobody has ever seen pass is its
+    own kind of dishonesty.
+
+    **The split is not a train/validation split**, and trying to make it one is a
+    mistake this port made once already. ``evolve()`` holds out the tail of the task
+    list and reports its reward. For :class:`Suite`, whose cases are sampled inputs
+    over one grammar, that is a generalisation estimate and it means something. Here
+    every task is a distinct **requirement**, so holding 40% of them back means
+    refusing to tell the system four tenths of what it has to do and then grading it
+    on them -- and the search never even sees those requirements fail, so nothing is
+    ever proposed for them. That is exactly how the jqx run stalled at 0.923.
+
+    The tail is an **audit set** instead: :attr:`audit` holds test files that are not
+    in the repository at all, so no agent can read them, injected only when a held-out
+    task runs. The driven suite is the whole specification; the audit set is the
+    honest headline number, because the executor is shown the source of the test it
+    is failing and could otherwise write to that one assertion. :meth:`held_out_frac`
+    returns the fraction that makes ``evolve()``'s positional split land exactly on
+    the boundary.
+    """
+
+    name: str
+    #: Human-supplied and never the agents': context records, the specification,
+    #: the test suite, any entry script.
+    given: Mapping[str, str]
+    #: Globs refused to every proposal and restored pristine before scoring. The
+    #: tests belong here -- a system that can edit its own tests has no tests.
+    frozen: Sequence[str]
+    #: Where the test functions live.
+    tests: Sequence[str] = ("tests/**",)
+    #: ``path -> source`` for tests the agents never see. Deliberately *not* part of
+    #: :meth:`initial_files`: frozen stops a file being written, not read, and an
+    #: audit test in the repository is an audit test the executor can read.
+    audit: Mapping[str, str] = field(default_factory=dict)
+    #: Seconds one test may take.
+    timeout: float = 60.0
+
+    def initial_files(self) -> Dict[str, str]:
+        return dict(self.given)
+
+    def held_out_frac(self) -> float:
+        """The ``held_out_frac`` that puts exactly the audit tasks in the tail.
+
+        ``evolve()`` cuts at ``round(n * (1 - frac))`` and refuses 0.0, so a domain
+        with no audit set falls back to holding out one task.
+        """
+        total = len(self.build_tasks())
+        audited = sum(1 for t in self.build_tasks() if t.meta.get("audit"))
+        return max(audited, 1) / total
+
+    def discover(self) -> List[Tuple[str, str, str]]:
+        """``(file, function, source)`` for every ``test_*`` in the driven suite.
+
+        Parsed rather than imported, so discovery works against a repository with
+        no implementation in it -- which is every repository this port starts from.
+        """
+        return _discover_tests({path: body for path, body in self.given.items()
+                                if match_any(path, self.tests)})
+
+    def discover_audit(self) -> List[Tuple[str, str, str]]:
+        """The same, over the audit files the repository does not contain."""
+        return _discover_tests(self.audit)
+
+    def build_tasks(self, limit: Optional[int] = None) -> List[Task]:
+        """One task per test. This is the loader, so ``--dry-run`` stops before it.
+
+        The tasks are **interleaved across files**, one from each in turn, because
+        ``evolve()`` splits train from held-out by position: grouped by file, the
+        last file or two would sit entirely in the held-out tail, no rollout could
+        ever fail on them, and nothing would ever be proposed for the layer they
+        test. That failure cost a whole jqx run to find.
+        """
+        found = self.discover()
+        if not found:
+            raise RuntimeError(f"the {self.name} suite declares no tests under "
+                               f"{', '.join(self.tests)}")
+        by_file: Dict[str, List[Tuple[str, str, str]]] = {}
+        for entry in found:
+            by_file.setdefault(entry[0], []).append(entry)
+        ordered: List[Tuple[str, str, str]] = []
+        for row in zip_longest(*by_file.values()):
+            ordered.extend(entry for entry in row if entry is not None)
+        tasks = [self._task(entry) for entry in (ordered[:limit] if limit else ordered)]
+        # Last, and in file order: `evolve()` splits by position, so this is what
+        # puts exactly the audit set in the held-out tail.
+        tasks += [self._task(entry, audit=True) for entry in self.discover_audit()]
+        return tasks
+
+    def _task(self, entry: Tuple[str, str, str], *, audit: bool = False) -> Task:
+        path, func, source = entry
+        stem = path.rsplit("/", 1)[-1].removeprefix("test_").removesuffix(".py")
+        return Task(id=f"{'audit:' if audit else ''}{stem}::{func}", prompt=source,
+                    meta={"file": path, "func": func, "kind": stem, "audit": audit})
+
+    def make_runner(self) -> Callable[[str, Task], str]:
+        """``run(rendered, task)`` -- one test against one candidate repository."""
+
+        def run(rendered: str, task: Task) -> str:
+            try:
+                state = dict(parse_tree(rendered))
+            except Exception:  # noqa: BLE001 - an empty artifact, before anything
+                return TEST_CRASHED
+            for path, content in self.given.items():
+                if match_any(path, self.frozen):
+                    state[path] = content
+            # Into the scratch copy the subprocess sees, never into the artifact:
+            # the audit tests exist only for the length of one evaluation.
+            state.update(self.audit)
+            return run_test(state, task.meta["file"], task.meta["func"],
+                            timeout=self.timeout)
+
+        return run
+
+    def review(self, tasks: Sequence[Task], *, sample: int = 8):
+        """The parent's integration evidence: how many of these tests still pass."""
+        chosen = [t for t in tasks if not t.meta.get("audit")][:sample]
+        cached: Dict[int, int] = {}
+
+        def passes(state: Mapping[str, str]) -> int:
+            return sum(1 for t in chosen
+                       if run_test(state, t.meta["file"], t.meta["func"],
+                                   timeout=self.timeout) == "PASS")
+
+        def review(parent, returned):
+            key = id(parent.state)
+            if key not in cached:
+                cached[key] = passes(parent.state)
+            candidate = dict(parent.state)
+            for edit in returned:
+                if edit.content is None:
+                    candidate.pop(edit.path, None)
+                else:
+                    candidate[edit.path] = edit.content
+            after = passes(candidate)
+            if after < cached[key]:
+                return ("rejected", f"integration check regressed "
+                                    f"{cached[key]}/{len(chosen)} -> "
+                                    f"{after}/{len(chosen)} tests")
+            return None
+
+        return review

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -396,10 +396,33 @@ def llm_executor(complete, *, editable: Sequence[str] = ("**",),
     return executor
 
 
+def preflight(complete) -> None:
+    """One call before the run, so a dead backend costs a second instead of an hour.
+
+    ``evolve()`` swallows an exception raised inside a proposal policy, and it is
+    right to: one model call that times out should cost its episode and nothing
+    more. But the same tolerance turns a *wrong endpoint* into a run that looks like
+    a failure of the mechanism. A base URL with ``/v1/messages`` already on it -- the
+    SDK appends its own -- 404s every call, the actors return no edits, every
+    proposal is an empty accepted step, and thirteen minutes later the run reports
+    ``reward 0.000  depth=0  accepted=400``. The only evidence was ``2400 failed``
+    in the usage line, and nothing in the header said the model had never answered.
+
+    So ask it one question first, and let that failure be loud.
+    """
+    try:
+        complete("Reply with the single word OK.")
+    except Exception as exc:  # noqa: BLE001 - anything at all means do not start
+        raise SystemExit(
+            f"model backend unreachable: {type(exc).__name__}: {exc}\n"
+            "check --provider/--model and the endpoint -- ANTHROPIC_BASE_URL is the "
+            "BASE url, and the SDK appends /v1/messages to it") from exc
+
+
 def _ask(complete, prompt: str) -> str:
     try:
         return complete(prompt) or ""
-    except Exception:  # noqa: BLE001 - a dead backend costs this episode, not the run
+    except Exception:  # noqa: BLE001 - a dead call costs this episode, not the run
         return ""
 
 

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -560,6 +560,34 @@ else:
     print("PASS", end="")
 """
 
+#: The whole suite in **one** interpreter, which is what `mix test` is and what
+#: `agents/manager.ex` means by "run ALL tests". Scoring one test per process is
+#: required by one-task-per-test and is structurally blind to anything that leaks
+#: between tests -- import order, module state, a global left dirty. A real run gave
+#: the sharpest possible example: an `rdf()` in `src/observe/__init__.py` whose body
+#: did `from .rdf import histogram`, so importing the submodule rebound
+#: `src.observe.rdf` from the function to the module and the function destroyed
+#: itself on its first call. Per test: 65/65. In one process: five failures.
+_SUITE_HARNESS = r"""
+import sys, json
+workspace, plan = sys.argv[1], json.loads(sys.argv[2])
+sys.path.insert(0, workspace)
+modules, failed = {}, []
+for path, func in plan:
+    try:
+        if path not in modules:
+            namespace = {"__name__": "_genesis_test_" + path, "__file__": path}
+            with open(path, encoding="utf-8") as handle:
+                exec(compile(handle.read(), path, "exec"), namespace)
+            modules[path] = namespace
+        modules[path][func]()
+    except BaseException as exc:
+        detail = " ".join(str(exc).split())[:120]
+        failed.append(path + "::" + func + " " + type(exc).__name__
+                      + (": " + detail if detail else ""))
+print(json.dumps(failed), end="")
+"""
+
 #: What a test scores when it could not be run at all.
 TEST_CRASHED = "FAIL:workspace"
 
@@ -567,6 +595,36 @@ TEST_CRASHED = "FAIL:workspace"
 def reward_test(task: Task, output: str) -> float:
     """One frozen test, passed or not. No expected value anywhere."""
     return 1.0 if output == "PASS" else 0.0
+
+
+def run_suite(state: Mapping[str, str], plan: Sequence[Tuple[str, str]], *,
+              timeout: float = 300.0) -> List[str]:
+    """Every test in ``plan``, in one interpreter, in the order given.
+
+    Returns the failures as ``file::func Error: detail``. A process that dies is one
+    failure naming that: a suite which could not be run is not a suite that passed.
+    """
+    workspace = tempfile.mkdtemp(prefix="genesis-suite-")
+    try:
+        materialize(state, workspace)
+        script = os.path.join(workspace, "_genesis_suite.py")
+        with open(script, "w", encoding="utf-8") as handle:
+            handle.write(_SUITE_HARNESS)
+        out = subprocess.run(
+            [sys.executable, script, workspace, json.dumps([list(p) for p in plan])],
+            cwd=workspace, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            timeout=timeout)
+        text = out.stdout.decode("utf-8", "replace").strip()
+        try:
+            return list(json.loads(text))
+        except Exception:  # noqa: BLE001 - the runner itself died
+            detail = (out.stderr.decode("utf-8", "replace").strip().splitlines()
+                      or ["no output"])[-1]
+            return [f"<the suite could not be run> {detail[:200]}"]
+    except subprocess.TimeoutExpired:
+        return [f"<the suite did not finish in {timeout:.0f}s>"]
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
 
 
 def run_test(state: Mapping[str, str], path: str, func: str,
@@ -727,6 +785,24 @@ class TestSuite:
                         break
             report[name] = killers
         return report
+
+    def suite_failures(self, state: Mapping[str, str], *,
+                       audit: bool = False) -> List[str]:
+        """The suite run the way a person runs it: one process, all of it.
+
+        The per-task score cannot see one test poisoning the next, because every task
+        gets a fresh interpreter -- the isolation that makes one-task-per-test possible
+        is a blind spot with a name. Upstream has no such blind spot: its manager runs
+        `mix test`, and its executor is told "run ALL tests".
+        """
+        state = dict(state)
+        for path, content in self.given.items():
+            if match_any(path, self.frozen):
+                state[path] = content
+        state.update(self.audit)
+        plan = [(t.meta["file"], t.meta["func"]) for t in self.build_tasks()
+                if audit or not t.meta.get("audit")]
+        return run_suite(state, plan, timeout=max(60.0, self.timeout * 4))
 
     def held_out_frac(self) -> float:
         """The ``held_out_frac`` that puts exactly the audit tasks in the tail.

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -15,13 +15,12 @@ the harness per domain is two places for the frozen-file restore to drift.
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Mapping, Optional, Sequence
 
 from agentdescent.evolution import Task
 from agentdescent.filetree import match_any, materialize, parse_tree

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -568,6 +568,16 @@ else:
 #: did `from .rdf import histogram`, so importing the submodule rebound
 #: `src.observe.rdf` from the function to the module and the function destroyed
 #: itself on its first call. Per test: 65/65. In one process: five failures.
+#: What the executor is shown when the suite as a whole is the failing unit.
+_SUITE_TASK_PROMPT = """The whole test suite, run in ONE interpreter -- every test in \
+the same process, in file order, the way `mix test` or `pytest` runs it and the way a \
+person does.
+
+Each of the other {n} tasks runs its test in a fresh process, so a test that passes \
+alone can still fail here: an import with a side effect, a module-level name rebound, \
+a global left dirty by an earlier test. The failures below are exactly that -- code \
+that works once and not twice, or works in isolation and not in company."""
+
 _SUITE_HARNESS = r"""
 import sys, json
 workspace, plan = sys.argv[1], json.loads(sys.argv[2])
@@ -801,7 +811,7 @@ class TestSuite:
                 state[path] = content
         state.update(self.audit)
         plan = [(t.meta["file"], t.meta["func"]) for t in self.build_tasks()
-                if audit or not t.meta.get("audit")]
+                if not t.meta.get("suite") and (audit or not t.meta.get("audit"))]
         return run_suite(state, plan, timeout=max(60.0, self.timeout * 4))
 
     def held_out_frac(self) -> float:
@@ -847,9 +857,23 @@ class TestSuite:
         for row in zip_longest(*by_file.values()):
             ordered.extend(entry for entry in row if entry is not None)
         tasks = [self._task(entry) for entry in (ordered[:limit] if limit else ordered)]
+        # One more, and it is not a test: the whole suite in one interpreter. Without
+        # it nothing in the *search* can fail on something that leaks between tests --
+        # every other task gets a fresh process by construction -- so a run could sit
+        # at "every test passes" forever while the suite does not run. It is a task
+        # rather than only a gate because a gate the search cannot see is a wall.
+        tasks.append(Task(id="suite::one-process",
+                          prompt=_SUITE_TASK_PROMPT.format(n=len(tasks)),
+                          meta={"file": "", "func": "", "kind": "suite",
+                                "audit": False, "suite": True}))
         # Last, and in file order: `evolve()` splits by position, so this is what
         # puts exactly the audit set in the held-out tail.
         tasks += [self._task(entry, audit=True) for entry in self.discover_audit()]
+        if self.audit:
+            tasks.append(Task(id="audit:suite::one-process",
+                              prompt=_SUITE_TASK_PROMPT.format(n=len(tasks)),
+                              meta={"file": "", "func": "", "kind": "suite",
+                                    "audit": True, "suite": True}))
         return tasks
 
     def _task(self, entry: Tuple[str, str, str], *, audit: bool = False) -> Task:
@@ -872,6 +896,13 @@ class TestSuite:
             # Into the scratch copy the subprocess sees, never into the artifact:
             # the audit tests exist only for the length of one evaluation.
             state.update(self.audit)
+            if task.meta.get("suite"):
+                plan = [(t.meta["file"], t.meta["func"]) for t in self.build_tasks()
+                        if not t.meta.get("suite")
+                        and (task.meta["audit"] or not t.meta["audit"])]
+                failures = run_suite(state, plan,
+                                     timeout=max(60.0, self.timeout * 4))
+                return "PASS" if not failures else "FAIL:" + "; ".join(failures[:4])
             return run_test(state, task.meta["file"], task.meta["func"],
                             timeout=self.timeout)
 
@@ -879,13 +910,17 @@ class TestSuite:
 
     def review(self, tasks: Sequence[Task], *, sample: int = 8):
         """The parent's integration evidence: how many of these tests still pass."""
-        chosen = [t for t in tasks if not t.meta.get("audit")][:sample]
+        chosen = [t for t in tasks
+                  if not t.meta.get("audit") and not t.meta.get("suite")][:sample]
         cached: Dict[int, int] = {}
 
         def passes(state: Mapping[str, str]) -> int:
-            return sum(1 for t in chosen
-                       if run_test(state, t.meta["file"], t.meta["func"],
-                                   timeout=self.timeout) == "PASS")
+            # One process for the sample, not one per test: the parent upstream runs
+            # `mix test`, and a check that cannot see one test poisoning the next is
+            # the check this port was already caught missing.
+            plan = [(t.meta["file"], t.meta["func"]) for t in chosen]
+            return len(chosen) - len(run_suite(dict(state), plan,
+                                               timeout=max(60.0, self.timeout * 2)))
 
         def review(parent, returned):
             key = id(parent.state)

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -38,7 +38,7 @@ from agentdescent.filetree import match_any, materialize, parse_tree
 
 from ._delegation import Brief, Delegation, Edit
 from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
-from ._world import normalise
+from ._world import CONTEXT_FILE, ROUTING_HEADING, SKILLS_DIR, normalise
 
 __all__ = ["CRASHED", "PYTHON_MODULE_SKILL", "Suite", "TestSuite", "llm_executor",
            "llm_manager", "reward", "reward_test", "run_cases", "run_test"]
@@ -394,6 +394,93 @@ def llm_executor(complete, *, editable: Sequence[str] = ("**",),
                 for edit in parse_situated_edits(reply)]
 
     return executor
+
+
+def cold_start(files: Mapping[str, str]) -> Dict[str, str]:
+    """The same repository with the **decomposition taken out**.
+
+    A formation domain ships a `CONTEXT.md` per node, each with a routing table, and
+    that is a fair reading of upstream -- the records are part of the accepted
+    version and a human writes the first ones. It is also, for every node below the
+    root, the system's own first job done for it: the paper's phase 1 is
+    *architecture and design*, and a tree that already says `src/potentials/pair/ ->
+    one module per interaction` has had its architecture handed to it.
+
+    So this strips every node record except the root's, and the root's routing table
+    with them, leaving only what a human cannot avoid supplying: the goal, the
+    contract, the suite that scores it, and any frozen entry script. The skills go
+    too -- a hint about how to lay out Python packages is a hint about the shape of
+    the answer.
+
+    Nothing frozen is touched, so scoring is identical; what changes is that the run
+    has to write its own `CONTEXT.md` chain as it goes, which `routing()` and
+    `_routing_note` already support (that is what `routes_opened` counts).
+    """
+    kept: Dict[str, str] = {}
+    for path, body in files.items():
+        if path == CONTEXT_FILE:
+            kept[path] = _without_routing(body)
+        elif path.endswith(CONTEXT_FILE) and not path.startswith("spec/"):
+            continue                                   # a node record: the run's job
+        elif f"/{SKILLS_DIR}/" in f"/{path}" or path.startswith(f"{SKILLS_DIR}/"):
+            continue                                   # a hint about the shape
+        else:
+            kept[path] = body
+    return kept
+
+
+def _without_routing(body: str) -> str:
+    """The root record with its routing table removed, and a note saying why."""
+    lines, out, dropping = body.splitlines(), [], False
+    for line in lines:
+        if line.strip().lower().startswith(ROUTING_HEADING.lower()):
+            dropping = True
+            out.append(ROUTING_HEADING)
+            out.append("- (empty: open the nodes this needs, and record them here)")
+            out.append("")
+            continue
+        if dropping:
+            if line.startswith("## "):
+                dropping = False
+            else:
+                continue
+        out.append(line)
+    return "\n".join(out) + "\n"
+
+
+def plan_delegations(brief: Brief, owes: Callable[[Mapping[str, str], str], bool],
+                     nodes: Sequence[str]) -> List[Delegation]:
+    """Where the rule-based manager sends work, cold start included.
+
+    The routing table first, which is what that table is for upstream: the
+    decomposition is read from `CONTEXT.md` rather than hardcoded, and only the
+    choice of *which* routed child to work on is a surrogate. But a cold-started
+    world has no tables at all, so a manager that can only delegate to what it
+    already routes to would have nothing to do forever. Upstream a manager may name
+    a new node inside its own subtree and the table records it afterwards, so this
+    one does the same: if nothing routed owes work, open the direct children its
+    plan still owes work to.
+
+    That makes the offline cold-start arm a test of the *mechanism* -- tables get
+    written, the recursion reaches depth -- and nothing at all about inventing a
+    decomposition, because the plan is the decomposition. Only a model arm can say
+    anything about that.
+    """
+    here = normalise(brief.world.path)
+    routed = [node for node in brief.world.routing(brief.state)
+              if owes(brief.state, node)]
+    if not routed:
+        prefix = f"{here}/" if here else ""
+        depth = len(prefix.split("/")) if here else 1
+        routed = sorted({node for node in nodes
+                         if node.startswith(prefix) and node != here
+                         and owes(brief.state, node)},
+                        key=len)
+        # direct children only: the recursion is what reaches the rest
+        routed = [node for node in routed
+                  if len(normalise(node).split("/")) == depth]
+    return [Delegation(node, f"clear the outstanding work under {node}/")
+            for node in routed]
 
 
 def preflight(complete) -> None:

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -65,11 +65,35 @@ import json, sys
 sys.path.insert(0, sys.argv[1])
 cases = json.loads(sys.argv[2])
 stages = json.loads(sys.argv[3])
+digits = json.loads(sys.argv[4])
 import src
+
+
+def canonical(value):
+    # Rounded before repr, for a domain whose answers are floating point: two
+    # correct implementations of the same formula differ in the last bits by
+    # summation order alone, and comparing full repr would score a correct
+    # candidate wrong. `None` leaves the value untouched.
+    if digits is None:
+        return value
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        rounded = round(value, digits)
+        return 0.0 if rounded == 0 else rounded
+    if isinstance(value, list):
+        return [canonical(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(canonical(v) for v in value)
+    if isinstance(value, dict):
+        return {k: canonical(v) for k, v in value.items()}
+    return value
+
+
 out = []
 for kind, source in cases:
     try:
-        out.append(repr(getattr(src, stages[kind])(source)))
+        out.append(repr(canonical(getattr(src, stages[kind])(source))))
     except Exception as exc:            # a stage that is not built yet
         out.append("ERROR:" + type(exc).__name__)
 print(json.dumps(out), end="")
@@ -77,8 +101,15 @@ print(json.dumps(out), end="")
 
 
 def run_cases(state: Mapping[str, str], cases: Sequence[Sequence[str]],
-              stages: Mapping[str, str], *, timeout: float = 60.0) -> List[str]:
-    """Materialise ``state`` and evaluate every case in one child process."""
+              stages: Mapping[str, str], *, digits: Optional[int] = None,
+              timeout: float = 60.0) -> List[str]:
+    """Materialise ``state`` and evaluate every case in one child process.
+
+    ``digits`` rounds every float in a result before it is compared. A domain
+    whose answers are exact -- a token list, a parse tree -- leaves it ``None``;
+    one whose answers are floating point needs it, because two correct
+    implementations of one formula differ in the last bits by summation order.
+    """
     if not cases:
         return []
     workspace = tempfile.mkdtemp(prefix="genesis-run-")
@@ -86,7 +117,7 @@ def run_cases(state: Mapping[str, str], cases: Sequence[Sequence[str]],
         materialize(state, workspace)
         proc = subprocess.run(
             [sys.executable, "-c", _HARNESS, workspace, json.dumps(list(cases)),
-             json.dumps(dict(stages))],
+             json.dumps(dict(stages)), json.dumps(digits)],
             capture_output=True, text=True, timeout=timeout, cwd=workspace)
         if proc.returncode != 0:
             return [CRASHED] * len(cases)
@@ -127,6 +158,9 @@ class Suite:
     #: The finished repository: the oracle the expectations come from, and what
     #: the offline actors reveal.
     reference: Mapping[str, str]
+    #: Decimal places every float in a result is rounded to before comparison.
+    #: ``None`` for a domain whose answers are exact.
+    digits: Optional[int] = None
 
     # -- the repository -----------------------------------------------------
 
@@ -147,7 +181,8 @@ class Suite:
         also the boundary ``--dry-run`` must not cross.
         """
         cases = list(self.cases)[:limit] if limit else list(self.cases)
-        gold = run_cases(self.reference_tree(), cases, self.stages)
+        gold = run_cases(self.reference_tree(), cases, self.stages,
+                         digits=self.digits)
         tasks: List[Task] = []
         for i, ((kind, source), expected) in enumerate(zip(cases, gold)):
             if expected.startswith("ERROR:"):
@@ -174,7 +209,8 @@ class Suite:
             for path, content in self.given.items():
                 if match_any(path, self.frozen):
                     state[path] = content
-            return run_cases(state, [(task.meta["kind"], task.prompt)], self.stages)[0]
+            return run_cases(state, [(task.meta["kind"], task.prompt)],
+                             self.stages, digits=self.digits)[0]
 
         return run
 
@@ -202,7 +238,7 @@ class Suite:
         cached: Dict[int, int] = {}
 
         def score(state: Mapping[str, str]) -> int:
-            got = run_cases(state, cases, self.stages)
+            got = run_cases(state, cases, self.stages, digits=self.digits)
             return sum(1 for out, want in zip(got, gold) if out == want)
 
         def review(parent, returned):

--- a/examples/genesis/_suite.py
+++ b/examples/genesis/_suite.py
@@ -34,7 +34,8 @@ from typing import (Callable, Dict, List, Mapping, Optional, Sequence,
                     Tuple)
 
 from agentdescent.evolution import Task
-from agentdescent.filetree import match_any, materialize, parse_tree
+from agentdescent.filetree import (canonical, match_any, materialize,
+                                   parse_tree)
 
 from ._delegation import Brief, Delegation, Edit
 from ._spatial import SITUATED_EDIT_PROTOCOL, parse_situated_edits
@@ -671,11 +672,61 @@ class TestSuite:
     #: :meth:`initial_files`: frozen stops a file being written, not read, and an
     #: audit test in the repository is an audit test the executor can read.
     audit: Mapping[str, str] = field(default_factory=dict)
+    #: ``name -> file overrides``: implementations that are **deliberately wrong**,
+    #: applied on top of the reference. A suite is only as good as what it rejects,
+    #: and nothing else in this design checks that. See :meth:`kill_report`.
+    baselines: Mapping[str, Mapping[str, str]] = field(default_factory=dict)
     #: Seconds one test may take.
     timeout: float = 60.0
 
     def initial_files(self) -> Dict[str, str]:
         return dict(self.given)
+
+    def kill_report(self, reference: Mapping[str, str], *,
+                    stop_after: int = 0) -> Dict[str, List[str]]:
+        """``baseline -> the task ids that fail on it``. Empty list means survived.
+
+        This is the mechanism the md domain was missing, and the cost of missing it
+        was a run that reported 1.000 with no force field in it. A suite validated
+        only against a *correct* implementation is not validated: it has been shown
+        to accept the right answer, and nothing has been shown about what it
+        refuses. A field that returns zero everywhere satisfies every invariant --
+        zero sums to zero, zero is the gradient of a constant, nothing moves so
+        nothing drifts -- so a suite of invariants is exactly the shape that looks
+        thorough and rejects nothing.
+
+        Mutation testing is the standard answer and this is its small form: keep the
+        wrong implementations, score each, and require every one of them to die.
+        Note what this does *not* need: a reference in the **scoring** path. The
+        reference exists beside the domain for jobs that are not scoring -- driving
+        the offline actor, proving the suite passable -- and suite QA is a third one.
+
+        Coverage, for the record, would not have caught it. The zero field executes
+        every line of every test.
+
+        This is the **harness**'s honesty check, not the algorithm's. Upstream has no
+        objective function at all -- ``grep -rio 'fitness|reward|score'`` over
+        ``apps/evo_git`` returns one hit, ``oom_score_adjust`` -- and what stands in
+        its place is a parent that reviews the diff and runs the tests
+        (``agents/manager.ex``). A reviewer reading the change is what rejects a
+        registry that pushes every pair past the cutoff; a scalar cannot. Both belong
+        in the port, in different places: this one keeps the *measurement* honest.
+
+        ``stop_after`` stops scoring a baseline once that many tests have killed it,
+        which is all a pass/fail guard needs and is much cheaper than the full grid.
+        """
+        run, tasks = self.make_runner(), self.build_tasks()
+        report: Dict[str, List[str]] = {}
+        for name, overrides in self.baselines.items():
+            rendered = canonical(dict(reference, **overrides))
+            killers: List[str] = []
+            for task in tasks:
+                if reward_test(task, run(rendered, task)) == 0.0:
+                    killers.append(task.id)
+                    if stop_after and len(killers) >= stop_after:
+                        break
+            report[name] = killers
+        return report
 
     def held_out_frac(self) -> float:
         """The ``held_out_frac`` that puts exactly the audit tasks in the tail.

--- a/examples/genesis/_worktree.py
+++ b/examples/genesis/_worktree.py
@@ -1,0 +1,187 @@
+"""Worktree isolation, a commit per episode, and the worktree deleted after.
+
+Upstream this is not an implementation detail, it is the scheduling model
+(``agents/manager.ex``):
+
+    When you spawn a subagent, you must yield: commit your changes, release your
+    worktree, and wait. The subagent gets its own worktree. Once it completes, you
+    are re-queued. This is why "commit before delegating" is not just a rule -- it's
+    a fundamental requirement of the worktree scheduling model. If you don't commit,
+    your changes are invisible to subagents.
+
+and the architect's Phase 1 spells out the order: create the child directory and its
+``CONTEXT.md`` with ``make_dir`` (**auto-commits**), *then* spawn the subagent there.
+
+What this class makes real, and what it does not. The episode tree in this port is a
+pure function over a ``state`` dict, so isolation is not what keeps two siblings from
+corrupting each other -- they already branch from the same base by construction, and
+a test holds that. What a real repository adds is threefold, and none of it is
+ceremony:
+
+* **The phylogenetic graph becomes git history.** Every episode commits, and a parent
+  that merged three children leaves a three-parent merge commit. ``git log --graph``
+  over a rollout is the tree the paper draws, and ``phylo_graph_node.ex``'s
+  ``find_merge_base/2`` has something to find.
+* **"Commit before delegating" becomes checkable.** A child's base is a SHA, so
+  "the parent's uncommitted work is invisible to its children" is a property with a
+  witness rather than an assertion about a dict.
+* **The lifecycle is accounted.** Every worktree created is removed -- ``git worktree
+  remove --force``, which is the deletion the scheduling model requires -- and the
+  counters say so. A leak is a bug with a number attached.
+
+Costs about four git invocations per episode and is off unless ``--worktrees`` is
+given.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Dict, List, Mapping, Optional, Sequence
+
+from agentdescent.filetree import materialize
+
+from ._delegation import apply_edits as edited
+
+__all__ = ["Rollout", "WorktreeLedger", "edited", "git_worktrees_available"]
+
+
+def _git(*args: str, cwd: str) -> str:
+    out = subprocess.run(("git",) + args, cwd=cwd, check=True,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return out.stdout.decode("utf-8", "replace").strip()
+
+
+def git_worktrees_available() -> bool:
+    """``git worktree`` exists and works here. Checked once, cheaply."""
+    try:
+        probe = tempfile.mkdtemp(prefix="genesis-probe-")
+        try:
+            _git("init", "-q", probe, cwd=os.path.dirname(probe) or ".")
+            _git("worktree", "list", cwd=probe)
+            return True
+        finally:
+            shutil.rmtree(probe, ignore_errors=True)
+    except Exception:  # noqa: BLE001 - no git, or a git too old
+        return False
+
+
+class WorktreeLedger:
+    """What the lifecycle did, in numbers. Shared by every rollout of a run."""
+
+    def __init__(self) -> None:
+        self.created = 0
+        self.removed = 0
+        self.commits = 0
+        self.merge_commits = 0
+        self.max_parents = 0
+        self.failures = 0
+
+    @property
+    def leaked(self) -> int:
+        return self.created - self.removed
+
+    def summary(self) -> str:
+        return (f"worktrees={self.created} created/{self.removed} removed  "
+                f"commits={self.commits} (+{self.merge_commits} merges, "
+                f"max parents {self.max_parents})"
+                + (f"  LEAKED={self.leaked}" if self.leaked else "")
+                + (f"  git_failures={self.failures}" if self.failures else ""))
+
+
+class Rollout:
+    """One repository for one rollout: a commit per episode, a worktree per commit.
+
+    Used as a context manager so the repository is gone when the rollout is, which
+    is the whole point of a transient agent's workspace.
+    """
+
+    def __init__(self, ledger: WorktreeLedger, *, root: Optional[str] = None,
+                 branch_prefix: str = "genesis") -> None:
+        self._ledger = ledger
+        self._branch = branch_prefix
+        self._repo = tempfile.mkdtemp(prefix="genesis-world-", dir=root)
+        self._trees = os.path.join(self._repo, ".worktrees")
+        _git("init", "-q", "-b", "main", self._repo, cwd=os.path.dirname(self._repo))
+        _git("config", "user.email", "genesis@example.invalid", cwd=self._repo)
+        _git("config", "user.name", "Genesis", cwd=self._repo)
+        # A root commit over the empty tree: `git worktree add` needs a commit to
+        # start from, and the first episode of a formation run starts from nothing.
+        self._empty = _git("commit-tree", _git("mktree", cwd=self._repo),
+                           "-m", "empty world", cwd=self._repo)
+        _git("update-ref", "refs/heads/main", self._empty, cwd=self._repo)
+
+    # -- the lifecycle -----------------------------------------------------
+
+    def commit(self, agent_id: str, state: Mapping[str, str], message: str,
+               parents: Sequence[str] = ()) -> str:
+        """Stage ``state`` in a worktree of this agent's own, commit it, remove it.
+
+        The three steps the scheduling model names, in order, every time: a worktree
+        to work in, a commit so the work is visible to anyone branching from it, and
+        the worktree released so the next agent can be scheduled.
+        """
+        path = self._add(agent_id, parents[0] if parents else None)
+        try:
+            for name in os.listdir(path):
+                if name != ".git":
+                    target = os.path.join(path, name)
+                    shutil.rmtree(target) if os.path.isdir(target) else os.remove(target)
+            materialize(state, path)
+            _git("add", "-A", cwd=path)
+            tree = _git("write-tree", cwd=path)
+            args = ["commit-tree", tree]
+            for parent in parents:
+                args += ["-p", parent]
+            sha = _git(*args, "-m", message, cwd=path)
+            # A branch per agent, as upstream commits to `evogit-agent-*`: without a
+            # ref the commit is unreachable and the graph it belongs to is not there.
+            _git("update-ref", f"refs/heads/{self._branch}/{agent_id}", sha,
+                 cwd=self._repo)
+            self._ledger.commits += 1
+            if len(parents) > 1:
+                self._ledger.merge_commits += 1
+            self._ledger.max_parents = max(self._ledger.max_parents, len(parents))
+            return sha
+        finally:
+            self._release(path)
+
+    def history(self) -> List[str]:
+        """``sha parents subject`` per commit, newest first -- the graph, as text."""
+        try:
+            out = _git("log", "--all", "--format=%h %p %s", cwd=self._repo)
+        except Exception:  # noqa: BLE001 - nothing committed yet
+            return []
+        return [line for line in out.splitlines() if line.strip()]
+
+    def close(self) -> None:
+        shutil.rmtree(self._repo, ignore_errors=True)
+
+    def __enter__(self) -> "Rollout":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    # -- internals ---------------------------------------------------------
+
+    def _add(self, agent_id: str, base: Optional[str]) -> str:
+        """``git worktree add`` off ``base``, or off an empty tree for the first one."""
+        path = os.path.join(self._trees, agent_id)
+        _git("worktree", "add", "--detach", "-f", path, base or self._empty,
+             cwd=self._repo)
+        self._ledger.created += 1
+        return path
+
+    def _release(self, path: str) -> None:
+        try:
+            _git("worktree", "remove", "--force", path, cwd=self._repo)
+        except Exception:  # noqa: BLE001 - fall back to the filesystem
+            shutil.rmtree(path, ignore_errors=True)
+            try:
+                _git("worktree", "prune", cwd=self._repo)
+            except Exception:  # noqa: BLE001
+                self._ledger.failures += 1
+        self._ledger.removed += 1

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -65,6 +65,15 @@ CONTEXT_FILE = "CONTEXT.md"
 #: a node later agents cannot find. Matched case-insensitively because upstream's
 #: own tree writes both "Routing Table" and "Routing table".
 ROUTING_HEADING = "## Routing Table"
+#: Upstream's four standard ``CONTEXT.md`` sections, in its order
+#: (``agents/manager.ex``, ``agents/context_extractor.ex``, ``prompt_fragments.ex``):
+#: "The standard four sections (Intent, API Surface, Constraints, Routing Table) are
+#: the foundation." ``API Surface`` was missing from this port's records, on a domain
+#: whose entire failure mode was a wrong public surface.
+STANDARD_SECTIONS = ("## Intent", "## API Surface", "## Constraints", ROUTING_HEADING)
+#: And the supplementary one this port writes into: "`## Known Issues` (problems to
+#: avoid re-discovering)".
+KNOWN_ISSUES = "## Known Issues"
 
 #: Per-node reusable knowledge. The paper lists it among what an accepted version
 #: carries -- "source files, path-specific context, constraints, validation
@@ -108,6 +117,25 @@ def parse_routing(body: str) -> List[str]:
             if path and path not in out:
                 out.append(path)
     return out
+
+
+def under_heading(body: str, heading: str, line: str) -> str:
+    """``body`` with ``line`` appended under ``heading``, creating it if need be.
+
+    Upstream keeps its findings in named sections rather than at the bottom of the
+    file, because the next agent reads the section and not the whole record.
+    """
+    lines = (body or "").splitlines()
+    for i, existing in enumerate(lines):
+        if existing.strip().lower() == heading.lower():
+            j = i + 1
+            while j < len(lines) and not lines[j].strip().startswith("## "):
+                j += 1
+            while j > i + 1 and not lines[j - 1].strip():
+                j -= 1
+            return "\n".join(lines[:j] + [line] + lines[j:]).rstrip("\n") + "\n"
+    tail = "" if not lines or not lines[-1].strip() else "\n"
+    return (body or "").rstrip("\n") + tail + f"\n{heading}\n{line}\n"
 
 
 def routing_entry(body: str, path: str, note: str) -> Optional[str]:
@@ -337,7 +365,8 @@ class LocalWorld:
         return f"{self.path}/{CONTEXT_FILE}" if self.path else CONTEXT_FILE
 
     def situate(self, state: Mapping[str, str], *,
-                contracts: Sequence[str] = (), max_chars: int = 8_000) -> str:
+                contracts: Sequence[str] = (), per_file_chars: int = 65_536,
+                max_chars: int = 0) -> str:
         """The context an agent entering this world is given.
 
         Upstream (``EvoGit.Core.ContextNode.build_context/2``) walks root → path
@@ -373,13 +402,27 @@ class LocalWorld:
         first, and what gets trimmed is the contract block rather than whatever
         happens to be last -- the file listing at the end is the part that says
         "this node owns no file yet", which is the most actionable line in here.
+
+        The budget is upstream's too, and it was the other half of that bug.
+        ``ContextNode.build_context/2`` truncates **each file** at
+        ``truncation.context_max_bytes`` (default 65_536) and has no global cap at
+        all; this had one global 8_000-char cap, eight times tighter than upstream's
+        per-file one, which is why two files could crowd out a third. So
+        ``per_file_chars`` is the per-file cap, ``max_chars=0`` means no overall cap,
+        and the truncation marker is upstream's string.
         """
+        def clip(body: str) -> str:
+            body = body.strip()
+            if per_file_chars and len(body) > per_file_chars:
+                return body[:per_file_chars] + "\n" + TRUNCATED
+            return body
+
         chain: List[str] = []
         for node in self._chain():
             key = f"{node}/{CONTEXT_FILE}" if node else CONTEXT_FILE
             body = state.get(key)
             if body:
-                chain.append(f"--- {key} ---\n{body.strip()}")
+                chain.append(f"--- {key} ---\n{clip(body)}")
 
         contract = ""
         if contracts:
@@ -387,7 +430,7 @@ class LocalWorld:
             if given:
                 contract = ("--- the contract you are building against "
                             "(human-supplied, read-only) ---\n"
-                            + "\n\n".join(f"# {k}\n{state[k].strip()}" for k in given))
+                            + "\n\n".join(f"# {k}\n{clip(state[k])}" for k in given))
 
         parts: List[str] = []
         skills = self.skills(state)
@@ -409,13 +452,16 @@ class LocalWorld:
             + f"\n--- files below {self.path or './'} (each child's own) ---\n"
             + ("\n".join(f"  {k}" for k in below) or "  (none yet)"))
 
+        blocks = chain + ([contract] if contract else []) + parts
         fixed = "\n\n".join(chain + parts)
-        if not contract:
-            return fixed if len(fixed) <= max_chars else fixed[:max_chars] + "\n" + TRUNCATED
-        room = max_chars - len(fixed) - 2
-        if len(contract) > room:
-            contract = contract[:max(0, room - len(TRUNCATED) - 1)] + "\n" + TRUNCATED
-        text = "\n\n".join(chain + [contract] + parts)
+        if not max_chars:
+            return "\n\n".join(blocks)
+        if contract and len(fixed) + len(contract) + 2 > max_chars:
+            # An overall cap is a backstop, not upstream's behaviour. When it binds,
+            # the contract block gives -- never the file listing at the end.
+            room = max(0, max_chars - len(fixed) - 2 - len(TRUNCATED) - 1)
+            blocks = chain + [contract[:room] + "\n" + TRUNCATED] + parts
+        text = "\n\n".join(blocks)
         return text if len(text) <= max_chars else text[:max_chars] + "\n" + TRUNCATED
 
     def _chain(self) -> List[str]:

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -232,6 +232,25 @@ def resolve_edit_path(state: Mapping[str, str], owner: str,
     return nested, True
 
 
+def _in_pattern_order(state: Mapping[str, str],
+                      patterns: Sequence[str]) -> List[str]:
+    """The files matching ``patterns``, in the order the patterns are given.
+
+    Sorted by path is the obvious implementation and the wrong one: it makes which
+    contract an agent actually receives depend on filenames, under a budget that
+    cannot hold all of them. A domain lists its contract in order of importance.
+    """
+    from agentdescent.filetree import match_any
+
+    seen, out = set(), []
+    for pattern in patterns:
+        for key in sorted(state):
+            if key not in seen and match_any(key, (pattern,)):
+                seen.add(key)
+                out.append(key)
+    return out
+
+
 @dataclass(frozen=True)
 class LocalWorld:
     """One ``w = (v, p)``.
@@ -319,20 +338,35 @@ class LocalWorld:
         signature, against a specification that says ``("num", 1)`` and
         ``parse(source)``. Five correct files, every one of them to the wrong
         contract, and a suite stuck at 0.000.
+
+        Measured *again*, on md, after two things that each looked harmless: the
+        contract files were emitted in **sorted** order, and the whole context was
+        truncated from the end. md's frozen set is ``spec/**``, ``tests/**``,
+        ``md.py`` -- and ``md.py`` sorts first, is 6.8 kB of driver, and ate a
+        budget the 4.5 kB specification then never reached. The agents inferred the
+        public surface from the one failing test each was shown, dropped five of the
+        seven keyword parameters, and the run scored 0.750. So the order is the
+        **order the domain declares**, the specification first because it is listed
+        first, and what gets trimmed is the contract block rather than whatever
+        happens to be last -- the file listing at the end is the part that says
+        "this node owns no file yet", which is the most actionable line in here.
         """
-        parts: List[str] = []
+        chain: List[str] = []
         for node in self._chain():
             key = f"{node}/{CONTEXT_FILE}" if node else CONTEXT_FILE
             body = state.get(key)
             if body:
-                parts.append(f"--- {key} ---\n{body.strip()}")
+                chain.append(f"--- {key} ---\n{body.strip()}")
+
+        contract = ""
         if contracts:
-            from agentdescent.filetree import match_any
-            given = [k for k in sorted(state) if match_any(k, contracts)]
+            given = _in_pattern_order(state, contracts)
             if given:
-                parts.append("--- the contract you are building against "
-                             "(human-supplied, read-only) ---\n"
-                             + "\n\n".join(f"# {k}\n{state[k].strip()}" for k in given))
+                contract = ("--- the contract you are building against "
+                            "(human-supplied, read-only) ---\n"
+                            + "\n\n".join(f"# {k}\n{state[k].strip()}" for k in given))
+
+        parts: List[str] = []
         skills = self.skills(state)
         if skills:
             parts.append("--- skills available here (read one before using it) ---\n"
@@ -351,7 +385,14 @@ class LocalWorld:
                or "  (none yet -- this node owns no file)")
             + f"\n--- files below {self.path or './'} (each child's own) ---\n"
             + ("\n".join(f"  {k}" for k in below) or "  (none yet)"))
-        text = "\n\n".join(parts)
+
+        fixed = "\n\n".join(chain + parts)
+        if not contract:
+            return fixed if len(fixed) <= max_chars else fixed[:max_chars] + "\n" + TRUNCATED
+        room = max_chars - len(fixed) - 2
+        if len(contract) > room:
+            contract = contract[:max(0, room - len(TRUNCATED) - 1)] + "\n" + TRUNCATED
+        text = "\n\n".join(chain + [contract] + parts)
         return text if len(text) <= max_chars else text[:max_chars] + "\n" + TRUNCATED
 
     def _chain(self) -> List[str]:

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -49,6 +49,7 @@ __all__ = [
     "normalise",
     "owns",
     "parse_routing",
+    "resolve_edit_path",
     "routing_entry",
 ]
 
@@ -177,6 +178,48 @@ def child_paths(owner: str, paths: Sequence[str]) -> List[str]:
     return sorted(out)
 
 
+def resolve_edit_path(state: Mapping[str, str], owner: str,
+                      path: str) -> "Tuple[str, bool]":
+    """``(path, was_node_relative)`` -- which path an agent at ``owner`` meant.
+
+    An agent situated at ``src/frontend`` that writes ``lexer.py`` means
+    ``src/frontend/lexer.py``; one that writes ``src/__init__.py`` means exactly
+    that, and is asking for a change outside its own node. Both are ordinary, and
+    telling them apart is the difference between a file landing where it belongs
+    and a second copy of the project appearing at the repository root.
+
+    Measured, before this existed: a `deepseek-v4-flash` run produced
+    ``__init__.py`` and ``lexer.py`` from an agent at ``src/frontend``; read as
+    repository-relative they fell outside its subtree, became requests, and the
+    root -- which has authority everywhere -- wrote them at the top level. Four
+    files of real work landed in the wrong place and the suite stayed at 0.000.
+
+    The rule, in order, so that a genuine cross-node request is never mangled
+    into a nested copy of its own path:
+
+    1. already inside ``owner`` -- take it as written;
+    2. ``owner/path`` exists in the tree -- the agent is editing its own file;
+    3. ``path`` exists, or its first segment is an existing top-level entry --
+       repository-relative, and therefore a request about someone else's node;
+    4. ``owner/path`` is new and ``path``'s first segment is unknown -- a bare
+       filename or a path below this node, so node-relative;
+    5. anything else -- repository-relative.
+    """
+    owner, path = normalise(owner), normalise(path)
+    if not path:
+        return path, False
+    if owns(owner, path) or not owner:
+        return path, False
+    nested = f"{owner}/{path}"
+    if nested in state:
+        return nested, True
+    head = path.split("/", 1)[0]
+    top = {key.split("/", 1)[0] for key in state}
+    if path in state or head in top:
+        return path, False
+    return nested, True
+
+
 @dataclass(frozen=True)
 class LocalWorld:
     """One ``w = (v, p)``.
@@ -239,7 +282,8 @@ class LocalWorld:
         """This node's own ``CONTEXT.md`` path."""
         return f"{self.path}/{CONTEXT_FILE}" if self.path else CONTEXT_FILE
 
-    def situate(self, state: Mapping[str, str], *, max_chars: int = 8_000) -> str:
+    def situate(self, state: Mapping[str, str], *,
+                contracts: Sequence[str] = (), max_chars: int = 8_000) -> str:
         """The context an agent entering this world is given.
 
         Upstream (``EvoGit.Core.ContextNode.build_context/2``) walks root → path
@@ -248,6 +292,21 @@ class LocalWorld:
         files it is responsible for -- an executor cannot edit what it cannot
         see, and handing it the whole tree is what the path coordinate exists to
         avoid.
+
+        ``contracts`` is the part that is *not* optional, and leaving it out was a
+        straight misreading of the paper: "An agent may inspect the complete
+        project represented by v, but it begins from p" (3.1). The chain is where
+        an agent **begins**, not a wall around what it may read. Upstream it would
+        open the specification with a read tool; an agent here has no tools, so
+        the human-supplied contract travels in the brief or it is invisible.
+
+        Measured before this existed: the language specification sat at
+        ``spec/CONTEXT.md`` -- a sibling of ``src/``, so on nobody's chain -- and
+        every agent inferred the whole language from one failing input. They built
+        a coherent toolchain with ``('NUMBER', '1')`` tokens and a ``parse(tokens)``
+        signature, against a specification that says ``("num", 1)`` and
+        ``parse(source)``. Five correct files, every one of them to the wrong
+        contract, and a suite stuck at 0.000.
         """
         parts: List[str] = []
         for node in self._chain():
@@ -255,6 +314,13 @@ class LocalWorld:
             body = state.get(key)
             if body:
                 parts.append(f"--- {key} ---\n{body.strip()}")
+        if contracts:
+            from agentdescent.filetree import match_any
+            given = [k for k in sorted(state) if match_any(k, contracts)]
+            if given:
+                parts.append("--- the contract you are building against "
+                             "(human-supplied, read-only) ---\n"
+                             + "\n\n".join(f"# {k}\n{state[k].strip()}" for k in given))
         skills = self.skills(state)
         if skills:
             parts.append("--- skills available here (read one before using it) ---\n"

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -1,0 +1,279 @@
+"""``(v, p)``: the two coordinates Genesis situates an agent by, and the log of
+what the finite-lived agents did while they existed.
+
+The paper's whole model is one pair::
+
+    w = (v, p)          accepted version, repository-relative path
+
+``v`` is already the engine's: a ledger snapshot with a version vector. ``p`` has
+no counterpart at all -- a worker here holds the whole artifact and may write any
+key -- so it is defined in this module, and everything downstream (the spatial
+contract in :mod:`examples.genesis._spatial`, the recursion in
+:mod:`examples.genesis._delegation`) is written against it rather than against a
+path string passed around by hand.
+
+Two operations act on the pair, and they differ in exactly one way:
+
+``(v, p) ⇝ (v, q)``   recursive delegation -- the path moves, the version does not
+``(v, p) → (v′, p)``  an accepted event -- the version moves
+
+The first is the proposal policy's business and never touches the ledger; the
+second is the aggregator's commit. Keeping them apart is the reason this file
+exists: a delegation that advanced the version would make the recursion a
+sequence of commits, which is the serial system Genesis is defined against.
+
+:class:`WorldLog` is the other half. Agents are finite-lived by construction here
+-- a rollout ends and its Python objects are collected -- so the only way depth,
+episode counts and a parent's verdict survive the episode is to write them
+somewhere the run can read afterwards. That is what the archive is upstream, and
+the log is deliberately *not* part of the artifact: a record the agents could
+edit is not evidence about them.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "CONTEXT_FILE",
+    "EpisodeRecord",
+    "LocalWorld",
+    "WorldLog",
+    "child_paths",
+    "normalise",
+    "owns",
+]
+
+#: The per-directory context record. Version-controlled, so it is part of ``v``
+#: and a later agent inherits it -- which is the point: it is how a rejected
+#: attempt leaves something behind (paper, appendix 1.4).
+CONTEXT_FILE = "CONTEXT.md"
+
+
+def normalise(path: str) -> str:
+    """Canonical prefix form: ``"./"``, ``"."``, ``"src/"`` and ``"src"`` agree.
+
+    The root is the empty string rather than ``"."`` so that ``owns`` and
+    ``startswith`` need no special case, and so a stray ``"./"`` from a model
+    reply cannot become a directory literally named ``.``.
+    """
+    p = (path or "").strip().replace("\\", "/").strip("/")
+    while p.startswith("./"):
+        p = p[2:]
+    return "" if p in ("", ".") else p
+
+
+def owns(owner: str, path: str) -> bool:
+    """Does an agent situated at ``owner`` have authority over ``path``?
+
+    The root owns everything; any other node owns its own subtree and nothing
+    else. This is the whole spatial contract -- everything in ``_spatial.py`` is
+    the enforcement of this one predicate.
+    """
+    owner = normalise(owner)
+    path = normalise(path)
+    return owner == "" or path == owner or path.startswith(owner + "/")
+
+
+def child_paths(owner: str, paths: Sequence[str]) -> List[str]:
+    """The immediate sub-directories of ``owner`` present in ``paths``.
+
+    What a manager can delegate *to* without inventing a decomposition: the
+    routing table of the node it is standing on.
+    """
+    owner = normalise(owner)
+    prefix = f"{owner}/" if owner else ""
+    out = set()
+    for path in paths:
+        path = normalise(path)
+        if not owns(owner, path) or path == owner:
+            continue
+        tail = path[len(prefix):]
+        if "/" in tail:
+            out.add(prefix + tail.split("/", 1)[0])
+    return sorted(out)
+
+
+@dataclass(frozen=True)
+class LocalWorld:
+    """One ``w = (v, p)``.
+
+    ``version`` is carried for the record only -- the engine stamps the real
+    version vector onto the diff -- but a world without it is not the paper's
+    object, and the delegation log is unreadable without knowing which version a
+    depth-3 executor was standing on.
+    """
+
+    version: int
+    path: str = ""
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", normalise(self.path))
+
+    def delegate(self, q: str) -> "LocalWorld":
+        """``(v, p) ⇝ (v, q)`` -- the path moves, the version does not.
+
+        Refuses to leave the subtree: a parent may only situate a child *below*
+        itself, or the contract its own parent is enforcing is unenforceable one
+        level down.
+        """
+        q = normalise(q)
+        if not owns(self.path, q):
+            raise ValueError(
+                f"delegation must stay inside the parent's subtree: "
+                f"{self.path or './'} cannot situate a child at {q or './'}")
+        return LocalWorld(version=self.version, path=q)
+
+    def situate(self, state: Mapping[str, str], *, max_chars: int = 8_000) -> str:
+        """The context an agent entering this world is given.
+
+        Upstream (``EvoGit.Core.ContextNode.build_context/2``) walks root → path
+        and concatenates each directory's ``CONTEXT.md``; the agent inherits the
+        chain, not just its own node. Reproduced here, plus a listing of the
+        files it is responsible for -- an executor cannot edit what it cannot
+        see, and handing it the whole tree is what the path coordinate exists to
+        avoid.
+        """
+        parts: List[str] = []
+        for node in self._chain():
+            key = f"{node}/{CONTEXT_FILE}" if node else CONTEXT_FILE
+            body = state.get(key)
+            if body:
+                parts.append(f"--- {key} ---\n{body.strip()}")
+        mine = sorted(p for p in state if owns(self.path, p))
+        listing = "\n".join(f"  {p} ({len(state[p])} bytes)" for p in mine) or "  (empty)"
+        parts.append(f"--- files under {self.path or './'} ---\n{listing}")
+        text = "\n\n".join(parts)
+        return text if len(text) <= max_chars else text[:max_chars] + "\n... [truncated]"
+
+    def _chain(self) -> List[str]:
+        """Root first, this node last -- the inheritance order upstream uses."""
+        if not self.path:
+            return [""]
+        nodes, acc = [""], ""
+        for part in self.path.split("/"):
+            acc = f"{acc}/{part}" if acc else part
+            nodes.append(acc)
+        return nodes
+
+
+@dataclass
+class EpisodeRecord:
+    """One finite-lived agent, after it has ceased to exist.
+
+    ``verdict`` is the responsible parent's, not the gate's: upstream the parent
+    decides accept / reject / request-more-work on the returned contribution, and
+    only what survives that is offered to the version history at all.
+    """
+
+    agent_id: str
+    role: str                    # "manager" | "executor"
+    path: str
+    depth: int
+    version: int
+    objective: str = ""
+    verdict: str = "accepted"    # "accepted" | "rejected" | "rework"
+    n_edits: int = 0
+    reason: str = ""
+
+
+class WorldLog:
+    """The archive: episodes, and the rework a parent asked for and did not get.
+
+    Thread-safe because the engine's workers are threads and every one of them
+    runs its own recursion into the same log.
+
+    ``rework`` is how "request more work" survives a boundary the engine has no
+    third outcome for. :class:`~agentdescent.policies.AcceptDecision` is a
+    boolean, so a parent's *not yet* is recorded here and read by the next
+    round's manager, which re-delegates to that path instead of choosing freely.
+    That is the upstream behaviour reconstructed out of parts the engine already
+    has -- not the engine growing a third verdict.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._episodes: List[EpisodeRecord] = []
+        self._rework: Dict[str, str] = {}
+        self._contract_violations = 0
+        self._counter = 0
+
+    # -- episodes ----------------------------------------------------------
+
+    def next_id(self, role: str) -> str:
+        with self._lock:
+            self._counter += 1
+            return f"{role[0].upper()}{self._counter:04d}"
+
+    def record(self, episode: EpisodeRecord) -> EpisodeRecord:
+        with self._lock:
+            self._episodes.append(episode)
+        return episode
+
+    @property
+    def episodes(self) -> List[EpisodeRecord]:
+        with self._lock:
+            return list(self._episodes)
+
+    def observed_depth(self) -> int:
+        """The deepest episode actually run -- the number upstream reports (4/5/8).
+
+        Observed, not configured: a ``--depth 8`` run whose managers never
+        delegate that far reports what happened, which is the only version of
+        this number worth comparing with a paper.
+        """
+        with self._lock:
+            return max((e.depth for e in self._episodes), default=0)
+
+    def verdicts(self) -> Dict[str, int]:
+        out: Dict[str, int] = {}
+        for episode in self.episodes:
+            out[episode.verdict] = out.get(episode.verdict, 0) + 1
+        return out
+
+    # -- rework ------------------------------------------------------------
+
+    def request_rework(self, path: str, reason: str) -> None:
+        with self._lock:
+            self._rework[normalise(path)] = reason
+
+    def take_rework(self) -> Optional[Tuple[str, str]]:
+        """Pop one outstanding request, oldest first. ``None`` when there is none."""
+        with self._lock:
+            if not self._rework:
+                return None
+            path = next(iter(self._rework))
+            return path, self._rework.pop(path)
+
+    @property
+    def pending_rework(self) -> Dict[str, str]:
+        with self._lock:
+            return dict(self._rework)
+
+    # -- the spatial contract ---------------------------------------------
+
+    def note_contract_violation(self, n: int = 1) -> None:
+        with self._lock:
+            self._contract_violations += n
+
+    @property
+    def contract_violations(self) -> int:
+        """Edits dropped for escaping their author's subtree.
+
+        Counted rather than swallowed, for the reason the engine counts
+        ``section-violation``: a run whose proposals were all discarded and a run
+        whose agents had nothing to say look identical without it, and they need
+        opposite fixes.
+        """
+        with self._lock:
+            return self._contract_violations
+
+    def summary(self) -> str:
+        verdicts = self.verdicts()
+        return (f"episodes={len(self.episodes)}  depth={self.observed_depth()}  "
+                f"accepted={verdicts.get('accepted', 0)}  "
+                f"rejected={verdicts.get('rejected', 0)}  "
+                f"rework={verdicts.get('rework', 0)}  "
+                f"contract_violations={self.contract_violations}")

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -493,6 +493,11 @@ class EpisodeRecord:
     verdict: str = "accepted"    # "accepted" | "rejected" | "rework"
     n_edits: int = 0
     reason: str = ""
+    #: The commit this episode left behind, when the run is using worktrees.
+    #: Upstream an agent "can always be resurrected from a (node_path, commit_sha,
+    #: objective) tuple" (``agents/manager.ex``) -- these three fields are that
+    #: tuple, and this is the field that was missing from it.
+    commit: str = ""
 
 
 class WorldLog:

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import re
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
 __all__ = [

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -263,6 +263,11 @@ class LocalWorld:
 
     version: int
     path: str = ""
+    #: Globs that are contract rather than work -- the frozen specification, the
+    #: suite, a frozen entry script. Carried on the world because it travels with
+    #: the brief, and :meth:`routing` must not send a manager into a directory
+    #: where nothing is writable.
+    readonly: Sequence[str] = ()
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "path", normalise(self.path))
@@ -279,7 +284,7 @@ class LocalWorld:
             raise ValueError(
                 f"delegation must stay inside the parent's subtree: "
                 f"{self.path or './'} cannot situate a child at {q or './'}")
-        return LocalWorld(version=self.version, path=q)
+        return LocalWorld(version=self.version, path=q, readonly=self.readonly)
 
     def routing(self, state: Mapping[str, str]) -> List[str]:
         """Where this node says work may be delegated to.
@@ -293,7 +298,25 @@ class LocalWorld:
         key = f"{self.path}/{CONTEXT_FILE}" if self.path else CONTEXT_FILE
         declared = [p for p in parse_routing(state.get(key, "")) if owns(self.path, p)
                     and normalise(p) != self.path]
-        return declared or child_paths(self.path, list(state))
+        if declared:
+            return declared
+        return [child for child in child_paths(self.path, list(state))
+                if not self._all_readonly(state, child)]
+
+    def _all_readonly(self, state: Mapping[str, str], child: str) -> bool:
+        """Is every file under ``child`` contract rather than work?
+
+        The fallback used to return any sub-directory, which was invisible while
+        every domain shipped a routing table at the root. Cold-started -- no tables
+        at all, which is the point of that mode -- the root's only sub-directories
+        are `spec/` and `tests/`, and a manager was duly sent to delegate into the
+        two directories it is forbidden to write.
+        """
+        if not self.readonly:
+            return False
+        from agentdescent.filetree import match_any
+        under = [key for key in state if owns(child, key)]
+        return bool(under) and all(match_any(key, self.readonly) for key in under)
 
     def skills(self, state: Mapping[str, str]) -> List[str]:
         """Skill files this node inherits, nearest ancestor last.

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -46,6 +46,7 @@ __all__ = [
     "TRUNCATED",
     "WorldLog",
     "child_paths",
+    "directly_at",
     "normalise",
     "owns",
     "parse_routing",
@@ -145,6 +146,17 @@ def normalise(path: str) -> str:
     while p.startswith("./"):
         p = p[2:]
     return "" if p in ("", ".") else p
+
+
+def directly_at(node: str, path: str) -> bool:
+    """Is ``path`` a file of ``node`` itself, rather than of one of its children?
+
+    The distinction upstream draws between what a manager delegates and what it
+    is directly responsible for writing.
+    """
+    node, path = normalise(node), normalise(path)
+    head = path.rsplit("/", 1)[0] if "/" in path else ""
+    return head == node
 
 
 def owns(owner: str, path: str) -> bool:
@@ -325,9 +337,20 @@ class LocalWorld:
         if skills:
             parts.append("--- skills available here (read one before using it) ---\n"
                          + "\n".join(f"  {k}" for k in skills))
-        mine = sorted(p for p in state if owns(self.path, p))
-        listing = "\n".join(f"  {p} ({len(state[p])} bytes)" for p in mine) or "  (empty)"
-        parts.append(f"--- files under {self.path or './'} ---\n{listing}")
+        # Split "mine" from "my children's". An agent is bad at noticing an
+        # absence inside a long list, and the absence is the actionable part:
+        # a node that owns no file yet says so on its own line.
+        own, below = [], []
+        for key in sorted(state):
+            if not owns(self.path, key):
+                continue
+            (own if directly_at(self.path, key) else below).append(key)
+        parts.append(
+            f"--- files AT {self.path or './'} (yours to write) ---\n"
+            + ("\n".join(f"  {k} ({len(state[k])} bytes)" for k in own)
+               or "  (none yet -- this node owns no file)")
+            + f"\n--- files below {self.path or './'} (each child's own) ---\n"
+            + ("\n".join(f"  {k}" for k in below) or "  (none yet)"))
         text = "\n\n".join(parts)
         return text if len(text) <= max_chars else text[:max_chars] + "\n" + TRUNCATED
 

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -42,6 +42,8 @@ __all__ = [
     "EpisodeRecord",
     "LocalWorld",
     "ROUTING_HEADING",
+    "SKILLS_DIR",
+    "TRUNCATED",
     "WorldLog",
     "child_paths",
     "normalise",
@@ -61,6 +63,19 @@ CONTEXT_FILE = "CONTEXT.md"
 #: a node later agents cannot find. Matched case-insensitively because upstream's
 #: own tree writes both "Routing Table" and "Routing table".
 ROUTING_HEADING = "## Routing Table"
+
+#: Per-node reusable knowledge. The paper lists it among what an accepted version
+#: carries -- "source files, path-specific context, constraints, validation
+#: results, reusable skills and provenance records" (3.1) -- and upstream loads it
+#: the same way it loads Context: along the chain, so a node inherits its
+#: ancestors' skills (``EvoGit.Skills.hierarchical_skill_names/2``).
+SKILLS_DIR = ".agents/skills"
+
+#: Upstream's exact marker. It is not decoration: a CONTEXT.md that comes back
+#: carrying it is telling the agent the file exceeded the per-file limit and
+#: needs pruning, which is the maintenance obligation that keeps these files
+#: "current state, not history".
+TRUNCATED = "... [Content Truncated] ..."
 
 _ROUTE_LINE = re.compile(
     r"""^\s*[-*]\s*          # a markdown list item
@@ -206,6 +221,20 @@ class LocalWorld:
                     and normalise(p) != self.path]
         return declared or child_paths(self.path, list(state))
 
+    def skills(self, state: Mapping[str, str]) -> List[str]:
+        """Skill files this node inherits, nearest ancestor last.
+
+        Names only reach the brief, not bodies: upstream hands an agent the skill
+        *names* available at its node and lets it read the ones it wants, because
+        pasting every ancestor's skills into every episode is how a context
+        window is spent on things nobody asked for.
+        """
+        out: List[str] = []
+        for node in self._chain():
+            prefix = f"{node}/{SKILLS_DIR}/" if node else f"{SKILLS_DIR}/"
+            out += sorted(k for k in state if k.startswith(prefix))
+        return out
+
     def context_key(self) -> str:
         """This node's own ``CONTEXT.md`` path."""
         return f"{self.path}/{CONTEXT_FILE}" if self.path else CONTEXT_FILE
@@ -226,11 +255,15 @@ class LocalWorld:
             body = state.get(key)
             if body:
                 parts.append(f"--- {key} ---\n{body.strip()}")
+        skills = self.skills(state)
+        if skills:
+            parts.append("--- skills available here (read one before using it) ---\n"
+                         + "\n".join(f"  {k}" for k in skills))
         mine = sorted(p for p in state if owns(self.path, p))
         listing = "\n".join(f"  {p} ({len(state[p])} bytes)" for p in mine) or "  (empty)"
         parts.append(f"--- files under {self.path or './'} ---\n{listing}")
         text = "\n\n".join(parts)
-        return text if len(text) <= max_chars else text[:max_chars] + "\n... [truncated]"
+        return text if len(text) <= max_chars else text[:max_chars] + "\n" + TRUNCATED
 
     def _chain(self) -> List[str]:
         """Root first, this node last -- the inheritance order upstream uses."""

--- a/examples/genesis/_world.py
+++ b/examples/genesis/_world.py
@@ -32,6 +32,7 @@ edit is not evidence about them.
 
 from __future__ import annotations
 
+import re
 import threading
 from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple
@@ -40,16 +41,81 @@ __all__ = [
     "CONTEXT_FILE",
     "EpisodeRecord",
     "LocalWorld",
+    "ROUTING_HEADING",
     "WorldLog",
     "child_paths",
     "normalise",
     "owns",
+    "parse_routing",
+    "routing_entry",
 ]
 
 #: The per-directory context record. Version-controlled, so it is part of ``v``
 #: and a later agent inherits it -- which is the point: it is how a rejected
 #: attempt leaves something behind (paper, appendix 1.4).
 CONTEXT_FILE = "CONTEXT.md"
+
+#: The section of a ``CONTEXT.md`` that says which child nodes exist and what
+#: each is for. Upstream this is not documentation: it is **how a manager knows
+#: where it may delegate**, and a node created without an entry at its parent is
+#: a node later agents cannot find. Matched case-insensitively because upstream's
+#: own tree writes both "Routing Table" and "Routing table".
+ROUTING_HEADING = "## Routing Table"
+
+_ROUTE_LINE = re.compile(
+    r"""^\s*[-*]\s*          # a markdown list item
+        `?\s*(?P<path>\.?/?[A-Za-z0-9._\-/]+?)\s*/?`?\s*   # the path, backticks optional
+        (?:$|[-=]+>|\u2192|:)  # end of line, '->', an arrow, or a colon
+    """, re.VERBOSE)
+
+
+def parse_routing(body: str) -> List[str]:
+    """The child paths a ``CONTEXT.md`` routes to, in the order it lists them.
+
+    Only the routing section is read: a path mentioned in prose is a mention,
+    and treating it as a route would let any sentence create authority.
+    """
+    if not body:
+        return []
+    lines, out, inside = body.splitlines(), [], False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("##"):
+            inside = stripped.lower().startswith(ROUTING_HEADING.lower())
+            continue
+        if not inside:
+            continue
+        match = _ROUTE_LINE.match(line)
+        if match:
+            path = normalise(match.group("path"))
+            if path and path not in out:
+                out.append(path)
+    return out
+
+
+def routing_entry(body: str, path: str, note: str) -> Optional[str]:
+    """``body`` with ``path`` added to its routing table, or ``None`` if listed.
+
+    Idempotent on purpose. Upstream's rule for these files is *current state, not
+    history* -- a routing table that grows an entry every time a manager passes
+    through is a transcript, which is the one thing it must not become.
+    """
+    path = normalise(path)
+    if not path or path in parse_routing(body):
+        return None
+    line = f"- `./{path}/` -> {note}"
+    lines = (body or "").splitlines()
+    for i, existing in enumerate(lines):
+        if existing.strip().lower().startswith(ROUTING_HEADING.lower()):
+            j = i + 1
+            while j < len(lines) and not lines[j].strip().startswith("##"):
+                j += 1
+            while j > i + 1 and not lines[j - 1].strip():
+                j -= 1
+            lines.insert(j, line)
+            return "\n".join(lines) + "\n"
+    tail = "" if not lines or not lines[-1].strip() else "\n"
+    return "\n".join(lines) + tail + f"\n{ROUTING_HEADING}\n\n{line}\n"
 
 
 def normalise(path: str) -> str:
@@ -126,6 +192,24 @@ class LocalWorld:
                 f"{self.path or './'} cannot situate a child at {q or './'}")
         return LocalWorld(version=self.version, path=q)
 
+    def routing(self, state: Mapping[str, str]) -> List[str]:
+        """Where this node says work may be delegated to.
+
+        Its own ``CONTEXT.md`` routing table first -- upstream that table is the
+        mechanism, not documentation: a manager delegates to the paths its node
+        routes to. Falling back to the sub-directories that actually exist keeps
+        a node without a table usable rather than sterile, which matters on the
+        first episodes of a repository that has almost no ``CONTEXT.md`` yet.
+        """
+        key = f"{self.path}/{CONTEXT_FILE}" if self.path else CONTEXT_FILE
+        declared = [p for p in parse_routing(state.get(key, "")) if owns(self.path, p)
+                    and normalise(p) != self.path]
+        return declared or child_paths(self.path, list(state))
+
+    def context_key(self) -> str:
+        """This node's own ``CONTEXT.md`` path."""
+        return f"{self.path}/{CONTEXT_FILE}" if self.path else CONTEXT_FILE
+
     def situate(self, state: Mapping[str, str], *, max_chars: int = 8_000) -> str:
         """The context an agent entering this world is given.
 
@@ -198,6 +282,7 @@ class WorldLog:
         self._episodes: List[EpisodeRecord] = []
         self._rework: Dict[str, str] = {}
         self._contract_violations = 0
+        self._shape_violations = 0
         self._counter = 0
 
     # -- episodes ----------------------------------------------------------
@@ -258,6 +343,21 @@ class WorldLog:
         with self._lock:
             self._contract_violations += n
 
+    def note_shape_violation(self, n: int = 1) -> None:
+        with self._lock:
+            self._shape_violations += n
+
+    @property
+    def shape_violations(self) -> int:
+        """Edits dropped for making the key space stop being a tree.
+
+        Separate from ``contract_violations`` because they need opposite fixes:
+        one is an agent writing outside its authority, the other is an agent
+        mistaking a file for a node.
+        """
+        with self._lock:
+            return self._shape_violations
+
     @property
     def contract_violations(self) -> int:
         """Edits dropped for escaping their author's subtree.
@@ -276,4 +376,5 @@ class WorldLog:
                 f"accepted={verdicts.get('accepted', 0)}  "
                 f"rejected={verdicts.get('rejected', 0)}  "
                 f"rework={verdicts.get('rework', 0)}  "
-                f"contract_violations={self.contract_violations}")
+                f"contract_violations={self.contract_violations}  "
+                f"shape_violations={self.shape_violations}")

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -310,6 +310,7 @@ def main(argv=None) -> None:
         completion = CompletionJudge(
             complete, tasks=tasks, run=run, reward=spec.reward,
             state_of=lambda: delegation.last_state, contracts=spec.CONTRACTS,
+            suite_failures=getattr(spec, "suite_failures", None),
             objective=DOMAIN_BLURB[args.domain])
 
     def _superseded(rendered, task, output, reward_):
@@ -341,6 +342,18 @@ def main(argv=None) -> None:
         **budget_kwargs(args),
     )
 
+    # The whole suite in one process, which is what `mix test` is. A per-task score
+    # cannot see one test poisoning the next: this run's own output is the example,
+    # 65/65 per test and five failures in one interpreter, from a function that
+    # rebound its own name on first call.
+    whole = getattr(spec, "suite_failures", None)
+    if whole is not None and delegation.last_state is not None:
+        failures = whole(result.state if isinstance(result.state, dict)
+                         else dict(result.state), audit=True)
+        print(f"suite, 1 process: {len(tasks) - len(failures)}/{len(tasks)}"
+              + ("" if not failures else
+                 "   <- these pass one-per-process and fail together:\n    "
+                 + "\n    ".join(failures[:6])))
     label = "audit reward" if audited else "held-out reward"
     print(f"{label:<16}: {result.final_reward:.3f}"
           + ("   (tests no agent ever saw)" if audited else ""))

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -21,9 +21,12 @@ Preserved from that revision:
 * The responsible parent's verdict -- accept / reject / ask again -- with
   upstream's monotone rule, *partial progress is accepted*
   (:mod:`examples.genesis._judge`, upstream ``agents/manager.ex:58``).
-* The ``CONTEXT.md`` chain is part of the accepted version and is what an
-  entering agent is given; a refusal is recorded there even though the refused
-  code is not (paper, appendix 1.4).
+* ``CONTEXT.md`` is part of the accepted version, in both directions: the chain
+  from the root down is what an entering agent is given, its **routing table is
+  where a manager may delegate**, a manager that opens an unrouted node records
+  it at its own level, and a refusal is written there even though the refused
+  code is not (paper, appendix 1.4; upstream ``core/context_node.ex`` and the
+  routing-table clauses of ``agents/prompt_fragments.ex``).
 * Human-supplied validation stays human-supplied: ``spec/**`` is frozen to every
   proposal and restored pristine before scoring.
 
@@ -56,6 +59,13 @@ Intentional differences
   enforced in the strategy instead, where creation is free.
 * **Depth is 2-3 here, 4-8 upstream**, because the domain is three nodes deep.
   The number reported is the depth *observed*, never the depth configured.
+* **Only the routing table is maintained automatically.** Upstream every
+  ``:read_write`` agent keeps its node's ``CONTEXT.md`` current -- intent, API
+  surface, known issues -- and the read-only roles exist to do nothing else. Here
+  the two writes an agent makes on its own are the routing entry for a node it
+  opened and the refusal note for a child it rejected; an LLM executor may write
+  more, and nothing requires it to. Skills (``.agents/skills/``) are not loaded
+  at all.
 * **Multi-repository work, the desktop shell and the dashboard are out of scope.**
   Upstream's task-level accept is a human action on that dashboard
   (``EvoGit.Review.merge_branch/2,3``); here the task-level gate is the
@@ -206,7 +216,9 @@ def main(argv=None) -> None:
     print(f"stop reason     : {result.stop_reason}")
     print(f"error           : {result.error or 'none'}")
     print(f"world           : root episodes={result.rollouts}  {log.summary()}  "
-          f"truncated_edits={delegation.truncated}")
+          f"truncated_edits={delegation.truncated}  "
+          f"routes_opened={delegation.routes_opened}  "
+          f"mistaken_nodes={delegation.mistaken_nodes}")
     if octopus is not None:
         print(f"merge           : merged={octopus.merged} conflicted={octopus.conflicted}")
     if not args.engine_gate:

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -184,7 +184,7 @@ def main(argv=None) -> None:
         manager=llm_manager(complete) if complete else offline_manager,
         executor=(llm_executor(complete, frozen=FROZEN) if complete
                   else offline_executor),
-        log=log, max_depth=args.depth, max_edits=4,
+        log=log, max_depth=args.depth, max_edits=4, contracts=FROZEN,
         # The parent's own test run, inside the episode, on one child's work --
         # the half of the upstream rule the acceptance gate cannot see.
         review=None if args.no_parent_tests else suite_review(tasks))
@@ -231,7 +231,8 @@ def main(argv=None) -> None:
     print(f"parent          : sibling_merges={delegation.sibling_merges}  "
           f"sibling_conflicts={delegation.sibling_conflicts}  "
           f"requests raised/handled/unmet={delegation.requests_raised}/"
-          f"{delegation.adopted_requests}/{delegation.unmet_requests}")
+          f"{delegation.adopted_requests}/{delegation.unmet_requests}  "
+          f"node_relative_paths={delegation.resolved_relative}")
     if octopus is not None:
         print(f"merge           : merged={octopus.merged} conflicted={octopus.conflicted}")
     if not args.engine_gate:

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -1,0 +1,226 @@
+"""EvoX Genesis -- persistent recursive worlds, on the AgentDescent engine.
+
+Upstream reference
+------------------
+Paper: *Persistent Recursive Worlds Enable Autonomous Software Evolution*,
+Beichen Huang, Zhenyu Liang, Bowen Zheng, Ran Cheng (arXiv:2608.10450v3).
+Repository: https://github.com/EMI-Group/genesis (v0.12.6, AGPL-3.0, Elixir).
+
+Preserved from that revision:
+
+* ``w = (v, p)`` -- an agent is situated by an accepted version and a
+  repository-relative path (:mod:`examples.genesis._world`).
+* ``(v, p) ⇝ (v, q)`` -- recursive delegation moves the path and **not** the
+  version; only an accepted event advances the project
+  (:mod:`examples.genesis._delegation`).
+* The spatial contract: an agent writes only inside its own subtree
+  (:mod:`examples.genesis._spatial`).
+* The parent merges what its children return with a three-way merge, so two
+  children editing different parts of one file both survive
+  (:mod:`examples.genesis._octopus`, upstream ``Git.merge_octopus/2``).
+* The responsible parent's verdict -- accept / reject / ask again -- with
+  upstream's monotone rule, *partial progress is accepted*
+  (:mod:`examples.genesis._judge`, upstream ``agents/manager.ex:58``).
+* The ``CONTEXT.md`` chain is part of the accepted version and is what an
+  entering agent is given; a refusal is recorded there even though the refused
+  code is not (paper, appendix 1.4).
+* Human-supplied validation stays human-supplied: ``spec/**`` is frozen to every
+  proposal and restored pristine before scoring.
+
+Intentional differences
+-----------------------
+* **The benchmark is not reproduced, and is not claimed.** Upstream's formation
+  run is 123.4 h, US$44.38 and one sample; its continuation and MESA runs are one
+  sample each. This port runs a compact formation domain that finishes offline
+  (:mod:`examples.genesis._domain`) and reports only what that measures.
+* **Acceptance is upstream's, and the engine's is the control arm.** The port
+  runs the parent's monotone rule because ``docs/port-fidelity.md`` puts the
+  acceptance rule in the *must not change* column; ``--engine-gate`` swaps in the
+  shipped Beta posterior so the two can be compared. On this domain they are not
+  interchangeable, and the page says why: a formation run's first steps are
+  structure, structure moves no case, and a gate that requires a measured
+  improvement never lets the run start.
+* **"Request more work" is reconstructed, not native.** ``AcceptDecision`` is a
+  boolean whose ``category`` is a closed vocabulary, so a parent's *not yet*
+  becomes an accepted partial step plus a request the next round's manager
+  re-delegates from.
+* **The world is L2, not L1.** The audit gate runs *before* acceptance and, above
+  ``FAST_MAX``, vetoes every candidate that does not strictly improve -- which
+  contradicts "partial progress is accepted". The reason the artifact can honestly
+  sit at L2 is that the agents cannot reach the evaluator at all: the suite, its
+  expectations and the harness that runs them live outside the artifact, and
+  ``spec/**`` is refused to every proposal and restored pristine before scoring.
+* **Tensor parallelism is refused rather than used.** TP's ownership map is fixed
+  before round 0 and a key outside it is a violation, so every newly created file
+  would be discarded -- and creating files is what formation *is*. The contract is
+  enforced in the strategy instead, where creation is free.
+* **Depth is 2-3 here, 4-8 upstream**, because the domain is three nodes deep.
+  The number reported is the depth *observed*, never the depth configured.
+* **Multi-repository work, the desktop shell and the dashboard are out of scope.**
+  Upstream's task-level accept is a human action on that dashboard
+  (``EvoGit.Review.merge_branch/2,3``); here the task-level gate is the
+  aggregator, and the parent's judging is the part that runs inside an episode.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from agentdescent import Policies, evolve
+from agentdescent.evolution import EvolvingArtifact
+from agentdescent.agents import Usage
+from agentdescent.governance import SKILL_BLAST_RADIUS, classify
+from examples._common import (add_standard_args, budget_kwargs, completion_for,
+                              confirm, report_engine, score_tasks, worker_count)
+
+from ._delegation import RecursiveDelegation
+from ._domain import (FROZEN, build_tasks, initial_files, llm_executor,
+                      llm_manager, make_runner, offline_executor,
+                      offline_manager, reward)
+from ._judge import ParentJudge
+from ._octopus import OctopusConflict, git_available
+from ._spatial import SpatialContract
+from ._world import WorldLog
+
+PORT_NAME = "EvoX Genesis (persistent recursive worlds)"
+PORT_AUTHOR = "chendanyang"
+UPSTREAM_RELEASED_CODE = "https://github.com/EMI-Group/genesis @ v0.12.6"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    add_standard_args(
+        parser, model_default=None, max_seconds_default=120.0,
+        model_help=("optional: let a model be the manager and executor agents "
+                    "(else rule-based offline actors -- see examples/genesis/_domain.py)"))
+    # Upstream's unit is the agent episode ("1,019 archived agent episodes"), not
+    # a round or a generation, so that is the flag -- and because a root episode
+    # is one rollout it is already the rollout budget, which is why `--workers`
+    # divides it rather than multiplying it.
+    parser.add_argument("--episodes", type=int, default=24,
+                        help="total ROOT episodes; one root episode is one rollout")
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--depth", type=int, default=3,
+                        help="maximum recursive delegation depth (v,p) -> (v,q)")
+    parser.add_argument("--engine-gate", action="store_true",
+                        help=("the control arm: accept on the engine's Beta "
+                              "posterior instead of the parent's monotone rule. "
+                              "Changes the acceptance rule; see the module docstring"))
+    parser.add_argument("--keyed-union", action="store_true",
+                        help=("the control arm: drop the three-way merge, so two "
+                              "agents editing one file contradict and one is "
+                              "dropped on held-out score (the engine's default)"))
+    parser.add_argument("--write-repo", default="", metavar="DIR",
+                        help=("write the grown repository here. The ledger is "
+                              "scratch and is reaped on exit, so without this the "
+                              "thing the run produced is not kept"))
+    return parser
+
+
+def main(argv=None) -> None:
+    args = build_parser().parse_args(argv)
+    # One root episode is one rollout, so the shared budget flag maps onto the
+    # port's own iteration flag rather than adding a second budget beside it.
+    if getattr(args, "budget_rollouts", None):
+        args.episodes = args.budget_rollouts
+    args.workers = worker_count(args, args.workers)
+    rounds = max(1, args.episodes // max(1, args.workers))
+
+    merge = "keyed union (control)" if args.keyed_union else "git three-way (octopus)"
+    gate = ("engine Beta gate (control)" if args.engine_gate
+            else "parent (partial progress accepted)")
+    print(f"Algorithm: {PORT_NAME} (port author: {PORT_AUTHOR})")
+    print(f"Upstream : {UPSTREAM_RELEASED_CODE}")
+    print("Dataset  : compact formation domain (minilang, staged suite) -- "
+          "NOT upstream's 123.4h C-compiler run")
+    print(f"Plan     : model={args.model or 'offline rule-based actors'}, "
+          f"episodes={args.episodes} root ({rounds} rounds x {args.workers} workers), "
+          f"max depth={args.depth}")
+    print(f"Merge    : {merge}" + ("" if git_available() else
+                                   "  [git missing: every contested file falls back]"))
+    print(f"Gate     : {gate}")
+
+    if args.dry_run:
+        print("Data     : deferred (dry-run performs no network access)")
+        print("\n[dry-run] plan only; no dataset or model API was accessed.")
+        return
+
+    tasks = build_tasks()
+    artifact = EvolvingArtifact("world", blast_radius=SKILL_BLAST_RADIUS)
+    print(f"Governance: world blast_radius={artifact.blast_radius} -> "
+          f"{classify(artifact).name} (the agents cannot reach the evaluator: the "
+          f"suite lives outside the artifact); frozen to every proposal: "
+          f"{', '.join(FROZEN)}")
+    print(f"Loaded   : {len(tasks)} validation cases over 3 stages; "
+          f"{len(initial_files())} files in the repository, none of them implementation")
+
+    usage = Usage()
+    complete = None
+    if args.model:
+        if not confirm(args):
+            return
+        complete = completion_for(args, usage=usage)
+
+    log = WorldLog()
+    strategy = SpatialContract(initial_files=initial_files(), frozen=FROZEN, log=log,
+                               max_files_per_diff=6)
+    delegation = RecursiveDelegation(
+        manager=llm_manager(complete) if complete else offline_manager,
+        executor=(llm_executor(complete, frozen=FROZEN) if complete
+                  else offline_executor),
+        log=log, max_depth=args.depth, max_edits=4)
+    judge = ParentJudge(log=log, enabled=not args.engine_gate)
+    octopus = None if args.keyed_union else OctopusConflict()
+
+    run = make_runner()
+
+    def _superseded(rendered, task, output, reward_):
+        # `evolve()` requires a `propose` before it installs the bundle's
+        # proposal policy over it. Raising rather than returning None so that a
+        # bundle that failed to install is a loud failure, not a silent round of
+        # nothing.
+        raise AssertionError("Policies(proposal=RecursiveDelegation) was not installed")
+
+    print(f"\nGrowing the world ({args.workers} workers, "
+          f"{'barrier-free' if args.asynchronous else 'synchronous DP'})...\n")
+    result = evolve(
+        tasks, reward, run=run, propose=_superseded, strategy=strategy,
+        artifact_id="world", blast_radius=SKILL_BLAST_RADIUS,
+        rounds=rounds, n_workers=args.workers,
+        max_concurrency=1 if args.asynchronous else args.workers,
+        asynchronous=args.asynchronous, async_ratio=args.async_ratio,
+        max_seconds=args.max_seconds if args.asynchronous else None,
+        # Upstream runs no local before/after re-check: a child returns its work
+        # and the parent judges it. Re-running every proposal here would also
+        # double the number of child processes the domain spawns.
+        self_verify=False,
+        held_out_frac=0.4, eval_concurrency=args.eval_concurrency or 8,
+        seed=args.seed, usage=usage,
+        policies=Policies(proposal=delegation, acceptance=judge,
+                          **({} if octopus is None else {"conflict": octopus})),
+        **budget_kwargs(args),
+    )
+
+    print(f"held-out reward : {result.final_reward:.3f}")
+    print(f"outcomes        : {result.outcomes()}")
+    print(f"stop reason     : {result.stop_reason}")
+    print(f"error           : {result.error or 'none'}")
+    print(f"world           : root episodes={result.rollouts}  {log.summary()}  "
+          f"truncated_edits={delegation.truncated}")
+    if octopus is not None:
+        print(f"merge           : merged={octopus.merged} conflicted={octopus.conflicted}")
+    if not args.engine_gate:
+        print(f"gate            : accepted={judge.accepted} rejected={judge.rejected} "
+              f"partial={judge.partial}")
+    if log.pending_rework:
+        print(f"open rework     : {sorted(log.pending_rework)}")
+    print(f"model usage     : {usage.summary()}")
+    report_engine(result)
+
+    if args.write_repo:
+        plan = result.write_to(args.write_repo)
+        print(f"\nwrote {len(plan.get('written', []))} files to {args.write_repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -85,20 +85,29 @@ from examples._common import (add_standard_args, budget_kwargs, completion_for,
 
 from ._delegation import RecursiveDelegation
 from . import _domain as minilang
+from . import _jqx as jqx
+from . import _md as md
 from . import _stackvm as stackvm
 from ._judge import ParentJudge
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
 from ._world import WorldLog
 
-#: The formation domains. Two, because one was not enough to show the recursion
-#: going anywhere: minilang is two nodes deep and four files, stackvm is four and
-#: ten. Both are stand-ins for upstream's 123.4-hour compiler run and say so.
-DOMAINS = {"minilang": minilang, "stackvm": stackvm}
+#: The formation domains. Three, and each answers something the one before could
+#: not: minilang shows the mechanism, stackvm gives the recursion somewhere to go,
+#: jqx comes out as a program you can run -- its command-line entry point is
+#: frozen beside the specification, so a finished run is software rather than a
+#: package nobody can invoke -- and md cannot be passed by code that merely
+#: parses, because four of its ten stages are invariants rather than values. All
+#: four are stand-ins for upstream's 123.4-hour compiler run and say so.
+DOMAINS = {"minilang": minilang, "stackvm": stackvm, "jqx": jqx, "md": md}
 
 DOMAIN_BLURB = {
     "minilang": "an integer expression language (2 nodes deep, 4 files)",
     "stackvm": "a stack machine and its assembler (4 nodes deep, 10 files)",
+    "jqx": "a JSON query tool with a frozen CLI (4 nodes, 9 files, 4 stages)",
+    "md": ("Lennard-Jones molecular dynamics (6 nodes, 15 files, 10 stages, "
+           "4 of them invariants)"),
 }
 
 

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -89,6 +89,7 @@ from . import _jqx as jqx
 from . import _md as md
 from . import _stackvm as stackvm
 from ._judge import ParentJudge
+from ._review import ParentCodeReview, chain_reviews
 from ._suite import cold_start, preflight
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
@@ -163,6 +164,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help=("make a manager a pure router: skip upstream's "
                               "review-and-accountability turn at its own node "
                               "after its children return"))
+    parser.add_argument("--no-parent-review", action="store_true",
+                        help="skip the parent reading its child's diff (one model "
+                             "call per returned child). The tests alone cannot see "
+                             "a function that computes nothing")
     parser.add_argument("--no-parent-tests", action="store_true",
                         help=("stop the parent running the suite on a child's "
                               "work before accepting it; leaves only the scope "
@@ -199,6 +204,8 @@ def main(argv=None) -> None:
     print(f"Gate     : {gate}")
     print("Parent   : scope check"
           + ("" if args.no_parent_tests else " + integration test on each child's work")
+          + ("" if args.no_parent_review or not args.model else
+             " + reads the diff (upstream's code-quality rejection)")
           + ("; manager routes only" if args.no_accountability
              else "; manager reviews and writes its own node last"))
 
@@ -253,13 +260,19 @@ def main(argv=None) -> None:
     log = WorldLog()
     strategy = SpatialContract(initial_files=initial, frozen=spec.FROZEN,
                                log=log, max_files_per_diff=6)
+    # `manager.ex` states the parent's validation as three things: review the child's
+    # results, run the tests, and reject anti-patterns it can see in the code. The
+    # middle one is a number and was all this port had; the zero-field run is what
+    # that cost. Both now, tests first because they are free.
+    code_review = (None if args.no_parent_review or complete is None else
+                   ParentCodeReview(complete, contracts=spec.CONTRACTS))
     delegation = RecursiveDelegation(
         manager=spec.llm_manager(complete) if complete else spec.offline_manager,
         executor=(spec.llm_executor(complete) if complete else spec.offline_executor),
-        log=log, max_depth=args.depth, max_edits=4, contracts=spec.FROZEN,
-        # The parent's own test run, inside the episode, on one child's work --
-        # the half of the upstream rule the acceptance gate cannot see.
-        review=None if args.no_parent_tests else spec.suite_review(tasks),
+        log=log, max_depth=args.depth, max_edits=4, contracts=spec.CONTRACTS,
+        readonly=spec.FROZEN,
+        review=chain_reviews(None if args.no_parent_tests else spec.suite_review(tasks),
+                             code_review),
         accountability=not args.no_accountability)
     judge = ParentJudge(log=log, enabled=not args.engine_gate)
     octopus = None if args.keyed_union else OctopusConflict()
@@ -311,6 +324,9 @@ def main(argv=None) -> None:
           f"node_relative_paths={delegation.resolved_relative}  "
           f"accountability={delegation.accountability_edits}/"
           f"{delegation.accountability_declined}")
+    if code_review is not None:
+        print(f"parent review   : read={code_review.reviewed} "
+              f"rejected={code_review.rejected} unparsed={code_review.unparsed}")
     if octopus is not None:
         print(f"merge           : merged={octopus.merged} conflicted={octopus.conflicted}")
     if not args.engine_gate:

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -81,7 +81,7 @@ from agentdescent.evolution import EvolvingArtifact
 from agentdescent.agents import Usage
 from agentdescent.governance import SKILL_BLAST_RADIUS, classify
 from examples._common import (add_standard_args, budget_kwargs, completion_for,
-                              confirm, report_engine, score_tasks, worker_count)
+                              confirm, report_engine, worker_count)
 
 from ._delegation import RecursiveDelegation
 from . import _domain as minilang
@@ -117,7 +117,8 @@ def build_parser() -> argparse.ArgumentParser:
     add_standard_args(
         parser, model_default=None, max_seconds_default=120.0,
         model_help=("optional: let a model be the manager and executor agents "
-                    "(else rule-based offline actors -- see examples/genesis/_domain.py)"))
+                    "(else rule-based offline actors -- see the selected "
+                    "--domain module)"))
     # Upstream's unit is the agent episode ("1,019 archived agent episodes"), not
     # a round or a generation, so that is the flag -- and because a root episode
     # is one rollout it is already the rollout budget, which is why `--workers`
@@ -178,7 +179,6 @@ def main(argv=None) -> None:
     print(f"Gate     : {gate}")
     print("Parent   : scope check"
           + ("" if args.no_parent_tests else " + integration test on each child's work")
-          + ("" if not args.no_accountability else "")
           + ("; manager routes only" if args.no_accountability
              else "; manager reviews and writes its own node last"))
 

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -93,21 +93,25 @@ from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
 from ._world import WorldLog
 
-#: The formation domains. Three, and each answers something the one before could
+#: The formation domains. Four, and each answers something the one before could
 #: not: minilang shows the mechanism, stackvm gives the recursion somewhere to go,
 #: jqx comes out as a program you can run -- its command-line entry point is
 #: frozen beside the specification, so a finished run is software rather than a
-#: package nobody can invoke -- and md cannot be passed by code that merely
-#: parses, because four of its ten stages are invariants rather than values. All
-#: four are stand-ins for upstream's 123.4-hour compiler run and say so.
+#: package nobody can invoke -- and md takes the oracle out of the scoring path
+#: altogether, because a frozen test suite is what a human actually writes and
+#: what upstream validates against. All four are stand-ins for upstream's
+#: 123.4-hour compiler run and say so.
 DOMAINS = {"minilang": minilang, "stackvm": stackvm, "jqx": jqx, "md": md}
 
 DOMAIN_BLURB = {
-    "minilang": "an integer expression language (2 nodes deep, 4 files)",
-    "stackvm": "a stack machine and its assembler (4 nodes deep, 10 files)",
-    "jqx": "a JSON query tool with a frozen CLI (4 nodes, 9 files, 4 stages)",
-    "md": ("Lennard-Jones molecular dynamics (6 nodes, 15 files, 10 stages, "
-           "4 of them invariants)"),
+    "minilang": ("an integer expression language (2 nodes deep, 4 files), "
+                 "staged suite"),
+    "stackvm": ("a stack machine and its assembler (4 nodes deep, 10 files), "
+                "staged suite"),
+    "jqx": ("a JSON query tool with a frozen CLI (4 nodes, 9 files, 4 stages), "
+            "staged suite"),
+    "md": ("Lennard-Jones molecular dynamics with a frozen driver (6 nodes, "
+           "14 files), test suite -- invariants, not values"),
 }
 
 
@@ -178,7 +182,7 @@ def main(argv=None) -> None:
     print(f"Algorithm: {PORT_NAME} (port author: {PORT_AUTHOR})")
     print(f"Upstream : {UPSTREAM_RELEASED_CODE}")
     print(f"Dataset  : compact formation domain -- {args.domain}: "
-          f"{DOMAIN_BLURB[args.domain]}, staged suite; "
+          f"{DOMAIN_BLURB[args.domain]}; "
           "NOT upstream's 123.4h C-compiler run")
     print(f"Plan     : model={args.model or 'offline rule-based actors'}, "
           f"episodes={args.episodes} root ({rounds} rounds x {args.workers} workers), "
@@ -203,10 +207,22 @@ def main(argv=None) -> None:
           f"{classify(artifact).name} (the agents cannot reach the evaluator: the "
           f"suite lives outside the artifact); frozen to every proposal: "
           f"{', '.join(spec.FROZEN)}")
-    print(f"Loaded   : {len(tasks)} validation cases over "
-          f"{len(set(t.meta['kind'] for t in tasks))} stages; "
+    audited = [t for t in tasks if t.meta.get("audit")]
+    print(f"Scoring  : {spec.SCORING}")
+    print(f"Loaded   : {len(tasks)} {spec.CASE_NOUN} over "
+          f"{len(set(t.meta['kind'] for t in tasks))} {spec.GROUP_NOUN}; "
           f"{len(spec.initial_files())} files in the repository, "
           "none of them implementation")
+    # Two different things live in the held-out tail depending on the domain, and
+    # conflating them is how the jqx run stalled: sampled inputs the search has not
+    # seen (a generalisation estimate), or requirements the search is not allowed to
+    # see (a bug). md holds out neither -- its tail is an audit set that is not in
+    # the repository at all, so every requirement drives the search.
+    print(f"Held out : {len(tasks) - int(round(len(tasks) * (1 - spec.HELD_OUT_FRAC)))}"
+          f" of {len(tasks)}"
+          + (f" -- an audit set the agents cannot read: {len(audited)} tests "
+             f"injected only at scoring time" if audited else
+             " -- the tail of the case list"))
 
     usage = Usage()
     complete = None
@@ -251,14 +267,17 @@ def main(argv=None) -> None:
         # and the parent judges it. Re-running every proposal here would also
         # double the number of child processes the domain spawns.
         self_verify=False,
-        held_out_frac=0.4, eval_concurrency=args.eval_concurrency or 8,
+        held_out_frac=spec.HELD_OUT_FRAC,
+        eval_concurrency=args.eval_concurrency or 8,
         seed=args.seed, usage=usage,
         policies=Policies(proposal=delegation, acceptance=judge,
                           **({} if octopus is None else {"conflict": octopus})),
         **budget_kwargs(args),
     )
 
-    print(f"held-out reward : {result.final_reward:.3f}")
+    label = "audit reward" if audited else "held-out reward"
+    print(f"{label:<16}: {result.final_reward:.3f}"
+          + ("   (tests no agent ever saw)" if audited else ""))
     print(f"outcomes        : {result.outcomes()}")
     print(f"stop reason     : {result.stop_reason}")
     print(f"error           : {result.error or 'none'}")

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -86,7 +86,7 @@ from examples._common import (add_standard_args, budget_kwargs, completion_for,
 from ._delegation import RecursiveDelegation
 from ._domain import (FROZEN, build_tasks, initial_files, llm_executor,
                       llm_manager, make_runner, offline_executor,
-                      offline_manager, reward)
+                      offline_manager, reward, suite_review)
 from ._judge import ParentJudge
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
@@ -120,6 +120,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help=("the control arm: drop the three-way merge, so two "
                               "agents editing one file contradict and one is "
                               "dropped on held-out score (the engine's default)"))
+    parser.add_argument("--no-parent-tests", action="store_true",
+                        help=("stop the parent running the suite on a child's "
+                              "work before accepting it; leaves only the scope "
+                              "check, which is the cheap half of the rule"))
     parser.add_argument("--write-repo", default="", metavar="DIR",
                         help=("write the grown repository here. The ledger is "
                               "scratch and is reaped on exit, so without this the "
@@ -149,6 +153,8 @@ def main(argv=None) -> None:
     print(f"Merge    : {merge}" + ("" if git_available() else
                                    "  [git missing: every contested file falls back]"))
     print(f"Gate     : {gate}")
+    print("Parent   : scope check"
+          + ("" if args.no_parent_tests else " + integration test on each child's work"))
 
     if args.dry_run:
         print("Data     : deferred (dry-run performs no network access)")
@@ -178,7 +184,10 @@ def main(argv=None) -> None:
         manager=llm_manager(complete) if complete else offline_manager,
         executor=(llm_executor(complete, frozen=FROZEN) if complete
                   else offline_executor),
-        log=log, max_depth=args.depth, max_edits=4)
+        log=log, max_depth=args.depth, max_edits=4,
+        # The parent's own test run, inside the episode, on one child's work --
+        # the half of the upstream rule the acceptance gate cannot see.
+        review=None if args.no_parent_tests else suite_review(tasks))
     judge = ParentJudge(log=log, enabled=not args.engine_gate)
     octopus = None if args.keyed_union else OctopusConflict()
 
@@ -219,6 +228,10 @@ def main(argv=None) -> None:
           f"truncated_edits={delegation.truncated}  "
           f"routes_opened={delegation.routes_opened}  "
           f"mistaken_nodes={delegation.mistaken_nodes}")
+    print(f"parent          : sibling_merges={delegation.sibling_merges}  "
+          f"sibling_conflicts={delegation.sibling_conflicts}  "
+          f"requests raised/handled/unmet={delegation.requests_raised}/"
+          f"{delegation.adopted_requests}/{delegation.unmet_requests}")
     if octopus is not None:
         print(f"merge           : merged={octopus.merged} conflicted={octopus.conflicted}")
     if not args.engine_gate:

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -309,7 +309,15 @@ def main(argv=None) -> None:
     if args.complete_task and complete is not None:
         completion = CompletionJudge(
             complete, tasks=tasks, run=run, reward=spec.reward,
-            state_of=lambda: delegation.last_state, contracts=spec.CONTRACTS,
+            # The strategy's window, not the proposal policy's: the engine renders the
+            # accepted artifact every round, while a proposal policy sees a state only
+            # when it is asked for a proposal -- and it stops being asked exactly when
+            # the run is finished. Scoring `delegation.last_state` meant scoring a
+            # stale tree forever, which is why the first run with --complete-task
+            # asked nobody anything.
+            state_of=lambda: (strategy.last_rendered if strategy.last_rendered
+                              is not None else delegation.last_state),
+            contracts=spec.CONTRACTS,
             suite_failures=getattr(spec, "suite_failures", None),
             objective=DOMAIN_BLURB[args.domain])
 

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -89,10 +89,11 @@ from . import _jqx as jqx
 from . import _md as md
 from . import _stackvm as stackvm
 from ._judge import ParentJudge
-from ._review import ParentCodeReview, chain_reviews
+from ._review import CompletionJudge, ParentCodeReview, chain_reviews
 from ._suite import cold_start, preflight
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
+from ._worktree import Rollout, WorktreeLedger, git_worktrees_available
 from ._world import CONTEXT_FILE, WorldLog
 
 #: The formation domains. Four, and each answers something the one before could
@@ -164,6 +165,16 @@ def build_parser() -> argparse.ArgumentParser:
                         help=("make a manager a pure router: skip upstream's "
                               "review-and-accountability turn at its own node "
                               "after its children return"))
+    parser.add_argument("--worktrees", action="store_true",
+                        help="give every episode its own git worktree, commit its "
+                             "work there, and remove the worktree after -- upstream's "
+                             "scheduling model. The run then leaves a real "
+                             "phylogenetic graph: one commit per episode, a parent's "
+                             "merge carrying every child commit as a parent")
+    parser.add_argument("--complete-task", action="store_true",
+                        help="let the root agent end the run when it judges the "
+                             "objective delivered, instead of exhausting the round "
+                             "budget. Asked only once every test it can see passes")
     parser.add_argument("--no-parent-review", action="store_true",
                         help="skip the parent reading its child's diff (one model "
                              "call per returned child). The tests alone cannot see "
@@ -202,6 +213,12 @@ def main(argv=None) -> None:
     print(f"Merge    : {merge}" + ("" if git_available() else
                                    "  [git missing: every contested file falls back]"))
     print(f"Gate     : {gate}")
+    print("Workspace: " + ("a git worktree per episode, a commit per episode, and "
+                           "the worktree removed after" if args.worktrees else
+                           "in-memory states (--worktrees for upstream's model)"))
+    print("Ends when: " + ("the root agent says the objective is delivered, or the "
+                           "rounds run out" if args.complete_task and args.model else
+                           "the rounds run out (--complete-task asks the root agent)"))
     print("Parent   : scope check"
           + ("" if args.no_parent_tests else " + integration test on each child's work")
           + ("" if args.no_parent_review or not args.model else
@@ -266,7 +283,12 @@ def main(argv=None) -> None:
     # that cost. Both now, tests first because they are free.
     code_review = (None if args.no_parent_review or complete is None else
                    ParentCodeReview(complete, contracts=spec.CONTRACTS))
+    ledger = WorktreeLedger() if args.worktrees else None
+    if ledger is not None and not git_worktrees_available():
+        print("Worktrees: git worktree is unavailable here -- running without it")
+        ledger = None
     delegation = RecursiveDelegation(
+        rollout_factory=(None if ledger is None else lambda: Rollout(ledger)),
         manager=spec.llm_manager(complete) if complete else spec.offline_manager,
         executor=(spec.llm_executor(complete) if complete else spec.offline_executor),
         log=log, max_depth=args.depth, max_edits=4, contracts=spec.CONTRACTS,
@@ -278,6 +300,17 @@ def main(argv=None) -> None:
     octopus = None if args.keyed_union else OctopusConflict()
 
     run = spec.make_runner()
+
+    # Upstream nothing watches a number: an agent decides its objective is met and
+    # calls `complete_task`. Asked only when every test the agents can see passes,
+    # which is upstream's own precondition, and never shown the held-out reward --
+    # that is this port's measurement, computed from tests no agent may read.
+    completion = None
+    if args.complete_task and complete is not None:
+        completion = CompletionJudge(
+            complete, tasks=tasks, run=run, reward=spec.reward,
+            state_of=lambda: delegation.last_state, contracts=spec.CONTRACTS,
+            objective=DOMAIN_BLURB[args.domain])
 
     def _superseded(rendered, task, output, reward_):
         # `evolve()` requires a `propose` before it installs the bundle's
@@ -299,6 +332,7 @@ def main(argv=None) -> None:
         # and the parent judges it. Re-running every proposal here would also
         # double the number of child processes the domain spawns.
         self_verify=False,
+        stop_when=completion,
         held_out_frac=spec.HELD_OUT_FRAC,
         eval_concurrency=args.eval_concurrency or 8,
         seed=args.seed, usage=usage,
@@ -311,7 +345,11 @@ def main(argv=None) -> None:
     print(f"{label:<16}: {result.final_reward:.3f}"
           + ("   (tests no agent ever saw)" if audited else ""))
     print(f"outcomes        : {result.outcomes()}")
-    print(f"stop reason     : {result.stop_reason}")
+    print(f"stop reason     : {result.stop_reason}"
+          + ("" if completion is None else
+             f"  (root agent asked {completion.asked}x, last said "
+             f"{completion.verdict or 'nothing'}"
+             + (f": {completion.reason}" if completion.reason else "") + ")"))
     print(f"error           : {result.error or 'none'}")
     print(f"world           : root episodes={result.rollouts}  {log.summary()}  "
           f"truncated_edits={delegation.truncated}  "
@@ -324,6 +362,8 @@ def main(argv=None) -> None:
           f"node_relative_paths={delegation.resolved_relative}  "
           f"accountability={delegation.accountability_edits}/"
           f"{delegation.accountability_declined}")
+    if ledger is not None:
+        print(f"workspace       : {ledger.summary()}")
     if code_review is not None:
         print(f"parent review   : read={code_review.reviewed} "
               f"rejected={code_review.rejected} unparsed={code_review.unparsed}")

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -89,6 +89,7 @@ from . import _jqx as jqx
 from . import _md as md
 from . import _stackvm as stackvm
 from ._judge import ParentJudge
+from ._suite import preflight
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
 from ._world import WorldLog
@@ -230,6 +231,9 @@ def main(argv=None) -> None:
         if not confirm(args):
             return
         complete = completion_for(args, usage=usage)
+        # One call before the run: a wrong endpoint is otherwise 400 episodes of
+        # silent nothing, which reads exactly like a broken mechanism.
+        preflight(complete)
 
     log = WorldLog()
     strategy = SpatialContract(initial_files=spec.initial_files(), frozen=spec.FROZEN,

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -120,6 +120,10 @@ def build_parser() -> argparse.ArgumentParser:
                         help=("the control arm: drop the three-way merge, so two "
                               "agents editing one file contradict and one is "
                               "dropped on held-out score (the engine's default)"))
+    parser.add_argument("--no-accountability", action="store_true",
+                        help=("make a manager a pure router: skip upstream's "
+                              "review-and-accountability turn at its own node "
+                              "after its children return"))
     parser.add_argument("--no-parent-tests", action="store_true",
                         help=("stop the parent running the suite on a child's "
                               "work before accepting it; leaves only the scope "
@@ -154,7 +158,10 @@ def main(argv=None) -> None:
                                    "  [git missing: every contested file falls back]"))
     print(f"Gate     : {gate}")
     print("Parent   : scope check"
-          + ("" if args.no_parent_tests else " + integration test on each child's work"))
+          + ("" if args.no_parent_tests else " + integration test on each child's work")
+          + ("" if not args.no_accountability else "")
+          + ("; manager routes only" if args.no_accountability
+             else "; manager reviews and writes its own node last"))
 
     if args.dry_run:
         print("Data     : deferred (dry-run performs no network access)")
@@ -187,7 +194,8 @@ def main(argv=None) -> None:
         log=log, max_depth=args.depth, max_edits=4, contracts=FROZEN,
         # The parent's own test run, inside the episode, on one child's work --
         # the half of the upstream rule the acceptance gate cannot see.
-        review=None if args.no_parent_tests else suite_review(tasks))
+        review=None if args.no_parent_tests else suite_review(tasks),
+        accountability=not args.no_accountability)
     judge = ParentJudge(log=log, enabled=not args.engine_gate)
     octopus = None if args.keyed_union else OctopusConflict()
 
@@ -232,7 +240,9 @@ def main(argv=None) -> None:
           f"sibling_conflicts={delegation.sibling_conflicts}  "
           f"requests raised/handled/unmet={delegation.requests_raised}/"
           f"{delegation.adopted_requests}/{delegation.unmet_requests}  "
-          f"node_relative_paths={delegation.resolved_relative}")
+          f"node_relative_paths={delegation.resolved_relative}  "
+          f"accountability={delegation.accountability_edits}/"
+          f"{delegation.accountability_declined}")
     if octopus is not None:
         print(f"merge           : merged={octopus.merged} conflicted={octopus.conflicted}")
     if not args.engine_gate:

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -89,10 +89,10 @@ from . import _jqx as jqx
 from . import _md as md
 from . import _stackvm as stackvm
 from ._judge import ParentJudge
-from ._suite import preflight
+from ._suite import cold_start, preflight
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
-from ._world import WorldLog
+from ._world import CONTEXT_FILE, WorldLog
 
 #: The formation domains. Four, and each answers something the one before could
 #: not: minilang shows the mechanism, stackvm gives the recursion somewhere to go,
@@ -145,6 +145,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--workers", type=int, default=4)
     parser.add_argument("--depth", type=int, default=3,
                         help="maximum recursive delegation depth (v,p) -> (v,q)")
+    parser.add_argument("--cold-start", action="store_true",
+                        help="start from the goal, the contract and the suite only: "
+                             "no node CONTEXT.md records, no routing tables, no "
+                             "skills. The run has to write its own decomposition, "
+                             "which is the paper's first phase and the part a "
+                             "pre-seeded tree hands it for free")
     parser.add_argument("--engine-gate", action="store_true",
                         help=("the control arm: accept on the engine's Beta "
                               "posterior instead of the parent's monotone rule. "
@@ -210,10 +216,19 @@ def main(argv=None) -> None:
           f"{', '.join(spec.FROZEN)}")
     audited = [t for t in tasks if t.meta.get("audit")]
     print(f"Scoring  : {spec.SCORING}")
+    initial = cold_start(spec.initial_files()) if args.cold_start else spec.initial_files()
     print(f"Loaded   : {len(tasks)} {spec.CASE_NOUN} over "
           f"{len(set(t.meta['kind'] for t in tasks))} {spec.GROUP_NOUN}; "
-          f"{len(spec.initial_files())} files in the repository, "
+          f"{len(initial)} files in the repository, "
           "none of them implementation")
+    print("Start    : " + ("cold -- the goal, the contract and the suite; no node "
+                           "records, no routing tables, no skills. The run writes "
+                           "its own decomposition."
+                           if args.cold_start else
+                           f"{sum(1 for p in initial if p.endswith(CONTEXT_FILE))} "
+                           "CONTEXT.md records with routing tables, human-written: "
+                           "the decomposition is given, not grown (--cold-start "
+                           "takes it away)"))
     # Two different things live in the held-out tail depending on the domain, and
     # conflating them is how the jqx run stalled: sampled inputs the search has not
     # seen (a generalisation estimate), or requirements the search is not allowed to
@@ -236,7 +251,7 @@ def main(argv=None) -> None:
         preflight(complete)
 
     log = WorldLog()
-    strategy = SpatialContract(initial_files=spec.initial_files(), frozen=spec.FROZEN,
+    strategy = SpatialContract(initial_files=initial, frozen=spec.FROZEN,
                                log=log, max_files_per_diff=6)
     delegation = RecursiveDelegation(
         manager=spec.llm_manager(complete) if complete else spec.offline_manager,

--- a/examples/genesis/genesis_recursive_worlds.py
+++ b/examples/genesis/genesis_recursive_worlds.py
@@ -84,13 +84,28 @@ from examples._common import (add_standard_args, budget_kwargs, completion_for,
                               confirm, report_engine, score_tasks, worker_count)
 
 from ._delegation import RecursiveDelegation
-from ._domain import (FROZEN, build_tasks, initial_files, llm_executor,
-                      llm_manager, make_runner, offline_executor,
-                      offline_manager, reward, suite_review)
+from . import _domain as minilang
+from . import _stackvm as stackvm
 from ._judge import ParentJudge
 from ._octopus import OctopusConflict, git_available
 from ._spatial import SpatialContract
 from ._world import WorldLog
+
+#: The formation domains. Two, because one was not enough to show the recursion
+#: going anywhere: minilang is two nodes deep and four files, stackvm is four and
+#: ten. Both are stand-ins for upstream's 123.4-hour compiler run and say so.
+DOMAINS = {"minilang": minilang, "stackvm": stackvm}
+
+DOMAIN_BLURB = {
+    "minilang": "an integer expression language (2 nodes deep, 4 files)",
+    "stackvm": "a stack machine and its assembler (4 nodes deep, 10 files)",
+}
+
+
+def build_tasks(domain: str = "minilang"):
+    """The selected domain's loader -- the boundary ``--dry-run`` must not cross."""
+    return DOMAINS[domain].build_tasks()
+
 
 PORT_NAME = "EvoX Genesis (persistent recursive worlds)"
 PORT_AUTHOR = "chendanyang"
@@ -107,6 +122,9 @@ def build_parser() -> argparse.ArgumentParser:
     # a round or a generation, so that is the flag -- and because a root episode
     # is one rollout it is already the rollout budget, which is why `--workers`
     # divides it rather than multiplying it.
+    parser.add_argument("--domain", default="minilang", choices=sorted(DOMAINS),
+                        help=("which software world to grow: minilang is two "
+                              "nodes deep, stackvm four"))
     parser.add_argument("--episodes", type=int, default=24,
                         help="total ROOT episodes; one root episode is one rollout")
     parser.add_argument("--workers", type=int, default=4)
@@ -149,7 +167,8 @@ def main(argv=None) -> None:
             else "parent (partial progress accepted)")
     print(f"Algorithm: {PORT_NAME} (port author: {PORT_AUTHOR})")
     print(f"Upstream : {UPSTREAM_RELEASED_CODE}")
-    print("Dataset  : compact formation domain (minilang, staged suite) -- "
+    print(f"Dataset  : compact formation domain -- {args.domain}: "
+          f"{DOMAIN_BLURB[args.domain]}, staged suite; "
           "NOT upstream's 123.4h C-compiler run")
     print(f"Plan     : model={args.model or 'offline rule-based actors'}, "
           f"episodes={args.episodes} root ({rounds} rounds x {args.workers} workers), "
@@ -168,14 +187,17 @@ def main(argv=None) -> None:
         print("\n[dry-run] plan only; no dataset or model API was accessed.")
         return
 
-    tasks = build_tasks()
+    spec = DOMAINS[args.domain]
+    tasks = build_tasks(args.domain)
     artifact = EvolvingArtifact("world", blast_radius=SKILL_BLAST_RADIUS)
     print(f"Governance: world blast_radius={artifact.blast_radius} -> "
           f"{classify(artifact).name} (the agents cannot reach the evaluator: the "
           f"suite lives outside the artifact); frozen to every proposal: "
-          f"{', '.join(FROZEN)}")
-    print(f"Loaded   : {len(tasks)} validation cases over 3 stages; "
-          f"{len(initial_files())} files in the repository, none of them implementation")
+          f"{', '.join(spec.FROZEN)}")
+    print(f"Loaded   : {len(tasks)} validation cases over "
+          f"{len(set(t.meta['kind'] for t in tasks))} stages; "
+          f"{len(spec.initial_files())} files in the repository, "
+          "none of them implementation")
 
     usage = Usage()
     complete = None
@@ -185,21 +207,20 @@ def main(argv=None) -> None:
         complete = completion_for(args, usage=usage)
 
     log = WorldLog()
-    strategy = SpatialContract(initial_files=initial_files(), frozen=FROZEN, log=log,
-                               max_files_per_diff=6)
+    strategy = SpatialContract(initial_files=spec.initial_files(), frozen=spec.FROZEN,
+                               log=log, max_files_per_diff=6)
     delegation = RecursiveDelegation(
-        manager=llm_manager(complete) if complete else offline_manager,
-        executor=(llm_executor(complete, frozen=FROZEN) if complete
-                  else offline_executor),
-        log=log, max_depth=args.depth, max_edits=4, contracts=FROZEN,
+        manager=spec.llm_manager(complete) if complete else spec.offline_manager,
+        executor=(spec.llm_executor(complete) if complete else spec.offline_executor),
+        log=log, max_depth=args.depth, max_edits=4, contracts=spec.FROZEN,
         # The parent's own test run, inside the episode, on one child's work --
         # the half of the upstream rule the acceptance gate cannot see.
-        review=None if args.no_parent_tests else suite_review(tasks),
+        review=None if args.no_parent_tests else spec.suite_review(tasks),
         accountability=not args.no_accountability)
     judge = ParentJudge(log=log, enabled=not args.engine_gate)
     octopus = None if args.keyed_union else OctopusConflict()
 
-    run = make_runner()
+    run = spec.make_runner()
 
     def _superseded(rendered, task, output, reward_):
         # `evolve()` requires a `propose` before it installs the bundle's
@@ -211,7 +232,7 @@ def main(argv=None) -> None:
     print(f"\nGrowing the world ({args.workers} workers, "
           f"{'barrier-free' if args.asynchronous else 'synchronous DP'})...\n")
     result = evolve(
-        tasks, reward, run=run, propose=_superseded, strategy=strategy,
+        tasks, spec.reward, run=run, propose=_superseded, strategy=strategy,
         artifact_id="world", blast_radius=SKILL_BLAST_RADIUS,
         rounds=rounds, n_workers=args.workers,
         max_concurrency=1 if args.asynchronous else args.workers,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_name: AgentDescent
 # named method -- were in none of these pages' metadata.
 site_description: >-
   A parallel, asynchronous framework for self-evolving LLM agents, with runnable
-  reproductions of nineteen published self-evolution algorithms.
+  reproductions of twenty published self-evolution algorithms.
 # Required for canonical URLs, an absolute-URL sitemap, and the social cards
 # below -- without it mkdocs emits neither, and the social plugin warns.
 site_url: https://birfy.github.io/agentdescent/
@@ -128,6 +128,7 @@ nav:
     - Agent0 — tool curriculum: algo-agent0.md
     - SICA — self-edit: algo-sica.md
     - Gödel Agent — self-modification: algo-godel-agent.md
+    - Genesis — persistent recursive worlds: algo-genesis.md
   - Design records:
     - Evolving a directory: design-directory-evolution.md
     - Plugin for DSH, Claude Code, Codex and other agents: plugin-design.md

--- a/tests/test_example_entrypoints.py
+++ b/tests/test_example_entrypoints.py
@@ -40,6 +40,7 @@ try:                                    # numpy is optional for this repo
 except ImportError:                     # ...and the LLM-SRBench task needs it
     era_srbench = None
 from examples.evoskill import evoskill_skill_discovery as evoskill
+from examples.genesis import genesis_recursive_worlds as genesis
 from examples.gepa import gepa_prompt_evolution as gepa
 from examples.porous import porous_tree_search as porous
 from examples.openevolve import openevolve_program_evolution as openevolve
@@ -124,6 +125,15 @@ PORTS = (
     # itself.
     Port(metasearch, "rounds", "deepseek-v4-flash", 1800.0, "run_outer",
          provider="openai", async_ratio=1),
+    # Genesis. Its model default is `None` for DGM's reason: the offline actors
+    # are rule-based and need no API. `--episodes` is upstream's own unit (an
+    # agent episode) and a ROOT episode is one rollout, so the shared budget flag
+    # maps onto it. Its loader computes the frozen suite's expectations from the
+    # reference tree, so `build_tasks` is the boundary a dry-run must not cross,
+    # and the async budget is wall-clock for child processes rather than API
+    # calls.
+    Port(genesis, "episodes", None, 120.0, "build_tasks",
+         async_ratio=3, budget_is_iterations=True),
 )
 
 # ERA's fourth task, equation discovery on LLM-SRBench. Same deviations again,
@@ -194,7 +204,11 @@ def test_every_port_can_hold_its_rollout_budget_fixed(port):
     """
     source = pathlib.Path(inspect.getfile(port.module)).read_text(encoding="utf-8")
     if port.budget_is_iterations:
-        assert "args.iterations = args.budget_rollouts" in source, (
+        # Named from the row rather than hardcoded to `iterations`: the whole
+        # point of `Port.iteration` is that a port keeps its upstream vocabulary,
+        # and a port whose unit is the episode was declaring this correctly and
+        # failing anyway.
+        assert f"args.{port.iteration} = args.budget_rollouts" in source, (
             f"{PORT_IDS[PORTS.index(port)]} declares its iteration budget is the "
             "rollout budget; map the shared flag onto it")
         return
@@ -223,7 +237,10 @@ def test_every_port_uses_the_standard_contract(port):
     for option in ("--provider", "--model", "--seed", "--async", "--async-ratio",
                    "--max-seconds", "--dry-run", "--yes", "--serial"):
         assert option_strings.count(option) == 1, f"{port.module.__name__}: {option}"
-    iteration_options = {"--rounds", "--generations", "--iterations", "--steps"}
+    # Upstream vocabulary, not a normalised one: `--episodes` is Genesis's own
+    # unit ("1,019 archived agent episodes"), as `--generations` is DGM's.
+    iteration_options = {"--rounds", "--generations", "--iterations", "--steps",
+                         "--episodes"}
     assert iteration_options.intersection(option_strings) == {f"--{port.iteration}"}
 
 

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -25,12 +25,15 @@ from examples.genesis import _stackvm as stackvm
 from examples.genesis._delegation import (Brief, Delegation, Edit,
                                           RecursiveDelegation, render_edits)
 from examples.genesis._judge import ParentJudge
+from examples.genesis._review import ParentCodeReview, chain_reviews
 from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
 from examples.genesis._suite import cold_start, preflight
-from examples.genesis._world import (CONTEXT_FILE, SKILLS_DIR, TRUNCATED,
+from examples.genesis._world import (CONTEXT_FILE, KNOWN_ISSUES, ROUTING_HEADING,
+                                     SKILLS_DIR, TRUNCATED,
                                      LocalWorld, WorldLog, owns, parse_routing,
-                                     resolve_edit_path, routing_entry)
+                                     resolve_edit_path, routing_entry,
+                                     under_heading)
 
 
 # ---------------------------------------------------------------------------
@@ -198,15 +201,25 @@ def test_an_agent_deep_in_the_tree_is_shown_the_contract_it_is_judged_against():
         domain.initial_files())
 
 
-def test_an_oversized_brief_carries_upstreams_own_truncation_marker():
-    """The marker is a signal to prune, not decoration -- so it has to be theirs."""
-    state = {CONTEXT_FILE: "x" * 50_000}
-    assert LocalWorld(version=1, path="").situate(state).endswith(TRUNCATED)
+def test_an_oversized_context_record_is_truncated_per_file_as_upstream_does():
+    """Per file, at upstream's cap, with upstream's marker -- and not globally.
 
-
-# ---------------------------------------------------------------------------
-# The parent's integration evidence, and the merge it does on its children
-# ---------------------------------------------------------------------------
+    `ContextNode.build_context/2` truncates each CONTEXT.md at
+    `truncation.context_max_bytes` (default 65_536) and has no overall budget at all.
+    This port had one global 8_000-char cap instead, eight times tighter, and that is
+    the other half of how md's agents never saw their specification: two frozen files
+    that sorted earlier spent the budget. The marker is a signal to prune the record,
+    so it is upstream's string.
+    """
+    context = LocalWorld(version=1, path="").situate({CONTEXT_FILE: "x" * 70_000})
+    assert TRUNCATED in context
+    assert context.count("x") == 65_536
+    # the record is not the last thing in the brief: the file listing survives it
+    assert context.rstrip().endswith("(none yet)")
+    # and a record under the cap is untouched, however large the whole brief gets
+    assert TRUNCATED not in LocalWorld(version=1, path="").situate(
+        {CONTEXT_FILE: "y" * 50_000, "spec/CONTEXT.md": "z" * 50_000},
+        contracts=("spec/**",))
 
 def test_a_parent_refuses_a_child_whose_work_breaks_the_suite():
     """Paper 3.3: the parent decides on tests and integration evidence."""
@@ -915,6 +928,123 @@ def test_the_md_suite_rejects_every_deliberately_wrong_implementation():
     assert not survived, f"the suite accepts these wrong implementations: {survived}"
     fragile = {name: killers for name, killers in report.items() if len(killers) < 2}
     assert not fragile, f"only one test stands between these and a false pass: {fragile}"
+
+
+# ---------------------------------------------------------------------------
+# The parent's other half: reading the change, not only counting tests
+# ---------------------------------------------------------------------------
+
+def _review_brief(state, objective="make the forces right"):
+    return Brief(world=LocalWorld(version=1, path="src", readonly=md.FROZEN),
+                 objective=objective, context="", state=state,
+                 task=Task(id="t", prompt="x"), output="", reward=0.0, depth=0)
+
+
+def test_the_parent_reads_the_change_and_can_reject_it_on_what_it_sees():
+    """`manager.ex` states the parent's validation as three things: review the
+    child's results, run the tests, AND reject code-quality anti-patterns. This port
+    had the middle one, which is a number -- and a number could not see a registry
+    whose minimum-image expression left every force at zero.
+    """
+    seen = []
+
+    def complete(prompt):
+        seen.append(prompt)
+        return '{"verdict": "reject", "reason": "evaluate() returns zeros"}'
+
+    review = ParentCodeReview(complete, contracts=md.CONTRACTS)
+    verdict = review(_review_brief(md.initial_files()),
+                     [Edit("src", "src/potentials/registry.py", "def evaluate(s, p):\n"
+                           "    return 0.0, [[0.0] * 3 for _ in s.positions]\n")])
+    assert verdict is not None
+    kind, reason = verdict
+    assert kind == "rejected" and "returns zeros" in reason
+    assert (review.reviewed, review.rejected) == (1, 0 + 1)
+    # it was shown the whole file and the contract, because four lines of arithmetic
+    # cannot be judged from a summary
+    assert "return 0.0, [[0.0] * 3" in seen[0]
+    assert "dudr_over_r" in seen[0]          # the spec travelled with it
+
+
+def test_the_parent_accepts_what_it_has_no_complaint_about():
+    review = ParentCodeReview(lambda prompt: '{"verdict": "accept", "reason": ""}')
+    assert review(_review_brief(md.initial_files()),
+                  [Edit("src", "src/__init__.py", "def energy(p):\n    return 1.0\n")]) is None
+    assert (review.reviewed, review.rejected) == (1, 0)
+
+
+def test_a_reviewer_that_cannot_speak_is_not_evidence_against_the_child():
+    """An unparseable reply, or a dead backend, must not reject work. The child did
+    the work; the reviewer failing is the reviewer's problem."""
+    garbled = ParentCodeReview(lambda prompt: "I think it looks fine?")
+    assert garbled(_review_brief(md.initial_files()),
+                   [Edit("src", "src/a.py", "x = 1\n")]) is None
+    assert (garbled.reviewed, garbled.rejected, garbled.unparsed) == (1, 0, 1)
+
+    def dead(prompt):
+        raise RuntimeError("502")
+
+    broken = ParentCodeReview(dead)
+    assert broken(_review_brief(md.initial_files()),
+                  [Edit("src", "src/a.py", "x = 1\n")]) is None
+    assert broken.rejected == 0
+
+
+def test_the_parent_does_not_spend_a_call_on_bookkeeping_alone():
+    """A routing note is not a change to review."""
+    review = ParentCodeReview(lambda prompt: pytest.fail("should not be called"))
+    assert review(_review_brief(md.initial_files()),
+                  [Edit("src", "src/CONTEXT.md", "# src\n", kind="context")]) is None
+    assert review.reviewed == 0
+
+
+def test_the_tests_run_before_the_reviewer_because_they_are_free():
+    """`chain_reviews` short-circuits: a regression needs no second opinion, and the
+    deterministic check costs no model call."""
+    calls = []
+    cheap = lambda parent, returned: (calls.append("cheap") or ("rejected", "tests"))
+    dear = lambda parent, returned: pytest.fail("the model was asked anyway")
+    chained = chain_reviews(cheap, dear)
+    assert chained(_review_brief({}), [Edit("src", "src/a.py", "x = 1\n")]) == ("rejected",
+                                                                               "tests")
+    assert calls == ["cheap"]
+    # and a disabled review is skipped rather than branched around by the caller
+    assert chain_reviews(None, None) is None
+    only = lambda parent, returned: None
+    assert chain_reviews(None, only) is only
+
+
+def test_a_refusal_is_written_under_upstreams_own_heading():
+    """"findings worth preserving belong in CONTEXT.md... `## Known Issues` (problems
+    to avoid re-discovering)" -- `agents/manager.ex`. A refusal is the cheapest such
+    finding: the next agent here would otherwise be refused for the same thing."""
+    body = under_heading("# src/core\n\n## Intent\nowns vectors.py\n",
+                         KNOWN_ISSUES, "- refused: out of scope")
+    assert body.endswith("## Known Issues\n- refused: out of scope\n")
+    again = under_heading(body, KNOWN_ISSUES, "- refused: twice")
+    assert again.count(KNOWN_ISSUES) == 1           # one section, two lines
+    assert again.endswith("- refused: out of scope\n- refused: twice\n")
+
+
+@pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
+def test_every_node_record_carries_upstreams_four_standard_sections(spec):
+    """"The standard four sections (Intent, API Surface, Constraints, Routing Table)
+    are the foundation" -- `agents/manager.ex`. API Surface was missing from every
+    record in this port, on a domain whose entire failure mode was a wrong public
+    surface: the 0.750 run dropped five of seven keyword parameters.
+
+    Intent and the routing table are required of every node; a leaf has no routing
+    table and constraints are inherited, so those two are checked where they appear.
+    """
+    files = spec.initial_files()
+    records = {p: body for p, body in files.items()
+               if p.endswith(CONTEXT_FILE) and not p.startswith("spec/")}
+    assert records
+    for path, body in records.items():
+        assert "## Intent" in body, path
+        assert "## API Surface" in body, f"{path} says nothing about what it exposes"
+    assert any(ROUTING_HEADING in body for body in records.values())
+    assert any("## Constraints" in body for body in records.values())
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -743,57 +743,6 @@ def test_the_md_audit_tests_are_injected_only_while_they_are_scored():
     assert sum(md.reward(t, run(rendered, t)) for t in audited) == len(audited)
 
 
-def test_the_md_suite_rejects_a_force_field_that_is_identically_zero():
-    """The cheapest way to pass a suite of invariants, and a run found it.
-
-    Zero sums to zero, zero is the gradient of a constant, nothing moves so nothing
-    drifts, and reversing nothing retraces it. A real run shipped exactly that -- a
-    minimum-image expression whose `// 1` bound after the multiplication, so every
-    pair in a periodic box landed past the cutoff -- and 42 of its 44 tests passed.
-    The suite pins values in a box now, and this is the guard that says so.
-    """
-    zeroed = dict(md.reference_tree())
-    zeroed[md.REGISTRY] = (
-        'def get(name):\n'
-        '    if name not in ("lennard_jones", "harmonic"):\n'
-        '        raise ValueError(name)\n'
-        '    return name\n'
-        '\n'
-        '\n'
-        'def evaluate(system, spec):\n'
-        '    get(spec["name"])\n'
-        '    return 0.0, [[0.0, 0.0, 0.0] for _ in system.positions]\n')
-    run, rendered = md.make_runner(), canonical(zeroed)
-    failed = [t.id for t in md.build_tasks() if md.reward(t, run(rendered, t)) == 0.0]
-    assert any("identically_zero" in t for t in failed), failed
-    assert any("closed_form" in t for t in failed), failed
-    # the audit set catches it too, which is what the audit set is for
-    assert any(t.startswith("audit:") for t in failed), failed
-
-
-def test_the_md_suite_catches_an_integrator_that_is_only_stable():
-    """Euler with one force evaluation per step is stable, plausible, and wrong.
-
-    This is what the invariants are for, and what an oracle over sampled values
-    would not reliably catch: the trajectory stays bounded, so a sampled position
-    often agrees to six places, but the scheme is first-order and not reversible.
-    """
-    broken = dict(md.reference_tree())
-    broken[md.VERLET] = broken[md.VERLET].replace(
-        "    _, forces = evaluate(system, spec)\n"
-        "    for i, mass in enumerate(system.masses):\n"
-        "        for axis in range(3):\n"
-        "            system.velocities[i][axis] += half * forces[i][axis] / mass\n"
-        "    return system\n",
-        "    return system\n")
-    assert broken[md.VERLET] != md.reference_tree()[md.VERLET]
-    run, rendered = md.make_runner(), canonical(broken)
-    failed = [t.id for t in md.build_tasks()
-              if md.reward(t, run(rendered, t)) == 0.0]
-    assert any("reversing" in t for t in failed), failed
-    assert any("conserved" in t for t in failed), failed
-
-
 def test_the_contract_reaches_the_agent_even_when_a_bigger_frozen_file_sorts_first():
     """Sorted order made *which* contract an agent sees depend on filenames.
 
@@ -929,6 +878,43 @@ def test_a_cold_started_world_writes_the_decomposition_it_was_not_given():
     assert written, "the run never recorded a node of its own"
     assert any(parse_routing(records[p]) for p in records), "no routing table grew"
     assert log.contract_violations == 0
+
+
+def test_the_md_suite_rejects_every_deliberately_wrong_implementation():
+    """A suite is only as good as what it refuses, and nothing else here checked that.
+
+    The md domain was validated only against a *correct* implementation -- the suite
+    accepts the right answer, and nothing was known about what it rejects. A field
+    that returns zero everywhere satisfies every invariant in it (zero sums to zero,
+    zero is the gradient of a constant, nothing moves so nothing drifts), and a real
+    run shipped exactly that: `d -= box * (d / box + 0.5) // 1`, where the `// 1`
+    binds after the multiplication. It reported audit reward 1.000.
+
+    So: keep the wrong implementations, and require every one of them to die. Writing
+    this found two more holes in the same sitting. A `round`-based geometry -- the one
+    thing the spec explicitly forbids, because Python's round is banker's rounding --
+    passed the entire suite; and the centre-of-mass-corrected temperature died to
+    exactly one test.
+
+    **Two killers, not one.** The zero field originally died to a single test, and
+    that test was the negative control (`a_far_too_large_timestep_does_not_conserve_
+    energy`), which exists only because "the conservation tests must be able to fail,
+    or they assert nothing". One test between a false 1.000 and the truth is not a
+    margin.
+
+    This is the harness keeping its own measurement honest, and it is not what
+    upstream relies on: Genesis has no objective function at all -- `grep -rio
+    'fitness|reward|score'` over `apps/evo_git` returns `oom_score_adjust` and nothing
+    else -- and in its place is a parent that reads the diff and runs the tests
+    (`agents/manager.ex`). Coverage, for the record, would not have caught any of
+    this: the zero field executes every line of every test.
+    """
+    report = md.MD.kill_report(md.reference_tree(), stop_after=2)
+    assert set(report) == set(md.BASELINES)
+    survived = sorted(name for name, killers in report.items() if not killers)
+    assert not survived, f"the suite accepts these wrong implementations: {survived}"
+    fragile = {name: killers for name, killers in report.items() if len(killers) < 2}
+    assert not fragile, f"only one test stands between these and a false pass: {fragile}"
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -210,7 +210,7 @@ def test_an_oversized_brief_carries_upstreams_own_truncation_marker():
 def test_a_parent_refuses_a_child_whose_work_breaks_the_suite():
     """Paper 3.3: the parent decides on tests and integration evidence."""
     review = domain.suite_review(domain.build_tasks(), sample=6)
-    state = dict(domain._reference_tree())
+    state = dict(domain.reference_tree())
     parent = Brief(world=LocalWorld(version=1, path="src"), objective="o", context="",
                    state=state, task=Task(id="t", prompt="1 + 2"), output="",
                    reward=1.0, depth=0)
@@ -645,10 +645,19 @@ DOMAIN_IDS = ["minilang", "stackvm", "jqx", "md"]
 
 
 @pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
-def test_every_formation_domain_agrees_with_its_own_oracle(spec):
-    """A suite that disagrees with its oracle scores a correct candidate wrong."""
+def test_every_formation_domain_has_been_seen_to_pass(spec):
+    """Two different claims, and both are worth a test.
+
+    For the three oracle-scored domains: a suite that disagrees with its own oracle
+    scores a *correct* candidate wrong, and no run could ever finish.
+
+    For md, where no reference is in the scoring path at all, this is the weaker but
+    more important claim -- the suite is passable. Shipping a specification nobody
+    has ever seen satisfied is its own kind of dishonesty, so the reference exists
+    for this test and for the offline actor, and for nothing else.
+    """
     tasks, run = spec.build_tasks(), spec.make_runner()
-    rendered = canonical(spec._reference_tree())
+    rendered = canonical(spec.reference_tree())
     assert sum(spec.reward(t, run(rendered, t)) for t in tasks) == len(tasks)
 
 
@@ -672,23 +681,88 @@ def test_every_stage_is_reachable_from_the_train_split(spec):
     builtins appeared only in the held-out tail. No rollout could fail on them, so
     no proposal was ever requested for them, and the run stalled at 0.923 with two
     stubs open and `stop reason: rounds`. `evolve()` splits by position, so this is
-    a property of the *order* of the case list, and nothing else checks it.
+    a property of the *order* of the task list, and nothing else checks it.
     """
     tasks = spec.build_tasks()
-    train = tasks[:int(len(tasks) * 0.6)]          # evolve(held_out_frac=0.4)
-    missing = sorted(set(t.meta["kind"] for t in tasks)
-                     - set(t.meta["kind"] for t in train))
+    cut = max(1, round(len(tasks) * (1 - spec.HELD_OUT_FRAC)))
+    missing = sorted(set(t.meta["kind"] for t in tasks if not t.meta.get("audit"))
+                     - set(t.meta["kind"] for t in tasks[:cut]))
     assert not missing, f"stages only in the held-out tail: {missing}"
 
 
-def test_the_md_suite_cannot_be_passed_by_returning_true():
-    """Four of md's ten stages are invariants, which is a cheatable shape.
+# ---------------------------------------------------------------------------
+# md: scored by a frozen test suite, with no oracle in the loop
+# ---------------------------------------------------------------------------
 
-    One `cons` case uses a timestep far too large, so its answer is `False` -- a
-    stage that returns `True` without computing anything fails the suite.
+def test_an_md_task_is_one_test_and_its_prompt_is_that_tests_source():
+    """The executor is shown the assertion it failed, which is the whole design:
+    the specification is executable, so the prompt can be the specification.
+
+    With the file's prelude above it, because a test body that reads
+    `forces(CONFIG, box=BOX)` says nothing on its own about what `CONFIG` is.
     """
-    golds = {t.meta["gold"] for t in md.build_tasks() if t.meta["kind"] == "cons"}
-    assert golds == {"True", "False"}
+    task = next(t for t in md.build_tasks()
+                if t.meta["func"] == "test_forces_sum_to_zero")
+    body = md.MD.given[task.meta["file"]]
+    assert task.prompt.startswith(f"# {task.meta['file']}\n")
+    assert "from src import energy, forces" in task.prompt       # the prelude
+    assert "CONFIG = [[0.0, 0.0, 0.0]" in task.prompt            # and its constants
+    assert task.prompt.endswith("assert max(abs(c) for c in total) < 1e-9, total")
+    assert body.count("def test_forces_sum_to_zero():") == 1
+    # Only this test. Showing the whole file would show the agent the tests it has
+    # not been asked about, and the episode is bounded at four edits anyway.
+    assert sum(1 for line in task.prompt.splitlines()
+               if line.startswith("def test_")) == 1
+
+
+def test_the_md_audit_set_is_not_in_the_repository_the_agents_see():
+    """`frozen` stops a file being *written*, not read. An audit test in the tree is
+    an audit test the executor can read and write code against."""
+    files = md.initial_files()
+    assert md._AUDIT and not any(path in files for path in md._AUDIT)
+    audited = [t for t in md.build_tasks() if t.meta["audit"]]
+    assert audited and all(t.meta["file"] not in files for t in audited)
+
+
+def test_the_md_audit_set_lands_exactly_in_the_held_out_tail():
+    """`HELD_OUT_FRAC` is computed, not chosen: every driven test -- every
+    requirement -- has to be on the search's side of the cut."""
+    tasks = md.build_tasks()
+    cut = max(1, round(len(tasks) * (1 - md.HELD_OUT_FRAC)))   # evolve()'s own split
+    assert [t.meta["audit"] for t in tasks[:cut]] == [False] * cut
+    assert all(t.meta["audit"] for t in tasks[cut:])
+
+
+def test_the_md_audit_tests_are_injected_only_while_they_are_scored():
+    """They are not in the candidate repository, and they still run against it."""
+    run = md.make_runner()
+    rendered = canonical(md.reference_tree())
+    assert "audit/" not in rendered
+    audited = [t for t in md.build_tasks() if t.meta["audit"]]
+    assert sum(md.reward(t, run(rendered, t)) for t in audited) == len(audited)
+
+
+def test_the_md_suite_catches_an_integrator_that_is_only_stable():
+    """Euler with one force evaluation per step is stable, plausible, and wrong.
+
+    This is what the invariants are for, and what an oracle over sampled values
+    would not reliably catch: the trajectory stays bounded, so a sampled position
+    often agrees to six places, but the scheme is first-order and not reversible.
+    """
+    broken = dict(md.reference_tree())
+    broken[md.VERLET] = broken[md.VERLET].replace(
+        "    _, forces = evaluate(system, spec)\n"
+        "    for i, mass in enumerate(system.masses):\n"
+        "        for axis in range(3):\n"
+        "            system.velocities[i][axis] += half * forces[i][axis] / mass\n"
+        "    return system\n",
+        "    return system\n")
+    assert broken[md.VERLET] != md.reference_tree()[md.VERLET]
+    run, rendered = md.make_runner(), canonical(broken)
+    failed = [t.id for t in md.build_tasks()
+              if md.reward(t, run(rendered, t)) == 0.0]
+    assert any("reversing" in t for t in failed), failed
+    assert any("conserved" in t for t in failed), failed
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():
@@ -708,7 +782,7 @@ def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():
 def test_the_frozen_suite_agrees_with_its_own_oracle():
     tasks = domain.build_tasks()
     run = domain.make_runner()
-    rendered = canonical(domain._reference_tree())
+    rendered = canonical(domain.reference_tree())
     assert sum(domain.reward(t, run(rendered, t)) for t in tasks) == len(tasks)
 
 

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -1241,12 +1241,17 @@ def test_a_per_test_score_cannot_see_a_test_poisoning_the_next_one():
     assert len(failures) == 5, failures
     assert all("not callable" in f for f in failures), failures
 
-    # every one of those five passes on its own, which is the whole point
+    # every one of those five passes on its own, which is the whole point -- and the
+    # only tasks that fail are the two that run the suite as one unit, which exist so
+    # that the *search* can see this at all and not only the gate
     run = md.make_runner()
     rendered = canonical(broken)
-    alone = {t.id: md.reward(t, run(rendered, t)) for t in md.build_tasks()
-             if any(t.meta["func"] in f for f in failures)}
-    assert alone and set(alone.values()) == {1.0}, alone
+    scores = {t.id: md.reward(t, run(rendered, t)) for t in md.build_tasks()}
+    named = [t for t in md.build_tasks()
+             if t.meta["func"] and any(t.meta["func"] in f for f in failures)]
+    assert len(named) == 5 and all(scores[t.id] == 1.0 for t in named), named
+    assert {i for i, v in scores.items() if v == 0.0} == {"suite::one-process",
+                                                          "audit:suite::one-process"}
 
     # and the reference is clean under both ways of running it
     assert md.MD.suite_failures(md.reference_tree(), audit=True) == []

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -1184,6 +1184,23 @@ def test_the_run_ends_when_the_root_agent_says_the_objective_is_delivered():
     assert "src/__init__.py" in prompts[0]          # the tree is what it judges
 
 
+def test_a_round_that_accepted_nothing_is_not_scored_twice():
+    """Fifty subprocesses a round, to ask about a codebase that did not change, would
+    cost more than the rounds being watched."""
+    runs = []
+    state = domain.initial_files()
+    judge = CompletionJudge(lambda p: pytest.fail("never green"),
+                            tasks=domain.build_tasks(),
+                            run=lambda rendered, task: runs.append(task.id) or "",
+                            reward=domain.reward, state_of=lambda: state,
+                            contracts=domain.CONTRACTS, objective="o")
+    info = RoundInfo(round=1, held_out_reward=0.0, n_items=0, committed=0, rejected=0)
+    assert judge(info) is False
+    assert len(runs) == 1, runs       # and it stops at the first failing test
+    assert judge(info) is False
+    assert len(runs) == 1            # the same version, so not scored again
+
+
 def test_an_unparseable_or_negative_answer_keeps_the_run_going():
     green = domain.reference_tree()
     assert _completion_judge(lambda p: "not sure yet", green)(

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -24,7 +24,8 @@ from examples.genesis._delegation import (Brief, Delegation, Edit,
 from examples.genesis._judge import ParentJudge
 from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
-from examples.genesis._world import CONTEXT_FILE, LocalWorld, WorldLog, owns
+from examples.genesis._world import (CONTEXT_FILE, LocalWorld, WorldLog, owns,
+                                     parse_routing, routing_entry)
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +56,94 @@ def test_situate_inherits_the_context_chain_root_first():
     text = LocalWorld(version=1, path="src/backend").situate(state)
     assert text.index("# root") < text.index("# src") < text.index("# backend")
     assert "src/backend/x.py" in text
+
+
+# ---------------------------------------------------------------------------
+# CONTEXT.md: inherited on the way in, maintained on the way out
+# ---------------------------------------------------------------------------
+
+_TABLE = """# src
+
+## Intent
+Everything under ./src/backend/ is mentioned here in prose, and that is all.
+
+## Routing Table
+- `./src/frontend/` -> tokenizer and parser
+
+## Constraints
+- `./spec/` is read-only.
+"""
+
+
+def test_only_the_routing_section_confers_a_route():
+    """A path named in prose is a mention; treating it as a route would let any
+    sentence create authority."""
+    assert parse_routing(_TABLE) == ["src/frontend"]
+
+
+def test_a_node_delegates_to_what_its_context_md_routes_to():
+    state = {"src/CONTEXT.md": _TABLE, "src/backend/evaluator.py": "x"}
+    assert LocalWorld(version=1, path="src").routing(state) == ["src/frontend"]
+
+
+def test_a_node_without_a_table_falls_back_to_the_directories_that_exist():
+    """A repository whose CONTEXT.md tree is not written yet stays usable."""
+    state = {"src/CONTEXT.md": "# src\n", "src/backend/e.py": "x", "src/frontend/l.py": "y"}
+    assert LocalWorld(version=1, path="src").routing(state) == ["src/backend", "src/frontend"]
+
+
+def test_a_routing_entry_is_written_once_and_only_once():
+    """*Current state, not history* -- the table must not become a transcript."""
+    once = routing_entry(_TABLE, "src/backend", "evaluation")
+    assert once is not None and once.count("`./src/backend/`") == 1
+    assert routing_entry(once, "src/backend", "evaluation") is None
+
+
+def test_a_manager_that_opens_an_unrouted_node_records_it_at_its_own_level():
+    """A node its parent does not route to is a node later agents cannot find."""
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/backend", "evaluate the parse tree")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, f"{b.world.path}/e.py", "x = 1\n")],
+        log=log, max_depth=3, root_path="src")
+    proposals = policy.propose(_proposal_ctx({"src/CONTEXT.md": _TABLE},
+                                             Task(id="t", prompt="x")))
+    edits = {e["path"]: e["content"] for e in parse_situated_edits(proposals[0])}
+    assert "src/backend/e.py" in edits, "the child's work must survive"
+    assert "src/backend" in parse_routing(edits["src/CONTEXT.md"])
+    assert policy.routes_opened == 1
+
+
+def test_a_routing_note_is_trimmed_before_a_source_file():
+    """Bookkeeping must never cost the change it is describing."""
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/a", "x"), Delegation("src/b", "y")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, f"{b.world.path}/f{i}.py", str(i))
+                            for i in range(2)],
+        log=log, max_depth=3, max_edits=4, root_path="src")
+    edits = parse_situated_edits(policy.propose(
+        _proposal_ctx({"src/CONTEXT.md": _TABLE}, Task(id="t", prompt="x")))[0])
+    assert len(edits) == 4 and policy.truncated == 1
+    assert all(not e["path"].endswith(CONTEXT_FILE) for e in edits)
+
+
+def test_the_offline_manager_takes_its_decomposition_from_context_md():
+    """The table is the mechanism: edit it and the delegation follows."""
+    state = domain.initial_files()
+    brief = Brief(world=LocalWorld(version=1, path=""), objective="o",
+                  context="", state=state, task=Task(id="t", prompt="1 + 2"),
+                  output="", reward=0.0, depth=0)
+    assert [d.path for d in domain.offline_manager(brief)] == ["src"]
+
+    rerouted = dict(state)
+    rerouted["CONTEXT.md"] = state["CONTEXT.md"].replace("`./src/`", "`./src/frontend/`")
+    brief = Brief(world=LocalWorld(version=1, path=""), objective="o",
+                  context="", state=rerouted, task=Task(id="t", prompt="1 + 2"),
+                  output="", reward=0.0, depth=0)
+    assert [d.path for d in domain.offline_manager(brief)] == ["src/frontend"]
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +189,39 @@ def test_the_strategy_declares_no_key_space_so_tp_is_refused_rather_than_lossy()
     file the run created -- the failure this port is built to avoid.
     """
     assert not hasattr(_strategy(), "keys")
+
+
+@pytest.mark.parametrize("existing,attempt", [
+    ("src/lexer.py", "src/lexer.py/__init__.py"),   # an ancestor is a file
+    ("src/pkg/a.py", "src/pkg"),                     # the target is a directory
+])
+def test_an_edit_that_would_stop_the_tree_being_a_tree_is_dropped(existing, attempt):
+    """`a/b.py` and `a/b.py/c.py` cannot both exist, and the engine never checks.
+
+    Found the expensive way: an agent delegated to `src/frontend/lexer.py` as
+    though it were a node, wrote inside it, and `EvolutionResult.write_to` raised
+    `FileExistsError` after 40 episodes and 328 model calls -- the whole run lost
+    at the one point where it was being saved.
+    """
+    log = WorldLog()
+    strategy = _strategy(log=log)
+    state = dict(strategy.initial(), **{existing: "x = 1\n"})
+    proposal = render_edits([Edit("src", attempt, "y = 2\n")], "r")
+    assert strategy.to_diff(state, proposal, "w0", 1, "world") is None
+    assert log.shape_violations == 1
+
+
+def test_a_delegation_to_a_file_is_refused_because_a_node_is_a_directory():
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: [Delegation("src/lexer.py", "fix the lexer")],
+        executor=lambda b: [Edit(b.world.path, f"{b.world.path}/x.py", "1")],
+        log=log, max_depth=3, root_path="src")
+    state = {"src/CONTEXT.md": "# src\n", "src/lexer.py": "x = 1\n"}
+    policy.propose(_proposal_ctx(state, Task(id="t", prompt="x")))
+    assert policy.mistaken_nodes == 1
+    assert [e.role for e in log.episodes] == ["executor"], \
+        "the refused delegation must not open an episode"
 
 
 def test_a_reply_that_ignores_the_protocol_costs_its_episode_and_does_not_crash():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -124,7 +124,8 @@ def test_a_routing_note_is_trimmed_before_a_source_file():
                            if b.world.path == "src" else []),
         executor=lambda b: [Edit(b.world.path, f"{b.world.path}/f{i}.py", str(i))
                             for i in range(2)],
-        log=log, max_depth=3, max_edits=4, root_path="src")
+        log=log, max_depth=3, max_edits=4, root_path="src",
+        accountability=False)
     edits = parse_situated_edits(policy.propose(
         _proposal_ctx({"src/CONTEXT.md": _TABLE}, Task(id="t", prompt="x")))[0])
     assert len(edits) == 4 and policy.truncated == 1
@@ -241,7 +242,8 @@ def test_two_children_writing_one_file_are_merged_rather_than_one_rejected():
         manager=lambda b: ([Delegation("src/a", "x"), Delegation("src/a/b", "y")]
                            if b.world.path == "src" else []),
         executor=lambda b: [Edit(b.world.path, "src/a/b/f.py", bodies[b.world.path])],
-        log=log, max_depth=3, root_path="src")
+        log=log, max_depth=3, root_path="src",
+        accountability=False)
     edits = parse_situated_edits(policy.propose(
         _proposal_ctx(state, Task(id="t", prompt="x")))[0])
     merged = next(e["content"] for e in edits if e["path"] == "src/a/b/f.py")
@@ -263,7 +265,8 @@ def test_an_overlapping_sibling_is_sent_back_and_its_other_work_stands():
                            if b.world.path == "src" else []),
         executor=lambda b: [Edit(b.world.path, "src/a/b/f.py", bodies[b.world.path]),
                             Edit(b.world.path, f"{b.world.path}/own.py", "1\n")],
-        log=log, max_depth=3, max_edits=8, root_path="src")
+        log=log, max_depth=3, max_edits=8, root_path="src",
+        accountability=False)
     edits = {e["path"] for e in parse_situated_edits(policy.propose(
         _proposal_ctx(state, Task(id="t", prompt="x")))[0])}
     assert policy.sibling_conflicts == 1
@@ -527,13 +530,58 @@ def test_a_node_relative_filename_lands_in_the_node_not_at_the_repository_root()
         manager=lambda b: ([Delegation("src/frontend", "build the lexer")]
                            if b.world.path == "src" else []),
         executor=lambda b: [Edit(b.world.path, "lexer.py", "lex\n")],
-        log=log, max_depth=3, root_path="src")
+        log=log, max_depth=3, root_path="src",
+        accountability=False)
     routed = {"src/CONTEXT.md": "# src\n\n## Routing Table\n- `./src/frontend/` -> lexer\n"}
     edits = parse_situated_edits(policy.propose(
         _proposal_ctx(routed, Task(id="t", prompt="x")))[0])
     assert [e["path"] for e in edits] == ["src/frontend/lexer.py"]
     assert policy.resolved_relative == 1
     assert policy.requests_raised == 0, "it was never a cross-node request"
+
+
+def test_a_manager_writes_its_own_nodes_file_after_its_children_return():
+    """Upstream's third phase: delegation does not discharge accountability.
+
+    Measured before this existed: a model run produced five correct modules and
+    no `src/__init__.py`, so the public surface the specification names did not
+    exist and every case scored zero. The manager had delegated, every time.
+    """
+    log = WorldLog()
+    seen = []
+
+    def executor(brief):
+        seen.append((brief.world.path, brief.objective.startswith("review")))
+        if brief.world.path == "src/frontend":
+            return [Edit(brief.world.path, "src/frontend/lexer.py", "lex\n")]
+        return [Edit(brief.world.path, "src/__init__.py", "surface\n")]
+
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/frontend", "lexer")]
+                           if b.world.path == "src" else []),
+        executor=executor, log=log, max_depth=3, root_path="src")
+    routed = {"src/CONTEXT.md": "# src\n\n## Routing Table\n- `./src/frontend/` -> lexer\n"}
+    edits = {e["path"] for e in parse_situated_edits(policy.propose(
+        _proposal_ctx(routed, Task(id="t", prompt="x")))[0])}
+    assert edits == {"src/frontend/lexer.py", "src/__init__.py"}
+    assert ("src", True) in seen, "the manager never got its accountability turn"
+    assert policy.accountability_edits == 1
+
+
+def test_the_accountability_turn_will_not_overwrite_a_childs_file():
+    """A manager is accountable for its subtree; a child's files are the child's."""
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/frontend", "lexer")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, "src/frontend/lexer.py",
+                                 "mine\n" if b.world.path == "src" else "theirs\n")],
+        log=log, max_depth=3, root_path="src")
+    routed = {"src/CONTEXT.md": "# src\n\n## Routing Table\n- `./src/frontend/` -> lexer\n"}
+    edits = {e["path"]: e["content"] for e in parse_situated_edits(policy.propose(
+        _proposal_ctx(routed, Task(id="t", prompt="x")))[0])}
+    assert edits == {"src/frontend/lexer.py": "theirs\n"}
+    assert policy.accountability_declined == 1
 
 
 def test_a_change_outside_a_childs_path_is_reported_up_and_handled_there():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -15,10 +15,12 @@ from agentdescent.aggregator import AggregatorConfig, MergeOutcome, diffs_contra
 from agentdescent.defaults import DefaultAcceptance, DefaultConflict
 from agentdescent.evolution import EvolvingArtifact, Task, evolve
 from agentdescent.evolvable import Diff, EvidenceCard
-from agentdescent.filetree import canonical
+from agentdescent.filetree import canonical, match_any
 from agentdescent.policies import MergeContext, Policies, ProposalContext
 
 from examples.genesis import _domain as domain
+from examples.genesis import _jqx as jqx
+from examples.genesis import _md as md
 from examples.genesis import _stackvm as stackvm
 from examples.genesis._delegation import (Brief, Delegation, Edit,
                                           RecursiveDelegation, render_edits)
@@ -638,7 +640,11 @@ def test_an_outstanding_rework_request_is_taken_before_a_free_choice():
 # The domain, and one end-to-end formation
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("spec", [domain, stackvm], ids=["minilang", "stackvm"])
+DOMAINS = [domain, stackvm, jqx, md]
+DOMAIN_IDS = ["minilang", "stackvm", "jqx", "md"]
+
+
+@pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
 def test_every_formation_domain_agrees_with_its_own_oracle(spec):
     """A suite that disagrees with its oracle scores a correct candidate wrong."""
     tasks, run = spec.build_tasks(), spec.make_runner()
@@ -646,12 +652,43 @@ def test_every_formation_domain_agrees_with_its_own_oracle(spec):
     assert sum(spec.reward(t, run(rendered, t)) for t in tasks) == len(tasks)
 
 
-@pytest.mark.parametrize("spec", [domain, stackvm], ids=["minilang", "stackvm"])
+@pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
 def test_every_formation_domain_starts_with_no_implementation(spec):
     files = spec.initial_files()
-    assert files and all(p.endswith(".md") for p in files)
+    # Markdown, plus any frozen entry script the human supplies -- a domain whose
+    # result is a program needs a shell around the library, and that shell is the
+    # human's, not an agent's.
+    frozen_scripts = [p for p in files if not p.endswith(".md")]
+    assert files and all(match_any(p, spec.FROZEN) for p in frozen_scripts)
     tasks, run = spec.build_tasks(), spec.make_runner()
     assert sum(spec.reward(t, run(canonical(files), t)) for t in tasks) == 0
+
+
+@pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
+def test_every_stage_is_reachable_from_the_train_split(spec):
+    """A unit the train split cannot reach is a unit the run can never grow.
+
+    Found the expensive way on jqx: the case list was ordered by filter, so two
+    builtins appeared only in the held-out tail. No rollout could fail on them, so
+    no proposal was ever requested for them, and the run stalled at 0.923 with two
+    stubs open and `stop reason: rounds`. `evolve()` splits by position, so this is
+    a property of the *order* of the case list, and nothing else checks it.
+    """
+    tasks = spec.build_tasks()
+    train = tasks[:int(len(tasks) * 0.6)]          # evolve(held_out_frac=0.4)
+    missing = sorted(set(t.meta["kind"] for t in tasks)
+                     - set(t.meta["kind"] for t in train))
+    assert not missing, f"stages only in the held-out tail: {missing}"
+
+
+def test_the_md_suite_cannot_be_passed_by_returning_true():
+    """Four of md's ten stages are invariants, which is a cheatable shape.
+
+    One `cons` case uses a timestep far too large, so its answer is `False` -- a
+    stage that returns `True` without computing anything fails the suite.
+    """
+    golds = {t.meta["gold"] for t in md.build_tasks() if t.meta["kind"] == "cons"}
+    assert golds == {"True", "False"}
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -27,6 +27,7 @@ from examples.genesis._delegation import (Brief, Delegation, Edit,
 from examples.genesis._judge import ParentJudge
 from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
+from examples.genesis._suite import preflight
 from examples.genesis._world import (CONTEXT_FILE, SKILLS_DIR, TRUNCATED,
                                      LocalWorld, WorldLog, owns, parse_routing,
                                      resolve_edit_path, routing_entry)
@@ -763,6 +764,28 @@ def test_the_md_suite_catches_an_integrator_that_is_only_stable():
               if md.reward(t, run(rendered, t)) == 0.0]
     assert any("reversing" in t for t in failed), failed
     assert any("conserved" in t for t in failed), failed
+
+
+def test_a_dead_backend_stops_the_run_before_it_starts():
+    """Thirteen minutes of a 404 endpoint reads exactly like a broken mechanism.
+
+    `evolve()` swallows an exception from a proposal policy, correctly -- one timed
+    out call should cost its episode and no more. But then every call failing is not
+    an error, it is an empty run: `reward 0.000  depth=0  accepted=400`, with the
+    only evidence `2400 failed` in the usage line. So the endpoint is asked one
+    question first, and that failure is loud.
+    """
+    def dead(prompt):
+        raise RuntimeError("Error code: 404 - the API does not exist")
+
+    with pytest.raises(SystemExit) as caught:
+        preflight(dead)
+    assert "ANTHROPIC_BASE_URL" in str(caught.value)
+    assert "404" in str(caught.value)
+
+    asked = []
+    preflight(lambda prompt: asked.append(prompt) or "OK")       # a live one is quiet
+    assert len(asked) == 1
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -24,8 +24,9 @@ from examples.genesis._delegation import (Brief, Delegation, Edit,
 from examples.genesis._judge import ParentJudge
 from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
-from examples.genesis._world import (CONTEXT_FILE, LocalWorld, WorldLog, owns,
-                                     parse_routing, routing_entry)
+from examples.genesis._world import (CONTEXT_FILE, SKILLS_DIR, TRUNCATED,
+                                     LocalWorld, WorldLog, owns, parse_routing,
+                                     routing_entry)
 
 
 # ---------------------------------------------------------------------------
@@ -144,6 +145,94 @@ def test_the_offline_manager_takes_its_decomposition_from_context_md():
                   context="", state=rerouted, task=Task(id="t", prompt="1 + 2"),
                   output="", reward=0.0, depth=0)
     assert [d.path for d in domain.offline_manager(brief)] == ["src/frontend"]
+
+
+def test_skills_are_inherited_along_the_chain_like_context():
+    """The paper lists reusable skills among what an accepted version carries."""
+    state = {f"{SKILLS_DIR}/house.md": "a", f"src/{SKILLS_DIR}/modules.md": "b",
+             f"src/other/{SKILLS_DIR}/not-mine.md": "c"}
+    world = LocalWorld(version=1, path="src")
+    assert world.skills(state) == [f"{SKILLS_DIR}/house.md", f"src/{SKILLS_DIR}/modules.md"]
+    assert f"{SKILLS_DIR}/modules.md" in world.situate(state)
+
+
+def test_an_oversized_brief_carries_upstreams_own_truncation_marker():
+    """The marker is a signal to prune, not decoration -- so it has to be theirs."""
+    state = {CONTEXT_FILE: "x" * 50_000}
+    assert LocalWorld(version=1, path="").situate(state).endswith(TRUNCATED)
+
+
+# ---------------------------------------------------------------------------
+# The parent's integration evidence, and the merge it does on its children
+# ---------------------------------------------------------------------------
+
+def test_a_parent_refuses_a_child_whose_work_breaks_the_suite():
+    """Paper 3.3: the parent decides on tests and integration evidence."""
+    review = domain.suite_review(domain.build_tasks(), sample=6)
+    state = dict(domain._reference_tree())
+    parent = Brief(world=LocalWorld(version=1, path="src"), objective="o", context="",
+                   state=state, task=Task(id="t", prompt="1 + 2"), output="",
+                   reward=1.0, depth=0)
+    broken = [Edit("src/frontend", domain.LEXER, "def tokenize(source):\n    return []\n")]
+    verdict = review(parent, broken)
+    assert verdict is not None and verdict[0] == "rejected"
+    assert "regressed" in verdict[1]
+
+
+def test_a_parent_accepts_structural_work_that_moves_no_case():
+    """A node's first file is structure, and structure moves nothing."""
+    review = domain.suite_review(domain.build_tasks(), sample=6)
+    parent = Brief(world=LocalWorld(version=1, path="src"), objective="o", context="",
+                   state=domain.initial_files(), task=Task(id="t", prompt="1 + 2"),
+                   output="", reward=0.0, depth=0)
+    assert review(parent, [Edit("src", "src/notes.py", "# nothing yet\n")]) is None
+
+
+@pytest.mark.skipif(not git_available(), reason="git merge-file is the merge engine")
+def test_two_children_writing_one_file_are_merged_rather_than_one_rejected():
+    """A child inside another's subtree may legally touch the same path.
+
+    Rejecting on a bare collision discarded a whole contribution for touching a
+    file a sibling also touched -- which is the merge the system exists to do.
+    """
+    # The reachable shape: one child is situated *inside* the other's subtree, so
+    # `src/a/b/f.py` is legally within the authority of both.
+    log = WorldLog()
+    state = {"src/CONTEXT.md": "# src\n", "src/a/b/f.py": _BASE}
+    bodies = {"src/a": _OURS, "src/a/b": _THEIRS}
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/a", "x"), Delegation("src/a/b", "y")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, "src/a/b/f.py", bodies[b.world.path])],
+        log=log, max_depth=3, root_path="src")
+    edits = parse_situated_edits(policy.propose(
+        _proposal_ctx(state, Task(id="t", prompt="x")))[0])
+    merged = next(e["content"] for e in edits if e["path"] == "src/a/b/f.py")
+    assert "return 1" in merged and "return 2" in merged
+    assert policy.sibling_merges == 1 and policy.sibling_conflicts == 0
+    assert [e.verdict for e in log.episodes if e.path.startswith("src/")] == \
+           ["accepted", "accepted"]
+
+
+@pytest.mark.skipif(not git_available(), reason="git merge-file is the merge engine")
+def test_an_overlapping_sibling_is_sent_back_and_its_other_work_stands():
+    log = WorldLog()
+    rival = _BASE.replace("def a():\n    raise NotImplementedError",
+                          "def a():\n    return 9")
+    state = {"src/CONTEXT.md": "# src\n", "src/a/b/f.py": _BASE}
+    bodies = {"src/a": _OURS, "src/a/b": rival}
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/a", "x"), Delegation("src/a/b", "y")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, "src/a/b/f.py", bodies[b.world.path]),
+                            Edit(b.world.path, f"{b.world.path}/own.py", "1\n")],
+        log=log, max_depth=3, max_edits=8, root_path="src")
+    edits = {e["path"] for e in parse_situated_edits(policy.propose(
+        _proposal_ctx(state, Task(id="t", prompt="x")))[0])}
+    assert policy.sibling_conflicts == 1
+    assert "src/a/b/own.py" in edits, "the child's non-overlapping work still stands"
+    assert "src/a/b" in log.pending_rework
+    assert [e.verdict for e in log.episodes if e.path == "src/a/b"] == ["rework"]
 
 
 # ---------------------------------------------------------------------------
@@ -375,19 +464,58 @@ def test_a_child_that_returns_nothing_is_sent_back_rather_than_annotated():
 
 
 def test_a_refused_child_leaves_its_reason_in_the_nodes_context_md():
-    """Appendix 1.4: the rejected code does not survive, the saved reason can."""
+    """Appendix 1.4: the rejected code does not survive, the saved reason can.
+
+    Rejection now comes from the parent's *evidence*, not from scope -- an edit
+    outside the child's path is a request, which is the next test.
+    """
     log = WorldLog()
     policy = RecursiveDelegation(
-        manager=lambda b: ([Delegation("src", "write outside your path")]
-                           if b.world.path == "" else []),
-        executor=lambda b: [Edit(b.world.path, "elsewhere/x.py", "nope")],
+        manager=lambda b: ([Delegation("src", "do it")] if b.world.path == "" else []),
+        executor=lambda b: [Edit(b.world.path, "src/x.py", "nope")],
+        review=lambda parent, returned: ("rejected", "it breaks the build"),
         log=log, max_depth=2)
     proposals = policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"},
                                              Task(id="t", prompt="x")))
     edits = parse_situated_edits(proposals[0])
     assert [e["path"] for e in edits] == [f"src/{CONTEXT_FILE}"]
-    assert "refused:" in edits[0]["content"]
+    assert "refused: it breaks the build" in edits[0]["content"]
     assert [e.verdict for e in log.episodes if e.path == "src"] == ["rejected"]
+
+
+def test_a_change_outside_a_childs_path_is_reported_up_and_handled_there():
+    """Upstream: "report the need back up to your parent, which will handle it".
+
+    The child never writes outside its subtree -- the ancestor that has authority
+    there makes the change, under its own name.
+    """
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/frontend", "build the lexer")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, "src/frontend/lexer.py", "lex\n"),
+                            Edit(b.world.path, "src/__init__.py", "surface\n")],
+        log=log, max_depth=3, root_path="src")
+    routed = {"src/CONTEXT.md": "# src\n\n## Routing Table\n- `./src/frontend/` -> lexer\n"}
+    edits = {e["owner"]: e["path"] for e in parse_situated_edits(policy.propose(
+        _proposal_ctx(routed, Task(id="t", prompt="x")))[0])}
+    assert edits == {"src/frontend": "src/frontend/lexer.py", "src": "src/__init__.py"}
+    assert (policy.requests_raised, policy.adopted_requests,
+            policy.unmet_requests) == (1, 1, 0)
+
+
+def test_a_need_nobody_in_the_chain_can_meet_is_counted_not_dropped():
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/frontend", "x")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, "src/frontend/a.py", "1\n"),
+                            Edit(b.world.path, "docs/guide.md", "2\n")],
+        log=log, max_depth=3, root_path="src")
+    policy.propose(_proposal_ctx({"src/CONTEXT.md": "# src\n"},
+                                 Task(id="t", prompt="x")))
+    assert (policy.requests_raised, policy.adopted_requests,
+            policy.unmet_requests) == (1, 0, 1)
 
 
 def test_an_outstanding_rework_request_is_taken_before_a_free_choice():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -19,6 +19,7 @@ from agentdescent.filetree import canonical
 from agentdescent.policies import MergeContext, Policies, ProposalContext
 
 from examples.genesis import _domain as domain
+from examples.genesis import _stackvm as stackvm
 from examples.genesis._delegation import (Brief, Delegation, Edit,
                                           RecursiveDelegation, render_edits)
 from examples.genesis._judge import ParentJudge
@@ -635,6 +636,36 @@ def test_an_outstanding_rework_request_is_taken_before_a_free_choice():
 # ---------------------------------------------------------------------------
 # The domain, and one end-to-end formation
 # ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spec", [domain, stackvm], ids=["minilang", "stackvm"])
+def test_every_formation_domain_agrees_with_its_own_oracle(spec):
+    """A suite that disagrees with its oracle scores a correct candidate wrong."""
+    tasks, run = spec.build_tasks(), spec.make_runner()
+    rendered = canonical(spec._reference_tree())
+    assert sum(spec.reward(t, run(rendered, t)) for t in tasks) == len(tasks)
+
+
+@pytest.mark.parametrize("spec", [domain, stackvm], ids=["minilang", "stackvm"])
+def test_every_formation_domain_starts_with_no_implementation(spec):
+    files = spec.initial_files()
+    assert files and all(p.endswith(".md") for p in files)
+    tasks, run = spec.build_tasks(), spec.make_runner()
+    assert sum(spec.reward(t, run(canonical(files), t)) for t in tasks) == 0
+
+
+def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():
+    """The second domain is not "harder code" -- it is somewhere for the
+    recursion to go. `src/vm/ops` is a node whose parent is itself a child."""
+    def node_depth(files):
+        # the nodes are where the CONTEXT.md records are; the skill directory is
+        # deep in both domains and is not a node.
+        return max(p.count("/") for p in files if p.endswith(CONTEXT_FILE))
+    assert node_depth(stackvm.initial_files()) == 3        # src/vm/ops/CONTEXT.md
+    assert node_depth(domain.initial_files()) == 2         # src/frontend/CONTEXT.md
+    assert "src/vm/ops/CONTEXT.md" in stackvm.initial_files()
+    routes = LocalWorld(version=1, path="src/vm").routing(stackvm.initial_files())
+    assert routes == ["src/vm/ops"]
+
 
 def test_the_frozen_suite_agrees_with_its_own_oracle():
     tasks = domain.build_tasks()

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -13,7 +13,7 @@ import pytest
 
 from agentdescent.aggregator import AggregatorConfig, MergeOutcome, diffs_contradict
 from agentdescent.defaults import DefaultAcceptance, DefaultConflict
-from agentdescent.evolution import EvolvingArtifact, Task, evolve
+from agentdescent.evolution import EvolvingArtifact, RoundInfo, Task, evolve
 from agentdescent.evolvable import Diff, EvidenceCard
 from agentdescent.filetree import canonical, match_any
 from agentdescent.policies import MergeContext, Policies, ProposalContext
@@ -25,9 +25,12 @@ from examples.genesis import _stackvm as stackvm
 from examples.genesis._delegation import (Brief, Delegation, Edit,
                                           RecursiveDelegation, render_edits)
 from examples.genesis._judge import ParentJudge
-from examples.genesis._review import ParentCodeReview, chain_reviews
+from examples.genesis._review import (CompletionJudge, ParentCodeReview,
+                                      chain_reviews)
 from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
+from examples.genesis._worktree import (Rollout, WorktreeLedger,
+                                        git_worktrees_available)
 from examples.genesis._suite import cold_start, preflight
 from examples.genesis._world import (CONTEXT_FILE, KNOWN_ISSUES, ROUTING_HEADING,
                                      SKILLS_DIR, TRUNCATED,
@@ -511,12 +514,23 @@ def test_one_rollout_is_a_tree_of_episodes_at_one_version():
 
 
 def test_a_child_that_returns_nothing_is_sent_back_rather_than_annotated():
-    """"Try again" is queued; only a refusal is written into the world."""
+    """"Try again" is queued; only a refusal is written into the world.
+
+    The node it opened is still recorded, and that is upstream's order rather than an
+    exception to this rule: the architect creates the child directory and its
+    CONTEXT.md with `make_dir` (which auto-commits) and *then* spawns the subagent, so
+    the node exists whether or not the work does. What is not written is any remark
+    about the attempt.
+    """
     log = WorldLog()
     policy = RecursiveDelegation(manager=lambda b: [Delegation("src", "do nothing")],
                                  executor=lambda b: [], log=log, max_depth=2)
-    assert policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"},
-                                        Task(id="t", prompt="x"))) == []
+    proposals = policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"},
+                                             Task(id="t", prompt="x")))
+    edits = parse_situated_edits(proposals[0]) if proposals else []
+    assert [e["path"] for e in edits] == [CONTEXT_FILE]       # the routing entry only
+    assert "refused" not in (edits[0]["content"] if edits else "")
+    assert log.pending_rework                                 # queued instead
     assert [e.verdict for e in log.episodes if e.path == "src"] == ["rework"]
     assert set(log.pending_rework) == {"src"}
 
@@ -536,8 +550,11 @@ def test_a_refused_child_leaves_its_reason_in_the_nodes_context_md():
     proposals = policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"},
                                              Task(id="t", prompt="x")))
     edits = parse_situated_edits(proposals[0])
-    assert [e["path"] for e in edits] == [f"src/{CONTEXT_FILE}"]
-    assert "refused: it breaks the build" in edits[0]["content"]
+    # The refusal at the child's own node, and the entry for the node the manager
+    # opened -- written before the child was briefed, as upstream's `make_dir` is.
+    assert [e["path"] for e in edits] == [CONTEXT_FILE, f"src/{CONTEXT_FILE}"]
+    assert "refused: it breaks the build" in edits[1]["content"]
+    assert KNOWN_ISSUES in edits[1]["content"]
     assert [e.verdict for e in log.episodes if e.path == "src"] == ["rejected"]
 
 
@@ -1045,6 +1062,145 @@ def test_every_node_record_carries_upstreams_four_standard_sections(spec):
         assert "## API Surface" in body, f"{path} says nothing about what it exposes"
     assert any(ROUTING_HEADING in body for body in records.values())
     assert any("## Constraints" in body for body in records.values())
+
+
+# ---------------------------------------------------------------------------
+# The scheduling model: a worktree per episode, a commit, and the worktree gone
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not git_worktrees_available(), reason="git worktree unavailable")
+def test_a_parents_merge_commit_carries_every_child_commit_as_a_parent():
+    """The phylogenetic graph, as git history rather than as a diagram.
+
+    `Git.merge_octopus/2` leaves a merge commit whose parents are the base and every
+    child; `phylo_graph_node.ex` then has a `find_merge_base/2` worth calling. With
+    the states kept in memory there was nothing for either to see.
+    """
+    ledger = WorktreeLedger()
+    with Rollout(ledger) as rollout:
+        base = rollout.commit("M0001", {CONTEXT_FILE: "# root\n"}, "before delegating")
+        left = rollout.commit("E0002", {CONTEXT_FILE: "# root\n", "src/a.py": "a\n"},
+                              "child a", [base])
+        right = rollout.commit("E0003", {CONTEXT_FILE: "# root\n", "src/b.py": "b\n"},
+                               "child b", [base])
+        merge = rollout.commit("M0001.merge",
+                               {CONTEXT_FILE: "# root\n", "src/a.py": "a\n",
+                                "src/b.py": "b\n"}, "merge 2 children",
+                               [base, left, right])
+        graph = {line.split()[0]: line.split()[1:] for line in rollout.history()}
+        assert merge[:7] in graph
+        assert len(graph[merge[:7]]) >= 3          # parents, then the subject words
+        assert base[:7] in graph and left[:7] in graph and right[:7] in graph
+    assert (ledger.created, ledger.removed) == (4, 4)
+    assert ledger.merge_commits == 1 and ledger.max_parents == 3
+    assert ledger.leaked == 0
+
+
+@pytest.mark.skipif(not git_worktrees_available(), reason="git worktree unavailable")
+def test_every_episode_commits_in_its_own_worktree_and_the_worktree_is_removed():
+    """"Commit your changes, release your worktree, and wait" -- `agents/manager.ex`.
+
+    The release is not optional upstream: an unreleased worktree is an agent that
+    never yielded, and the scheduler is cooperative. So the ledger has to balance.
+    """
+    ledger = WorktreeLedger()
+    log = WorldLog()
+    seen = []
+    policy = RecursiveDelegation(
+        rollout_factory=lambda: Rollout(ledger),
+        manager=lambda b: ([Delegation("src/frontend", "lex"),
+                            Delegation("src/backend", "eval")] if b.world.path == "src"
+                           else ([Delegation("src", "all of it")] if not b.world.path
+                                 else [])),
+        executor=lambda b: (seen.append(b.world.path) or
+                            [Edit(b.world.path, f"{b.world.path}/x.py", "x = 1\n")]),
+        log=log, max_depth=3)
+    policy.propose(_proposal_ctx({CONTEXT_FILE: "# root\n"}, Task(id="t", prompt="x")))
+
+    # the two leaves first, then each manager's accountability turn at its own node
+    assert seen[:2] == ["src/frontend", "src/backend"] and "src" in seen[2:]
+    assert ledger.created == ledger.removed > 0, ledger.summary()
+    assert ledger.leaked == 0
+    assert ledger.commits >= 4            # two leaves, the base, and the merges
+    assert ledger.max_parents >= 3        # a parent, and the two children it kept
+    # and every episode carries the sha it could be resurrected from
+    assert all(e.commit for e in log.episodes), [e.agent_id for e in log.episodes
+                                                 if not e.commit]
+
+
+def test_a_child_sees_the_node_record_its_parent_wrote_before_briefing_it():
+    """"Create the child directory with CONTEXT.md via `make_dir` (auto-commits),
+    **then** spawn the subagent" -- `agents/architect.ex`, Phase 1. A child briefed
+    before that write arrives at a node its own parent's routing table does not
+    mention, which is exactly the thing the routing table exists to prevent.
+    """
+    briefs = {}
+    policy = RecursiveDelegation(
+        manager=lambda b: [Delegation("src", "do it")] if not b.world.path else [],
+        executor=lambda b: (briefs.__setitem__(b.world.path, b.context) or []),
+        log=WorldLog(), max_depth=3)
+    policy.propose(_proposal_ctx({CONTEXT_FILE: "# root\n"}, Task(id="t", prompt="x")))
+    assert "src" in briefs
+    assert "`./src/` -> do it" in briefs["src"], briefs["src"]
+
+
+# ---------------------------------------------------------------------------
+# complete_task: the run ends when an agent says so, not when the budget does
+# ---------------------------------------------------------------------------
+
+def _completion_judge(complete, state):
+    return CompletionJudge(complete, tasks=domain.build_tasks(),
+                           run=domain.make_runner(), reward=domain.reward,
+                           state_of=lambda: state, contracts=domain.CONTRACTS,
+                           objective="an integer expression language")
+
+
+def test_the_root_agent_is_not_asked_while_a_test_it_can_see_still_fails():
+    """Upstream's own precondition: "aim for a 100% pass rate on the given test
+    suites -- treat them as the definition of done". Below that the question is not
+    asked, and no model call is spent asking it."""
+    judge = _completion_judge(lambda prompt: pytest.fail("asked too early"),
+                              domain.initial_files())
+    assert judge(RoundInfo(round=1, held_out_reward=0.0, n_items=0, committed=0,
+                           rejected=0)) is False
+    assert judge.asked == 0
+
+
+def test_the_run_ends_when_the_root_agent_says_the_objective_is_delivered():
+    prompts = []
+
+    def complete(prompt):
+        prompts.append(prompt)
+        return '{"complete": true, "reason": "every module is implemented"}'
+
+    judge = _completion_judge(complete, domain.reference_tree())
+    info = RoundInfo(round=4, held_out_reward=1.0, n_items=4, committed=3, rejected=0)
+    assert judge(info) is True
+    assert judge.asked == 1 and judge.verdict == "complete"
+    # the decision is about the codebase, and the port's own measurement is not shown:
+    # that number comes from tests no agent may read, and handing it over would turn
+    # the judgment back into a threshold.
+    assert "1.0" not in prompts[0] and "held-out" not in prompts[0]
+    assert "src/__init__.py" in prompts[0]          # the tree is what it judges
+
+
+def test_an_unparseable_or_negative_answer_keeps_the_run_going():
+    green = domain.reference_tree()
+    assert _completion_judge(lambda p: "not sure yet", green)(
+        RoundInfo(round=1, held_out_reward=1.0, n_items=1, committed=1,
+                  rejected=0)) is False
+    judge = _completion_judge(lambda p: '{"complete": false, "reason": "stubs left"}',
+                              green)
+    assert judge(RoundInfo(round=1, held_out_reward=1.0, n_items=1, committed=1,
+                           rejected=0)) is False
+    assert (judge.verdict, judge.reason) == ("incomplete", "stubs left")
+
+    def dead(prompt):
+        raise RuntimeError("502")
+
+    assert _completion_judge(dead, green)(
+        RoundInfo(round=1, held_out_reward=1.0, n_items=1, committed=1,
+                  rejected=0)) is False
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -26,7 +26,7 @@ from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
 from examples.genesis._world import (CONTEXT_FILE, SKILLS_DIR, TRUNCATED,
                                      LocalWorld, WorldLog, owns, parse_routing,
-                                     routing_entry)
+                                     resolve_edit_path, routing_entry)
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +147,27 @@ def test_the_offline_manager_takes_its_decomposition_from_context_md():
     assert [d.path for d in domain.offline_manager(brief)] == ["src/frontend"]
 
 
+_TREE = {CONTEXT_FILE: "r", "src/CONTEXT.md": "s", "src/frontend/CONTEXT.md": "f",
+         "src/frontend/lexer.py": "old", "spec/CONTEXT.md": "p"}
+
+
+@pytest.mark.parametrize("owner,written,expected,relative", [
+    # the defect this exists for: a node-relative filename read as
+    # repository-relative sent real work to the top of the repository
+    ("src/frontend", "lexer.py", "src/frontend/lexer.py", True),
+    ("src/frontend", "__init__.py", "src/frontend/__init__.py", True),
+    ("src", "backend/evaluator.py", "src/backend/evaluator.py", True),
+    ("src/frontend", "CONTEXT.md", "src/frontend/CONTEXT.md", True),
+    # ...and the case it must never mangle: a genuine request about another node
+    ("src/frontend", "src/__init__.py", "src/__init__.py", False),
+    ("src/frontend", "src/frontend/parser.py", "src/frontend/parser.py", False),
+    ("", "anything.py", "anything.py", False),
+])
+def test_a_path_is_resolved_against_the_node_the_agent_stands_in(
+        owner, written, expected, relative):
+    assert resolve_edit_path(_TREE, owner, written) == (expected, relative)
+
+
 def test_skills_are_inherited_along_the_chain_like_context():
     """The paper lists reusable skills among what an accepted version carries."""
     state = {f"{SKILLS_DIR}/house.md": "a", f"src/{SKILLS_DIR}/modules.md": "b",
@@ -154,6 +175,22 @@ def test_skills_are_inherited_along_the_chain_like_context():
     world = LocalWorld(version=1, path="src")
     assert world.skills(state) == [f"{SKILLS_DIR}/house.md", f"src/{SKILLS_DIR}/modules.md"]
     assert f"{SKILLS_DIR}/modules.md" in world.situate(state)
+
+
+def test_an_agent_deep_in_the_tree_is_shown_the_contract_it_is_judged_against():
+    """Paper 3.1: an agent may inspect the whole project; it only *begins* at p.
+
+    The specification is a sibling of the implementation, so it is on nobody's
+    CONTEXT.md chain. Before this, every agent inferred the language from one
+    failing input and built a coherent toolchain against the wrong contract.
+    """
+    brief = LocalWorld(version=1, path="src/frontend").situate(
+        domain.initial_files(), contracts=domain.FROZEN)
+    assert "src.parse(source)" in brief
+    assert '("num", <int>)' in brief
+    # ...and without it, invisible -- which is the defect, stated as a test.
+    assert "src.parse(source)" not in LocalWorld(version=1, path="src/frontend").situate(
+        domain.initial_files())
 
 
 def test_an_oversized_brief_carries_upstreams_own_truncation_marker():
@@ -483,6 +520,22 @@ def test_a_refused_child_leaves_its_reason_in_the_nodes_context_md():
     assert [e.verdict for e in log.episodes if e.path == "src"] == ["rejected"]
 
 
+def test_a_node_relative_filename_lands_in_the_node_not_at_the_repository_root():
+    """The whole of a real run's work went to the top of the tree over this."""
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src/frontend", "build the lexer")]
+                           if b.world.path == "src" else []),
+        executor=lambda b: [Edit(b.world.path, "lexer.py", "lex\n")],
+        log=log, max_depth=3, root_path="src")
+    routed = {"src/CONTEXT.md": "# src\n\n## Routing Table\n- `./src/frontend/` -> lexer\n"}
+    edits = parse_situated_edits(policy.propose(
+        _proposal_ctx(routed, Task(id="t", prompt="x")))[0])
+    assert [e["path"] for e in edits] == ["src/frontend/lexer.py"]
+    assert policy.resolved_relative == 1
+    assert policy.requests_raised == 0, "it was never a cross-node request"
+
+
 def test_a_change_outside_a_childs_path_is_reported_up_and_handled_there():
     """Upstream: "report the need back up to your parent, which will handle it".
 
@@ -510,9 +563,11 @@ def test_a_need_nobody_in_the_chain_can_meet_is_counted_not_dropped():
         manager=lambda b: ([Delegation("src/frontend", "x")]
                            if b.world.path == "src" else []),
         executor=lambda b: [Edit(b.world.path, "src/frontend/a.py", "1\n"),
-                            Edit(b.world.path, "docs/guide.md", "2\n")],
+                            Edit(b.world.path, "spec/extra.md", "2\n")],
         log=log, max_depth=3, root_path="src")
-    policy.propose(_proposal_ctx({"src/CONTEXT.md": "# src\n"},
+    # `spec/` is a real top-level node, so the path is repository-relative and the
+    # request is genuine -- and nobody from `src` down has authority there.
+    policy.propose(_proposal_ctx({"src/CONTEXT.md": "# src\n", "spec/CONTEXT.md": "s"},
                                  Task(id="t", prompt="x")))
     assert (policy.requests_raised, policy.adopted_requests,
             policy.unmet_requests) == (1, 0, 1)

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -766,6 +766,46 @@ def test_the_md_suite_catches_an_integrator_that_is_only_stable():
     assert any("conserved" in t for t in failed), failed
 
 
+def test_the_contract_reaches_the_agent_even_when_a_bigger_frozen_file_sorts_first():
+    """Sorted order made *which* contract an agent sees depend on filenames.
+
+    md froze `spec/**`, `tests/**` and `md.py`; `md.py` sorts first, is 6.8 kB of
+    driver, and ate a budget the 4.5 kB specification then never reached. Every
+    agent inferred the public surface from the one failing test it was shown, five
+    of the seven keyword parameters went missing, and the run scored 0.750 against
+    a specification nobody had read. The order is the domain's now.
+    """
+    state = {CONTEXT_FILE: "# root\n", "aaa_driver.py": "# driver\n" + "x" * 9000,
+             "spec/CONTEXT.md": "# the contract\nTHE SIGNATURE IS f(a, b=1)\n"}
+    context = LocalWorld(0, "").situate(state, contracts=("spec/**", "aaa_driver.py"),
+                                        max_chars=4000)
+    assert "THE SIGNATURE IS f(a, b=1)" in context
+    assert len(context) <= 4000
+
+
+def test_the_file_listing_survives_a_contract_too_big_to_fit():
+    """Truncating from the end dropped the listing, which is the actionable part:
+    a node that owns no file yet only learns it from that line."""
+    state = {CONTEXT_FILE: "# root\n", "spec/CONTEXT.md": "# spec\n" + "y" * 9000}
+    context = LocalWorld(0, "src").situate(state, contracts=("spec/**",),
+                                           max_chars=2000)
+    assert TRUNCATED in context                                  # the contract gave
+    assert "(none yet -- this node owns no file)" in context      # the listing stayed
+
+
+@pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
+def test_every_node_of_every_domain_is_given_the_whole_contract(spec):
+    """At the default budget, from every node, for every domain -- not just the one
+    whose frozen file happens to sort early."""
+    files = spec.initial_files()
+    nodes = sorted(p[:-len(CONTEXT_FILE)].rstrip("/") for p in files
+                   if p.endswith(CONTEXT_FILE) and not p.startswith("spec/"))
+    contract = files["spec/CONTEXT.md"].strip()
+    for node in nodes:
+        context = LocalWorld(0, node).situate(files, contracts=spec.FROZEN)
+        assert contract in context, f"{spec.MD.name if hasattr(spec, 'MD') else node}"
+
+
 def test_a_dead_backend_stops_the_run_before_it_starts():
     """Thirteen minutes of a 404 endpoint reads exactly like a broken mechanism.
 

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -743,6 +743,34 @@ def test_the_md_audit_tests_are_injected_only_while_they_are_scored():
     assert sum(md.reward(t, run(rendered, t)) for t in audited) == len(audited)
 
 
+def test_the_md_suite_rejects_a_force_field_that_is_identically_zero():
+    """The cheapest way to pass a suite of invariants, and a run found it.
+
+    Zero sums to zero, zero is the gradient of a constant, nothing moves so nothing
+    drifts, and reversing nothing retraces it. A real run shipped exactly that -- a
+    minimum-image expression whose `// 1` bound after the multiplication, so every
+    pair in a periodic box landed past the cutoff -- and 42 of its 44 tests passed.
+    The suite pins values in a box now, and this is the guard that says so.
+    """
+    zeroed = dict(md.reference_tree())
+    zeroed[md.REGISTRY] = (
+        'def get(name):\n'
+        '    if name not in ("lennard_jones", "harmonic"):\n'
+        '        raise ValueError(name)\n'
+        '    return name\n'
+        '\n'
+        '\n'
+        'def evaluate(system, spec):\n'
+        '    get(spec["name"])\n'
+        '    return 0.0, [[0.0, 0.0, 0.0] for _ in system.positions]\n')
+    run, rendered = md.make_runner(), canonical(zeroed)
+    failed = [t.id for t in md.build_tasks() if md.reward(t, run(rendered, t)) == 0.0]
+    assert any("identically_zero" in t for t in failed), failed
+    assert any("closed_form" in t for t in failed), failed
+    # the audit set catches it too, which is what the audit set is for
+    assert any(t.startswith("audit:") for t in failed), failed
+
+
 def test_the_md_suite_catches_an_integrator_that_is_only_stable():
     """Euler with one force evaluation per step is stable, plausible, and wrong.
 

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -488,9 +488,10 @@ def test_one_rollout_is_a_tree_of_episodes_at_one_version():
     state = domain.initial_files()
     assert policy.propose(_proposal_ctx(state, Task(id="t", prompt="1 + 2")))
     episodes = log.episodes
-    assert [e.role for e in episodes][:2] == ["manager", "executor"]
+    roles = [e.role for e in episodes]
+    assert roles[0] == "manager" and "executor" in roles, roles
     assert {e.version for e in episodes} == {3}, "delegation must not move the version"
-    assert log.observed_depth() >= 1
+    assert log.observed_depth() >= 2, "the tree must be a tree"
 
 
 def test_a_child_that_returns_nothing_is_sent_back_rather_than_annotated():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -1,0 +1,327 @@
+"""EvoX Genesis port: the mechanism, one component at a time, offline.
+
+Every test here is about a piece of the paper's model, not about the domain --
+the domain is a compact stand-in and its numbers prove nothing about upstream.
+What the numbers *can* prove is that the mechanism is the one described: the path
+coordinate bounds authority, delegation does not advance the version, the parent's
+verdict is the parent's, and two agents editing one file both survive.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentdescent.aggregator import AggregatorConfig, MergeOutcome, diffs_contradict
+from agentdescent.defaults import DefaultAcceptance, DefaultConflict
+from agentdescent.evolution import EvolvingArtifact, Task, evolve
+from agentdescent.evolvable import Diff, EvidenceCard
+from agentdescent.filetree import canonical
+from agentdescent.policies import MergeContext, Policies, ProposalContext
+
+from examples.genesis import _domain as domain
+from examples.genesis._delegation import (Brief, Delegation, Edit,
+                                          RecursiveDelegation, render_edits)
+from examples.genesis._judge import ParentJudge
+from examples.genesis._octopus import OctopusConflict, git_available, three_way
+from examples.genesis._spatial import SpatialContract, parse_situated_edits
+from examples.genesis._world import CONTEXT_FILE, LocalWorld, WorldLog, owns
+
+
+# ---------------------------------------------------------------------------
+# w = (v, p), and the two operations on it
+# ---------------------------------------------------------------------------
+
+def test_delegation_moves_the_path_and_not_the_version():
+    """(v, p) -> (v, q). The paper's whole distinction from a serial loop."""
+    parent = LocalWorld(version=7, path="src")
+    child = parent.delegate("src/backend")
+    assert (child.path, child.version) == ("src/backend", 7)
+
+
+def test_delegation_cannot_leave_the_subtree():
+    with pytest.raises(ValueError):
+        LocalWorld(version=1, path="src/frontend").delegate("src/backend")
+
+
+@pytest.mark.parametrize("raw", ["./", ".", "", "/"])
+def test_the_root_is_one_path(raw):
+    assert LocalWorld(version=1, path=raw).path == ""
+    assert owns(raw, "anything/at/all.py")
+
+
+def test_situate_inherits_the_context_chain_root_first():
+    state = {CONTEXT_FILE: "# root", "src/CONTEXT.md": "# src",
+             "src/backend/CONTEXT.md": "# backend", "src/backend/x.py": "x = 1"}
+    text = LocalWorld(version=1, path="src/backend").situate(state)
+    assert text.index("# root") < text.index("# src") < text.index("# backend")
+    assert "src/backend/x.py" in text
+
+
+# ---------------------------------------------------------------------------
+# The spatial contract
+# ---------------------------------------------------------------------------
+
+def _strategy(**kwargs) -> SpatialContract:
+    return SpatialContract(initial_files={CONTEXT_FILE: "# root"},
+                           frozen=("spec/**",), **kwargs)
+
+
+def test_an_edit_outside_the_authors_subtree_is_dropped_and_counted():
+    log = WorldLog()
+    strategy = _strategy(log=log)
+    proposal = render_edits([Edit("src/frontend", "src/backend/evaluator.py", "x")], "r")
+    assert strategy.to_diff(strategy.initial(), proposal, "w0", 1, "world") is None
+    assert log.contract_violations == 1
+
+
+def test_a_frozen_path_is_refused_even_to_the_root():
+    strategy = _strategy()
+    proposal = render_edits([Edit("", "spec/CONTEXT.md", "rewritten")], "r")
+    assert strategy.to_diff(strategy.initial(), proposal, "w0", 1, "world") is None
+
+
+def test_a_new_file_inside_the_subtree_is_an_ordinary_edit():
+    """The property tensor parallelism cannot give: creation is what formation is.
+
+    Under TP the ownership map is fixed before round 0, so a path that is not in
+    it belongs to no section and every creation is a `section-violation`. Here it
+    is just an edit.
+    """
+    strategy = _strategy()
+    proposal = render_edits([Edit("src", "src/brand/new/file.py", "print(1)\n")], "r")
+    diff = strategy.to_diff(strategy.initial(), proposal, "w0", 1, "world")
+    assert diff is not None and diff.ops == {"src/brand/new/file.py": "print(1)\n"}
+
+
+def test_the_strategy_declares_no_key_space_so_tp_is_refused_rather_than_lossy():
+    """`evolve()` refuses TP for a strategy with no `keys()`, which is the point.
+
+    Declaring a partial key space would let TP run and silently discard every
+    file the run created -- the failure this port is built to avoid.
+    """
+    assert not hasattr(_strategy(), "keys")
+
+
+def test_a_reply_that_ignores_the_protocol_costs_its_episode_and_does_not_crash():
+    assert parse_situated_edits("I would rather not.") == []
+    assert _strategy().to_diff({}, "I would rather not.", "w0", 1, "world") is None
+
+
+# ---------------------------------------------------------------------------
+# The octopus merge
+# ---------------------------------------------------------------------------
+
+_BASE = "def a():\n    raise NotImplementedError\n\n\ndef b():\n    raise NotImplementedError\n"
+_OURS = _BASE.replace("def a():\n    raise NotImplementedError", "def a():\n    return 1")
+_THEIRS = _BASE.replace("def b():\n    raise NotImplementedError", "def b():\n    return 2")
+
+
+@pytest.mark.skipif(not git_available(), reason="git merge-file is the merge engine")
+def test_three_way_merges_disjoint_hunks_and_conflicts_on_an_overlap():
+    merged = three_way(_BASE, _OURS, _THEIRS)
+    assert merged is not None and "return 1" in merged and "return 2" in merged
+    rival = _BASE.replace("def a():\n    raise NotImplementedError", "def a():\n    return 9")
+    assert three_way(_BASE, _OURS, rival) is None
+
+
+class _Verifier:
+    """Enough of the verifier protocol for `DefaultConflict` to rank two cards."""
+
+    def cheap_eval(self, artifact) -> float:
+        return float(len(artifact.state.get("f.py", "")))
+
+
+def _cards():
+    artifact = EvolvingArtifact("world", state={"f.py": _BASE})
+    ours = EvidenceCard(diff=Diff("d1", "world", {"f.py": _OURS}), base_version={}, touched=["f.py"])
+    theirs = EvidenceCard(diff=Diff("d2", "world", {"f.py": _THEIRS}), base_version={}, touched=["f.py"])
+    return artifact, [ours, theirs]
+
+
+@pytest.mark.skipif(not git_available(), reason="git merge-file is the merge engine")
+def test_octopus_keeps_both_edits_where_the_keyed_union_drops_one():
+    """The comparison the port exists to make runnable.
+
+    One file, two agents, two different functions. The engine's rule is "same
+    key, different value -> contradiction", so one of them is dropped on score.
+    Upstream three-way merges them and keeps both.
+    """
+    artifact, cards = _cards()
+    assert diffs_contradict(cards[0].diff, cards[1].diff)
+
+    kept_default, dropped = DefaultConflict(_Verifier()).resolve(artifact, list(cards))
+    assert (len(kept_default), dropped) == (1, 1)
+
+    policy = OctopusConflict(inner=DefaultConflict(_Verifier()))
+    kept, dropped = policy.resolve(artifact, list(cards))
+    assert dropped == 0 and policy.merged == 1
+    merged = kept[0].diff.ops["f.py"]
+    assert "return 1" in merged and "return 2" in merged
+
+
+def test_octopus_defers_a_real_overlap_to_the_inner_rule():
+    artifact, cards = _cards()
+    rival = _BASE.replace("def a():\n    raise NotImplementedError", "def a():\n    return 9")
+    cards[1] = EvidenceCard(diff=Diff("d2", "world", {"f.py": rival}),
+                            base_version={}, touched=["f.py"])
+    policy = OctopusConflict(inner=DefaultConflict(_Verifier()))
+    kept, dropped = policy.resolve(artifact, cards)
+    assert policy.merged == 0 and policy.conflicted == 1
+    assert len(kept) == 1 and dropped == 1
+
+
+# ---------------------------------------------------------------------------
+# The parent's verdict
+# ---------------------------------------------------------------------------
+
+def _ctx(base, cand, ops=None):
+    artifact = EvolvingArtifact("world", state={})
+    return MergeContext(artifact=artifact, candidate=artifact, cards=[],
+                        base_counts=base, cand_counts=cand,
+                        diff=Diff("d", "world", ops or {"src/a.py": "x"}))
+
+
+def _configured(policy):
+    policy.configure(AggregatorConfig())
+    return policy
+
+
+def test_disabled_it_is_the_engines_rule_exactly():
+    """`--engine-gate` has to be the shipped gate, not an imitation of it."""
+    judge = _configured(ParentJudge(enabled=False))
+    shipped = _configured(DefaultAcceptance())
+    for base, cand in (((5, 5), (9, 1)), ((5, 5), (5, 5)), ((5, 5), (1, 9))):
+        mine, theirs = judge.accept(_ctx(base, cand)), shipped.accept(_ctx(base, cand))
+        assert (mine.accept, mine.category, mine.detail) == \
+               (theirs.accept, theirs.category, theirs.detail)
+
+
+def test_partial_progress_is_accepted_and_asks_for_more_work():
+    """Upstream's rule, verbatim: a tie is progress, and the subtree is revisited."""
+    log = WorldLog()
+    judge = ParentJudge(log=log, enabled=True)
+    decision = judge.accept(_ctx((5, 5), (5, 5), {"src/backend/a.py": "x",
+                                                  "src/backend/b.py": "y"}))
+    assert decision.accept and judge.partial == 1
+    assert set(log.pending_rework) == {"src/backend"}
+
+
+def test_a_regression_is_refused():
+    judge = ParentJudge(enabled=True)
+    assert judge.accept(_ctx((5, 5), (2, 8))).accept is False
+    assert judge.rejected == 1
+
+
+def test_every_verdict_is_a_category_the_aggregator_can_name():
+    """`MergeOutcome` is a closed vocabulary: an invented category raises mid-merge."""
+    judge = ParentJudge(log=WorldLog(), enabled=True)
+    for base, cand in (((5, 5), (9, 1)), ((5, 5), (5, 5)), ((5, 5), (1, 9))):
+        MergeOutcome(judge.accept(_ctx(base, cand)).category)
+
+
+# ---------------------------------------------------------------------------
+# The recursion
+# ---------------------------------------------------------------------------
+
+def _proposal_ctx(state, task, reward=0.0):
+    return ProposalContext(rendered=canonical(state), task=task, output="",
+                           reward=reward, base_version=3)
+
+
+def test_one_rollout_is_a_tree_of_episodes_at_one_version():
+    log = WorldLog()
+    policy = RecursiveDelegation(manager=domain.offline_manager,
+                                 executor=domain.offline_executor, log=log,
+                                 max_depth=3)
+    state = domain.initial_files()
+    assert policy.propose(_proposal_ctx(state, Task(id="t", prompt="1 + 2")))
+    episodes = log.episodes
+    assert [e.role for e in episodes][:2] == ["manager", "executor"]
+    assert {e.version for e in episodes} == {3}, "delegation must not move the version"
+    assert log.observed_depth() >= 1
+
+
+def test_a_child_that_returns_nothing_is_sent_back_rather_than_annotated():
+    """"Try again" is queued; only a refusal is written into the world."""
+    log = WorldLog()
+    policy = RecursiveDelegation(manager=lambda b: [Delegation("src", "do nothing")],
+                                 executor=lambda b: [], log=log, max_depth=2)
+    assert policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"},
+                                        Task(id="t", prompt="x"))) == []
+    assert [e.verdict for e in log.episodes if e.path == "src"] == ["rework"]
+    assert set(log.pending_rework) == {"src"}
+
+
+def test_a_refused_child_leaves_its_reason_in_the_nodes_context_md():
+    """Appendix 1.4: the rejected code does not survive, the saved reason can."""
+    log = WorldLog()
+    policy = RecursiveDelegation(
+        manager=lambda b: ([Delegation("src", "write outside your path")]
+                           if b.world.path == "" else []),
+        executor=lambda b: [Edit(b.world.path, "elsewhere/x.py", "nope")],
+        log=log, max_depth=2)
+    proposals = policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"},
+                                             Task(id="t", prompt="x")))
+    edits = parse_situated_edits(proposals[0])
+    assert [e["path"] for e in edits] == [f"src/{CONTEXT_FILE}"]
+    assert "refused:" in edits[0]["content"]
+    assert [e.verdict for e in log.episodes if e.path == "src"] == ["rejected"]
+
+
+def test_an_outstanding_rework_request_is_taken_before_a_free_choice():
+    log = WorldLog()
+    log.request_rework("src/backend", "keep going here")
+    seen = []
+    policy = RecursiveDelegation(manager=lambda b: (seen.append(b.world.path) or []),
+                                 executor=lambda b: [], log=log, max_depth=2)
+    policy.propose(_proposal_ctx({CONTEXT_FILE: "# root"}, Task(id="t", prompt="x")))
+    assert seen == ["src/backend"]
+    assert log.pending_rework == {}
+
+
+# ---------------------------------------------------------------------------
+# The domain, and one end-to-end formation
+# ---------------------------------------------------------------------------
+
+def test_the_frozen_suite_agrees_with_its_own_oracle():
+    tasks = domain.build_tasks()
+    run = domain.make_runner()
+    rendered = canonical(domain._reference_tree())
+    assert sum(domain.reward(t, run(rendered, t)) for t in tasks) == len(tasks)
+
+
+def test_the_repository_starts_with_no_implementation_in_it():
+    files = domain.initial_files()
+    assert files and all(p.endswith(".md") for p in files)
+    tasks = domain.build_tasks()
+    run = domain.make_runner()
+    rendered = canonical(files)
+    assert sum(domain.reward(t, run(rendered, t)) for t in tasks) == 0
+
+
+def test_formation_grows_a_working_toolchain_from_the_empty_repository():
+    """End to end, offline: the parent's rule takes 0.000 to a working world."""
+    tasks = domain.build_tasks()
+    log = WorldLog()
+    strategy = SpatialContract(initial_files=domain.initial_files(),
+                               frozen=domain.FROZEN, log=log, max_files_per_diff=6)
+    delegation = RecursiveDelegation(manager=domain.offline_manager,
+                                     executor=domain.offline_executor, log=log,
+                                     max_depth=3)
+
+    def superseded(rendered, task, output, reward):  # replaced by the bundle
+        raise AssertionError("the proposal policy was not installed")
+
+    result = evolve(
+        tasks, domain.reward, run=domain.make_runner(), propose=superseded,
+        strategy=strategy, artifact_id="world", blast_radius=0.2,
+        rounds=12, n_workers=4, max_concurrency=4, self_verify=False,
+        held_out_frac=0.4, seed=0,
+        policies=Policies(proposal=delegation,
+                          acceptance=ParentJudge(log=log, enabled=True),
+                          conflict=OctopusConflict()))
+
+    assert result.error is None
+    assert result.final_reward > 0.9, result.outcomes()
+    assert log.observed_depth() >= 2, "the run never delegated past the first level"
+    assert log.contract_violations == 0

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -27,7 +27,7 @@ from examples.genesis._delegation import (Brief, Delegation, Edit,
 from examples.genesis._judge import ParentJudge
 from examples.genesis._octopus import OctopusConflict, git_available, three_way
 from examples.genesis._spatial import SpatialContract, parse_situated_edits
-from examples.genesis._suite import preflight
+from examples.genesis._suite import cold_start, preflight
 from examples.genesis._world import (CONTEXT_FILE, SKILLS_DIR, TRUNCATED,
                                      LocalWorld, WorldLog, owns, parse_routing,
                                      resolve_edit_path, routing_entry)
@@ -826,6 +826,81 @@ def test_a_dead_backend_stops_the_run_before_it_starts():
     asked = []
     preflight(lambda prompt: asked.append(prompt) or "OK")       # a live one is quiet
     assert len(asked) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cold start: the decomposition is the run's job, not the human's
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spec", DOMAINS, ids=DOMAIN_IDS)
+def test_cold_start_keeps_the_goal_the_contract_and_the_suite_and_nothing_else(spec):
+    """Every file a human cannot avoid supplying, and not one more.
+
+    A formation domain ships a `CONTEXT.md` per node, each with a routing table, and
+    for every node below the root that is the system's own first job done for it --
+    the paper's phase 1 is architecture and design. `--cold-start` takes it away:
+    what is left is the goal, the frozen contract, the suite that scores it and any
+    frozen entry script.
+    """
+    cold = cold_start(spec.initial_files())
+    assert set(cold) <= set(spec.initial_files())
+    # the root record survives, with an emptied table
+    assert parse_routing(cold[CONTEXT_FILE]) == []
+    # no other record, and no skill
+    assert [p for p in cold if p.endswith(CONTEXT_FILE)] == [CONTEXT_FILE] + \
+           [p for p in cold if p.endswith(CONTEXT_FILE) and p.startswith("spec/")]
+    assert not [p for p in cold if SKILLS_DIR in p]
+    # and nothing frozen was touched: scoring is identical
+    frozen = [p for p in spec.initial_files() if match_any(p, spec.FROZEN)]
+    assert frozen and all(cold.get(p) == spec.initial_files()[p] for p in frozen)
+
+
+def test_a_cold_started_root_is_not_sent_into_the_read_only_directories():
+    """`routing()` falls back to the sub-directories that exist, which was invisible
+    while every domain shipped a table at the root. Cold-started, the root's only
+    sub-directories are `spec/` and `tests/` -- and a manager was duly told to
+    delegate into the two places it is forbidden to write."""
+    cold = cold_start(md.initial_files())
+    assert LocalWorld(0, "", readonly=md.FROZEN).routing(cold) == []
+    assert LocalWorld(0, "").routing(cold) == ["spec", "tests"]      # the old bug
+    # a directory with anything writable in it is still a route
+    grown = dict(cold, **{"src/__init__.py": "x\n"})
+    assert LocalWorld(0, "", readonly=md.FROZEN).routing(grown) == ["src"]
+
+
+def test_a_cold_started_world_writes_the_decomposition_it_was_not_given():
+    """End to end, offline, from eight files: the run opens its own nodes, records
+    them in its own routing tables, and still reaches a working world."""
+    tasks = domain.build_tasks()
+    log = WorldLog()
+    cold = cold_start(domain.initial_files())
+    assert [p for p in cold if p.endswith(CONTEXT_FILE)] == [CONTEXT_FILE,
+                                                             "spec/" + CONTEXT_FILE]
+    strategy = SpatialContract(initial_files=cold, frozen=domain.FROZEN, log=log,
+                               max_files_per_diff=6)
+    delegation = RecursiveDelegation(manager=domain.offline_manager,
+                                     executor=domain.offline_executor, log=log,
+                                     max_depth=3, contracts=domain.FROZEN)
+    result = evolve(
+        tasks, domain.reward, run=domain.make_runner(),
+        propose=lambda *a: (_ for _ in ()).throw(AssertionError("not installed")),
+        strategy=strategy, artifact_id="world", blast_radius=0.2,
+        rounds=14, n_workers=4, max_concurrency=4, self_verify=False,
+        held_out_frac=0.4, seed=0,
+        policies=Policies(proposal=delegation,
+                          acceptance=ParentJudge(log=log, enabled=True),
+                          conflict=OctopusConflict()))
+
+    assert result.error is None
+    assert result.final_reward > 0.9, result.outcomes()
+    assert delegation.routes_opened > 0, "no node was ever opened"
+    grown = result.state if isinstance(result.state, dict) else dict(result.state)
+    records = {p: grown[p] for p in grown if p.endswith(CONTEXT_FILE)}
+    assert len(records) > 1, sorted(records)
+    written = [p for p in records if p != CONTEXT_FILE and not p.startswith("spec/")]
+    assert written, "the run never recorded a node of its own"
+    assert any(parse_routing(records[p]) for p in records), "no routing table grew"
+    assert log.contract_violations == 0
 
 
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():

--- a/tests/test_genesis_example.py
+++ b/tests/test_genesis_example.py
@@ -1220,6 +1220,38 @@ def test_an_unparseable_or_negative_answer_keeps_the_run_going():
                   rejected=0)) is False
 
 
+def test_a_per_test_score_cannot_see_a_test_poisoning_the_next_one():
+    """One process per test is what makes one-task-per-test possible, and it is blind
+    to anything that leaks between tests. A real run produced the sharpest possible
+    case, and this baseline is that code with nothing changed:
+
+        def rdf(positions, box, bins, rmax):        # in src/observe/__init__.py
+            from .rdf import histogram              # <- rebinds src.observe.rdf
+            ...                                     #    from this function to the
+                                                    #    module. It destroys itself.
+
+    The first call in a process works; every call after it raises. Scored one test per
+    process it is perfect, and the run reported audit reward 1.000 for it. Run the way
+    a person runs a suite -- `mix test`, which is what `agents/manager.ex` means by
+    "run ALL tests" -- five tests fail.
+    """
+    broken = dict(md.reference_tree(),
+                  **md.SUITE_ONLY_BASELINES["self-clobbering-import"])
+    failures = md.MD.suite_failures(broken, audit=True)
+    assert len(failures) == 5, failures
+    assert all("not callable" in f for f in failures), failures
+
+    # every one of those five passes on its own, which is the whole point
+    run = md.make_runner()
+    rendered = canonical(broken)
+    alone = {t.id: md.reward(t, run(rendered, t)) for t in md.build_tasks()
+             if any(t.meta["func"] in f for f in failures)}
+    assert alone and set(alone.values()) == {1.0}, alone
+
+    # and the reference is clean under both ways of running it
+    assert md.MD.suite_failures(md.reference_tree(), audit=True) == []
+
+
 def test_stackvm_is_deeper_than_minilang_which_is_why_it_exists():
     """The second domain is not "harder code" -- it is somewhere for the
     recursion to go. `src/vm/ops` is a node whose parent is itself a child."""


### PR DESCRIPTION
Closes part of #183 — and corrects it: that issue concluded the central mechanism needed an engine change. It does not. **`agentdescent/` is untouched by this PR.**

## What it is

[EvoX Genesis](https://github.com/EMI-Group/genesis) ([arXiv:2608.10450](https://arxiv.org/abs/2608.10450)) organises long-horizon development around a persistent project rather than a persistent agent. An agent is situated by `w = (v, p)` — an accepted version and a repository-relative path — and two operations differ in exactly one way:

| operation | version | path |
|---|---|---|
| recursive delegation `(v,p) ⇝ (v,q)` | **unchanged** | moves to `q` |
| accepted event `(v,p) → (v′,p′)` | **advances** | stays, or is explicitly mapped |

The first is the proposal policy's business and never touches the ledger; the second is the aggregator's commit. Everything else follows from that split.

## How it plugs in

Eleven components, every one on a seam that already existed:

| component | slot | what it does |
|---|---|---|
| `SpatialContract` | `strategy=` | a directory, one key per path; an edit carries the path of the agent that made it, and one outside that subtree is dropped and **counted** |
| `RecursiveDelegation` | `Policies(proposal=)` | one rollout is a whole episode tree at **one** version |
| `OctopusConflict` | `Policies(conflict=)` | `git merge-file` three-way, so two agents editing two functions of one file both survive |
| `ParentJudge` | `Policies(acceptance=)` | upstream's monotone rule — *partial progress is accepted* |
| `ReflectiveStaleness` | `Policies(staleness=)` | a lagging proposal is replayed on the current head and kept only if it still improves |
| `Suite.review` | `RecursiveDelegation(review=)` | the parent's own test run on one child's work, inside the episode |
| `ParentCodeReview` | `RecursiveDelegation(review=)` | the parent **reads the diff** — upstream's code-quality rejection |
| `CompletionJudge` | `evolve(stop_when=)` | the root agent ends the run when it judges the objective delivered |
| `ArchitectPhase` / `ExtractPhase` | `--mode b` / `--mode a` | upstream's two entry points: design the tree, or read it off a repository |
| `ClaudeCodeExecutor` | `--executor claude-code` | an episode as one headless Claude Code session in a throwaway worktree |
| `Rollout` / `WorktreeLedger` | `--worktrees` | a git worktree and a commit per episode, the worktree released after |

## Two phases, and where the tree comes from

`Genesis.run` branches on whether the codebase exists, and each branch has a different root agent:

```elixir
if mode == :new do
  run_new_codebase(...)       # Mode B: Architect, then Manager
else
  run_existing_codebase(...)  # Mode A: ContextExtractor
end
```

`--mode` is that branch. **`b`** designs the tree before a line is written against it; **`a`**'s root agent is the *ContextExtractor*, because a repository with code and no `CONTEXT.md` cannot be worked on by recursive delegation at all — the routing table is the map. **`given`**, the default, is what this port did before either existed: the domain's hand-written records, which is Phase 1 done by a person.

An architect **invents** children; an extractor **finds** them. Extraction is the easier job, and every degenerate tree `--mode b` produced turned out to be this port's mistake rather than the model's — see the list below.

## Measured, with `deepseek-v4-flash`

Oracle-scored domains:

| domain | held-out | accepted | episodes | depth | calls | wall-clock |
|---|---|---|---|---|---|---|
| `minilang` ×3 seeds | **1.000** | 5 | 34 | 3 / 3 / 2 | 284 / 306 / 242 | 135 / 173 / 100 s |
| `stackvm` | **1.000** | 12 | 114 | 3 | 659 | 902 s |

And `md` — Lennard-Jones molecular dynamics scored by a **frozen test suite with no reference implementation in the scoring path** — through all three entry points, same model, same policies, barrier-free:

| entry point | the tree | held out | suite, one process | rollouts | episodes | calls | wall-clock | ended by |
|---|---|---|---|---|---|---|---|---|
| `given` | 8 hand-written records | **1.000** | 67/67 | 2 791 | 111 | 3 731 | 9.3 min | **the root agent** |
| `--mode b` | an architect's own 12 nodes | **1.000** | 67/67 | **243** | 155 | 1 453 | 9.4 min | **the root agent** |
| `--mode a` | extracted over a 57/65 repository | 0.938 | 65/67 | 30 003 | 205 | 31 918 | 15.0 min | the budget |

`--mode b` is the interesting column: phase 1 designs the decomposition, the implementation phase grows it, and the run ends because its own root agent says so —

> All 51 tests pass, every required entry point is implemented with real physics (nearest-image displacement, wrapped positions, Lennard-Jones and harmonic potentials, Velocity Verlet integration, observables, and RDF histogram) using lazy imports

Verified three ways rather than one: `pytest` on what `--write-repo` wrote with the audit set injected — **65 passed**; the whole suite in **one interpreter** — 67/67; and a 108-particle, 600-step thermostatted run against an independent reference implementation — **identical line for line**, every temperature, kinetic energy and momentum to six decimals over 600 steps of chaotic dynamics. The layout is the architect's own, and it is not the one the hand-written records propose.

`--mode a`'s remaining 0.062 is two ordinary physics defects with live failing tests (energy jumps 1.15 when a particle crosses the periodic boundary; time-reversal drifts 6.5e-6 against a 1e-6 tolerance). What it is short of is episodes, not mechanism: 30 003 rollouts bought 205 of them.

Offline, deterministic across seeds, the merge comparison that motivates `OctopusConflict`:

| domain | arm | accepted events |
|---|---|---|
| `minilang` | `--serial` / N=4 / N=8 | 5 / **4** / **3** |
| `minilang` | `--keyed-union`, any width | **5 / 5 / 5** |
| `stackvm` | N=8 / N=8 `--keyed-union` | **6** / 8 |

Under the engine's rule — "same key" means "same file" — parallelism buys nothing here. Two agents filling two different functions of one file is an edit a keyed union cannot fuse.

## What a measurement is worth, and six times it was worth less than it looked

Every one of these was found by a real run and cost a published number.

1. **A suite of invariants is satisfied by returning zero.** A run reported `audit reward 1.000` for a repository whose force field is identically zero: `d -= box * (d / box + 0.5) // 1`, where the `// 1` binds after the multiplication. 42 of the then 44 tests passed, and the only one that noticed was the negative control. Fixed in the *suite*: value anchors in a periodic box, plus `BASELINES` — six deliberately wrong implementations that must each die to **at least two** tests. Writing that check immediately found two more holes.
2. **A per-test score cannot see a test poisoning the next one.** The next run reported 1.000 and shipped an `rdf()` that destroyed itself on first call. One process per test: 65/65. In one interpreter, the way `mix test` runs: 60/65. The whole suite in one process is now a **task**, not only a gate.
3. **The agents never received the specification.** `situate()` emitted frozen contract files in *sorted* order under one global budget, and `md.py` sorts before `spec/CONTEXT.md` and is bigger. The run scored 0.750 against a contract nobody had read. Upstream truncates **per file** at 65 536 bytes with no global cap; so does this now.
4. **An objective is not a catalogue line.** Phase 1 was handed `DOMAIN_BLURB` — the string the header prints — and an architect given twelve words invents the rest. It read the specification correctly (the API Surface it wrote names `src/geometry.py`) and then its routing table said `./geometry/`, dropping the package root. `src/` was never delegated to, every child that read the same spec built its own `src/` inside its own node, and 900 episodes later the world was `integrate/step/src/geometry/displacement/src/`. Each domain now carries an `OBJECTIVE`, and the header keeps its catalogue line.
5. **The architect designs the codebase, not the repository around it.** Fixing the brief did not fix the tree: situated at the repository root and told the library lives at `src/`, the architect decided it *was* `src` — three samples out of three, and saying otherwise in the prompt did not move it. Upstream starts its architect on the codebase it creates; the spec, the suite and the entry point are the harness *around* it. The root record is now generated from what the domain already declares — the frozen globs, and the package root implied by its entry point — and phase 1 starts one level down. One record a person did not write per domain, against eight in `given`.
6. **A node and a module of one name, and neither side can repair it.** `rdf/` beside `rdf.py` are both `src.observe.rdf` to Python and the module wins, so everything written in the directory is unreachable from every import. Both halves had to be closed, and each was found by a run that could not move:
   * *The parent's finding had nowhere to go.* `--mode a` inherited such a pair. The parent review diagnosed it exactly — *"the actual file `src/observe/rdf/rdf.py` defines a function named `rdf`, not `histogram`, so this import will fail at runtime"* — and rejected the **child** over it, though the files belong to the parent. Upstream review and accountability are one phase run by the agent "ACCOUNTABLE for all code in its node path"; the port had the accountability turn but ran it **blind**. It now carries the findings (`findings_carried`), and the manager did rewrite its own file — which then read `from src.observe.rdf.rdf import rdf`, raising `'src.observe.rdf' is not a package`, because the name resolves back to the forwarding file.
   * *So the collision is refused where it is made, from both directions.* A delegation opening a node beside a module of that name (`shadowed_nodes`), and an edit writing a file beside a node directory of that name (`shadowing_edits`) — the second is the one that bit `--mode b`, whose manager delegated `lennard_jones/` and then wrote `lennard_jones.py` beside it on its own accountability turn, which `_is_node` cannot see because the file did not exist yet. Where `--mode a` *inherits* a pair, the extractor writes it into `## Known Issues` naming both halves and that one of the two has to go.

   Closing both is what produced the table above: `--mode b` went from spending its whole budget and having its root agent refuse to sign off, to **ending on `stop_when` in 243 rollouts**, with no collision anywhere in the result.

## Scheduling: barrier-free, and what staleness means here

The default is `asynchronous=True` — upstream has no round barrier, agents commit as they finish. That made the staleness policy load-bearing, and the first reading of it was wrong.

| `--staleness` | what it does | `md`, `given` |
|---|---|---|
| `full` | ACCEPT the lagging proposal as-is | 0.812, never self-stopped |
| `reflective` (default) | replay on the current head, keep iff it still improves | **1.000**, **self-stopped**, 9.3 min |

`full` is not a merge: a stale whole-file diff taken as-is reverts newer work, and the self-clobbering `rdf` came back that way.

`--signal-weighted` is measured too, and the answer is no. It converts rollouts to episodes better (104 vs 78 on one budget) and changed the score not at all, because `4·p·(1−p)` treats *never passes* and *always passes* alike — and on this workload the only task carrying signal is the one that never passes. Round-robin stays the default.

## Aligned against the released source, not against memory

`grep -rio 'fitness|reward|score'` over `apps/evo_git` returns exactly one hit: `oom_score_adjust`. **Upstream has no objective function.** What stands in its place is local — the executor verifies its own work, the parent reviews the result *and* runs the suite *and* rejects anti-patterns, tests are "the definition of done", termination is an agent calling `complete_task`. So `evolve()`'s scalar is this port's **measurement**, and the mechanism it reproduces is the per-node gate.

Five alignments followed from reading the source: the parent **reads the diff**; **per-file** context truncation at upstream's cap; upstream's four standard `CONTEXT.md` sections including **API Surface**; `FROZEN` / `CONTRACTS` / `readonly` as three sets for three jobs; and a refusal written under `## Known Issues`, upstream's own heading.

## The episode, and `--executor claude-code`

An episode upstream is a supervised session of up to **2 048 root turns** with file, shell and test tools; here it is **one model call**. That is the largest single distance between this port and the system it ports, so the port now offers the other side of it: `--executor claude-code` makes an executor episode one headless Claude Code session in a throwaway worktree, and what it did is recovered by **diffing the worktree** rather than parsed out of a reply. Three fences, none replacing the others: the session's own allow-list with the network tools off; a settings file denying every frozen glob by name; and the spatial contract, which drops anything outside the node's subtree whatever the session believed.

## What this does not claim

* **The benchmark is not reproduced and is not claimed.** The page carries the paper's numbers beside this port's, row by row: 123.402 h against 0.6; 1 019 archived episodes against 155; observed depth 5 against 4; 248 989 lines against ~400; US$44.38 against an endpoint that does not bill.
* **The suite constrains the surface, not the structure.** The `stackvm` run passes with a decomposition it invented and two pieces of dead code the suite cannot see. On `md` it was `complete_task`, not the score, that caught dead scaffolding — the score was already 1.000.
* Upstream's archive shows 26 `CONTEXT.md` creations and **62 later accepted updates**; here the records are written on two occasions.
* Two places where the paper and the released code disagree, both following the code; skills are inherited but never extracted; multi-repo, the desktop shell and the dashboard — **including the human merge that is the last gate upstream** — are out of scope.

## Three engine boundaries, recorded rather than routed around

* **Tensor parallelism cannot express this.** Its ownership map is built before round 0, so every newly created file is a `section-violation` — and creating files is what a formation run *is*. `SpatialContract` declares no `keys()`, so `evolve()` refuses TP with a message naming the reason.
* **`AcceptDecision.category` is a closed vocabulary**, so "request more work" is reconstructed from parts the engine has rather than added to it.
* **The audit gate runs before acceptance** and above `FAST_MAX` vetoes anything that does not strictly improve, contradicting "partial progress is accepted". The world runs at L2, and the page says why that is honest here.

## Verification

```bash
pytest -q                                                            # offline, no API key
python -m examples.genesis.genesis_recursive_worlds                  # minilang, offline, ~3 s
python -m examples.genesis.genesis_recursive_worlds --domain md      # tests, not an oracle
python -m examples.genesis.genesis_recursive_worlds --mode b --model ...   # the architect designs it
python -m examples.genesis.genesis_recursive_worlds --mode a --continue-from DIR
python -m examples.genesis.genesis_recursive_worlds --executor claude-code
python -m examples.genesis.genesis_recursive_worlds --worktrees      # a worktree and a commit per episode
python -m examples.genesis.genesis_recursive_worlds --keyed-union    # the control arm
```

Full suite green. 255 offline tests across `tests/test_genesis_example.py` and the entry-point contract. `--dry-run` crosses no boundary, and the default run needs no key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CjFJhQ2Wxq9Vr3Fu38KrW